### PR TITLE
docs: update links to reflect changes in Rspack rules structure

### DIFF
--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -271,7 +271,7 @@ export interface SourceConfig {
    * Specify additional JavaScript files that need to be compiled by SWC.
    * Through the `source.include` config, you can specify directories or modules
    * that need to be compiled by Rsbuild. The usage of `source.include` is
-   * consistent with [Rule.include](https://rspack.rs/config/module#ruleinclude)
+   * consistent with [rules[].include](https://rspack.rs/config/module-rules#rulesinclude)
    * in Rspack, which supports passing in strings or regular expressions to match
    * the module path.
    * @default

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -379,13 +379,13 @@ export type TransformHandler<Raw extends boolean = false> = (
 
 export type TransformDescriptor = {
   /**
-   * Include modules that match the test assertion, the same as `rule.test`
-   * @see https://rspack.rs/config/module#ruletest
+   * Include modules that match the test assertion, the same as `rules[].test`
+   * @see https://rspack.rs/config/module-rules#rulestest
    */
   test?: Rspack.RuleSetCondition;
   /**
    * A condition that matches the resource query.
-   * @see https://rspack.rs/config/module#ruleresourcequery
+   * @see https://rspack.rs/config/module-rules#rulesresourcequery
    */
   resourceQuery?: Rspack.RuleSetCondition;
   /**
@@ -409,31 +409,31 @@ export type TransformDescriptor = {
   /**
    * Marks the layer of the matching module, can be used to group a group of
    * modules into one layer
-   * @see https://rspack.rs/config/module#rulelayer
+   * @see https://rspack.rs/config/module-rules#ruleslayer
    */
   layer?: string;
   /**
    * Matches all modules that match this resource, and will match against layer of
    * the module that issued the current module.
-   * @see https://rspack.rs/config/module#ruleissuerlayer
+   * @see https://rspack.rs/config/module-rules#rulesissuerlayer
    */
   issuerLayer?: string;
   /**
    * Matches all modules that match this resource, and will match against Resource
    * (the absolute path without query and fragment) of the module that issued the
    * current module.
-   * @see https://rspack.rs/config/module#ruleissuer
+   * @see https://rspack.rs/config/module-rules#rulesissuer
    */
   issuer?: Rspack.RuleSetCondition;
   /**
    * Matches [import attributes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import/with)
-   * @see https://rspack.rs/config/module#rulewith
+   * @see https://rspack.rs/config/module-rules#ruleswith
    */
   with?: Record<string, Rspack.RuleSetCondition>;
   /**
    * Matches modules based on MIME type instead of file extension. It's primarily
    * useful for data URI module (like `data:text/javascript,...`).
-   * @see https://rspack.rs/config/module#rulemimetype
+   * @see https://rspack.rs/config/module-rules#rulesmimetype
    */
   mimetype?: Rspack.RuleSetCondition;
   /**
@@ -447,7 +447,7 @@ export type TransformDescriptor = {
    * transform functions (or Rspack loaders).
    * - When specified as 'post', the transform function will execute after other
    * transform functions (or Rspack loaders).
-   * @see https://rspack.rs/config/module#ruleenforce
+   * @see https://rspack.rs/config/module-rules#rulesenforce
    */
   order?: HookOrder;
 };

--- a/packages/plugin-preact/src/index.ts
+++ b/packages/plugin-preact/src/index.ts
@@ -16,13 +16,13 @@ export type PluginPreactOptions = {
   prefreshEnabled?: boolean;
   /**
    * Include files to be processed by the `@rspack/plugin-preact-refresh` plugin.
-   * The value is the same as the `rule.test` option in Rspack.
+   * The value is the same as the `rules[].test` option in Rspack.
    * @default /\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/
    */
   include?: Rspack.RuleSetCondition;
   /**
    * Exclude files from being processed by the `@rspack/plugin-preact-refresh` plugin.
-   * The value is the same as the `rule.exclude` option in Rspack.
+   * The value is the same as the `rules[].exclude` option in Rspack.
    * @default /[\\/]node_modules[\\/]/
    */
   exclude?: Rspack.RuleSetCondition;
@@ -117,9 +117,8 @@ export const pluginPreact = (
         return;
       }
 
-      const { default: PreactRefreshPlugin } = await import(
-        '@rspack/plugin-preact-refresh'
-      );
+      const { default: PreactRefreshPlugin } =
+        await import('@rspack/plugin-preact-refresh');
 
       const preactPath = require.resolve('preact', {
         paths: [api.context.rootPath],

--- a/website/docs/en/config/source/assets-include.mdx
+++ b/website/docs/en/config/source/assets-include.mdx
@@ -1,6 +1,6 @@
 # source.assetsInclude
 
-- **Type:** [Rspack.RuleSetCondition](https://rspack.rs/config/module#condition)
+- **Type:** [Rspack.RuleSetCondition](https://rspack.rs/config/module-rules#condition)
 - **Default:** `undefined`
 - **Version:** `>= 1.0.18`
 
@@ -8,7 +8,7 @@ Include additional files that should be treated as static assets.
 
 By default, Rsbuild treats common image, font, audio, and video files as static assets. Through the `source.assetsInclude` config, you can specify additional file types that should be treated as static assets. These added static assets are processed using the same rules as the built-in supported static assets, see [Static Assets](/guide/basic/static-assets).
 
-The value of `source.assetsInclude` is the same as the `test` option in Rspack loader. It can be a regular expression, string, array, logical condition, etc. For more details, see [Rspack RuleSetCondition](https://rspack.rs/config/module#condition).
+The value of `source.assetsInclude` is the same as the `test` option in Rspack loader. It can be a regular expression, string, array, logical condition, etc. For more details, see [Rspack RuleSetCondition](https://rspack.rs/config/module-rules#condition).
 
 ## Example
 

--- a/website/docs/en/config/source/exclude.mdx
+++ b/website/docs/en/config/source/exclude.mdx
@@ -1,6 +1,6 @@
 # source.exclude
 
-- **Type:** [Rspack.RuleSetCondition](https://rspack.rs/config/module#condition)
+- **Type:** [Rspack.RuleSetCondition](https://rspack.rs/config/module-rules#condition)
 - **Default:** `[]`
 
 Exclude JavaScript or TypeScript files that do not need to be compiled by [SWC](/guide/configuration/swc).

--- a/website/docs/en/config/source/include.mdx
+++ b/website/docs/en/config/source/include.mdx
@@ -1,6 +1,6 @@
 # source.include
 
-- **Type:** [Rspack.RuleSetCondition](https://rspack.rs/config/module#condition)
+- **Type:** [Rspack.RuleSetCondition](https://rspack.rs/config/module-rules#condition)
 
 Specify additional JavaScript files that need to be compiled by [SWC](/guide/configuration/swc).
 
@@ -22,7 +22,7 @@ const defaultInclude = [
 
 ## Usage
 
-Through the `source.include` configuration, you can specify directories or modules that need to be compiled by Rsbuild. The usage of `source.include` is consistent with [Rule.include](https://rspack.rs/config/module#ruleinclude) in Rspack, which supports passing in strings or regular expressions to match the module path.
+Through the `source.include` configuration, you can specify directories or modules that need to be compiled by Rsbuild. The usage of `source.include` is consistent with [rules[].include](https://rspack.rs/config/module-rules#rulesinclude) in Rspack, which supports passing in strings or regular expressions to match the module path.
 
 For example:
 

--- a/website/docs/en/config/tools/rspack.mdx
+++ b/website/docs/en/config/tools/rspack.mdx
@@ -270,7 +270,7 @@ export default {
 
 - **Type:** `(rules: RuleSetRule | RuleSetRule[]) => void`
 
-Add additional [Rspack rules](https://rspack.rs/config/module#modulerules) to the head of the internal Rspack module rules array.
+Add additional [Rspack rules](https://rspack.rs/config/module-rules) to the head of the internal Rspack module rules array.
 
 It should be noted that Rspack loaders will be executed in right-to-left order. If you want the loader you added to be executed before other loaders (Normal Phase), you should use [appendRules](#appendrules) to add the rule to the end.
 
@@ -306,7 +306,7 @@ export default {
 
 - **Type:** `(rules: RuleSetRule | RuleSetRule[]) => void`
 
-Add additional [Rspack rules](https://rspack.rs/config/module#modulerules) to the end of the internal Rspack module rules array.
+Add additional [Rspack rules](https://rspack.rs/config/module-rules) to the end of the internal Rspack module rules array.
 
 For example:
 

--- a/website/docs/en/plugins/dev/core.mdx
+++ b/website/docs/en/plugins/dev/core.mdx
@@ -349,7 +349,7 @@ type TransformDescriptor = {
 
 The `descriptor` param supports the following matching conditions:
 
-- `test`: matches module's path (without query), the same as Rspack's [Rule.test](https://rspack.rs/config/module#ruletest).
+- `test`: matches module's path (without query), the same as Rspack's [rules[].test](https://rspack.rs/config/module-rules#rulestest).
 
 ```js
 api.transform({ test: /\.md$/ }, ({ code }) => {
@@ -373,7 +373,7 @@ api.transform({ test: /\.md$/, environments: ['web'] }, ({ code }) => {
 });
 ```
 
-- `resourceQuery`: matches module's query, the same as Rspack's [Rule.resourceQuery](https://rspack.rs/config/module#ruleresourcequery).
+- `resourceQuery`: matches module's query, the same as Rspack's [rules[].resourceQuery](https://rspack.rs/config/module-rules#rulesresourcequery).
 
 ```js
 // match raw query: "foo.ext?raw"
@@ -390,7 +390,7 @@ api.transform({ test: /\.node$/, raw: true }, ({ code }) => {
 });
 ```
 
-- `layer`: marks the layer of the matching module, can be used to group a group of modules into one layer, the same as Rspack's [Rule.layer](https://rspack.rs/config/module#rulelayer).
+- `layer`: marks the layer of the matching module, can be used to group a group of modules into one layer, the same as Rspack's [rules[].layer](https://rspack.rs/config/module-rules#ruleslayer).
 
 ```js
 api.transform({ test: /\.md$/, layer: 'foo' }, ({ code }) => {
@@ -398,7 +398,7 @@ api.transform({ test: /\.md$/, layer: 'foo' }, ({ code }) => {
 });
 ```
 
-- `issuerLayer`: matches the layer of the module that issues the current module, the same as Rspack's [Rule.issuerLayer](https://rspack.rs/config/module#ruleissuerlayer).
+- `issuerLayer`: matches the layer of the module that issues the current module, the same as Rspack's [rules[].issuerLayer](https://rspack.rs/config/module-rules#rulesissuerlayer).
 
 ```js
 api.transform({ test: /\.md$/, issuerLayer: 'foo' }, ({ code }) => {
@@ -406,7 +406,7 @@ api.transform({ test: /\.md$/, issuerLayer: 'foo' }, ({ code }) => {
 });
 ```
 
-- `issuer`: matches the absolute path of the module that issues the current module, the same as Rspack's [Rule.issuer](https://rspack.rs/config/module#ruleissuer).
+- `issuer`: matches the absolute path of the module that issues the current module, the same as Rspack's [rules[].issuer](https://rspack.rs/config/module-rules#rulesissuer).
 
 ```js
 api.transform({ test: /\.md$/, issuer: /\.js$/ }, ({ code }) => {
@@ -414,7 +414,7 @@ api.transform({ test: /\.md$/, issuer: /\.js$/ }, ({ code }) => {
 });
 ```
 
-- `with`: matches [import attributes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import/with), the same as Rspack's [Rule.with](https://rspack.rs/config/module#rulewith).
+- `with`: matches [import attributes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import/with), the same as Rspack's [rules[].with](https://rspack.rs/config/module-rules#ruleswith).
 
 ```js
 api.transform({ test: /\.md$/, with: { type: 'url' } }, ({ code }) => {
@@ -422,7 +422,7 @@ api.transform({ test: /\.md$/, with: { type: 'url' } }, ({ code }) => {
 });
 ```
 
-- `mimetype`: Matches modules based on MIME type instead of file extension. It's primarily useful for data URI module (like `data:text/javascript,...`), the same as Rspack's [Rule.mimetype](https://rspack.rs/config/module#rulemimetype).
+- `mimetype`: Matches modules based on MIME type instead of file extension. It's primarily useful for data URI module (like `data:text/javascript,...`), the same as Rspack's [rules[].mimetype](https://rspack.rs/config/module-rules#rulesmimetype).
 
 ```js
 api.transform({ mimetype: 'text/javascript' }, ({ code }) => {
@@ -430,7 +430,7 @@ api.transform({ mimetype: 'text/javascript' }, ({ code }) => {
 });
 ```
 
-- `enforce`: Specifies the execution order of the transform function, the same as Rspack's [Rule.enforce](https://rspack.rs/config/module#ruleenforce).
+- `enforce`: Specifies the execution order of the transform function, the same as Rspack's [rules[].enforce](https://rspack.rs/config/module-rules#rulesenforce).
   - When `enforce` is `pre`, the transform function will be executed before other transform functions (or Rspack loaders).
   - When `enforce` is `post`, the transform function will be executed after other transform functions (or Rspack loaders).
 

--- a/website/docs/en/plugins/list/plugin-less.mdx
+++ b/website/docs/en/plugins/list/plugin-less.mdx
@@ -91,11 +91,11 @@ The `lessLoaderOptions.lessOptions` config is passed to Less. See the [Less docu
 
 ### include
 
-- **Type:** [RuleSetCondition](https://rspack.rs/config/module#condition)
+- **Type:** [Rspack.RuleSetCondition](https://rspack.rs/config/module-rules#condition)
 - **Default:** `/\.less$/`
 - **Version:** `>= 1.1.0`
 
-Include some `.less` files, they will be transformed by `less-loader`. The value is the same as the `rule.test` option in Rspack.
+Include some `.less` files, they will be transformed by `less-loader`. The value is the same as the [rules[].test](https://rspack.rs/config/module-rules#rulestest) option in Rspack.
 
 For example:
 
@@ -107,7 +107,7 @@ pluginLess({
 
 ### exclude
 
-- **Type:** [RuleSetCondition](https://rspack.rs/config/module#condition)
+- **Type:** [Rspack.RuleSetCondition](https://rspack.rs/config/module-rules#condition)
 - **Default:** `undefined`
 
 Exclude some `.less` files, they will not be transformed by `less-loader`.
@@ -136,7 +136,7 @@ pluginLess({
 });
 ```
 
-> See [Rspack - Rule.use.parallel](https://rspack.rs/config/module#ruleuseparallel) for more details.
+> See [Rspack - Rule.use.parallel](https://rspack.rs/config/module-rules#rulesuseparallel) for more details.
 
 ## Modifying Less version
 

--- a/website/docs/en/plugins/list/plugin-preact.mdx
+++ b/website/docs/en/plugins/list/plugin-preact.mdx
@@ -63,9 +63,9 @@ pluginPreact({
 
 ### include
 
-Include files to be processed by the [@rspack/plugin-preact-refresh](https://github.com/rspack-contrib/rspack-plugin-preact-refresh) plugin. The value is the same as the `rule.test` option in Rspack.
+Include files to be processed by the [@rspack/plugin-preact-refresh](https://github.com/rspack-contrib/rspack-plugin-preact-refresh) plugin. The value is the same as the [rules[].test](https://rspack.rs/config/module-rules#rulestest) option in Rspack.
 
-- **Type:** [RuleSetCondition](https://rspack.rs/config/module#condition)
+- **Type:** [Rspack.RuleSetCondition](https://rspack.rs/config/module-rules#condition)
 - **Default:** `/\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/`
 - **Version:** `>= v1.1.0`
 
@@ -77,9 +77,9 @@ pluginPreact({
 
 ### exclude
 
-Exclude files from being processed by the [@rspack/plugin-preact-refresh](https://github.com/rspack-contrib/rspack-plugin-preact-refresh) plugin. The value is the same as the `rule.exclude` option in Rspack.
+Exclude files from being processed by the [@rspack/plugin-preact-refresh](https://github.com/rspack-contrib/rspack-plugin-preact-refresh) plugin. The value is the same as the [rules[].exclude](https://rspack.rs/config/module-rules#rulesexclude) option in Rspack.
 
-- **Type:** [RuleSetCondition](https://rspack.rs/config/module#condition)
+- **Type:** [Rspack.RuleSetCondition](https://rspack.rs/config/module-rules#condition)
 - **Default:** `/[\\/]node_modules[\\/]/`
 - **Version:** `>= v1.1.0`
 

--- a/website/docs/en/plugins/list/plugin-react.mdx
+++ b/website/docs/en/plugins/list/plugin-react.mdx
@@ -231,7 +231,7 @@ As Windows does not support the above usage, you can also use [cross-env](https:
 
 ```ts
 type ReactRefreshOptions = {
-  // @link https://rspack.rs/config/module#condition
+  // @link https://rspack.rs/config/module-rules#condition
   test?: Rspack.RuleSetCondition;
   include?: Rspack.RuleSetCondition;
   exclude?: Rspack.RuleSetCondition;

--- a/website/docs/en/plugins/list/plugin-sass.mdx
+++ b/website/docs/en/plugins/list/plugin-sass.mdx
@@ -86,11 +86,11 @@ pluginSass({
 
 ### include
 
-- **Type:** [RuleSetCondition](https://rspack.rs/config/module#condition)
+- **Type:** [Rspack.RuleSetCondition](https://rspack.rs/config/module-rules#condition)
 - **Default:** `/\.s(?:a|c)ss$/`
 - **Version:** `>= 1.1.0`
 
-Include some `.scss` or `.sass` files, they will be transformed by `sass-loader`. The value is the same as the `rule.test` option in Rspack.
+Include some `.scss` or `.sass` files, they will be transformed by `sass-loader`. The value is the same as the [rules[].test](https://rspack.rs/config/module-rules#rulestest) option in Rspack.
 
 For example:
 
@@ -102,7 +102,7 @@ pluginSass({
 
 ### exclude
 
-- **Type:** [RuleSetCondition](https://rspack.rs/config/module#condition)
+- **Type:** [Rspack.RuleSetCondition](https://rspack.rs/config/module-rules#condition)
 - **Default:** `undefined`
 
 Exclude some `.sass` or `.scss` files, they will not be transformed by `sass-loader`.

--- a/website/docs/en/plugins/list/plugin-svgr.mdx
+++ b/website/docs/en/plugins/list/plugin-svgr.mdx
@@ -275,7 +275,7 @@ export const App = () => <Logo />;
 
 ### exclude
 
-- **Type:** [RuleSetCondition](https://rspack.rs/config/module#condition)
+- **Type:** [Rspack.RuleSetCondition](https://rspack.rs/config/module-rules#condition)
 - **Default:** `undefined`
 
 Exclude some SVG files, they will not be transformed by SVGR.
@@ -303,7 +303,7 @@ console.log(url); // => resource url
 
 ### excludeImporter
 
-- **Type:** [RuleSetCondition](https://rspack.rs/config/module#condition)
+- **Type:** [Rspack.RuleSetCondition](https://rspack.rs/config/module-rules#condition)
 - **Default:** `undefined`
 
 Exclude some modules, the SVGs imported by these modules will not be transformed by SVGR.

--- a/website/docs/en/plugins/list/plugin-vue.mdx
+++ b/website/docs/en/plugins/list/plugin-vue.mdx
@@ -106,7 +106,7 @@ pluginVue({
 
 Customize the matching rule for Vue Single File Components (SFC).
 
-- **Type:** [Rspack.RuleSetCondition](https://rspack.rs/config/module#condition)
+- **Type:** [Rspack.RuleSetCondition](https://rspack.rs/config/module-rules#condition)
 - **Default:** `/\.vue$/`
 - **Version:** `>= 1.2.1`
 

--- a/website/docs/zh/config/resolve/condition-names.mdx
+++ b/website/docs/zh/config/resolve/condition-names.mdx
@@ -1,7 +1,7 @@
 # resolve.conditionNames
 
 - **类型：** `string[]`
-- **默认值：** 与 Rspack 的 [resolve.conditionNames](https://rspack.rs/config/resolve#resolveconditionnames) 一致
+- **默认值：** 与 Rspack 的 [resolve.conditionNames](https://rspack.rs/zh/config/resolve#resolveconditionnames) 一致
 - **版本：** `>= 1.5.7`
 
 指定用于匹配包 [`exports` 字段](https://nodejs.org/api/packages.html#packages_exports) 入口点的 condition names（条件名称）。

--- a/website/docs/zh/config/source/assets-include.mdx
+++ b/website/docs/zh/config/source/assets-include.mdx
@@ -1,6 +1,6 @@
 # source.assetsInclude
 
-- **类型：** [Rspack.RuleSetCondition](https://rspack.rs/zh/config/module#condition)
+- **类型：** [Rspack.RuleSetCondition](https://rspack.rs/zh/config/module-rules#condition)
 - **默认值：** `undefined`
 - **版本：** `>= 1.0.18`
 
@@ -8,7 +8,7 @@
 
 Rsbuild 默认会将常见的图片、字体、音频、视频等文件视为静态资源。通过配置 `source.assetsInclude`，你可以添加更多的文件类型，这些新增的静态资源将按照与内置静态资源相同的规则进行处理，详见 [静态资源](/guide/basic/static-assets)。
 
-`source.assetsInclude` 的值与 Rspack loader 的 `test` 选项相同，可以是正则表达式、字符串、数组、逻辑条件等，详见 [Rspack RuleSetCondition](https://rspack.rs/zh/config/module#condition)。
+`source.assetsInclude` 的值与 Rspack loader 的 `test` 选项相同，可以是正则表达式、字符串、数组、逻辑条件等，详见 [Rspack RuleSetCondition](https://rspack.rs/zh/config/module-rules#condition)。
 
 ## 示例
 

--- a/website/docs/zh/config/source/exclude.mdx
+++ b/website/docs/zh/config/source/exclude.mdx
@@ -1,6 +1,6 @@
 # source.exclude
 
-- **类型：** [RuleSetCondition](https://rspack.rs/zh/config/module#condition)
+- **类型：** [Rspack.RuleSetCondition](https://rspack.rs/zh/config/module-rules#condition)
 - **默认值：** `[]`
 
 排除不需要被 [SWC](/guide/configuration/swc) 编译的 JavaScript 或 TypeScript 文件。

--- a/website/docs/zh/config/source/include.mdx
+++ b/website/docs/zh/config/source/include.mdx
@@ -1,6 +1,6 @@
 # source.include
 
-- **类型：** [RuleSetCondition](https://rspack.rs/zh/config/module#condition)
+- **类型：** [Rspack.RuleSetCondition](https://rspack.rs/zh/config/module-rules#condition)
 
 用于指定额外需要被 [SWC](/guide/configuration/swc) 编译的 JavaScript 文件。
 
@@ -22,7 +22,7 @@ const defaultInclude = [
 
 ## 用法
 
-通过 `source.include` 配置项，你可以指定需要 Rsbuild 额外进行编译的目录或模块。`source.include` 的用法与 Rspack 中的 [Rule.include](https://rspack.rs/zh/config/module#ruleinclude) 一致，支持传入字符串、正则表达式来匹配模块的路径。
+通过 `source.include` 配置项，你可以指定需要 Rsbuild 额外进行编译的目录或模块。`source.include` 的用法与 Rspack 中的 [rules[].include](https://rspack.rs/zh/config/module-rules#rulesinclude) 一致，支持传入字符串、正则表达式来匹配模块的路径。
 
 比如:
 

--- a/website/docs/zh/config/tools/rspack.mdx
+++ b/website/docs/zh/config/tools/rspack.mdx
@@ -270,7 +270,7 @@ export default {
 
 - **类型：** `(rules: RuleSetRule | RuleSetRule[]) => void`
 
-添加额外的 [Rspack rules](https://rspack.rs/zh/config/module#modulerules) 到 Rspack rules 列表的最前面。
+添加额外的 [Rspack rules](https://rspack.rs/zh/config/module-rules) 到 Rspack rules 列表的最前面。
 
 需要注意的是，Rspack loaders 会按照从右到左的顺序执行，如果你希望你添加的 loader（Normal Phase）先于其他 loader 执行，应使用 [appendRules](#appendrules) 将该规则添加到最后面。
 
@@ -306,7 +306,7 @@ export default {
 
 - **类型：** `(rules: RuleSetRule | RuleSetRule[]) => void`
 
-添加额外的 [Rspack rules](https://rspack.rs/zh/config/module#modulerules) 到 Rspack rules 列表的最后面。
+添加额外的 [Rspack rules](https://rspack.rs/zh/config/module-rules) 到 Rspack rules 列表的最后面。
 
 示例：
 

--- a/website/docs/zh/plugins/dev/core.mdx
+++ b/website/docs/zh/plugins/dev/core.mdx
@@ -349,7 +349,7 @@ type TransformDescriptor = {
 
 `descriptor` 参数支持设置以下匹配条件：
 
-- `test`：匹配模块的路径（不包含 query），等价于 Rspack 的 [Rule.test](https://rspack.rs/zh/config/module#ruletest)。
+- `test`：匹配模块的路径（不包含 query），等价于 Rspack 的 [rules[].test](https://rspack.rs/zh/config/module-rules#rulestest)。
 
 ```js
 api.transform({ test: /\.md$/ }, ({ code }) => {
@@ -373,7 +373,7 @@ api.transform({ test: /\.md$/, environments: ['web'] }, ({ code }) => {
 });
 ```
 
-- `resourceQuery`：匹配模块的 query，等价于 Rspack 的 [Rule.resourceQuery](https://rspack.rs/zh/config/module#ruleresourcequery)。
+- `resourceQuery`：匹配模块的 query，等价于 Rspack 的 [rules[].resourceQuery](https://rspack.rs/zh/config/module-rules#rulesresourcequery)。
 
 ```js
 // 匹配 raw query: "foo.ext?raw"
@@ -390,7 +390,7 @@ api.transform({ test: /\.node$/, raw: true }, ({ code }) => {
 });
 ```
 
-- `layer`：标识匹配的模块的 [layer](https://rspack.rs/zh/config/experiments#experimentslayers)，可以将一组模块聚合到一个 layer 中，等同于 Rspack 的 [Rule.layer](https://rspack.rs/zh/config/module#rulelayer)。
+- `layer`：标识匹配的模块的 [layer](https://rspack.rs/zh/config/experiments#experimentslayers)，可以将一组模块聚合到一个 layer 中，等同于 Rspack 的 [rules[].layer](https://rspack.rs/zh/config/module-rules#ruleslayer)。
 
 ```js
 api.transform({ test: /\.md$/, layer: 'foo' }, ({ code }) => {
@@ -398,7 +398,7 @@ api.transform({ test: /\.md$/, layer: 'foo' }, ({ code }) => {
 });
 ```
 
-- `issuerLayer`：与"引入当前模块"的模块的 [layer](https://rspack.rs/zh/config/experiments#experimentslayers) 进行匹配，等同于 Rspack 的 [Rule.issuerLayer](https://rspack.rs/zh/config/module#ruleissuerlayer)。
+- `issuerLayer`：与"引入当前模块"的模块的 [layer](https://rspack.rs/zh/config/experiments#experimentslayers) 进行匹配，等同于 Rspack 的 [rules[].issuerLayer](https://rspack.rs/zh/config/module-rules#rulesissuerlayer)。
 
 ```js
 api.transform({ test: /\.md$/, issuerLayer: 'foo' }, ({ code }) => {
@@ -406,7 +406,7 @@ api.transform({ test: /\.md$/, issuerLayer: 'foo' }, ({ code }) => {
 });
 ```
 
-- `issuer`：匹配"引入当前模块"的模块的绝对路径，等同于 Rspack 的 [Rule.issuer](https://rspack.rs/zh/config/module#ruleissuer)。
+- `issuer`：匹配"引入当前模块"的模块的绝对路径，等同于 Rspack 的 [rules[].issuer](https://rspack.rs/zh/config/module-rules#rulesissuer)。
 
 ```js
 api.transform({ test: /\.md$/, issuer: /\.js$/ }, ({ code }) => {
@@ -414,7 +414,7 @@ api.transform({ test: /\.md$/, issuer: /\.js$/ }, ({ code }) => {
 });
 ```
 
-- `with`：匹配 [import attributes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import/with)，等同于 Rspack 的 [Rule.with](https://rspack.rs/zh/config/module#rulewith)。
+- `with`：匹配 [import attributes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import/with)，等同于 Rspack 的 [rules[].with](https://rspack.rs/zh/config/module-rules#ruleswith)。
 
 ```js
 api.transform({ test: /\.md$/, with: { type: 'url' } }, ({ code }) => {
@@ -422,7 +422,7 @@ api.transform({ test: /\.md$/, with: { type: 'url' } }, ({ code }) => {
 });
 ```
 
-- `mimetype`：根据 MIME 类型（而非文件扩展名）匹配模块。主要用于 data URI 模块（例如 `data:text/javascript,...`），等同于 Rspack 的 [Rule.mimetype](https://rspack.rs/zh/config/module#rulemimetype)。
+- `mimetype`：根据 MIME 类型（而非文件扩展名）匹配模块。主要用于 data URI 模块（例如 `data:text/javascript,...`），等同于 Rspack 的 [rules[].mimetype](https://rspack.rs/zh/config/module-rules#rulesmimetype)。
 
 ```js
 api.transform({ mimetype: 'text/javascript' }, ({ code }) => {
@@ -430,7 +430,7 @@ api.transform({ mimetype: 'text/javascript' }, ({ code }) => {
 });
 ```
 
-- `enforce`：指定 transform 函数的执行顺序，等同于 Rspack 的 [Rule.enforce](https://rspack.rs/zh/config/module#ruleenforce)。
+- `enforce`：指定 transform 函数的执行顺序，等同于 Rspack 的 [rules[].enforce](https://rspack.rs/zh/config/module-rules#rulesenforce)。
   - 当 `enforce` 为 `pre` 时，transform 函数会在其他 transform 函数（或 Rspack loader）之前执行。
   - 当 `enforce` 为 `post` 时，transform 函数会在其他 transform 函数（或 Rspack loader）之后执行。
 

--- a/website/docs/zh/plugins/list/plugin-less.mdx
+++ b/website/docs/zh/plugins/list/plugin-less.mdx
@@ -91,11 +91,11 @@ pluginLess({
 
 ### include
 
-- **类型：** [RuleSetCondition](https://rspack.rs/zh/config/module#condition)
+- **类型：** [Rspack.RuleSetCondition](https://rspack.rs/zh/config/module-rules#condition)
 - **默认值：** `/\.less$/`
 - **版本：** `>= 1.1.0`
 
-用于指定一部分 `.less` 模块，这些模块会被 `less-loader` 编译。这个值与 Rspack 中的 `rule.test` 选项相同。
+用于指定一部分 `.less` 模块，这些模块会被 `less-loader` 编译。这个值与 Rspack 中的 [rules[].test](https://rspack.rs/zh/config/module-rules#rulestest) 选项相同。
 
 比如：
 
@@ -107,7 +107,7 @@ pluginLess({
 
 ### exclude
 
-- **类型：** [RuleSetCondition](https://rspack.rs/zh/config/module#condition)
+- **类型：** [Rspack.RuleSetCondition](https://rspack.rs/zh/config/module-rules#condition)
 - **默认值：** `undefined`
 
 用于排除一部分 `.less` 模块，这些模块不会被 `less-loader` 编译。
@@ -136,7 +136,7 @@ pluginLess({
 });
 ```
 
-> 详见 [Rspack - Rule.use.parallel](https://rspack.rs/config/module#ruleuseparallel)。
+> 详见 [Rspack - Rule.use.parallel](https://rspack.rs/zh/config/module-rules#rulesuseparallel)。
 
 ## 修改 Less 版本
 

--- a/website/docs/zh/plugins/list/plugin-preact.mdx
+++ b/website/docs/zh/plugins/list/plugin-preact.mdx
@@ -63,9 +63,9 @@ pluginPreact({
 
 ### include
 
-指定要由 [@rspack/plugin-preact-refresh](https://github.com/rspack-contrib/rspack-plugin-preact-refresh) 插件处理的文件。这个值与 Rspack 中的 `rule.test` 选项相同。
+指定要由 [@rspack/plugin-preact-refresh](https://github.com/rspack-contrib/rspack-plugin-preact-refresh) 插件处理的文件。这个值与 Rspack 中的 [rules[].test](https://rspack.rs/zh/config/module-rules#rulestest) 选项相同。
 
-- **类型：** [RuleSetCondition](https://rspack.rs/zh/config/module#condition)
+- **类型：** [Rspack.RuleSetCondition](https://rspack.rs/zh/config/module-rules#condition)
 - **默认值：** `/\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/`
 - **版本：** `>= v1.1.0`
 
@@ -77,9 +77,9 @@ pluginPreact({
 
 ### exclude
 
-排除 [@rspack/plugin-preact-refresh](https://github.com/rspack-contrib/rspack-plugin-preact-refresh) 插件处理的文件。这个值与 Rspack 中的 `rule.exclude` 选项相同。
+排除 [@rspack/plugin-preact-refresh](https://github.com/rspack-contrib/rspack-plugin-preact-refresh) 插件处理的文件。这个值与 Rspack 中的 [rules[].exclude](https://rspack.rs/zh/config/module-rules#rulesexclude) 选项相同。
 
-- **类型：** [RuleSetCondition](https://rspack.rs/zh/config/module#condition)
+- **类型：** [Rspack.RuleSetCondition](https://rspack.rs/zh/config/module-rules#condition)
 - **默认值：** `/[\\/]node_modules[\\/]/`
 - **版本：** `>= v1.1.0`
 

--- a/website/docs/zh/plugins/list/plugin-react.mdx
+++ b/website/docs/zh/plugins/list/plugin-react.mdx
@@ -231,7 +231,7 @@ pluginReact({
 
 ```ts
 type ReactRefreshOptions = {
-  // @link https://rspack.rs/config/module#condition
+  // @link https://rspack.rs/zh/config/module-rules#condition
   test?: Rspack.RuleSetCondition;
   include?: Rspack.RuleSetCondition;
   exclude?: Rspack.RuleSetCondition;

--- a/website/docs/zh/plugins/list/plugin-sass.mdx
+++ b/website/docs/zh/plugins/list/plugin-sass.mdx
@@ -86,11 +86,11 @@ pluginSass({
 
 ### include
 
-- **类型：** [RuleSetCondition](https://rspack.rs/zh/config/module#condition)
+- **类型：** [Rspack.RuleSetCondition](https://rspack.rs/zh/config/module-rules#condition)
 - **默认值：** `/\.s(?:a|c)ss$/`
 - **版本：** `>= 1.1.0`
 
-用于指定一部分 `.scss` 或 `.sass` 模块，这些模块会被 `sass-loader` 编译。这个值与 Rspack 中的 `rule.test` 选项相同。
+用于指定一部分 `.scss` 或 `.sass` 模块，这些模块会被 `sass-loader` 编译。这个值与 Rspack 中的 [rules[].test](https://rspack.rs/zh/config/module-rules#rulestest) 选项相同。
 
 比如：
 
@@ -102,7 +102,7 @@ pluginSass({
 
 ### exclude
 
-- **类型：** [RuleSetCondition](https://rspack.rs/zh/config/module#condition)
+- **类型：** [Rspack.RuleSetCondition](https://rspack.rs/zh/config/module-rules#condition)
 - **默认值：** `undefined`
 
 用于排除一部分 `.sass` 或 `.scss` 模块，这些模块不会被 `sass-loader` 编译。

--- a/website/docs/zh/plugins/list/plugin-svgr.mdx
+++ b/website/docs/zh/plugins/list/plugin-svgr.mdx
@@ -275,7 +275,7 @@ export const App = () => <Logo />;
 
 ### exclude
 
-- **类型：** [RuleSetCondition](https://rspack.rs/zh/config/module#condition)
+- **类型：** [Rspack.RuleSetCondition](https://rspack.rs/zh/config/module-rules#condition)
 - **默认值：** `undefined`
 
 用于排除一部分 SVG 模块，这些 SVG 模块不会经过 SVGR 处理。
@@ -303,7 +303,7 @@ console.log(url); // => 资源 url
 
 ### excludeImporter
 
-- **类型：** [RuleSetCondition](https://rspack.rs/zh/config/module#condition)
+- **类型：** [Rspack.RuleSetCondition](https://rspack.rs/zh/config/module-rules#condition)
 - **默认值：** `undefined`
 
 用于排除一部分模块，这些模块引用的 SVG 文件不会经过 SVGR 处理。

--- a/website/docs/zh/plugins/list/plugin-vue.mdx
+++ b/website/docs/zh/plugins/list/plugin-vue.mdx
@@ -106,7 +106,7 @@ pluginVue({
 
 用于自定义 Vue 单文件组件（SFC）的匹配规则。
 
-- **类型：** [Rspack.RuleSetCondition](https://rspack.rs/config/module#condition)
+- **类型：** [Rspack.RuleSetCondition](https://rspack.rs/zh/config/module-rules#condition)
 - **默认值：** `/\.vue$/`
 - **版本：** `>= 1.2.1`
 


### PR DESCRIPTION
## Summary

- Updated links to reflect changes in Rspack rules structure
- Updated references from `Rule` to `rules[]` in various documentation files to align with the new Rspack configuration structure.
- Adjusted links in the TypeScript type definitions and plugin documentation for clarity and accuracy.

## Related Links

- https://github.com/web-infra-dev/rspack/pull/12452

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
