### PR TITLE
feat: update node builtins set for hints

### DIFF
--- a/packages/core/src/helpers/format.ts
+++ b/packages/core/src/helpers/format.ts
@@ -229,7 +229,7 @@ const hintNodePolyfill = (message: string): string => {
   }
 
   const moduleName = matchArray[1];
-  const nodeModules = [
+  const nodeBuiltins = new Set([
     'assert',
     'buffer',
     'child_process',
@@ -238,39 +238,48 @@ const hintNodePolyfill = (message: string): string => {
     'constants',
     'crypto',
     'dgram',
+    'diagnostics_channel',
     'dns',
     'domain',
     'events',
     'fs',
     'http',
+    'http2',
     'https',
+    'inspector',
     'module',
     'net',
     'os',
     'path',
-    'punycode',
+    'perf_hooks',
     'process',
+    'punycode',
     'querystring',
     'readline',
     'repl',
     'stream',
+    'string_decoder',
+    'sys',
+    'timers',
+    'tls',
+    'trace_events',
+    'tty',
+    'url',
+    'util',
+    'v8',
+    'vm',
+    'wasi',
+    'worker_threads',
+    'zlib',
+    // Internal Node.js stream aliases
     '_stream_duplex',
     '_stream_passthrough',
     '_stream_readable',
     '_stream_transform',
     '_stream_writable',
-    'string_decoder',
-    'sys',
-    'timers',
-    'tls',
-    'tty',
-    'url',
-    'util',
-    'vm',
-    'zlib',
-  ];
+  ]);
 
-  if (moduleName && nodeModules.includes(moduleName)) {
+  if (moduleName && nodeBuiltins.has(moduleName)) {
     return getTips(moduleName);
   }
 


### PR DESCRIPTION
## Summary

Updated and expanded the list of recognized built-in modules: added missing modules like `diagnostics_channel`, `http2`, `inspector`, `perf_hooks`, `trace_events`, `v8`, `wasi`, and `worker_threads`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
