### PR TITLE
fix(overlay): avoid matching HTML fragments when linking file paths

### DIFF
--- a/packages/core/src/server/overlay.ts
+++ b/packages/core/src/server/overlay.ts
@@ -16,7 +16,7 @@ export function convertLinksInHtml(text: string, root?: string): string {
    * 7. `file:///C:/Users/username/project/src/index.js:1:1`
    */
   const PATH_RE =
-    /(?:\.\.?[/\\]|(file:\/\/\/)?[a-zA-Z]:\\|(file:\/\/)?\/)[^:]*:\d+:\d+/g;
+    /(?:\.\.?[/\\]|(file:\/\/\/)?[a-zA-Z]:\\|(file:\/\/)?\/)[^\s:]*:\d+:\d+/g;
 
   const URL_RE =
     /(https?:\/\/(?:[\w-]+\.)+[a-z0-9](?:[\w-.~:/?#[\]@!$&'*+,;=])*)/gi;

--- a/packages/core/tests/overlay.test.ts
+++ b/packages/core/tests/overlay.test.ts
@@ -138,6 +138,17 @@ describe('convertLinksInHtml', () => {
     expect(convertLinksInHtml(ansiHTML(input), root)).toEqual(expected);
   });
 
+  it('should convert file path in stack frame', () => {
+    const input = '\u001b[2m│\u001b[0m     at /path/to/src/index.js:1:1\n';
+    const root = '/path/to';
+    const expected =
+      process.platform === 'win32'
+        ? '<span style="opacity:0.5;">│</span>     at <a class="file-link" data-file="/path/to/src/index.js:1:1">.\\src\\index.js:1:1</a>\n'
+        : '<span style="opacity:0.5;">│</span>     at <a class="file-link" data-file="/path/to/src/index.js:1:1">./src/index.js:1:1</a>\n';
+    console.log(ansiHTML(input));
+    expect(convertLinksInHtml(ansiHTML(input), root)).toEqual(expected);
+  });
+
   it('should convert relative path as expected', () => {
     const root = '/path/to';
     const input = '[\u001b[36;1;4m./src/index.js\u001b[0m:4:1]\n';


### PR DESCRIPTION
## Summary

Exclude whitespace from path matching to avoid capturing HTML fragments and intermediate text. This ensures only valid file paths in stack traces are linked.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
