### PR TITLE
chore: add constant for default browserLogs trace

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -33,6 +33,7 @@ export const DEFAULT_DATA_URL_SIZE = 4096;
 export const DEFAULT_MOUNT_ID = 'root';
 export const DEFAULT_DEV_HOST = '0.0.0.0';
 export const DEFAULT_ASSET_PREFIX = '/';
+export const DEFAULT_STACK_TRACE = 'summary';
 export const DEFAULT_WEB_BROWSERSLIST: string[] = [
   'chrome >= 87',
   'edge >= 88',

--- a/packages/core/src/defaultConfig.ts
+++ b/packages/core/src/defaultConfig.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_DEV_HOST,
   DEFAULT_MOUNT_ID,
   DEFAULT_PORT,
+  DEFAULT_STACK_TRACE,
   FAVICON_DIST_DIR,
   FONT_DIST_DIR,
   HMR_SOCKET_PATH,
@@ -46,7 +47,7 @@ const getDefaultDevConfig = (): NormalizedDevConfig => ({
   hmr: true,
   liveReload: true,
   browserLogs: {
-    stackTrace: 'summary',
+    stackTrace: DEFAULT_STACK_TRACE,
   },
   watchFiles: [],
   // Temporary placeholder, default: `${server.base}`

--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage } from 'node:http';
 import type { Socket } from 'node:net';
 import type Ws from '../../compiled/ws/index.js';
+import { DEFAULT_STACK_TRACE } from '../constants.js';
 import { formatStatsError } from '../helpers/format';
 import { isObject } from '../helpers/index';
 import { getStatsErrors, getStatsWarnings } from '../helpers/stats';
@@ -309,7 +310,12 @@ export class SocketServer {
           typeof data === 'string' ? data : data.toString(),
         );
 
-        const { browserLogs } = this.context.normalizedConfig?.dev || {};
+        const config = this.context.normalizedConfig;
+        if (!config) {
+          return;
+        }
+
+        const { browserLogs } = config.dev;
         if (
           message.type === 'client-error' &&
           // Do not report browser error when using webpack
@@ -319,7 +325,9 @@ export class SocketServer {
           browserLogs
         ) {
           const stackTrace =
-            (isObject(browserLogs) && browserLogs.stackTrace) || 'summary';
+            (isObject(browserLogs) && browserLogs.stackTrace) ||
+            DEFAULT_STACK_TRACE;
+
           const log = await formatBrowserErrorLog(
             message,
             this.context,


### PR DESCRIPTION
## Summary

Introduced a new constant to centralize the default value for browser log stack traces.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
