### PR TITLE
fix(overlay): enhance link conversion for relative paths

### DIFF
--- a/packages/core/src/server/overlay.ts
+++ b/packages/core/src/server/overlay.ts
@@ -7,16 +7,17 @@ export function convertLinksInHtml(text: string, root?: string): string {
   /**
    * Match absolute or relative paths with line and column
    * @example
-   * 1. `./src/index.js:1:1`
-   * 2. `.\src\index.js:1:1`
-   * 3. `../Button.js:1:1`
-   * 4. `C:\Users\username\project\src\index.js:1:1`
-   * 5. `/home/user/project/src/index.js:1:1`
-   * 6. `file:///home/user/project/src/index.js:1:1`
-   * 7. `file:///C:/Users/username/project/src/index.js:1:1`
+   * 1. ./src/index.js:1:1
+   * 2. .\src\index.js:1:1
+   * 3. src/index.js:1:1
+   * 4. ../Button.js:1:1
+   * 5. C:\Users\username\project\src\index.js:1:1
+   * 6. /home/user/project/src/index.js:1:1
+   * 7. file:///home/user/project/src/index.js:1:1
+   * 8. file:///C:/Users/username/project/src/index.js:1:1
    */
   const PATH_RE =
-    /(?:\.\.?[/\\]|(file:\/\/\/)?[a-zA-Z]:\\|(file:\/\/)?\/)[^\s:]*:\d+:\d+/g;
+    /(?:\.\.?[/\\]|(file:\/\/\/)?[a-zA-Z]:\\|(file:\/\/)?\/|[A-Za-z0-9._-]+[/\\])[^\s:]*:\d+:\d+/g;
 
   const URL_RE =
     /(https?:\/\/(?:[\w-]+\.)+[a-z0-9](?:[\w-.~:/?#[\]@!$&'*+,;=])*)/gi;

--- a/packages/core/tests/overlay.test.ts
+++ b/packages/core/tests/overlay.test.ts
@@ -145,11 +145,10 @@ describe('convertLinksInHtml', () => {
       process.platform === 'win32'
         ? '<span style="opacity:0.5;">│</span>     at <a class="file-link" data-file="/path/to/src/index.js:1:1">.\\src\\index.js:1:1</a>\n'
         : '<span style="opacity:0.5;">│</span>     at <a class="file-link" data-file="/path/to/src/index.js:1:1">./src/index.js:1:1</a>\n';
-    console.log(ansiHTML(input));
     expect(convertLinksInHtml(ansiHTML(input), root)).toEqual(expected);
   });
 
-  it('should convert relative path as expected', () => {
+  it('should convert relative path with ./ prefix as expected', () => {
     const root = '/path/to';
     const input = '[\u001b[36;1;4m./src/index.js\u001b[0m:4:1]\n';
     const expected =
@@ -157,6 +156,16 @@ describe('convertLinksInHtml', () => {
         ? `[<span style="color:#6eecf7;font-weight:bold;text-decoration:underline;text-underline-offset:3px;"><a class="file-link" data-file="\\path\\to\\src\\index.js:4:1">./src/index.js:4:1</a></span>]\n`
         : `[<span style="color:#6eecf7;font-weight:bold;text-decoration:underline;text-underline-offset:3px;"><a class="file-link" data-file="${root}/src/index.js:4:1">./src/index.js:4:1</a></span>]\n`;
     expect(convertLinksInHtml(ansiHTML(input), root)).toEqual(expected);
+  });
+
+  it('should convert relative path without ./ prefix as expected', () => {
+    const root = '/path/to';
+    const input = ' (src/index.js:5:0)';
+    expect(convertLinksInHtml(ansiHTML(input), root)).toEqual(
+      process.platform === 'win32'
+        ? ' (<a class="file-link" data-file="\\path\\to\\src\\index.js:5:0">src/index.js:5:0</a>)'
+        : ' (<a class="file-link" data-file="/path/to/src/index.js:5:0">src/index.js:5:0</a>)',
+    );
   });
 
   it('should not convert node internal path', () => {


### PR DESCRIPTION
## Summary

Improve file path matching in the error overlay. The path matching regex now supports common relative paths without a `./` or `../` prefix, such as `src/index.js:1:1`.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
