### PR TITLE
chore: update lazy compilation middleware path

### DIFF
--- a/packages/core/src/server/devMiddlewares.ts
+++ b/packages/core/src/server/devMiddlewares.ts
@@ -131,8 +131,7 @@ const applyDefaultMiddlewares = ({
     // We check the compiler options to determine whether lazy compilation is enabled.
     // Rsbuild users can enable lazy compilation in two ways:
     // 1. Use Rsbuild's `dev.lazyCompilation` option
-    // 2. Use Rspack's `experiments.lazyCompilation` option
-    // 3. Use Rspack's configuration top-level `lazyCompilation` option
+    // 2. Use Rspack's configuration top-level `lazyCompilation` option
     const isLazyCompilationEnabled = () => {
       if (isMultiCompiler(compiler)) {
         return compiler.compilers.some(


### PR DESCRIPTION
## Summary

Update the usage of the lazy compilation middleware, switch from using `rspack.experiments.lazyCompilationMiddleware` to `rspack.lazyCompilationMiddleware`.

## Related Links

- https://github.com/web-infra-dev/rspack/pull/12429

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
