### PR TITLE
chore: update SubresourceIntegrityPlugin reference

### DIFF
--- a/e2e/cases/lazy-compilation/basic/index.test.ts
+++ b/e2e/cases/lazy-compilation/basic/index.test.ts
@@ -35,7 +35,7 @@ rspackTest(
 );
 
 rspackTest(
-  'should allow to configure `tools.rspack.experiments.lazyCompilation`',
+  'should allow to configure `tools.rspack.lazyCompilation`',
   async ({ page, dev }) => {
     const rsbuild = await dev({
       config: {

--- a/packages/core/src/plugins/sri.ts
+++ b/packages/core/src/plugins/sri.ts
@@ -36,7 +36,7 @@ export const pluginSri = (): RsbuildPlugin => ({
 
       chain
         .plugin(CHAIN_ID.PLUGIN.SUBRESOURCE_INTEGRITY)
-        .use(rspack.experiments.SubresourceIntegrityPlugin, [
+        .use(rspack.SubresourceIntegrityPlugin, [
           {
             enabled: true,
             hashFuncNames: castArray(algorithm) as [


### PR DESCRIPTION
## Summary

Updated the usage of SubresourceIntegrityPlugin from `rspack.experiments.SubresourceIntegrityPlugin` to `rspack.SubresourceIntegrityPlugin`

## Related Links

- https://github.com/web-infra-dev/rspack/pull/12483

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
