### PR TITLE
docs: add `client.overlay` configuration details

### DIFF
--- a/website/docs/en/config/dev/client.mdx
+++ b/website/docs/en/config/dev/client.mdx
@@ -91,6 +91,9 @@ Hot-update files are considered to be static assets. If you need to configure th
 
 ### overlay
 
+- **Type:** `boolean`
+- **Default:** `true`
+
 The `dev.client.overlay` option allows you to choose whether or not to enable the error overlay feature.
 
 By default, Rsbuild will display an error overlay in the browser when a compilation error occurs, providing error messages and stacks:

--- a/website/docs/zh/config/dev/client.mdx
+++ b/website/docs/zh/config/dev/client.mdx
@@ -87,6 +87,9 @@ hot-update 文件属于静态资源，如果你需要配置 hot-update 文件的
 
 ### overlay
 
+- **类型：** `boolean`
+- **默认值：** `true`
+
 通过 `dev.client.overlay` 选项，可以选择是否启用错误浮层。
 
 默认情况下，当编译发生错误时，Rsbuild会在浏览器中显示错误浮层，并提供错误信息和错误堆栈：


### PR DESCRIPTION
## Summary

Updates the documentation for the `dev.client.overlay` configuration option, adds the type and default value for this option to make the documentation more complete

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
