### PR TITLE
fix: avoid bundling duplicate mrmime package

### DIFF
--- a/packages/core/prebundle.config.ts
+++ b/packages/core/prebundle.config.ts
@@ -56,6 +56,9 @@ export default {
     {
       name: 'sirv',
       ignoreDts: true,
+      externals: {
+        mrmime: '../mrmime/index.js',
+      },
     },
     {
       name: 'rspack-chain',


### PR DESCRIPTION
## Summary

Both `@rsbuild/core` and `sirv` depend on the `mrmime` package. This PR marks it as external to avoid bundling it twice.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
