### PR TITLE
fix: preserve filename and dirname for ESM bundles

### DIFF
--- a/e2e/cases/polyfill/dirname-filename-node/index.test.ts
+++ b/e2e/cases/polyfill/dirname-filename-node/index.test.ts
@@ -1,0 +1,13 @@
+import { expect, rspackTest } from '@e2e/helper';
+
+rspackTest(
+  'should not polyfill dirname and filename in node target when output.module is enabled',
+  async ({ build }) => {
+    const rsbuild = await build();
+    const content = await rsbuild.getIndexBundle();
+    expect(content).toContain(`"__dirname",__dirname`);
+    expect(content).toContain(`"__filename",__filename`);
+    expect(content).toContain(`"import.meta.dirname",import.meta.dirname`);
+    expect(content).toContain(`"import.meta.filename",import.meta.filename`);
+  },
+);

--- a/e2e/cases/polyfill/dirname-filename-node/rsbuild.config.ts
+++ b/e2e/cases/polyfill/dirname-filename-node/rsbuild.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    module: true,
+    target: 'node',
+    filenameHash: false,
+  },
+});

--- a/e2e/cases/polyfill/dirname-filename-node/src/index.js
+++ b/e2e/cases/polyfill/dirname-filename-node/src/index.js
@@ -1,0 +1,4 @@
+console.log('__dirname', __dirname);
+console.log('__filename', __filename);
+console.log('import.meta.dirname', import.meta.dirname);
+console.log('import.meta.filename', import.meta.filename);

--- a/e2e/cases/polyfill/dirname-filename-web/index.test.ts
+++ b/e2e/cases/polyfill/dirname-filename-web/index.test.ts
@@ -1,0 +1,15 @@
+import { expect, rspackTest } from '@e2e/helper';
+
+rspackTest(
+  'should not polyfill dirname and filename in web target when output.module is enabled',
+  async ({ page, buildPreview }) => {
+    await buildPreview();
+    const values = await page.evaluate('window.testValues');
+    expect(values).toEqual({
+      dirname: 'undefined',
+      filename: 'undefined',
+      importMetaDirname: 'undefined',
+      importMetaFilename: 'undefined',
+    });
+  },
+);

--- a/e2e/cases/polyfill/dirname-filename-web/rsbuild.config.ts
+++ b/e2e/cases/polyfill/dirname-filename-web/rsbuild.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    module: true,
+  },
+});

--- a/e2e/cases/polyfill/dirname-filename-web/src/index.js
+++ b/e2e/cases/polyfill/dirname-filename-web/src/index.js
@@ -1,0 +1,6 @@
+window.testValues = {
+  dirname: typeof __dirname,
+  filename: typeof __filename,
+  importMetaDirname: typeof import.meta.dirname,
+  importMetaFilename: typeof import.meta.filename,
+};

--- a/packages/core/src/plugins/esm.ts
+++ b/packages/core/src/plugins/esm.ts
@@ -24,6 +24,10 @@ export const pluginEsm = (): RsbuildPlugin => ({
         );
       }
 
+      // For ESM targets, import.meta.dirname / import.meta.filename / __dirname / __filename
+      // are preserved as-is. This matches the native behavior in browsers and Node.js.
+      chain.node.set('__dirname', false).set('__filename', false);
+
       chain.output
         .module(true)
         .chunkFormat('module')


### PR DESCRIPTION
## Summary

Disable automatic `__dirname` / `__filename` / `import.meta.dirname` / `import.meta.filename` polyfills when output.module is enabled so ESM bundles preserve native Node.js / browser behavior.

## Related link

- https://github.com/web-infra-dev/rspack/releases/tag/v1.6.7

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
