### PR TITLE
test(e2e): centralize log expectations with shared constants

### DIFF
--- a/e2e/cases/browser-logs/skip-build-error/index.test.ts
+++ b/e2e/cases/browser-logs/skip-build-error/index.test.ts
@@ -1,10 +1,10 @@
-import { rspackTest } from '@e2e/helper';
+import { MODULE_BUILD_FAILED_LOG, rspackTest } from '@e2e/helper';
 
 rspackTest(
   'should skip browser error logs if build failed',
   async ({ dev }) => {
     const rsbuild = await dev();
-    await rsbuild.expectLog('Module build failed');
+    await rsbuild.expectLog(MODULE_BUILD_FAILED_LOG);
     rsbuild.expectNoLog('[browser]');
   },
 );

--- a/e2e/cases/hmr/error-recovery/index.test.ts
+++ b/e2e/cases/hmr/error-recovery/index.test.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, MODULE_BUILD_FAILED_LOG, rspackTest } from '@e2e/helper';
 
 rspackTest(
   'HMR should work after fixing compilation error',
@@ -26,7 +26,7 @@ rspackTest(
       ),
     );
 
-    await rsbuild.expectLog('Module build failed');
+    await rsbuild.expectLog(MODULE_BUILD_FAILED_LOG);
 
     await editFile(join(tempSrc, 'App.tsx'), (code) =>
       code.replace(

--- a/e2e/cases/hmr/log-level/index.test.ts
+++ b/e2e/cases/hmr/log-level/index.test.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, HMR_CONNECTED_LOG, rspackTest } from '@e2e/helper';
 
 rspackTest(
   'should respect dev.client.logLevel when set to warn',
@@ -29,7 +29,7 @@ rspackTest(
     const locator = page.locator('#test');
     await expect(locator).toHaveText('Hello Rsbuild');
 
-    expect(expectNoLog('[rsbuild] WebSocket connected.')).toBe(true);
+    expect(expectNoLog(HMR_CONNECTED_LOG)).toBe(true);
   },
 );
 
@@ -53,7 +53,7 @@ rspackTest(
       },
     });
 
-    await expectLog('[rsbuild] WebSocket connected.');
+    await expectLog(HMR_CONNECTED_LOG);
   },
 );
 
@@ -80,7 +80,7 @@ rspackTest(
 
     const locator = page.locator('#test');
     await expect(locator).toHaveText('Hello Rsbuild');
-    expect(expectNoLog('[rsbuild] WebSocket connected.')).toBe(true);
+    expect(expectNoLog(HMR_CONNECTED_LOG)).toBe(true);
   },
 );
 

--- a/e2e/cases/overlay/basic/index.test.ts
+++ b/e2e/cases/overlay/basic/index.test.ts
@@ -1,5 +1,12 @@
 import { join } from 'node:path';
-import { expect, test } from '@e2e/helper';
+import {
+  expect,
+  HMR_CONNECTED_LOG,
+  MODULE_BUILD_FAILED_LOG,
+  OVERLAY_ID,
+  OVERLAY_TITLE_BUILD_FAILED,
+  test,
+} from '@e2e/helper';
 
 test('should show overlay correctly', async ({
   page,
@@ -26,15 +33,17 @@ test('should show overlay correctly', async ({
     },
   });
 
-  await expectLog('[rsbuild] WebSocket connected.');
+  await expectLog(HMR_CONNECTED_LOG);
 
-  const errorOverlay = page.locator('rsbuild-error-overlay');
+  const errorOverlay = page.locator(OVERLAY_ID);
   expect(await errorOverlay.locator('.title').count()).toBe(0);
 
   await editFile(join(tempSrc, 'App.tsx'), (code) =>
     code.replace('</div>', '</aaaaa>'),
   );
 
-  await expectLog('Module build failed');
-  await expect(errorOverlay.locator('.title')).toHaveText('Build failed');
+  await expectLog(MODULE_BUILD_FAILED_LOG);
+  await expect(errorOverlay.locator('.title')).toHaveText(
+    OVERLAY_TITLE_BUILD_FAILED,
+  );
 });

--- a/e2e/cases/overlay/disabled/index.test.ts
+++ b/e2e/cases/overlay/disabled/index.test.ts
@@ -1,5 +1,11 @@
 import { join } from 'node:path';
-import { expect, test } from '@e2e/helper';
+import {
+  expect,
+  HMR_CONNECTED_LOG,
+  MODULE_BUILD_FAILED_LOG,
+  OVERLAY_ID,
+  test,
+} from '@e2e/helper';
 
 test('should disable error overlay when dev.client.overlay is false', async ({
   page,
@@ -25,14 +31,14 @@ test('should disable error overlay when dev.client.overlay is false', async ({
     },
   });
 
-  await expectLog('[rsbuild] WebSocket connected.');
+  await expectLog(HMR_CONNECTED_LOG);
 
-  await expect(page.locator('rsbuild-error-overlay')).toHaveCount(0);
+  await expect(page.locator(OVERLAY_ID)).toHaveCount(0);
 
   await editFile(join(tempSrc, 'App.tsx'), (code) =>
     code.replace('</div>', '</aaaa>'),
   );
 
-  await expectLog('Module build failed');
-  await expect(page.locator('rsbuild-error-overlay')).toHaveCount(0);
+  await expectLog(MODULE_BUILD_FAILED_LOG);
+  await expect(page.locator(OVERLAY_ID)).toHaveCount(0);
 });

--- a/e2e/cases/overlay/runtime-errors/index.test.ts
+++ b/e2e/cases/overlay/runtime-errors/index.test.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, HMR_CONNECTED_LOG, OVERLAY_ID, rspackTest } from '@e2e/helper';
 
 rspackTest(
   'should show runtime errors on overlay',
@@ -20,9 +20,9 @@ rspackTest(
       },
     });
 
-    await logHelper.expectLog('[rsbuild] WebSocket connected.');
+    await logHelper.expectLog(HMR_CONNECTED_LOG);
 
-    const errorOverlay = page.locator('rsbuild-error-overlay');
+    const errorOverlay = page.locator(OVERLAY_ID);
     expect(await errorOverlay.locator('.title').count()).toBe(0);
 
     // Introduce a runtime error

--- a/e2e/cases/overlay/type-errors/index.test.ts
+++ b/e2e/cases/overlay/type-errors/index.test.ts
@@ -1,10 +1,17 @@
-import { expect, test } from '@e2e/helper';
+import {
+  expect,
+  OVERLAY_ID,
+  OVERLAY_TITLE_BUILD_FAILED,
+  test,
+} from '@e2e/helper';
 import type { Page } from 'playwright';
 
 const expectErrorOverlay = async (page: Page) => {
-  await page.waitForSelector('rsbuild-error-overlay', { state: 'attached' });
-  const errorOverlay = page.locator('rsbuild-error-overlay');
-  await expect(errorOverlay.locator('.title')).toHaveText('Build failed');
+  await page.waitForSelector(OVERLAY_ID, { state: 'attached' });
+  const errorOverlay = page.locator(OVERLAY_ID);
+  await expect(errorOverlay.locator('.title')).toHaveText(
+    OVERLAY_TITLE_BUILD_FAILED,
+  );
 
   // Get "<span style="color:#888">TS2322: </span>"
   const tsSpan = errorOverlay.locator('span').getByText('TS2322: ');

--- a/e2e/helper/constants.ts
+++ b/e2e/helper/constants.ts
@@ -1,6 +1,11 @@
 import { join } from 'node:path';
 
 export const BUILD_END_LOG = 'built in';
+export const HMR_CONNECTED_LOG = '[rsbuild] WebSocket connected.';
+export const MODULE_BUILD_FAILED_LOG = 'Module build failed';
+
+export const OVERLAY_ID = 'rsbuild-error-overlay';
+export const OVERLAY_TITLE_BUILD_FAILED = 'Build failed';
 
 export const RSBUILD_BIN_PATH = join(
   import.meta.dirname,


### PR DESCRIPTION
## Summary

- Summary: replace hardcoded log/overlay strings in e2e cases with shared constants for HMR, build failures, and overlay selectors/titles.
- Why: keeps tests consistent and easier to update when log text or overlay selectors change.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
