### PR TITLE
release: 1.7.0-beta.1

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/core",
-  "version": "1.7.0-beta.0",
+  "version": "1.7.0-beta.1",
   "description": "The Rspack-based build tool.",
   "homepage": "https://rsbuild.rs",
   "bugs": {

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-preact",
-  "version": "1.7.0-beta.0",
+  "version": "1.7.0-beta.1",
   "description": "Preact plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/webpack",
-  "version": "1.7.0-beta.0",
+  "version": "1.7.0-beta.1",
   "homepage": "https://rsbuild.rs",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### New Features 🎉
* feat: support displaying runtime errors on overlay by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6793
* feat(deps): update @rspack/core to v1.7.0-beta.1 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6826
### Performance 🚀
* perf: bundle rslog dependency to main chunk by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6746
* perf: use native relative source maps by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6798
### Bug Fixes 🐞
* fix: avoid bundling duplicate mrmime package by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6809
* fix: preserve filename and dirname for ESM bundles by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6811
### Document 📖
* docs: add `client.overlay` configuration details by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6804
* docs: polish start guides and align README with start guide by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6812
* docs: simplify README files by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6813
* docs: fix preload.dedupe behavior description by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/6817
* docs(en): update `preload.dedupe` behavior description by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/6818
### Other Changes
* chore(deps): update dependency react-router-dom to ^7.11.0 by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6801
* chore: update SubresourceIntegrityPlugin reference by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6803
* chore(deps): update swc monorepo to ^12.1.0 by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6808
* chore(deps): update all patch dependencies by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6807
* chore(deps): update dependency nx to ^22.3.3 by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6810
* test(e2e): add runtime error overlay test by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6814
* test(e2e): centralize log expectations with shared constants by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6815
* chore(deps): update all patch dependencies by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6816
* chore: no need to set inlineExports by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6819
* test: add error recovery overlay test case by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6821
* release: 1.7.0-beta.1 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6827


**Full Changelog**: https://github.com/web-infra-dev/rsbuild/compare/v1.7.0-beta.0...v1.7.0-beta.1