### PR TITLE
fix: improve overlay link color for better visibility

### DIFF
--- a/packages/core/src/client/overlay.ts
+++ b/packages/core/src/client/overlay.ts
@@ -128,7 +128,7 @@ function getOverlayHtml(title: string, content: string) {
   }
 }
 .file-link {
-  color: #6eecf7;
+  color: #61cfd8;
 }
 .url-link {
   color: #eff986;


### PR DESCRIPTION
## Summary

Improve overlay link color for better visibility (The previous link was too bright).

### Before

<img width="1033" height="698" alt="Screenshot 2025-12-25 at 10 26 38" src="https://github.com/user-attachments/assets/882ee2b8-8111-4d24-9c9e-e03c1dc2fc17" />

### After

<img width="1035" height="695" alt="Screenshot 2025-12-25 at 10 28 54" src="https://github.com/user-attachments/assets/809bb923-44b0-4de9-bac6-875dac4688db" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
