### PR TITLE
fix: enhance overlay to display full stack trace for runtime errors

### DIFF
--- a/e2e/cases/overlay/runtime-errors/index.test.ts
+++ b/e2e/cases/overlay/runtime-errors/index.test.ts
@@ -35,9 +35,15 @@ rspackTest(
       ),
     );
     await logHelper.expectLog('Runtime error occurred');
+
+    // expect overlay to show runtime error
     await expect(errorOverlay.locator('.title')).toHaveText('Runtime errors');
     await expect(
       errorOverlay.getByText('Uncaught Error: Runtime error occurred'),
     ).toBeAttached();
+
+    // expect stack trace to be shown fully
+    await expect(errorOverlay.getByText('at App')).toBeAttached();
+    await expect(errorOverlay.getByText('at renderWithHooks')).toBeAttached();
   },
 );


### PR DESCRIPTION
## Summary

Always send the full stack trace for runtime errors, ensuring the overlay displays complete error information.

### Before

<img width="1078" height="275" alt="Screenshot 2025-12-25 at 10 46 06" src="https://github.com/user-attachments/assets/8669bf49-a61c-4470-a447-1bc0f610c6a1" />

### After

<img width="1093" height="686" alt="Screenshot 2025-12-25 at 10 45 54" src="https://github.com/user-attachments/assets/ca2cf8ba-2cbd-471a-a3d6-437e6ef0c1c6" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
