### PR TITLE
perf: introduce cached trace map for stack parsing

### DIFF
--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -14,7 +14,7 @@ import type {
   RsbuildStatsItem,
   Rspack,
 } from '../types';
-import { formatBrowserErrorLog } from './browserLogs';
+import { type CachedTraceMap, formatBrowserErrorLog } from './browserLogs';
 import { renderErrorToHtml } from './overlay';
 
 interface ExtWebSocket extends Ws {
@@ -351,12 +351,15 @@ export class SocketServer {
           const outputFs = this.getOutputFileSystem();
 
           const stackFrames = payload.stack ? parseStack(payload.stack) : null;
+          const cachedTraceMap: CachedTraceMap = new Map();
+
           const log = await formatBrowserErrorLog(
             payload.message,
             context,
             outputFs,
             stackTrace,
             stackFrames,
+            cachedTraceMap,
           );
 
           if (!this.reportedBrowserLogs.has(log)) {
@@ -376,6 +379,7 @@ export class SocketServer {
                     outputFs,
                     'full',
                     stackFrames,
+                    cachedTraceMap,
                   );
 
             this.sockWrite(


### PR DESCRIPTION
## Summary

Create and pass a `cachedTraceMap` map when formatting browser error logs and full stack traces, further reducing redundant file reads and `new TraceMap()` during error handling.

### Before

<img width="1061" height="211" alt="Screenshot 2025-12-25 at 22 03 48" src="https://github.com/user-attachments/assets/db9585b7-758d-4182-ad50-8ee6e0203044" />

### After

<img width="1067" height="204" alt="Screenshot 2025-12-25 at 22 04 50" src="https://github.com/user-attachments/assets/58ec660c-e4b8-40d1-9aee-48f2ee0e40b5" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
