### PR TITLE
fix: improve diagnostics for Rspack runtime modules

### DIFF
--- a/e2e/cases/browser-logs/stack-trace-full-rspack-runtime/index.test.ts
+++ b/e2e/cases/browser-logs/stack-trace-full-rspack-runtime/index.test.ts
@@ -1,0 +1,12 @@
+import { rspackTest } from '@e2e/helper';
+
+rspackTest(
+  'should display stack frame for Rspack runtime modules',
+  async ({ dev }) => {
+    const rsbuild = await dev();
+    await rsbuild.expectLog('[browser] Uncaught Error: foo');
+    await rsbuild.expectLog(
+      /at __webpack_require__\.O \(webpack\/runtime\/on_chunk_loaded:\d+:\d+\)/,
+    );
+  },
+);

--- a/e2e/cases/browser-logs/stack-trace-full-rspack-runtime/rsbuild.config.ts
+++ b/e2e/cases/browser-logs/stack-trace-full-rspack-runtime/rsbuild.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+
+export default defineConfig({
+  plugins: [pluginReact()],
+  dev: {
+    browserLogs: {
+      stackTrace: 'full',
+    },
+  },
+});

--- a/e2e/cases/browser-logs/stack-trace-full-rspack-runtime/src/index.js
+++ b/e2e/cases/browser-logs/stack-trace-full-rspack-runtime/src/index.js
@@ -1,0 +1,1 @@
+throw new Error('foo');

--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -219,3 +219,6 @@ export async function hash(data: string): Promise<string> {
   const hasher = crypto.createHash('sha256');
   return hasher.update(data).digest('hex').slice(0, 16);
 }
+
+export const isRspackRuntimeModule = (identifier: string): boolean =>
+  identifier.startsWith('webpack/runtime/');

--- a/packages/core/src/server/browserLogs.ts
+++ b/packages/core/src/server/browserLogs.ts
@@ -7,7 +7,7 @@ import type {
   TraceMap,
 } from '../../compiled/@jridgewell/trace-mapping';
 import { SCRIPT_REGEX } from '../constants';
-import { color } from '../helpers';
+import { color, isRspackRuntimeModule } from '../helpers';
 import { requireCompiledPackage } from '../helpers/vendors';
 import { logger } from '../logger';
 import type { BrowserLogsStackTrace, InternalContext, Rspack } from '../types';
@@ -127,6 +127,11 @@ const resolveSourceRelativeToRoot = (
   sourceMapPath: string,
   context: InternalContext,
 ) => {
+  // For Rspack runtime modules, return as is
+  if (isRspackRuntimeModule(source)) {
+    return source;
+  }
+
   const absoluteSourcePath = path.isAbsolute(source)
     ? source
     : path.join(path.dirname(sourceMapPath), source);

--- a/packages/core/src/server/overlay.ts
+++ b/packages/core/src/server/overlay.ts
@@ -23,6 +23,7 @@ export function convertLinksInHtml(text: string, root?: string): string {
     /(https?:\/\/(?:[\w-]+\.)+[a-z0-9](?:[\w-.~:/?#[\]@!$&'*+,;=])*)/gi;
 
   const NODE_INTERNAL_RE = /node:internal[/\\]/;
+  const RSPACK_RUNTIME_RE = /webpack\/runtime\//;
   const FILE_URI_WINDOWS_RE = /^file:\/\/\/([A-Za-z]:)/;
   const FILE_URI_UNIX_RE = /^file:\/\//;
 
@@ -43,8 +44,8 @@ export function convertLinksInHtml(text: string, root?: string): string {
 
   const lines = text.split('\n');
   const replacedLines = lines.map((line) => {
-    // Skip processing node internal paths
-    if (NODE_INTERNAL_RE.test(line)) {
+    // Skip processing node internal paths and Rspack runtime modules
+    if (NODE_INTERNAL_RE.test(line) || RSPACK_RUNTIME_RE.test(line)) {
       return line;
     }
 

--- a/packages/core/tests/overlay.test.ts
+++ b/packages/core/tests/overlay.test.ts
@@ -173,6 +173,12 @@ describe('convertLinksInHtml', () => {
     expect(convertLinksInHtml(ansiHTML(input))).toEqual(input);
   });
 
+  it('should not convert Rspack runtime modules', () => {
+    const input =
+      'at __webpack_require__.O (webpack/runtime/on_chunk_loaded:1:1)';
+    expect(convertLinksInHtml(ansiHTML(input))).toEqual(input);
+  });
+
   it('should convert Windows absolute path as expected', () => {
     // only run on Windows
     if (process.platform !== 'win32') {


### PR DESCRIPTION
## Summary

Leave Rspack runtime modules as-is when resolving source paths for error overlay and browser logs.

### Before

<img width="1032" height="401" alt="Screenshot 2025-12-25 at 22 16 11" src="https://github.com/user-attachments/assets/70b64aa4-3de8-4735-8db8-3dbbaa3e7c2b" />

### After

<img width="1039" height="391" alt="Screenshot 2025-12-25 at 22 40 30" src="https://github.com/user-attachments/assets/d722d524-0f9c-407f-aaca-aa13af07a1ba" />

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
