### PR TITLE
fix: hide unmapped runtime frames by default in error overlay

### DIFF
--- a/e2e/cases/browser-logs/stack-trace-full/index.test.ts
+++ b/e2e/cases/browser-logs/stack-trace-full/index.test.ts
@@ -4,7 +4,7 @@ import { rspackTest } from '@e2e/helper';
 const EXPECTED_LOG = `error   [browser] Uncaught Error: foo
     at foo (src/foo.js:2:0)
     at src/index.js:3:0
-    at __webpack_require__ (http://localhost`;
+    at __webpack_require__`;
 
 rspackTest('should display formatted full stack trace', async ({ dev }) => {
   const rsbuild = await dev();

--- a/packages/core/src/server/browserLogs.ts
+++ b/packages/core/src/server/browserLogs.ts
@@ -9,7 +9,7 @@ import type {
 import { SCRIPT_REGEX } from '../constants';
 import { color, isRspackRuntimeModule } from '../helpers';
 import { requireCompiledPackage } from '../helpers/vendors';
-import { logger } from '../logger';
+import { isVerbose, logger } from '../logger';
 import type { BrowserLogsStackTrace, InternalContext, Rspack } from '../types';
 import { getFileFromUrl } from './assets-middleware/getFileFromUrl';
 
@@ -199,6 +199,7 @@ const formatFullStack = async (
       parts.push(methodName);
     }
 
+    let parsed = false;
     if (parsedFrame) {
       const { sourceMapPath, originalPosition } = parsedFrame;
       const originalLocation = formatOriginalLocation(
@@ -208,13 +209,13 @@ const formatFullStack = async (
       );
       if (originalLocation) {
         parts.push(originalLocation);
-      } else {
-        const frameString = formatFrameLocation(frame);
-        if (frameString) {
-          parts.push(frameString);
-        }
+        parsed = true;
       }
-    } else {
+    }
+
+    // Fallback to original frame location if source map parsing failed
+    // These frames are usually low-signal for users, so only show them in verbose mode.
+    if (!parsed && isVerbose()) {
       const frameString = formatFrameLocation(frame);
       if (frameString) {
         parts.push(frameString);


### PR DESCRIPTION
## Summary

When a stack frame cannot be resolved via source maps, it often points to raw bundle offsets, which are usually low-signal and not actionable for end users. Showing these frames by default can add unnecessary noise.

With this change, unmapped frames only show in verbose mode, this keeps the overlay clean by default.

### Before

<img width="1039" height="391" alt="Screenshot 2025-12-25 at 22 40 30" src="https://github.com/user-attachments/assets/d55ff3c5-43ce-42b5-be5d-5ccb93021e26" />

### After

<img width="1050" height="335" alt="Screenshot 2025-12-26 at 11 16 39" src="https://github.com/user-attachments/assets/6d969811-7c9c-4665-a8e0-90dcb82b6a2a" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
