### PR TITLE
chore: simplify HMR init function parameter structure

### DIFF
--- a/packages/core/src/client/hmr.ts
+++ b/packages/core/src/client/hmr.ts
@@ -19,23 +19,15 @@ export const registerOverlay = (
   clearOverlay = clearFn;
 };
 
-export function init({
-  token,
-  config,
-  serverHost,
-  serverPort,
-  liveReload,
-  browserLogs,
-  logLevel,
-}: {
-  token: string;
-  config: NormalizedClientConfig;
-  serverHost: string;
-  serverPort: number;
-  liveReload: boolean;
-  browserLogs: boolean;
-  logLevel: LogLevel;
-}): void {
+export function init(
+  token: string,
+  config: NormalizedClientConfig,
+  serverHost: string,
+  serverPort: number,
+  liveReload: boolean,
+  browserLogs: boolean,
+  logLevel: LogLevel,
+): void {
   logger.level = logLevel;
 
   const queuedMessages: ClientMessage[] = [];

--- a/packages/core/src/server/assets-middleware/index.ts
+++ b/packages/core/src/server/assets-middleware/index.ts
@@ -177,16 +177,15 @@ function applyHMREntry({
 
   const hmrEntry = `import { init } from '${toPosixPath(join(CLIENT_PATH, 'hmr.js'))}';
 ${config.dev.client.overlay ? `import '${toPosixPath(join(CLIENT_PATH, 'overlay.js'))}';` : ''}
-
-init({
-  token: '${token}',
-  config: ${JSON.stringify(clientConfig)},
-  serverHost: ${JSON.stringify(resolvedHost)},
-  serverPort: ${resolvedPort},
-  liveReload: ${config.dev.liveReload},
-  browserLogs: ${Boolean(config.dev.browserLogs)},
-  logLevel: ${JSON.stringify(config.dev.client.logLevel)}
-});
+init(
+  '${token}',
+  ${JSON.stringify(clientConfig)},
+  ${JSON.stringify(resolvedHost)},
+  ${resolvedPort},
+  ${config.dev.liveReload},
+  ${Boolean(config.dev.browserLogs)},
+  ${JSON.stringify(config.dev.client.logLevel)}
+)
 `;
 
   new compiler.webpack.EntryPlugin(


### PR DESCRIPTION
## Summary

Simplify HMR init function parameter structure. Since the HMR entry module is a data-URI module, it should be kept as simple as possible.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
