### PR TITLE
release: 1.7.0-beta.2

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/core",
-  "version": "1.7.0-beta.1",
+  "version": "1.7.0-beta.2",
   "description": "The Rspack-based build tool.",
   "homepage": "https://rsbuild.rs",
   "bugs": {

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-preact",
-  "version": "1.7.0-beta.1",
+  "version": "1.7.0-beta.2",
   "description": "Preact plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/webpack",
-  "version": "1.7.0-beta.1",
+  "version": "1.7.0-beta.2",
   "homepage": "https://rsbuild.rs",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### Performance 🚀
* perf: reuse parsed stack frames by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6837
* perf: introduce cached trace map for stack parsing by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6839
### Bug Fixes 🐞
* fix: should throw error when custom config file not found by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/6828
* fix: strip browser prefix from error logs before rendering overlay by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6831
* fix: improve overlay link color for better visibility by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6833
* fix: enhance overlay to display full stack trace for runtime errors by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6834
* fix: improve diagnostics for Rspack runtime modules by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6840
* fix: hide unmapped runtime frames by default in error overlay by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6841
* fix: Node.js addons loading for ESM output by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6842
### Document 📖
* docs: enhance `content.devServer` type by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6830
* docs: fix Rspack dynamically set publicPath links by @lxKylin in https://github.com/web-infra-dev/rsbuild/pull/6832
* docs: add `overlay.runtime` option in client configuration by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6838
### Other Changes
* chore(deps): update module federation to v0.22.0 by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6836
* chore(deps): update dependency @rsdoctor/rspack-plugin to v1.4.0 by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6835
* chore: simplify HMR init function parameter structure by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6843
* release: 1.7.0-beta.2 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6844


**Full Changelog**: https://github.com/web-infra-dev/rsbuild/compare/v1.7.0-beta.1...v1.7.0-beta.2