### PR TITLE
fix: normalize default charset to lowercase `utf-8`

### DIFF
--- a/e2e/cases/html/html-loader/src/template.html
+++ b/e2e/cases/html/html-loader/src/template.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>html-loader</title>
   </head>

--- a/e2e/cases/html/html-tags/function-usage/index.test.ts
+++ b/e2e/cases/html/html-tags/function-usage/index.test.ts
@@ -14,7 +14,7 @@ rspackTest(
     const indexHtml = getFileContent(files, 'index.html');
 
     expect(normalizeNewlines(indexHtml)).toEqual(
-      `<!DOCTYPE html><html><head><script src="/foo.js"></script><script src="/bar.js"></script><script src="/baz.js"></script><title>Rsbuild App</title><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><script defer src="/static/js/index.js"></script></head><body><div id="root"></div></body></html>`,
+      `<!DOCTYPE html><html><head><script src="/foo.js"></script><script src="/bar.js"></script><script src="/baz.js"></script><title>Rsbuild App</title><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><script defer src="/static/js/index.js"></script></head><body><div id="root"></div></body></html>`,
     );
   },
 );

--- a/e2e/cases/html/inject/index.test.ts
+++ b/e2e/cases/html/inject/index.test.ts
@@ -60,11 +60,11 @@ rspackTest('should set inject via function correctly', async ({ build }) => {
 
   const fooHtml = getFileContent(files, 'foo.html');
   expect(normalizeNewlines(fooHtml)).toEqual(
-    `<!DOCTYPE html><html><head><title>Rsbuild App</title><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"></head><body><div id="root"></div><script defer src="/static/js/foo.js"></script></body></html>`,
+    `<!DOCTYPE html><html><head><title>Rsbuild App</title><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"></head><body><div id="root"></div><script defer src="/static/js/foo.js"></script></body></html>`,
   );
 
   const indexHtml = getFileContent(files, 'index.html');
   expect(normalizeNewlines(indexHtml)).toEqual(
-    `<!DOCTYPE html><html><head><title>Rsbuild App</title><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><script defer src="/static/js/index.js"></script><link href="/static/css/index.css" rel="stylesheet"></head><body><div id="root"></div></body></html>`,
+    `<!DOCTYPE html><html><head><title>Rsbuild App</title><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><script defer src="/static/js/index.js"></script><link href="/static/css/index.css" rel="stylesheet"></head><body><div id="root"></div></body></html>`,
   );
 });

--- a/e2e/cases/html/template-no-head/index.test.ts
+++ b/e2e/cases/html/template-no-head/index.test.ts
@@ -9,7 +9,7 @@ rspackTest(
 
     const indexHtml = getFileContent(files, 'index.html');
     expect(indexHtml).toContain(
-      '<!doctype html><head><title>Rsbuild App</title><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><script defer src=',
+      '<!doctype html><head><title>Rsbuild App</title><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><script defer src=',
     );
   },
 );

--- a/e2e/cases/server/ssr-type-module/template.html
+++ b/e2e/cases/server/ssr-type-module/template.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Rsbuild + React + TS</title>
   </head>

--- a/e2e/cases/server/ssr/template.html
+++ b/e2e/cases/server/ssr/template.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Rsbuild + React + TS</title>
   </head>

--- a/packages/core/src/defaultConfig.ts
+++ b/packages/core/src/defaultConfig.ts
@@ -115,7 +115,7 @@ const getDefaultSourceConfig = (): NormalizedSourceConfig => {
 
 const getDefaultHtmlConfig = (): NormalizedHtmlConfig => ({
   meta: {
-    charset: { charset: 'UTF-8' },
+    charset: { charset: 'utf-8' },
     viewport: 'width=device-width, initial-scale=1.0',
   },
   title: 'Rsbuild App',

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1630,7 +1630,7 @@ export interface HtmlConfig {
    * @default
    * ```js
    * const defaultMeta = {
-   *   charset: { charset: 'UTF-8' },
+   *   charset: { charset: 'utf-8' },
    *   viewport: 'width=device-width, initial-scale=1.0',
    * };
    * ```

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -444,7 +444,7 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
         "inject": "head",
         "meta": {
           "charset": {
-            "charset": "UTF-8",
+            "charset": "utf-8",
           },
           "viewport": "width=device-width, initial-scale=1.0",
         },

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -444,7 +444,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
         "inject": "head",
         "meta": {
           "charset": {
-            "charset": "UTF-8",
+            "charset": "utf-8",
           },
           "viewport": "width=device-width, initial-scale=1.0",
         },
@@ -994,7 +994,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
         "inject": "head",
         "meta": {
           "charset": {
-            "charset": "UTF-8",
+            "charset": "utf-8",
           },
           "viewport": "width=device-width, initial-scale=1.0",
         },

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -28,7 +28,7 @@ exports[`environment config > should normalize environment config correctly 1`] 
     "inject": "head",
     "meta": {
       "charset": {
-        "charset": "UTF-8",
+        "charset": "utf-8",
       },
       "viewport": "width=device-width, initial-scale=1.0",
     },
@@ -187,7 +187,7 @@ exports[`environment config > should normalize environment config correctly 2`] 
     "inject": "head",
     "meta": {
       "charset": {
-        "charset": "UTF-8",
+        "charset": "utf-8",
       },
       "viewport": "width=device-width, initial-scale=1.0",
     },
@@ -350,7 +350,7 @@ exports[`environment config > should print environment config when inspect confi
       "inject": "head",
       "meta": {
         "charset": {
-          "charset": "UTF-8",
+          "charset": "utf-8",
         },
         "viewport": "width=device-width, initial-scale=1.0",
       },
@@ -509,7 +509,7 @@ exports[`environment config > should print environment config when inspect confi
       "inject": "head",
       "meta": {
         "charset": {
-          "charset": "UTF-8",
+          "charset": "utf-8",
         },
         "viewport": "width=device-width, initial-scale=1.0",
       },
@@ -688,7 +688,7 @@ exports[`environment config > should support modify environment config by api.mo
       "inject": "head",
       "meta": {
         "charset": {
-          "charset": "UTF-8",
+          "charset": "utf-8",
         },
         "viewport": "width=device-width, initial-scale=1.0",
       },
@@ -847,7 +847,7 @@ exports[`environment config > should support modify environment config by api.mo
       "inject": "head",
       "meta": {
         "charset": {
-          "charset": "UTF-8",
+          "charset": "utf-8",
         },
         "viewport": "width=device-width, initial-scale=1.0",
       },
@@ -1007,7 +1007,7 @@ exports[`environment config > should support modify environment config by api.mo
       "inject": "head",
       "meta": {
         "charset": {
-          "charset": "UTF-8",
+          "charset": "utf-8",
         },
         "viewport": "width=device-width, initial-scale=1.0",
       },
@@ -1170,7 +1170,7 @@ exports[`environment config > should support modify single environment config by
       "inject": "head",
       "meta": {
         "charset": {
-          "charset": "UTF-8",
+          "charset": "utf-8",
         },
         "viewport": "width=device-width, initial-scale=1.0",
       },
@@ -1329,7 +1329,7 @@ exports[`environment config > should support modify single environment config by
       "inject": "head",
       "meta": {
         "charset": {
-          "charset": "UTF-8",
+          "charset": "utf-8",
         },
         "viewport": "width=device-width, initial-scale=1.0",
       },

--- a/packages/core/tests/__snapshots__/html.test.ts.snap
+++ b/packages/core/tests/__snapshots__/html.test.ts.snap
@@ -31,7 +31,7 @@ exports[`plugin-html > should allow to configure html.tags 1`] = `
         "inject": "head",
         "meta": {
           "charset": {
-            "charset": "UTF-8",
+            "charset": "utf-8",
           },
           "viewport": "width=device-width, initial-scale=1.0",
         },
@@ -64,7 +64,7 @@ exports[`plugin-html > should allow to configure html.tags 1`] = `
         "inject": "head",
         "meta": {
           "charset": {
-            "charset": "UTF-8",
+            "charset": "utf-8",
           },
           "viewport": "width=device-width, initial-scale=1.0",
         },
@@ -147,7 +147,7 @@ exports[`plugin-html > should enable minify in production 1`] = `
         "inject": "head",
         "meta": {
           "charset": {
-            "charset": "UTF-8",
+            "charset": "utf-8",
           },
           "viewport": "width=device-width, initial-scale=1.0",
         },
@@ -200,7 +200,7 @@ exports[`plugin-html > should register html plugin correctly 1`] = `
         "inject": "head",
         "meta": {
           "charset": {
-            "charset": "UTF-8",
+            "charset": "utf-8",
           },
           "viewport": "width=device-width, initial-scale=1.0",
         },
@@ -274,7 +274,7 @@ exports[`plugin-html > should support environment html config 1`] = `
           "inject": "head",
           "meta": {
             "charset": {
-              "charset": "UTF-8",
+              "charset": "utf-8",
             },
             "viewport": "width=device-width, initial-scale=1.0",
           },
@@ -324,7 +324,7 @@ exports[`plugin-html > should support environment html config 1`] = `
           "inject": "head",
           "meta": {
             "charset": {
-              "charset": "UTF-8",
+              "charset": "utf-8",
             },
             "viewport": "width=device-width, initial-scale=1.0",
           },
@@ -381,7 +381,7 @@ exports[`plugin-html > should support multi entry 1`] = `
         "inject": "head",
         "meta": {
           "charset": {
-            "charset": "UTF-8",
+            "charset": "utf-8",
           },
           "viewport": "width=device-width, initial-scale=1.0",
         },
@@ -414,7 +414,7 @@ exports[`plugin-html > should support multi entry 1`] = `
         "inject": "head",
         "meta": {
           "charset": {
-            "charset": "UTF-8",
+            "charset": "utf-8",
           },
           "viewport": "width=device-width, initial-scale=1.0",
         },

--- a/website/docs/en/config/html/meta.mdx
+++ b/website/docs/en/config/html/meta.mdx
@@ -5,9 +5,9 @@
 
 ```ts
 const defaultMeta = {
-  // <meta charset="UTF-8" />
+  // <meta charset="utf-8" />
   charset: {
-    charset: 'UTF-8',
+    charset: 'utf-8',
   },
   // <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   viewport: 'width=device-width, initial-scale=1.0',
@@ -78,7 +78,7 @@ export default {
   html: {
     meta: {
       charset: {
-        charset: 'UTF-8',
+        charset: 'utf-8',
       },
     },
   },
@@ -88,7 +88,7 @@ export default {
 The `meta` tag in HTML is:
 
 ```html
-<meta charset="UTF-8" />
+<meta charset="utf-8" />
 ```
 
 ### Open Graph tags

--- a/website/docs/en/guide/basic/html-template.mdx
+++ b/website/docs/en/guide/basic/html-template.mdx
@@ -118,7 +118,7 @@ You can set meta tags using the [html.meta](/config/html/meta) config.
 Rsbuild defaults to setting the charset and viewport meta tags:
 
 ```html
-<meta charset="UTF-8" />
+<meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 ```
 

--- a/website/docs/zh/config/html/meta.mdx
+++ b/website/docs/zh/config/html/meta.mdx
@@ -5,9 +5,9 @@
 
 ```ts
 const defaultMeta = {
-  // <meta charset="UTF-8" />
+  // <meta charset="utf-8" />
   charset: {
-    charset: 'UTF-8',
+    charset: 'utf-8',
   },
   // <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   viewport: 'width=device-width, initial-scale=1.0',
@@ -76,7 +76,7 @@ export default {
   html: {
     meta: {
       charset: {
-        charset: 'UTF-8',
+        charset: 'utf-8',
       },
     },
   },
@@ -86,7 +86,7 @@ export default {
 在 HTML 中生成的 `meta` 标签为：
 
 ```html
-<meta charset="UTF-8" />
+<meta charset="utf-8" />
 ```
 
 ### Open Graph 标签

--- a/website/docs/zh/guide/basic/html-template.mdx
+++ b/website/docs/zh/guide/basic/html-template.mdx
@@ -118,7 +118,7 @@ export default {
 Rsbuild 默认设置了 charset 和 viewport meta 标签：
 
 ```html
-<meta charset="UTF-8" />
+<meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 ```
 


### PR DESCRIPTION
## Summary

The default HTML charset is now emitted as lowercase `utf-8`, matching the HTML Living Standard examples. Charset parsing remains case-insensitive, so there is no behavioral change.

## Related Links

- https://html.spec.whatwg.org/#charset
- https://github.com/web-infra-dev/rsbuild/pull/6853#issuecomment-3694911154

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
