### PR TITLE
chore(deps): bump Rslib to v0.19.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,7 +61,7 @@
   "devDependencies": {
     "@jridgewell/remapping": "^2.3.5",
     "@jridgewell/trace-mapping": "^0.3.31",
-    "@rslib/core": "0.18.6",
+    "@rslib/core": "0.19.0",
     "@types/connect": "3.4.38",
     "@types/cors": "^2.8.19",
     "@types/node": "^24.10.4",

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -83,9 +83,6 @@ export default defineConfig({
     {
       id: 'esm_index',
       format: 'esm',
-      experiments: {
-        advancedEsm: true,
-      },
       syntax: 'es2022',
       plugins: [pluginFixDtsTypes],
       dts: {
@@ -111,9 +108,6 @@ export default defineConfig({
     {
       id: 'esm_loaders',
       format: 'esm',
-      experiments: {
-        advancedEsm: true,
-      },
       syntax: 'es2022',
       source: {
         entry: {
@@ -145,9 +139,6 @@ export default defineConfig({
     {
       id: 'esm_client',
       format: 'esm',
-      experiments: {
-        advancedEsm: true,
-      },
       syntax: 'es2017',
       source: {
         entry: {

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -39,7 +39,7 @@
     "@rsbuild/plugin-solid": "workspace:*",
     "@rsbuild/plugin-svelte": "workspace:*",
     "@rsbuild/plugin-vue": "workspace:*",
-    "@rslib/core": "0.18.6",
+    "@rslib/core": "0.19.0",
     "@types/node": "^24.10.4",
     "typescript": "^5.9.3"
   },

--- a/packages/create-rsbuild/rslib.config.ts
+++ b/packages/create-rsbuild/rslib.config.ts
@@ -4,9 +4,6 @@ export default defineConfig({
   lib: [
     {
       format: 'esm',
-      experiments: {
-        advancedEsm: true,
-      },
       syntax: 'es2022',
     },
   ],

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.18.6",
+    "@rslib/core": "0.19.0",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^24.10.4",
     "babel-loader": "10.0.0",

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.18.6",
+    "@rslib/core": "0.19.0",
     "@scripts/test-helper": "workspace:*",
     "@types/less": "^3.0.8",
     "less": "4.3.0",

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.18.6",
+    "@rslib/core": "0.19.0",
     "@types/node": "^24.10.4",
     "preact": "^10.28.1",
     "typescript": "^5.9.3"

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.18.6",
+    "@rslib/core": "0.19.0",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^24.10.4",
     "typescript": "^5.9.3"

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.18.6",
+    "@rslib/core": "0.19.0",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^24.10.4",
     "@types/sass-loader": "^8.0.10",

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.18.6",
+    "@rslib/core": "0.19.0",
     "@scripts/test-helper": "workspace:*",
     "@types/babel__core": "^7.20.5",
     "typescript": "^5.9.3"

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.18.6",
+    "@rslib/core": "0.19.0",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^24.10.4",
     "typescript": "^5.9.3"

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.18.6",
+    "@rslib/core": "0.19.0",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^24.10.4",
     "svelte": "^5.46.1",

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.18.6",
+    "@rslib/core": "0.19.0",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^24.10.4",
     "file-loader": "6.2.0",

--- a/packages/plugin-svgr/rslib.config.ts
+++ b/packages/plugin-svgr/rslib.config.ts
@@ -7,9 +7,6 @@ export default defineConfig({
     ...dualPackage.lib,
     {
       format: 'esm',
-      experiments: {
-        advancedEsm: true,
-      },
       source: {
         entry: {
           loader: './src/loader.ts',

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.18.6",
+    "@rslib/core": "0.19.0",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^24.10.4",
     "typescript": "^5.9.3",

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.18.6",
+    "@rslib/core": "0.19.0",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^24.10.4",
     "ansi-escapes": "4.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -536,8 +536,8 @@ importers:
         specifier: ^0.3.31
         version: 0.3.31
       '@rslib/core':
-        specifier: 0.18.6
-        version: 0.18.6(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)
+        specifier: 0.19.0
+        version: 0.19.0(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)
       '@types/connect':
         specifier: 3.4.38
         version: 3.4.38
@@ -690,8 +690,8 @@ importers:
         specifier: workspace:*
         version: link:../plugin-vue
       '@rslib/core':
-        specifier: 0.18.6
-        version: 0.18.6(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)
+        specifier: 0.19.0
+        version: 0.19.0(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)
       '@types/node':
         specifier: ^24.10.4
         version: 24.10.4
@@ -730,8 +730,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.18.6
-        version: 0.18.6(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)
+        specifier: 0.19.0
+        version: 0.19.0(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -761,8 +761,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.18.6
-        version: 0.18.6(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)
+        specifier: 0.19.0
+        version: 0.19.0(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -801,8 +801,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.18.6
-        version: 0.18.6(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)
+        specifier: 0.19.0
+        version: 0.19.0(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)
       '@types/node':
         specifier: ^24.10.4
         version: 24.10.4
@@ -826,8 +826,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.18.6
-        version: 0.18.6(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)
+        specifier: 0.19.0
+        version: 0.19.0(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -860,8 +860,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.18.6
-        version: 0.18.6(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)
+        specifier: 0.19.0
+        version: 0.19.0(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -900,8 +900,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.18.6
-        version: 0.18.6(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)
+        specifier: 0.19.0
+        version: 0.19.0(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -931,8 +931,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.18.6
-        version: 0.18.6(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)
+        specifier: 0.19.0
+        version: 0.19.0(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -956,8 +956,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.18.6
-        version: 0.18.6(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)
+        specifier: 0.19.0
+        version: 0.19.0(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -996,8 +996,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.18.6
-        version: 0.18.6(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)
+        specifier: 0.19.0
+        version: 0.19.0(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1033,8 +1033,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.18.6
-        version: 0.18.6(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)
+        specifier: 0.19.0
+        version: 0.19.0(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1076,8 +1076,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.18.6
-        version: 0.18.6(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)
+        specifier: 0.19.0
+        version: 0.19.0(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1103,8 +1103,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       '@rslib/core':
-        specifier: 0.18.6
-        version: 0.18.6(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)
+        specifier: 0.19.0
+        version: 0.19.0(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)
       '@types/node':
         specifier: ^24.10.4
         version: 24.10.4
@@ -1134,8 +1134,8 @@ importers:
         version: 5.9.3
     devDependencies:
       '@rslib/core':
-        specifier: 0.18.6
-        version: 0.18.6(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)
+        specifier: 0.19.0
+        version: 0.19.0(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)
 
   website:
     devDependencies:
@@ -2295,8 +2295,8 @@ packages:
   '@rsdoctor/utils@1.4.0':
     resolution: {integrity: sha512-kJVv+9UveTNRjpEhqlcThuqpHKepzbMnHBbPA4BLwC6S9qFLFy1P4bxp59T8e6nJ5ljxT4C5LDVEgmmvjsaUlA==}
 
-  '@rslib/core@0.18.6':
-    resolution: {integrity: sha512-mMjfmtXRPHOCzO1A8KcAQckIHi/vA+qOHT/zK4M8Nnr5h1eAO6HIEN7AvJdgbIf5YXsVH6bXonrXdAwwP0gHow==}
+  '@rslib/core@0.19.0':
+    resolution: {integrity: sha512-t94QnZGU8YSn5xQ8vNqxIpee5Mo+S77SEVA/0Tjft0I0dLmU6GZHeYAmoztNfWLudSUl4KrvilnxGPlySMdPvw==}
     engines: {node: '>=18.12.0'}
     hasBin: true
     peerDependencies:
@@ -5640,8 +5640,8 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  rsbuild-plugin-dts@0.18.6:
-    resolution: {integrity: sha512-E0KxiXxY5T3D+DjMMQS3/DMlNwjzNp1xEYyH68gwI7Ptm3a1ChawvlZ1DqVW5m8NWkdbCbcAyazwOnDD3yVOLQ==}
+  rsbuild-plugin-dts@0.19.0:
+    resolution: {integrity: sha512-5NkHONFDMBXv0qr1voHQigVhPmqai2icbJtckXJSCrpSTAJO0eXkGsHNVR8QvnsZEZWXL+KsIgNEJ7C8tYginQ==}
     engines: {node: '>=18.12.0'}
     peerDependencies:
       '@microsoft/api-extractor': ^7
@@ -7962,10 +7962,10 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rslib/core@0.18.6(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)':
+  '@rslib/core@0.19.0(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)':
     dependencies:
       '@rsbuild/core': 1.7.0-beta.2
-      rsbuild-plugin-dts: 0.18.6(@rsbuild/core@1.7.0-beta.2)(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)
+      rsbuild-plugin-dts: 0.19.0(@rsbuild/core@1.7.0-beta.2)(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -11789,7 +11789,7 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': link:packages/core
 
-  rsbuild-plugin-dts@0.18.6(@rsbuild/core@1.7.0-beta.2)(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3):
+  rsbuild-plugin-dts@0.19.0(@rsbuild/core@1.7.0-beta.2)(@typescript/native-preview@7.0.0-dev.20251203.1)(typescript@5.9.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 1.7.0-beta.2

--- a/scripts/config/package.json
+++ b/scripts/config/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.18.6",
+    "@rslib/core": "0.19.0",
     "@types/node": "^24.10.4",
     "@typescript/native-preview": "7.0.0-dev.20251203.1",
     "rsbuild-plugin-arethetypeswrong": "0.1.1",

--- a/scripts/config/rslib.config.ts
+++ b/scripts/config/rslib.config.ts
@@ -24,9 +24,6 @@ export const nodeMinifyConfig: Minify = {
 
 export const esmConfig: LibConfig = {
   format: 'esm',
-  experiments: {
-    advancedEsm: true,
-  },
   syntax: 'es2022',
   dts: {
     build: true,

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -30,7 +30,7 @@
     "typescript": "^5.9.3"
   },
   "devDependencies": {
-    "@rslib/core": "0.18.6"
+    "@rslib/core": "0.19.0"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Summary

Bump Rslib v0.19.0 and remove `experiments.advancedEsm` config since it defaults to `true`.

## Related Links

https://github.com/web-infra-dev/rslib/releases/tag/v0.19.0

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
