### PR TITLE
feat(create-rsbuild): use `happy-dom` instead of `jsdom`

### DIFF
--- a/packages/create-rsbuild/template-rstest/react-js/package.json
+++ b/packages/create-rsbuild/template-rstest/react-js/package.json
@@ -11,6 +11,6 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
     "@rstest/core": "^0.7.7",
-    "jsdom": "^27.4.0"
+    "happy-dom": "^20.0.11"
   }
 }

--- a/packages/create-rsbuild/template-rstest/react-js/rstest.config.js
+++ b/packages/create-rsbuild/template-rstest/react-js/rstest.config.js
@@ -4,6 +4,6 @@ import { defineConfig } from '@rstest/core';
 // Docs: https://rstest.rs/config/
 export default defineConfig({
   plugins: [pluginReact()],
-  testEnvironment: 'jsdom',
+  testEnvironment: 'happy-dom',
   setupFiles: ['./rstest.setup.js'],
 });

--- a/packages/create-rsbuild/template-rstest/react-ts/package.json
+++ b/packages/create-rsbuild/template-rstest/react-ts/package.json
@@ -11,6 +11,6 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
     "@rstest/core": "^0.7.7",
-    "jsdom": "^27.4.0"
+    "happy-dom": "^20.0.11"
   }
 }

--- a/packages/create-rsbuild/template-rstest/react-ts/rstest.config.ts
+++ b/packages/create-rsbuild/template-rstest/react-ts/rstest.config.ts
@@ -4,6 +4,6 @@ import { defineConfig } from '@rstest/core';
 // Docs: https://rstest.rs/config/
 export default defineConfig({
   plugins: [pluginReact()],
-  testEnvironment: 'jsdom',
+  testEnvironment: 'happy-dom',
   setupFiles: ['./rstest.setup.ts'],
 });

--- a/packages/create-rsbuild/template-rstest/vanilla-js/package.json
+++ b/packages/create-rsbuild/template-rstest/vanilla-js/package.json
@@ -10,6 +10,6 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@rstest/core": "^0.7.7",
-    "jsdom": "^27.4.0"
+    "happy-dom": "^20.0.11"
   }
 }

--- a/packages/create-rsbuild/template-rstest/vanilla-js/rstest.config.js
+++ b/packages/create-rsbuild/template-rstest/vanilla-js/rstest.config.js
@@ -2,6 +2,6 @@ import { defineConfig } from '@rstest/core';
 
 // Docs: https://rstest.rs/config/
 export default defineConfig({
-  testEnvironment: 'jsdom',
+  testEnvironment: 'happy-dom',
   setupFiles: ['./rstest.setup.js'],
 });

--- a/packages/create-rsbuild/template-rstest/vanilla-ts/package.json
+++ b/packages/create-rsbuild/template-rstest/vanilla-ts/package.json
@@ -10,6 +10,6 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@rstest/core": "^0.7.7",
-    "jsdom": "^27.4.0"
+    "happy-dom": "^20.0.11"
   }
 }

--- a/packages/create-rsbuild/template-rstest/vanilla-ts/rstest.config.ts
+++ b/packages/create-rsbuild/template-rstest/vanilla-ts/rstest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from '@rstest/core';
 
 // Docs: https://rstest.rs/config/
 export default defineConfig({
-  testEnvironment: 'jsdom',
+  testEnvironment: 'happy-dom',
   setupFiles: ['./rstest.setup.ts'],
 });

--- a/packages/create-rsbuild/template-rstest/vue-js/package.json
+++ b/packages/create-rsbuild/template-rstest/vue-js/package.json
@@ -11,6 +11,6 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/vue": "^8.1.0",
     "@rstest/core": "^0.7.7",
-    "jsdom": "^27.4.0"
+    "happy-dom": "^20.0.11"
   }
 }

--- a/packages/create-rsbuild/template-rstest/vue-js/rstest.config.js
+++ b/packages/create-rsbuild/template-rstest/vue-js/rstest.config.js
@@ -4,6 +4,6 @@ import { defineConfig } from '@rstest/core';
 // Docs: https://rstest.rs/config/
 export default defineConfig({
   plugins: [pluginVue()],
-  testEnvironment: 'jsdom',
+  testEnvironment: 'happy-dom',
   setupFiles: ['./rstest.setup.js'],
 });

--- a/packages/create-rsbuild/template-rstest/vue-ts/package.json
+++ b/packages/create-rsbuild/template-rstest/vue-ts/package.json
@@ -11,6 +11,6 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/vue": "^8.1.0",
     "@rstest/core": "^0.7.7",
-    "jsdom": "^27.4.0"
+    "happy-dom": "^20.0.11"
   }
 }

--- a/packages/create-rsbuild/template-rstest/vue-ts/rstest.config.ts
+++ b/packages/create-rsbuild/template-rstest/vue-ts/rstest.config.ts
@@ -4,6 +4,6 @@ import { defineConfig } from '@rstest/core';
 // Docs: https://rstest.rs/config/
 export default defineConfig({
   plugins: [pluginVue()],
-  testEnvironment: 'jsdom',
+  testEnvironment: 'happy-dom',
   setupFiles: ['./rstest.setup.ts'],
 });


### PR DESCRIPTION
## Summary

Use `happy-dom` instead of `jsdom` as default testEnvironment in Rstest template.

`happy-dom` is considered faster than `jsdom`, but it lacks some APIs.

https://github.com/capricorn86/happy-dom/wiki/

```bash
hyperfine 'pnpm test --testEnvironment jsdom' 'pnpm test --testEnvironment happy-dom'

Benchmark 1: pnpm test --testEnvironment jsdom
  Time (mean ± σ):     845.1 ms ± 182.3 ms    [User: 682.0 ms, System: 252.9 ms]
  Range (min … max):   768.9 ms … 1362.4 ms    10 runs
 
 
Benchmark 2: pnpm test --testEnvironment happy-dom
  Time (mean ± σ):     637.2 ms ±  21.6 ms    [User: 582.0 ms, System: 209.4 ms]
  Range (min … max):   611.7 ms … 676.8 ms    10 runs
 
Summary
  pnpm test --testEnvironment happy-dom ran
    1.33 ± 0.29 times faster than pnpm test --testEnvironment jsdom
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
