### PR TITLE
fix(plugin-api): allow to override exposed API

### DIFF
--- a/e2e/cases/plugin-api/plugin-expose/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-expose/index.test.ts
@@ -6,19 +6,29 @@ type ParentAPI = {
   double: (val: number) => number;
 };
 
+const parentSymbol = Symbol('parent-api');
+
+const pluginParent: RsbuildPlugin = {
+  name: 'plugin-parent',
+  setup(api) {
+    api.expose<ParentAPI>(parentSymbol, {
+      initial: 1,
+      double: (val: number) => val * 2,
+    });
+  },
+};
+
+const pluginParent2: RsbuildPlugin = {
+  name: 'plugin-parent2',
+  setup(api) {
+    api.expose<ParentAPI>(parentSymbol, {
+      initial: 2,
+      double: (val: number) => val * 2,
+    });
+  },
+};
+
 rspackTest('should allow plugin to expose and consume API', async () => {
-  const parentSymbol = Symbol('parent-api');
-
-  const pluginParent: RsbuildPlugin = {
-    name: 'plugin-parent',
-    setup(api) {
-      api.expose<ParentAPI>(parentSymbol, {
-        initial: 1,
-        double: (val: number) => val * 2,
-      });
-    },
-  };
-
   const pluginChild: RsbuildPlugin = {
     name: 'plugin-child',
     setup(api) {
@@ -33,6 +43,23 @@ rspackTest('should allow plugin to expose and consume API', async () => {
       plugins: [pluginParent, pluginChild],
     },
   });
+  await rsbuild.build();
+});
 
+rspackTest('should override the previous exposed API', async () => {
+  const pluginChild: RsbuildPlugin = {
+    name: 'plugin-child',
+    setup(api) {
+      const parentAPI = api.useExposed<ParentAPI>(parentSymbol);
+      expect(parentAPI?.double(parentAPI.initial)).toEqual(4);
+    },
+  };
+
+  const rsbuild = await createRsbuild({
+    cwd: import.meta.dirname,
+    config: {
+      plugins: [pluginParent, pluginParent2, pluginChild],
+    },
+  });
   await rsbuild.build();
 });

--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -136,17 +136,12 @@ export function initPluginAPI({
     );
   }) as GetRsbuildConfig;
 
-  const exposed: { id: string | symbol; api: any }[] = [];
+  const exposed = new Map<string | symbol, any>();
 
   const expose = (id: string | symbol, api: any) => {
-    exposed.push({ id, api });
+    exposed.set(id, api);
   };
-  const useExposed = (id: string | symbol) => {
-    const matched = exposed.find((item) => item.id === id);
-    if (matched) {
-      return matched.api;
-    }
-  };
+  const useExposed = (id: string | symbol) => exposed.get(id);
 
   let transformId = 0;
   const transformer: Record<string, TransformHandler<boolean>> = {};

--- a/website/docs/en/plugins/dev/core.mdx
+++ b/website/docs/en/plugins/dev/core.mdx
@@ -752,6 +752,10 @@ const pluginParent = () => ({
 });
 ```
 
+:::tip
+If `api.expose` is called multiple times with the same `id`, the latter call will overwrite the previously exposed API.
+:::
+
 ## api.useExposed
 
 Used for plugin communication.

--- a/website/docs/zh/plugins/dev/core.mdx
+++ b/website/docs/zh/plugins/dev/core.mdx
@@ -752,6 +752,10 @@ const pluginParent = () => ({
 });
 ```
 
+:::tip
+如果 `api.expose` 被多次调用且使用了相同的 `id`，则后一次调用会覆盖前一次调用暴露的 API。
+:::
+
 ## api.useExposed
 
 用于插件间通信。


### PR DESCRIPTION
## Summary

Changed the internal implementation of exposed APIs from an array to a `Map`, so that calling `api.expose` with the same `id` will overwrite the previous API instead of accumulating multiple entries.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
