### PR TITLE
perf: minify some pre-bundled packages

### DIFF
--- a/packages/core/prebundle.config.ts
+++ b/packages/core/prebundle.config.ts
@@ -27,11 +27,14 @@ export default {
     'html-rspack-plugin',
     '@jridgewell/trace-mapping',
     'mrmime',
-    'memfs',
     'tinyglobby',
     'chokidar',
     'cors',
     'webpack-merge',
+    {
+      name: 'memfs',
+      minify: true,
+    },
     {
       name: 'picocolors',
       beforeBundle({ depPath }) {
@@ -133,6 +136,7 @@ export default {
     {
       name: 'postcss',
       copyDts: true,
+      minify: true,
       externals: {
         picocolors: '../picocolors/index.js',
       },
@@ -159,6 +163,7 @@ export type SourceMapGenerator = unknown;
     {
       name: 'css-loader',
       ignoreDts: true,
+      minify: true,
       externals: {
         postcss: '../postcss/index.js',
       },


### PR DESCRIPTION
## Summary

Minify some pre-bundled packages (`css-loader` / `postcss` / `memfs`) to reduce memory usage and install size.

This may affect the debugging experience for these packages, but I rarely need to debug this code, so it seems worth it.

### Before

![20251230-103042](https://github.com/user-attachments/assets/95aa4615-c9ae-4069-8b5c-626ae6e1ff2a)

### After

![20251230-103031](https://github.com/user-attachments/assets/9a4af117-216b-4e65-84a7-3b9047fb8ef5)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
