### PR TITLE
refactor: adjust position of collectTypeScriptInfo in swc-loader

### DIFF
--- a/packages/core/src/plugins/swc.ts
+++ b/packages/core/src/plugins/swc.ts
@@ -98,11 +98,9 @@ function getDefaultSwcConfig({
     env: {
       targets: browserslist,
     },
-    rspackExperiments: {
-      collectTypeScriptInfo: {
-        typeExports: true,
-        exportedEnum: isProd,
-      },
+    collectTypeScriptInfo: {
+      typeExports: true,
+      exportedEnum: isProd,
     },
   };
 }

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -173,11 +173,9 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
                   "legacyDecorator": false,
                 },
               },
-              "rspackExperiments": {
-                "collectTypeScriptInfo": {
-                  "exportedEnum": false,
-                  "typeExports": true,
-                },
+              "collectTypeScriptInfo": {
+                "exportedEnum": false,
+                "typeExports": true,
               },
             },
           },
@@ -231,11 +229,9 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
                   "legacyDecorator": false,
                 },
               },
-              "rspackExperiments": {
-                "collectTypeScriptInfo": {
-                  "exportedEnum": false,
-                  "typeExports": true,
-                },
+              "collectTypeScriptInfo": {
+                "exportedEnum": false,
+                "typeExports": true,
               },
             },
           },

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -173,11 +173,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                   "legacyDecorator": false,
                 },
               },
-              "rspackExperiments": {
-                "collectTypeScriptInfo": {
-                  "exportedEnum": false,
-                  "typeExports": true,
-                },
+              "collectTypeScriptInfo": {
+                "exportedEnum": false,
+                "typeExports": true,
               },
             },
           },
@@ -231,11 +229,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                   "legacyDecorator": false,
                 },
               },
-              "rspackExperiments": {
-                "collectTypeScriptInfo": {
-                  "exportedEnum": false,
-                  "typeExports": true,
-                },
+              "collectTypeScriptInfo": {
+                "exportedEnum": false,
+                "typeExports": true,
               },
             },
           },
@@ -694,11 +690,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
                   "legacyDecorator": false,
                 },
               },
-              "rspackExperiments": {
-                "collectTypeScriptInfo": {
-                  "exportedEnum": true,
-                  "typeExports": true,
-                },
+              "collectTypeScriptInfo": {
+                "exportedEnum": true,
+                "typeExports": true,
               },
             },
           },
@@ -752,11 +746,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
                   "legacyDecorator": false,
                 },
               },
-              "rspackExperiments": {
-                "collectTypeScriptInfo": {
-                  "exportedEnum": true,
-                  "typeExports": true,
-                },
+              "collectTypeScriptInfo": {
+                "exportedEnum": true,
+                "typeExports": true,
               },
             },
           },
@@ -1216,11 +1208,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                   "legacyDecorator": false,
                 },
               },
-              "rspackExperiments": {
-                "collectTypeScriptInfo": {
-                  "exportedEnum": false,
-                  "typeExports": true,
-                },
+              "collectTypeScriptInfo": {
+                "exportedEnum": false,
+                "typeExports": true,
               },
             },
           },
@@ -1270,11 +1260,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                   "legacyDecorator": false,
                 },
               },
-              "rspackExperiments": {
-                "collectTypeScriptInfo": {
-                  "exportedEnum": false,
-                  "typeExports": true,
-                },
+              "collectTypeScriptInfo": {
+                "exportedEnum": false,
+                "typeExports": true,
               },
             },
           },
@@ -1690,11 +1678,9 @@ exports[`tools.rspack > should match snapshot 1`] = `
                   "legacyDecorator": false,
                 },
               },
-              "rspackExperiments": {
-                "collectTypeScriptInfo": {
-                  "exportedEnum": false,
-                  "typeExports": true,
-                },
+              "collectTypeScriptInfo": {
+                "exportedEnum": false,
+                "typeExports": true,
               },
             },
           },
@@ -1748,11 +1734,9 @@ exports[`tools.rspack > should match snapshot 1`] = `
                   "legacyDecorator": false,
                 },
               },
-              "rspackExperiments": {
-                "collectTypeScriptInfo": {
-                  "exportedEnum": false,
-                  "typeExports": true,
-                },
+              "collectTypeScriptInfo": {
+                "exportedEnum": false,
+                "typeExports": true,
               },
             },
           },

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1631,11 +1631,9 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
                     "legacyDecorator": false,
                   },
                 },
-                "rspackExperiments": {
-                  "collectTypeScriptInfo": {
-                    "exportedEnum": false,
-                    "typeExports": true,
-                  },
+                "collectTypeScriptInfo": {
+                  "exportedEnum": false,
+                  "typeExports": true,
                 },
               },
             },
@@ -1689,11 +1687,9 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
                     "legacyDecorator": false,
                   },
                 },
-                "rspackExperiments": {
-                  "collectTypeScriptInfo": {
-                    "exportedEnum": false,
-                    "typeExports": true,
-                  },
+                "collectTypeScriptInfo": {
+                  "exportedEnum": false,
+                  "typeExports": true,
                 },
               },
             },
@@ -2071,11 +2067,9 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
                     "legacyDecorator": false,
                   },
                 },
-                "rspackExperiments": {
-                  "collectTypeScriptInfo": {
-                    "exportedEnum": false,
-                    "typeExports": true,
-                  },
+                "collectTypeScriptInfo": {
+                  "exportedEnum": false,
+                  "typeExports": true,
                 },
               },
             },
@@ -2125,11 +2119,9 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
                     "legacyDecorator": false,
                   },
                 },
-                "rspackExperiments": {
-                  "collectTypeScriptInfo": {
-                    "exportedEnum": false,
-                    "typeExports": true,
-                  },
+                "collectTypeScriptInfo": {
+                  "exportedEnum": false,
+                  "typeExports": true,
                 },
               },
             },

--- a/packages/core/tests/__snapshots__/swc.test.ts.snap
+++ b/packages/core/tests/__snapshots__/swc.test.ts.snap
@@ -55,11 +55,9 @@ exports[`plugin-swc > should add browserslist 1`] = `
                     "legacyDecorator": false,
                   },
                 },
-                "rspackExperiments": {
-                  "collectTypeScriptInfo": {
-                    "exportedEnum": false,
-                    "typeExports": true,
-                  },
+                "collectTypeScriptInfo": {
+                  "exportedEnum": false,
+                  "typeExports": true,
                 },
               },
             },
@@ -110,11 +108,9 @@ exports[`plugin-swc > should add browserslist 1`] = `
                     "legacyDecorator": false,
                   },
                 },
-                "rspackExperiments": {
-                  "collectTypeScriptInfo": {
-                    "exportedEnum": false,
-                    "typeExports": true,
-                  },
+                "collectTypeScriptInfo": {
+                  "exportedEnum": false,
+                  "typeExports": true,
                 },
               },
             },
@@ -189,11 +185,11 @@ exports[`plugin-swc > should add pluginImport 1`] = `
                     "legacyDecorator": false,
                   },
                 },
+                "collectTypeScriptInfo": {
+                  "exportedEnum": false,
+                  "typeExports": true,
+                },
                 "rspackExperiments": {
-                  "collectTypeScriptInfo": {
-                    "exportedEnum": false,
-                    "typeExports": true,
-                  },
                   "import": [
                     {
                       "libraryName": "foo",
@@ -252,11 +248,11 @@ exports[`plugin-swc > should add pluginImport 1`] = `
                     "legacyDecorator": false,
                   },
                 },
+                "collectTypeScriptInfo": {
+                  "exportedEnum": false,
+                  "typeExports": true,
+                },
                 "rspackExperiments": {
-                  "collectTypeScriptInfo": {
-                    "exportedEnum": false,
-                    "typeExports": true,
-                  },
                   "import": [
                     {
                       "libraryName": "foo",
@@ -385,11 +381,9 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
               "legacyDecorator": false,
             },
           },
-          "rspackExperiments": {
-            "collectTypeScriptInfo": {
-              "exportedEnum": false,
-              "typeExports": true,
-            },
+          "collectTypeScriptInfo": {
+            "exportedEnum": false,
+            "typeExports": true,
           },
         },
       },
@@ -443,11 +437,9 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
               "legacyDecorator": false,
             },
           },
-          "rspackExperiments": {
-            "collectTypeScriptInfo": {
-              "exportedEnum": false,
-              "typeExports": true,
-            },
+          "collectTypeScriptInfo": {
+            "exportedEnum": false,
+            "typeExports": true,
           },
         },
       },
@@ -516,11 +508,11 @@ exports[`plugin-swc > should apply environment config correctly 1`] = `
               "legacyDecorator": false,
             },
           },
+          "collectTypeScriptInfo": {
+            "exportedEnum": false,
+            "typeExports": true,
+          },
           "rspackExperiments": {
-            "collectTypeScriptInfo": {
-              "exportedEnum": false,
-              "typeExports": true,
-            },
             "import": [
               {
                 "libraryName": "foo",
@@ -584,11 +576,11 @@ exports[`plugin-swc > should apply environment config correctly 1`] = `
               "legacyDecorator": false,
             },
           },
+          "collectTypeScriptInfo": {
+            "exportedEnum": false,
+            "typeExports": true,
+          },
           "rspackExperiments": {
-            "collectTypeScriptInfo": {
-              "exportedEnum": false,
-              "typeExports": true,
-            },
             "import": [
               {
                 "libraryName": "foo",
@@ -651,11 +643,11 @@ exports[`plugin-swc > should apply environment config correctly 2`] = `
               "legacyDecorator": false,
             },
           },
+          "collectTypeScriptInfo": {
+            "exportedEnum": false,
+            "typeExports": true,
+          },
           "rspackExperiments": {
-            "collectTypeScriptInfo": {
-              "exportedEnum": false,
-              "typeExports": true,
-            },
             "import": [
               {
                 "libraryName": "bar",
@@ -710,11 +702,11 @@ exports[`plugin-swc > should apply environment config correctly 2`] = `
               "legacyDecorator": false,
             },
           },
+          "collectTypeScriptInfo": {
+            "exportedEnum": false,
+            "typeExports": true,
+          },
           "rspackExperiments": {
-            "collectTypeScriptInfo": {
-              "exportedEnum": false,
-              "typeExports": true,
-            },
             "import": [
               {
                 "libraryName": "bar",
@@ -786,11 +778,11 @@ exports[`plugin-swc > should apply pluginImport correctly when ConfigChain 1`] =
                     "legacyDecorator": false,
                   },
                 },
+                "collectTypeScriptInfo": {
+                  "exportedEnum": false,
+                  "typeExports": true,
+                },
                 "rspackExperiments": {
-                  "collectTypeScriptInfo": {
-                    "exportedEnum": false,
-                    "typeExports": true,
-                  },
                   "import": [
                     {
                       "libraryName": "foo",
@@ -852,11 +844,11 @@ exports[`plugin-swc > should apply pluginImport correctly when ConfigChain 1`] =
                     "legacyDecorator": false,
                   },
                 },
+                "collectTypeScriptInfo": {
+                  "exportedEnum": false,
+                  "typeExports": true,
+                },
                 "rspackExperiments": {
-                  "collectTypeScriptInfo": {
-                    "exportedEnum": false,
-                    "typeExports": true,
-                  },
                   "import": [
                     {
                       "libraryName": "foo",
@@ -939,11 +931,9 @@ exports[`plugin-swc > should disable pluginImport when return undefined 1`] = `
                     "legacyDecorator": false,
                   },
                 },
-                "rspackExperiments": {
-                  "collectTypeScriptInfo": {
-                    "exportedEnum": false,
-                    "typeExports": true,
-                  },
+                "collectTypeScriptInfo": {
+                  "exportedEnum": false,
+                  "typeExports": true,
                 },
               },
             },
@@ -997,11 +987,9 @@ exports[`plugin-swc > should disable pluginImport when return undefined 1`] = `
                     "legacyDecorator": false,
                   },
                 },
-                "rspackExperiments": {
-                  "collectTypeScriptInfo": {
-                    "exportedEnum": false,
-                    "typeExports": true,
-                  },
+                "collectTypeScriptInfo": {
+                  "exportedEnum": false,
+                  "typeExports": true,
                 },
               },
             },
@@ -1072,11 +1060,9 @@ exports[`plugin-swc > should disable preset_env in target other than web 1`] = `
                     "legacyDecorator": false,
                   },
                 },
-                "rspackExperiments": {
-                  "collectTypeScriptInfo": {
-                    "exportedEnum": false,
-                    "typeExports": true,
-                  },
+                "collectTypeScriptInfo": {
+                  "exportedEnum": false,
+                  "typeExports": true,
                 },
               },
             },
@@ -1126,11 +1112,9 @@ exports[`plugin-swc > should disable preset_env in target other than web 1`] = `
                     "legacyDecorator": false,
                   },
                 },
-                "rspackExperiments": {
-                  "collectTypeScriptInfo": {
-                    "exportedEnum": false,
-                    "typeExports": true,
-                  },
+                "collectTypeScriptInfo": {
+                  "exportedEnum": false,
+                  "typeExports": true,
                 },
               },
             },
@@ -1205,11 +1189,9 @@ exports[`plugin-swc > should disable preset_env mode 1`] = `
                     "legacyDecorator": false,
                   },
                 },
-                "rspackExperiments": {
-                  "collectTypeScriptInfo": {
-                    "exportedEnum": false,
-                    "typeExports": true,
-                  },
+                "collectTypeScriptInfo": {
+                  "exportedEnum": false,
+                  "typeExports": true,
                 },
               },
             },
@@ -1263,11 +1245,9 @@ exports[`plugin-swc > should disable preset_env mode 1`] = `
                     "legacyDecorator": false,
                   },
                 },
-                "rspackExperiments": {
-                  "collectTypeScriptInfo": {
-                    "exportedEnum": false,
-                    "typeExports": true,
-                  },
+                "collectTypeScriptInfo": {
+                  "exportedEnum": false,
+                  "typeExports": true,
                 },
               },
             },
@@ -1349,11 +1329,9 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
                     "legacyDecorator": false,
                   },
                 },
-                "rspackExperiments": {
-                  "collectTypeScriptInfo": {
-                    "exportedEnum": false,
-                    "typeExports": true,
-                  },
+                "collectTypeScriptInfo": {
+                  "exportedEnum": false,
+                  "typeExports": true,
                 },
               },
             },
@@ -1411,11 +1389,9 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
                     "legacyDecorator": false,
                   },
                 },
-                "rspackExperiments": {
-                  "collectTypeScriptInfo": {
-                    "exportedEnum": false,
-                    "typeExports": true,
-                  },
+                "collectTypeScriptInfo": {
+                  "exportedEnum": false,
+                  "typeExports": true,
                 },
               },
             },
@@ -1497,11 +1473,9 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
                     "legacyDecorator": false,
                   },
                 },
-                "rspackExperiments": {
-                  "collectTypeScriptInfo": {
-                    "exportedEnum": false,
-                    "typeExports": true,
-                  },
+                "collectTypeScriptInfo": {
+                  "exportedEnum": false,
+                  "typeExports": true,
                 },
               },
             },
@@ -1560,11 +1534,9 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
                     "legacyDecorator": false,
                   },
                 },
-                "rspackExperiments": {
-                  "collectTypeScriptInfo": {
-                    "exportedEnum": false,
-                    "typeExports": true,
-                  },
+                "collectTypeScriptInfo": {
+                  "exportedEnum": false,
+                  "typeExports": true,
                 },
               },
             },
@@ -1646,11 +1618,9 @@ exports[`plugin-swc > should has correct core-js 1`] = `
                     "legacyDecorator": false,
                   },
                 },
-                "rspackExperiments": {
-                  "collectTypeScriptInfo": {
-                    "exportedEnum": false,
-                    "typeExports": true,
-                  },
+                "collectTypeScriptInfo": {
+                  "exportedEnum": false,
+                  "typeExports": true,
                 },
               },
             },
@@ -1708,11 +1678,9 @@ exports[`plugin-swc > should has correct core-js 1`] = `
                     "legacyDecorator": false,
                   },
                 },
-                "rspackExperiments": {
-                  "collectTypeScriptInfo": {
-                    "exportedEnum": false,
-                    "typeExports": true,
-                  },
+                "collectTypeScriptInfo": {
+                  "exportedEnum": false,
+                  "typeExports": true,
                 },
               },
             },
@@ -1783,11 +1751,9 @@ exports[`plugin-swc > should has correct core-js 2`] = `
                     "legacyDecorator": false,
                   },
                 },
-                "rspackExperiments": {
-                  "collectTypeScriptInfo": {
-                    "exportedEnum": false,
-                    "typeExports": true,
-                  },
+                "collectTypeScriptInfo": {
+                  "exportedEnum": false,
+                  "typeExports": true,
                 },
               },
             },
@@ -1837,11 +1803,9 @@ exports[`plugin-swc > should has correct core-js 2`] = `
                     "legacyDecorator": false,
                   },
                 },
-                "rspackExperiments": {
-                  "collectTypeScriptInfo": {
-                    "exportedEnum": false,
-                    "typeExports": true,
-                  },
+                "collectTypeScriptInfo": {
+                  "exportedEnum": false,
+                  "typeExports": true,
                 },
               },
             },

--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -53,11 +53,9 @@ exports[`plugins/babel > babel-loader should works with builtin:swc-loader 1`] =
             "legacyDecorator": false,
           },
         },
-        "rspackExperiments": {
-          "collectTypeScriptInfo": {
-            "exportedEnum": false,
-            "typeExports": true,
-          },
+        "collectTypeScriptInfo": {
+          "exportedEnum": false,
+          "typeExports": true,
         },
       },
     },
@@ -145,11 +143,9 @@ exports[`plugins/babel > should apply environment config correctly 1`] = `
             "legacyDecorator": false,
           },
         },
-        "rspackExperiments": {
-          "collectTypeScriptInfo": {
-            "exportedEnum": false,
-            "typeExports": true,
-          },
+        "collectTypeScriptInfo": {
+          "exportedEnum": false,
+          "typeExports": true,
         },
       },
     },
@@ -234,11 +230,9 @@ exports[`plugins/babel > should apply environment config correctly 2`] = `
             "useDefineForClassFields": false,
           },
         },
-        "rspackExperiments": {
-          "collectTypeScriptInfo": {
-            "exportedEnum": false,
-            "typeExports": true,
-          },
+        "collectTypeScriptInfo": {
+          "exportedEnum": false,
+          "typeExports": true,
         },
       },
     },
@@ -324,11 +318,9 @@ exports[`plugins/babel > should set babel-loader 1`] = `
             "legacyDecorator": false,
           },
         },
-        "rspackExperiments": {
-          "collectTypeScriptInfo": {
-            "exportedEnum": false,
-            "typeExports": true,
-          },
+        "collectTypeScriptInfo": {
+          "exportedEnum": false,
+          "typeExports": true,
         },
       },
     },
@@ -413,11 +405,9 @@ exports[`plugins/babel > should set babel-loader when config is add 1`] = `
             "legacyDecorator": false,
           },
         },
-        "rspackExperiments": {
-          "collectTypeScriptInfo": {
-            "exportedEnum": false,
-            "typeExports": true,
-          },
+        "collectTypeScriptInfo": {
+          "exportedEnum": false,
+          "typeExports": true,
         },
       },
     },

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -62,11 +62,9 @@ exports[`plugins/react > should configuring \`tools.swc\` to override react runt
               },
             },
           },
-          "rspackExperiments": {
-            "collectTypeScriptInfo": {
-              "exportedEnum": false,
-              "typeExports": true,
-            },
+          "collectTypeScriptInfo": {
+            "exportedEnum": false,
+            "typeExports": true,
           },
         },
       },
@@ -193,11 +191,9 @@ exports[`plugins/react > should work with swc-loader 1`] = `
               },
             },
           },
-          "rspackExperiments": {
-            "collectTypeScriptInfo": {
-              "exportedEnum": false,
-              "typeExports": true,
-            },
+          "collectTypeScriptInfo": {
+            "exportedEnum": false,
+            "typeExports": true,
           },
         },
       },

--- a/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
@@ -60,11 +60,9 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
               "legacyDecorator": false,
             },
           },
-          "rspackExperiments": {
-            "collectTypeScriptInfo": {
-              "exportedEnum": false,
-              "typeExports": true,
-            },
+          "collectTypeScriptInfo": {
+            "exportedEnum": false,
+            "typeExports": true,
           },
         },
       },
@@ -125,11 +123,9 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
               "legacyDecorator": false,
             },
           },
-          "rspackExperiments": {
-            "collectTypeScriptInfo": {
-              "exportedEnum": false,
-              "typeExports": true,
-            },
+          "collectTypeScriptInfo": {
+            "exportedEnum": false,
+            "typeExports": true,
           },
         },
       },
@@ -192,11 +188,9 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
               "legacyDecorator": false,
             },
           },
-          "rspackExperiments": {
-            "collectTypeScriptInfo": {
-              "exportedEnum": false,
-              "typeExports": true,
-            },
+          "collectTypeScriptInfo": {
+            "exportedEnum": false,
+            "typeExports": true,
           },
         },
       },
@@ -257,11 +251,9 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
               "legacyDecorator": false,
             },
           },
-          "rspackExperiments": {
-            "collectTypeScriptInfo": {
-              "exportedEnum": false,
-              "typeExports": true,
-            },
+          "collectTypeScriptInfo": {
+            "exportedEnum": false,
+            "typeExports": true,
           },
         },
       },
@@ -307,11 +299,9 @@ exports[`plugin-svelte > should add svelte loader and resolve config properly 1`
               "legacyDecorator": false,
             },
           },
-          "rspackExperiments": {
-            "collectTypeScriptInfo": {
-              "exportedEnum": false,
-              "typeExports": true,
-            },
+          "collectTypeScriptInfo": {
+            "exportedEnum": false,
+            "typeExports": true,
           },
         },
       },
@@ -412,11 +402,9 @@ exports[`plugin-svelte > should override default svelte-loader options throw opt
               "legacyDecorator": false,
             },
           },
-          "rspackExperiments": {
-            "collectTypeScriptInfo": {
-              "exportedEnum": false,
-              "typeExports": true,
-            },
+          "collectTypeScriptInfo": {
+            "exportedEnum": false,
+            "typeExports": true,
           },
         },
       },
@@ -473,11 +461,9 @@ exports[`plugin-svelte > should set dev and hotReload to false in production mod
               "legacyDecorator": false,
             },
           },
-          "rspackExperiments": {
-            "collectTypeScriptInfo": {
-              "exportedEnum": true,
-              "typeExports": true,
-            },
+          "collectTypeScriptInfo": {
+            "exportedEnum": true,
+            "typeExports": true,
           },
         },
       },
@@ -538,11 +524,9 @@ exports[`plugin-svelte > should support pass custom preprocess options 1`] = `
               "legacyDecorator": false,
             },
           },
-          "rspackExperiments": {
-            "collectTypeScriptInfo": {
-              "exportedEnum": false,
-              "typeExports": true,
-            },
+          "collectTypeScriptInfo": {
+            "exportedEnum": false,
+            "typeExports": true,
           },
         },
       },
@@ -603,11 +587,9 @@ exports[`plugin-svelte > should turn off HMR by hand correctly 1`] = `
               "legacyDecorator": false,
             },
           },
-          "rspackExperiments": {
-            "collectTypeScriptInfo": {
-              "exportedEnum": false,
-              "typeExports": true,
-            },
+          "collectTypeScriptInfo": {
+            "exportedEnum": false,
+            "typeExports": true,
           },
         },
       },

--- a/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
@@ -59,11 +59,9 @@ exports[`svgr > configure SVGR options 1`] = `
                 },
               },
             },
-            "rspackExperiments": {
-              "collectTypeScriptInfo": {
-                "exportedEnum": false,
-                "typeExports": true,
-              },
+            "collectTypeScriptInfo": {
+              "exportedEnum": false,
+              "typeExports": true,
             },
           },
         },
@@ -165,11 +163,9 @@ exports[`svgr > exportType default / mixedImport false 1`] = `
                 },
               },
             },
-            "rspackExperiments": {
-              "collectTypeScriptInfo": {
-                "exportedEnum": false,
-                "typeExports": true,
-              },
+            "collectTypeScriptInfo": {
+              "exportedEnum": false,
+              "typeExports": true,
             },
           },
         },
@@ -239,11 +235,9 @@ exports[`svgr > exportType default / mixedImport false 1`] = `
                 },
               },
             },
-            "rspackExperiments": {
-              "collectTypeScriptInfo": {
-                "exportedEnum": false,
-                "typeExports": true,
-              },
+            "collectTypeScriptInfo": {
+              "exportedEnum": false,
+              "typeExports": true,
             },
           },
         },
@@ -344,11 +338,9 @@ exports[`svgr > exportType default / mixedImport true 1`] = `
                 },
               },
             },
-            "rspackExperiments": {
-              "collectTypeScriptInfo": {
-                "exportedEnum": false,
-                "typeExports": true,
-              },
+            "collectTypeScriptInfo": {
+              "exportedEnum": false,
+              "typeExports": true,
             },
           },
         },
@@ -418,11 +410,9 @@ exports[`svgr > exportType default / mixedImport true 1`] = `
                 },
               },
             },
-            "rspackExperiments": {
-              "collectTypeScriptInfo": {
-                "exportedEnum": false,
-                "typeExports": true,
-              },
+            "collectTypeScriptInfo": {
+              "exportedEnum": false,
+              "typeExports": true,
             },
           },
         },
@@ -523,11 +513,9 @@ exports[`svgr > exportType named / mixedImport false 1`] = `
                 },
               },
             },
-            "rspackExperiments": {
-              "collectTypeScriptInfo": {
-                "exportedEnum": false,
-                "typeExports": true,
-              },
+            "collectTypeScriptInfo": {
+              "exportedEnum": false,
+              "typeExports": true,
             },
           },
         },
@@ -597,11 +585,9 @@ exports[`svgr > exportType named / mixedImport false 1`] = `
                 },
               },
             },
-            "rspackExperiments": {
-              "collectTypeScriptInfo": {
-                "exportedEnum": false,
-                "typeExports": true,
-              },
+            "collectTypeScriptInfo": {
+              "exportedEnum": false,
+              "typeExports": true,
             },
           },
         },
@@ -702,11 +688,9 @@ exports[`svgr > exportType named / mixedImport true 1`] = `
                 },
               },
             },
-            "rspackExperiments": {
-              "collectTypeScriptInfo": {
-                "exportedEnum": false,
-                "typeExports": true,
-              },
+            "collectTypeScriptInfo": {
+              "exportedEnum": false,
+              "typeExports": true,
             },
           },
         },
@@ -776,11 +760,9 @@ exports[`svgr > exportType named / mixedImport true 1`] = `
                 },
               },
             },
-            "rspackExperiments": {
-              "collectTypeScriptInfo": {
-                "exportedEnum": false,
-                "typeExports": true,
-              },
+            "collectTypeScriptInfo": {
+              "exportedEnum": false,
+              "typeExports": true,
             },
           },
         },


### PR DESCRIPTION
## Summary

Adjust the position of the collectTypeScriptInfo in swc plugin, removing the rspackExperiments level.

## Related Links

https://rspack.rs/blog/announcing-1-7#remove-deprecated-configuration

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
