### PR TITLE
chore(CI): separate Playwright browser installation step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,11 @@ jobs:
 
       - name: Install Dependencies
         if: steps.changes.outputs.changed == 'true'
-        run: pnpm install && cd ./e2e && pnpm run setup
+        run: pnpm install
+
+      - name: Install Playwright Browsers
+        if: steps.changes.outputs.changed == 'true'
+        run: cd ./e2e && pnpm run setup
 
       - name: E2E Test - 1
         if: steps.changes.outputs.changed == 'true'
@@ -151,7 +155,11 @@ jobs:
 
       - name: Install Dependencies
         if: steps.changes.outputs.changed == 'true'
-        run: pnpm install && cd ./e2e && pnpm run setup
+        run: pnpm install
+
+      - name: Install Playwright Browsers
+        if: steps.changes.outputs.changed == 'true'
+        run: cd ./e2e && pnpm run setup
 
       - name: E2E Test - 1
         if: steps.changes.outputs.changed == 'true'


### PR DESCRIPTION
## Summary

Split the combined dependency and Playwright browser installation into two separate steps.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
