### PR TITLE
chore(CI): run E2E type checker

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,7 +106,11 @@ jobs:
 
       - name: Run E2E tests
         if: steps.changes.outputs.changed == 'true'
-        run: npm run e2e:rspack
+        run: pnpm run e2e:rspack
+
+      - name: Run E2E type checker
+        if: steps.changes.outputs.changed == 'true'
+        run: cd e2e && pnpm run type-check
 
   # ======== e2e-webpack ========
   e2e-webpack:
@@ -151,4 +155,4 @@ jobs:
 
       - name: Run E2E tests
         if: steps.changes.outputs.changed == 'true'
-        run: npm run e2e:webpack
+        run: pnpm run e2e:webpack

--- a/e2e/cases/css/postcss-add-plugins/rsbuild.config.ts
+++ b/e2e/cases/css/postcss-add-plugins/rsbuild.config.ts
@@ -1,9 +1,9 @@
 import { defineConfig } from '@rsbuild/core';
 
-const createPostcssPlugin = (color) => {
+const createPostcssPlugin = (color: string) => {
   const plugin = () => ({
     postcssPlugin: 'simple-postcss-plugin',
-    Declaration(decl) {
+    Declaration(decl: { value: unknown }) {
       if (typeof decl.value === 'string') {
         decl.value = decl.value.replace(/red/g, color);
       }


### PR DESCRIPTION
## Summary

Added a new "run type checker" step to the E2E job in the workflow to ensure type safety for E2E tests.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
