### PR TITLE
perf: improve path handling in emptyDir

### DIFF
--- a/packages/core/src/helpers/fs.ts
+++ b/packages/core/src/helpers/fs.ts
@@ -81,8 +81,11 @@ export async function emptyDir(
     await Promise.all(
       entries.map(async (entry) => {
         const fullPath = path.join(dir, entry.name);
-        if (keep.some((reg) => reg.test(toPosixPath(fullPath)))) {
-          return;
+        if (keep.length) {
+          const posixFullPath = toPosixPath(fullPath);
+          if (keep.some((regex) => regex.test(posixFullPath))) {
+            return;
+          }
         }
 
         if (entry.isDirectory()) {


### PR DESCRIPTION
## Summary

Refactored the `emptyDir` function to only convert `fullPath` to POSIX format and check against `keep` regexes if the `keep` array is not empty, making the code more efficient.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
