### PR TITLE
chore(CI): update Node.js to v24 in workflow files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
-          node-version: 22
+          node-version: 24
           package-manager-cache: false
 
       - name: Install Dependencies

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
-          node-version: 22.x
+          node-version: 24
           cache: 'pnpm'
 
       - name: Install Dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
-          node-version: 22
+          node-version: 24
           package-manager-cache: false
 
       # Update npm to the latest version to enable OIDC

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
         if: steps.changes.outputs.changed == 'true'
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
-          node-version: 22
+          node-version: 24
           package-manager-cache: false
 
       - name: Install Dependencies
@@ -97,7 +97,7 @@ jobs:
         if: steps.changes.outputs.changed == 'true'
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
-          node-version: 22
+          node-version: 24
           package-manager-cache: false
 
       - name: Install Dependencies
@@ -146,7 +146,7 @@ jobs:
         if: steps.changes.outputs.changed == 'true'
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
-          node-version: 22
+          node-version: 24
           package-manager-cache: false
 
       - name: Install Dependencies


### PR DESCRIPTION
## Summary

This pull request updates the Node.js version used in all GitHub Actions workflow files from version 22 to version 24.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
