### PR TITLE
chore(CI): no longer run webpack-related e2e tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,53 +106,8 @@ jobs:
 
       - name: Run E2E tests
         if: steps.changes.outputs.changed == 'true'
-        run: pnpm run e2e:rspack
+        run: pnpm run e2e
 
       - name: Run E2E type checker
         if: steps.changes.outputs.changed == 'true'
         run: cd e2e && pnpm run type-check
-
-  # ======== e2e-webpack ========
-  e2e-webpack:
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        with:
-          fetch-depth: 1
-
-      - name: Install Pnpm
-        run: |
-          npm install -g corepack@latest --force
-          corepack enable
-
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: changes
-        with:
-          predicate-quantifier: 'every'
-          filters: |
-            changed:
-              - "!**/*.md"
-              - "!**/*.mdx"
-              - "!**/_meta.json"
-              - "!**/dictionary.txt"
-
-      - name: Setup Node.js
-        if: steps.changes.outputs.changed == 'true'
-        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
-        with:
-          node-version: 24
-          package-manager-cache: false
-
-      - name: Install Dependencies
-        if: steps.changes.outputs.changed == 'true'
-        run: pnpm install
-
-      - name: Run E2E tests
-        if: steps.changes.outputs.changed == 'true'
-        run: pnpm run e2e:webpack

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ This monorepo contains the Rsbuild build tool, plugins, and related packages. Rs
 
 - **Build**: `pnpm build` (all packages) | `npx nx build @rsbuild/core` (specific)
 - **Test**: `pnpm test` (unit tests) | `pnpm test:watch` (watch mode) | `pnpm e2e` (E2E tests)
-- **Single test**: `pnpm test packages/core/src/foo.test.ts` (unit test) | `pnpm e2e:rspack cli/base/index.test.ts` (E2E test)
+- **Single test**: `pnpm test packages/core/src/foo.test.ts` (unit test) | `pnpm e2e cli/base/index.test.ts` (E2E test)
 - **Lint**: `pnpm lint` (REQUIRED before commits) | `pnpm format` (format code)
 
 ## Code style

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,8 +89,8 @@ pnpm run e2e
 If you need to run a specified test, you can add keywords to filter:
 
 ```sh
-# Only run test cases which contains `vue` keyword in file path with Rspack
-pnpm e2e:rspack vue
+# Only run test cases which contains `css` keyword in file path
+pnpm e2e css
 ```
 
 ---

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -16,15 +16,8 @@ Most of the E2E tests in Rsbuild are run by both Rspack and webpack at the same 
 # Run all test cases, including Rspack and webpack
 pnpm e2e
 
-# Run test cases for Rspack
-pnpm e2e:rspack
-
-# Run test cases for webpack
-pnpm e2e:webpack
-
 # Run specific test case, such as "css"
-pnpm e2e:webpack css
-pnpm e2e:rspack css
+pnpm e2e css
 ```
 
 ## Debugging

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -5,9 +5,7 @@
   "version": "1.0.0",
   "scripts": {
     "setup": "pnpm exec playwright install chromium --with-deps",
-    "e2e": "pnpm e2e:rspack && pnpm e2e:webpack && pnpm type-check",
-    "e2e:rspack": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --no-warnings\" playwright test",
-    "e2e:webpack": "cross-env PROVIDE_TYPE=webpack playwright test",
+    "e2e": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --no-warnings\" playwright test",
     "type-check": "tsc"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,6 @@
     "check-spell": "pnpx cspell && heading-case",
     "doc": "cd website && pnpm dev",
     "e2e": "cd ./e2e && pnpm e2e",
-    "e2e:rspack": "cd ./e2e && pnpm e2e:rspack",
-    "e2e:webpack": "cd ./e2e && pnpm e2e:webpack",
     "format": "prettier --experimental-cli --write . && heading-case --write",
     "lint": "biome check && pnpm lint:type",
     "lint:type": "rslint",


### PR DESCRIPTION
## Summary

No longer run webpack-related e2e tests as Rsbuild v2 does not support switching to webpack.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
