### PR TITLE
test: remove webpack-related e2e helpers

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -10,10 +10,8 @@ This folder contains the E2E test cases of Rsbuild. The E2E suite is powered by 
 
 ## Commands
 
-Most of the E2E tests in Rsbuild are run by both Rspack and webpack at the same time. This is to check that the functionality of Rspack is correctly aligned with webpack.
-
 ```bash
-# Run all test cases, including Rspack and webpack
+# Run all test cases
 pnpm e2e
 
 # Run specific test case, such as "css"
@@ -32,23 +30,10 @@ npx rsbuild build
 
 ## Add test cases
 
-Test cases added using the `test` method will run in both Rspack and webpack.
-
 ```ts
 import { test, expect } from '@playwright/test';
 
-// both webpack and Rspack
 test('test 1 + 1', () => {
-  expect(1 + 1).toBe(2);
-});
-```
-
-You can run tests for Rspack only by using the `rspackTest` method.
-
-```ts
-import { rspackTest } from '@e2e/helper';
-
-rspackTest('test 1 + 1', () => {
   expect(1 + 1).toBe(2);
 });
 ```

--- a/e2e/cases/assets/filename-conflict-hint/index.test.ts
+++ b/e2e/cases/assets/filename-conflict-hint/index.test.ts
@@ -1,16 +1,13 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should print output.filename hints as expected',
-  async ({ build }) => {
-    const rsbuild = await build({
-      catchBuildError: true,
-    });
+test('should print output.filename hints as expected', async ({ build }) => {
+  const rsbuild = await build({
+    catchBuildError: true,
+  });
 
-    expect(rsbuild.buildError).toBeTruthy();
+  expect(rsbuild.buildError).toBeTruthy();
 
-    await rsbuild.expectLog(
-      'You may need to adjust output.filename configuration to prevent name conflicts.',
-    );
-  },
-);
+  await rsbuild.expectLog(
+    'You may need to adjust output.filename configuration to prevent name conflicts.',
+  );
+});

--- a/e2e/cases/assets/filename-hash/index.test.ts
+++ b/e2e/cases/assets/filename-hash/index.test.ts
@@ -1,6 +1,6 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest('should set the hash format to fullhash', async ({ build }) => {
+test('should set the hash format to fullhash', async ({ build }) => {
   const rsbuild = await build();
 
   const files = rsbuild.getDistFiles();

--- a/e2e/cases/assets/import-json-attributes/index.test.ts
+++ b/e2e/cases/assets/import-json-attributes/index.test.ts
@@ -1,13 +1,13 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should import JSON with import attributes and tree shake unused properties',
-  async ({ page, buildPreview }) => {
-    const rsbuild = await buildPreview();
-    const content = await rsbuild.getIndexBundle();
-    expect(content.includes('foo')).toBeFalsy();
-    expect(content.includes('list')).toBeFalsy();
-    expect(content.includes('window.testValue=20')).toBeTruthy();
-    expect(await page.evaluate('window.testValue')).toBe(20);
-  },
-);
+test('should import JSON with import attributes and tree shake unused properties', async ({
+  page,
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview();
+  const content = await rsbuild.getIndexBundle();
+  expect(content.includes('foo')).toBeFalsy();
+  expect(content.includes('list')).toBeFalsy();
+  expect(content.includes('window.testValue=20')).toBeTruthy();
+  expect(await page.evaluate('window.testValue')).toBe(20);
+});

--- a/e2e/cases/assets/import-json-default/index.test.ts
+++ b/e2e/cases/assets/import-json-default/index.test.ts
@@ -1,13 +1,13 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should import JSON with default import and tree shake unused properties',
-  async ({ page, buildPreview }) => {
-    const rsbuild = await buildPreview();
-    const content = await rsbuild.getIndexBundle();
-    expect(content.includes('foo')).toBeFalsy();
-    expect(content.includes('list')).toBeFalsy();
-    expect(content.includes('window.testValue=20')).toBeTruthy();
-    expect(await page.evaluate('window.testValue')).toBe(20);
-  },
-);
+test('should import JSON with default import and tree shake unused properties', async ({
+  page,
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview();
+  const content = await rsbuild.getIndexBundle();
+  expect(content.includes('foo')).toBeFalsy();
+  expect(content.includes('list')).toBeFalsy();
+  expect(content.includes('window.testValue=20')).toBeTruthy();
+  expect(await page.evaluate('window.testValue')).toBe(20);
+});

--- a/e2e/cases/assets/import-json-named/index.test.ts
+++ b/e2e/cases/assets/import-json-named/index.test.ts
@@ -1,13 +1,13 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should import JSON with named import and tree shake unused properties',
-  async ({ page, buildPreview }) => {
-    const rsbuild = await buildPreview();
-    const content = await rsbuild.getIndexBundle();
-    expect(content.includes('foo')).toBeFalsy();
-    expect(content.includes('list')).toBeFalsy();
-    expect(content.includes('window.testValue=20')).toBeTruthy();
-    expect(await page.evaluate('window.testValue')).toBe(20);
-  },
-);
+test('should import JSON with named import and tree shake unused properties', async ({
+  page,
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview();
+  const content = await rsbuild.getIndexBundle();
+  expect(content.includes('foo')).toBeFalsy();
+  expect(content.includes('list')).toBeFalsy();
+  expect(content.includes('window.testValue=20')).toBeTruthy();
+  expect(await page.evaluate('window.testValue')).toBe(20);
+});

--- a/e2e/cases/assets/import-json-raw-query/index.test.ts
+++ b/e2e/cases/assets/import-json-raw-query/index.test.ts
@@ -1,17 +1,17 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should import raw JSON with raw query',
-  async ({ page, buildPreview }) => {
-    await buildPreview();
+test('should import raw JSON with raw query', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview();
 
-    expect(await page.evaluate('window.a')).toBe(
-      readFileSync(join(import.meta.dirname, './src/a.json'), 'utf-8'),
-    );
-    expect(await page.evaluate('window.b')).toBe(
-      readFileSync(join(import.meta.dirname, './src/b.json'), 'utf-8'),
-    );
-  },
-);
+  expect(await page.evaluate('window.a')).toBe(
+    readFileSync(join(import.meta.dirname, './src/a.json'), 'utf-8'),
+  );
+  expect(await page.evaluate('window.b')).toBe(
+    readFileSync(join(import.meta.dirname, './src/b.json'), 'utf-8'),
+  );
+});

--- a/e2e/cases/assets/script-as-assets/index.test.ts
+++ b/e2e/cases/assets/script-as-assets/index.test.ts
@@ -1,39 +1,39 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should allow to use `new URL` to reference script as assets',
-  async ({ page, buildPreview }) => {
-    const rsbuild = await buildPreview();
+test('should allow to use `new URL` to reference script as assets', async ({
+  page,
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview();
 
-    const files = rsbuild.getDistFiles();
-    const filenames = Object.keys(files);
+  const files = rsbuild.getDistFiles();
+  const filenames = Object.keys(files);
 
-    const test1 = filenames.find((filename) =>
-      filename.includes('dist/static/assets/test1.js'),
-    );
-    const test2 = filenames.find((filename) =>
-      filename.includes('dist/static/assets/test2.ts'),
-    );
-    const test3 = filenames.find((filename) =>
-      filename.includes('dist/static/assets/test3.mjs'),
-    );
+  const test1 = filenames.find((filename) =>
+    filename.includes('dist/static/assets/test1.js'),
+  );
+  const test2 = filenames.find((filename) =>
+    filename.includes('dist/static/assets/test2.ts'),
+  );
+  const test3 = filenames.find((filename) =>
+    filename.includes('dist/static/assets/test3.mjs'),
+  );
 
-    expect(test1).toBeDefined();
-    expect(test2).toBeDefined();
-    expect(test3).toBeDefined();
+  expect(test1).toBeDefined();
+  expect(test2).toBeDefined();
+  expect(test3).toBeDefined();
 
-    expect(files[test1!]).toEqual('export const test="test1";');
-    expect(files[test2!]).toContain(`export const test2: string = 'test2';`);
-    expect(files[test3!]).toEqual('export const test="test3";');
+  expect(files[test1!]).toEqual('export const test="test1";');
+  expect(files[test2!]).toContain(`export const test2: string = 'test2';`);
+  expect(files[test3!]).toEqual('export const test="test3";');
 
-    expect(await page.evaluate('window.test1')).toBe(
-      `http://localhost:${rsbuild.port}/static/assets/test1.js`,
-    );
-    expect(await page.evaluate('window.test2')).toBe(
-      `http://localhost:${rsbuild.port}/static/assets/test2.ts`,
-    );
-    expect(await page.evaluate('window.test3')).toBe(
-      `http://localhost:${rsbuild.port}/static/assets/test3.mjs`,
-    );
-  },
-);
+  expect(await page.evaluate('window.test1')).toBe(
+    `http://localhost:${rsbuild.port}/static/assets/test1.js`,
+  );
+  expect(await page.evaluate('window.test2')).toBe(
+    `http://localhost:${rsbuild.port}/static/assets/test2.ts`,
+  );
+  expect(await page.evaluate('window.test3')).toBe(
+    `http://localhost:${rsbuild.port}/static/assets/test3.mjs`,
+  );
+});

--- a/e2e/cases/assets/styles-as-assets/index.test.ts
+++ b/e2e/cases/assets/styles-as-assets/index.test.ts
@@ -1,45 +1,45 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should allow to use `new URL` to reference styles as assets',
-  async ({ page, buildPreview }) => {
-    const rsbuild = await buildPreview();
+test('should allow to use `new URL` to reference styles as assets', async ({
+  page,
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview();
 
-    const files = rsbuild.getDistFiles();
-    const filenames = Object.keys(files);
+  const files = rsbuild.getDistFiles();
+  const filenames = Object.keys(files);
 
-    const test1 = filenames.find((filename) =>
-      filename.includes('dist/static/assets/test1.css'),
-    );
-    const test2 = filenames.find((filename) =>
-      filename.includes('dist/static/assets/test2.less'),
-    );
-    const test3 = filenames.find((filename) =>
-      filename.includes('dist/static/assets/test3.scss'),
-    );
-    const test4 = filenames.find((filename) =>
-      filename.includes('dist/static/assets/test4.styl'),
-    );
+  const test1 = filenames.find((filename) =>
+    filename.includes('dist/static/assets/test1.css'),
+  );
+  const test2 = filenames.find((filename) =>
+    filename.includes('dist/static/assets/test2.less'),
+  );
+  const test3 = filenames.find((filename) =>
+    filename.includes('dist/static/assets/test3.scss'),
+  );
+  const test4 = filenames.find((filename) =>
+    filename.includes('dist/static/assets/test4.styl'),
+  );
 
-    expect(test1).toBeDefined();
-    expect(test2).toBeDefined();
-    expect(test3).toBeDefined();
-    expect(test4).toBeDefined();
-    expect(files[test1!]).toContain('body{color:red}');
-    expect(files[test2!]).toContain('& .foo');
-    expect(files[test3!]).toContain('& .foo');
-    expect(files[test4!]).toContain('color yellow');
-    expect(await page.evaluate('window.test1')).toBe(
-      `http://localhost:${rsbuild.port}/static/assets/test1.css`,
-    );
-    expect(await page.evaluate('window.test2')).toBe(
-      `http://localhost:${rsbuild.port}/static/assets/test2.less`,
-    );
-    expect(await page.evaluate('window.test3')).toBe(
-      `http://localhost:${rsbuild.port}/static/assets/test3.scss`,
-    );
-    expect(await page.evaluate('window.test4')).toBe(
-      `http://localhost:${rsbuild.port}/static/assets/test4.styl`,
-    );
-  },
-);
+  expect(test1).toBeDefined();
+  expect(test2).toBeDefined();
+  expect(test3).toBeDefined();
+  expect(test4).toBeDefined();
+  expect(files[test1!]).toContain('body{color:red}');
+  expect(files[test2!]).toContain('& .foo');
+  expect(files[test3!]).toContain('& .foo');
+  expect(files[test4!]).toContain('color yellow');
+  expect(await page.evaluate('window.test1')).toBe(
+    `http://localhost:${rsbuild.port}/static/assets/test1.css`,
+  );
+  expect(await page.evaluate('window.test2')).toBe(
+    `http://localhost:${rsbuild.port}/static/assets/test2.less`,
+  );
+  expect(await page.evaluate('window.test3')).toBe(
+    `http://localhost:${rsbuild.port}/static/assets/test3.scss`,
+  );
+  expect(await page.evaluate('window.test4')).toBe(
+    `http://localhost:${rsbuild.port}/static/assets/test4.styl`,
+  );
+});

--- a/e2e/cases/browser-logs/basic-error/index.test.ts
+++ b/e2e/cases/browser-logs/basic-error/index.test.ts
@@ -1,17 +1,16 @@
-import { rspackTest } from '@e2e/helper';
+import { test } from '@e2e/helper';
 
 const EXPECTED_LOG =
   'error   [browser] Uncaught Error: test (src/index.js:1:0)';
 
-rspackTest(
-  'should forward browser error logs to terminal by default',
-  async ({ dev }) => {
-    const rsbuild = await dev();
-    await rsbuild.expectLog(EXPECTED_LOG, { posix: true });
-  },
-);
+test('should forward browser error logs to terminal by default', async ({
+  dev,
+}) => {
+  const rsbuild = await dev();
+  await rsbuild.expectLog(EXPECTED_LOG, { posix: true });
+});
 
-rspackTest('should disable forwarding browser error logs', async ({ dev }) => {
+test('should disable forwarding browser error logs', async ({ dev }) => {
   const rsbuild = await dev({
     config: {
       dev: {

--- a/e2e/cases/browser-logs/custom-source-map/index.test.ts
+++ b/e2e/cases/browser-logs/custom-source-map/index.test.ts
@@ -1,48 +1,46 @@
 import { join, relative } from 'node:path';
-import { rspackTest, toPosixPath } from '@e2e/helper';
+import { test, toPosixPath } from '@e2e/helper';
 
 const EXPECTED_LOG =
   'error   [browser] Uncaught Error: test (src/index.js:1:0)';
 
-rspackTest(
-  'should parse source map correctly if source path is absolute',
-  async ({ dev }) => {
-    const rsbuild = await dev({
-      config: {
-        tools: {
-          rspack: {
-            output: {
-              devtoolModuleFilenameTemplate(info) {
-                return toPosixPath(info.absoluteResourcePath);
-              },
+test('should parse source map correctly if source path is absolute', async ({
+  dev,
+}) => {
+  const rsbuild = await dev({
+    config: {
+      tools: {
+        rspack: {
+          output: {
+            devtoolModuleFilenameTemplate(info) {
+              return toPosixPath(info.absoluteResourcePath);
             },
           },
         },
       },
-    });
-    await rsbuild.expectLog(EXPECTED_LOG, { posix: true });
-  },
-);
+    },
+  });
+  await rsbuild.expectLog(EXPECTED_LOG, { posix: true });
+});
 
-rspackTest(
-  'should parse source map correctly if source path is relative to source map path',
-  async ({ dev }) => {
-    const sourceMapPath = join(import.meta.dirname, 'dist/static/js');
-    const rsbuild = await dev({
-      config: {
-        tools: {
-          rspack: {
-            output: {
-              devtoolModuleFilenameTemplate(info) {
-                return toPosixPath(
-                  relative(sourceMapPath, info.absoluteResourcePath),
-                );
-              },
+test('should parse source map correctly if source path is relative to source map path', async ({
+  dev,
+}) => {
+  const sourceMapPath = join(import.meta.dirname, 'dist/static/js');
+  const rsbuild = await dev({
+    config: {
+      tools: {
+        rspack: {
+          output: {
+            devtoolModuleFilenameTemplate(info) {
+              return toPosixPath(
+                relative(sourceMapPath, info.absoluteResourcePath),
+              );
             },
           },
         },
       },
-    });
-    await rsbuild.expectLog(EXPECTED_LOG, { posix: true });
-  },
-);
+    },
+  });
+  await rsbuild.expectLog(EXPECTED_LOG, { posix: true });
+});

--- a/e2e/cases/browser-logs/dedupe-log/index.test.ts
+++ b/e2e/cases/browser-logs/dedupe-log/index.test.ts
@@ -1,40 +1,42 @@
 import { join } from 'node:path';
-import { gotoPage, rspackTest } from '@e2e/helper';
+import { gotoPage, test } from '@e2e/helper';
 
-rspackTest(
-  'should not output the same browser log',
-  async ({ devOnly, page, editFile, copySrcDir }) => {
-    const tempSrc = await copySrcDir();
+test('should not output the same browser log', async ({
+  devOnly,
+  page,
+  editFile,
+  copySrcDir,
+}) => {
+  const tempSrc = await copySrcDir();
 
-    const rsbuild = await devOnly({
-      config: {
-        source: {
-          entry: {
-            index: join(tempSrc, 'index.js'),
-          },
+  const rsbuild = await devOnly({
+    config: {
+      source: {
+        entry: {
+          index: join(tempSrc, 'index.js'),
         },
       },
-    });
+    },
+  });
 
-    // initial build
-    await gotoPage(page, rsbuild, '/', { hash: 'test1' });
-    await rsbuild.expectLog('Error: value is #test1');
-    rsbuild.clearLogs();
+  // initial build
+  await gotoPage(page, rsbuild, '/', { hash: 'test1' });
+  await rsbuild.expectLog('Error: value is #test1');
+  rsbuild.clearLogs();
 
-    // change hash
-    await gotoPage(page, rsbuild, '/', { hash: 'test2' });
-    await page.reload();
-    await rsbuild.expectLog('Error: value is #test2');
-    rsbuild.expectNoLog('Error: value is #test1');
-    rsbuild.clearLogs();
+  // change hash
+  await gotoPage(page, rsbuild, '/', { hash: 'test2' });
+  await page.reload();
+  await rsbuild.expectLog('Error: value is #test2');
+  rsbuild.expectNoLog('Error: value is #test1');
+  rsbuild.clearLogs();
 
-    // after rebuild, logs can be printed again
-    await editFile(join(tempSrc, 'index.js'), (content) =>
-      content.replace('value', 'value2'),
-    );
-    await rsbuild.expectLog('Error: value2 is #test2');
-    await gotoPage(page, rsbuild, '/', { hash: 'test1' });
-    await page.reload();
-    await rsbuild.expectLog('Error: value2 is #test1');
-  },
-);
+  // after rebuild, logs can be printed again
+  await editFile(join(tempSrc, 'index.js'), (content) =>
+    content.replace('value', 'value2'),
+  );
+  await rsbuild.expectLog('Error: value2 is #test2');
+  await gotoPage(page, rsbuild, '/', { hash: 'test1' });
+  await page.reload();
+  await rsbuild.expectLog('Error: value2 is #test1');
+});

--- a/e2e/cases/browser-logs/react-error/index.test.ts
+++ b/e2e/cases/browser-logs/react-error/index.test.ts
@@ -1,27 +1,27 @@
-import { gotoPage, rspackTest } from '@e2e/helper';
+import { gotoPage, test } from '@e2e/helper';
 
-rspackTest(
-  'should forward React runtime error logs to terminal',
-  async ({ devOnly, page }) => {
-    const rsbuild = await devOnly();
+test('should forward React runtime error logs to terminal', async ({
+  devOnly,
+  page,
+}) => {
+  const rsbuild = await devOnly();
 
-    await gotoPage(page, rsbuild, '/undefinedError');
-    await rsbuild.expectLog(
-      `error   [browser] Uncaught TypeError: Cannot read properties of undefined (reading 'name') at ComponentWithUndefinedError (src/undefinedError.jsx:5:0)`,
-      { posix: true },
-    );
+  await gotoPage(page, rsbuild, '/undefinedError');
+  await rsbuild.expectLog(
+    `error   [browser] Uncaught TypeError: Cannot read properties of undefined (reading 'name') at ComponentWithUndefinedError (src/undefinedError.jsx:5:0)`,
+    { posix: true },
+  );
 
-    await gotoPage(page, rsbuild, '/effectError');
-    await rsbuild.expectLog(
-      `error   [browser] Uncaught SyntaxError: Unexpected token 'i', "invalid json" is not valid JSON (src/effectError.jsx:6:0)`,
-      { posix: true },
-    );
+  await gotoPage(page, rsbuild, '/effectError');
+  await rsbuild.expectLog(
+    `error   [browser] Uncaught SyntaxError: Unexpected token 'i', "invalid json" is not valid JSON (src/effectError.jsx:6:0)`,
+    { posix: true },
+  );
 
-    await gotoPage(page, rsbuild, '/eventError');
-    await page.click('button');
-    await rsbuild.expectLog(
-      `error   [browser] Uncaught TypeError: Cannot read properties of null (reading 'someMethod') at handleClick (src/eventError.jsx:6:0)`,
-      { posix: true },
-    );
-  },
-);
+  await gotoPage(page, rsbuild, '/eventError');
+  await page.click('button');
+  await rsbuild.expectLog(
+    `error   [browser] Uncaught TypeError: Cannot read properties of null (reading 'someMethod') at handleClick (src/eventError.jsx:6:0)`,
+    { posix: true },
+  );
+});

--- a/e2e/cases/browser-logs/skip-build-error/index.test.ts
+++ b/e2e/cases/browser-logs/skip-build-error/index.test.ts
@@ -1,10 +1,7 @@
-import { MODULE_BUILD_FAILED_LOG, rspackTest } from '@e2e/helper';
+import { MODULE_BUILD_FAILED_LOG, test } from '@e2e/helper';
 
-rspackTest(
-  'should skip browser error logs if build failed',
-  async ({ dev }) => {
-    const rsbuild = await dev();
-    await rsbuild.expectLog(MODULE_BUILD_FAILED_LOG);
-    rsbuild.expectNoLog('[browser]');
-  },
-);
+test('should skip browser error logs if build failed', async ({ dev }) => {
+  const rsbuild = await dev();
+  await rsbuild.expectLog(MODULE_BUILD_FAILED_LOG);
+  rsbuild.expectNoLog('[browser]');
+});

--- a/e2e/cases/browser-logs/stack-trace-full-react-error/index.test.ts
+++ b/e2e/cases/browser-logs/stack-trace-full-react-error/index.test.ts
@@ -1,14 +1,13 @@
-import { rspackTest } from '@e2e/helper';
+import { test } from '@e2e/helper';
 
 // Omitted some parts of the stack trace as they are not static
 const EXPECTED_LOG = `error   [browser] Uncaught ReferenceError: undefinedValue is not defined
     at App (src/App.jsx:4:0)
     at Object.react_stack_bottom_frame (../../../../node_modules/.pnpm/react-dom`;
 
-rspackTest(
-  'should display formatted full stack trace in React component',
-  async ({ dev }) => {
-    const rsbuild = await dev();
-    await rsbuild.expectLog(EXPECTED_LOG, { posix: true });
-  },
-);
+test('should display formatted full stack trace in React component', async ({
+  dev,
+}) => {
+  const rsbuild = await dev();
+  await rsbuild.expectLog(EXPECTED_LOG, { posix: true });
+});

--- a/e2e/cases/browser-logs/stack-trace-full-rspack-runtime/index.test.ts
+++ b/e2e/cases/browser-logs/stack-trace-full-rspack-runtime/index.test.ts
@@ -1,12 +1,11 @@
-import { rspackTest } from '@e2e/helper';
+import { test } from '@e2e/helper';
 
-rspackTest(
-  'should display stack frame for Rspack runtime modules',
-  async ({ dev }) => {
-    const rsbuild = await dev();
-    await rsbuild.expectLog('[browser] Uncaught Error: foo');
-    await rsbuild.expectLog(
-      /at __webpack_require__\.O \(webpack\/runtime\/on_chunk_loaded:\d+:\d+\)/,
-    );
-  },
-);
+test('should display stack frame for Rspack runtime modules', async ({
+  dev,
+}) => {
+  const rsbuild = await dev();
+  await rsbuild.expectLog('[browser] Uncaught Error: foo');
+  await rsbuild.expectLog(
+    /at __webpack_require__\.O \(webpack\/runtime\/on_chunk_loaded:\d+:\d+\)/,
+  );
+});

--- a/e2e/cases/browser-logs/stack-trace-full/index.test.ts
+++ b/e2e/cases/browser-logs/stack-trace-full/index.test.ts
@@ -1,4 +1,4 @@
-import { rspackTest } from '@e2e/helper';
+import { test } from '@e2e/helper';
 
 // Omitted some parts of the stack trace as they are not static
 const EXPECTED_LOG = `error   [browser] Uncaught Error: foo
@@ -6,7 +6,7 @@ const EXPECTED_LOG = `error   [browser] Uncaught Error: foo
     at src/index.js:3:0
     at __webpack_require__`;
 
-rspackTest('should display formatted full stack trace', async ({ dev }) => {
+test('should display formatted full stack trace', async ({ dev }) => {
   const rsbuild = await dev();
   await rsbuild.expectLog(EXPECTED_LOG, { posix: true });
 });

--- a/e2e/cases/browser-logs/stack-trace-none/index.test.ts
+++ b/e2e/cases/browser-logs/stack-trace-none/index.test.ts
@@ -1,11 +1,8 @@
-import { rspackTest } from '@e2e/helper';
+import { test } from '@e2e/helper';
 
 const EXPECTED_LOG = 'error   [browser] Uncaught Error: test';
 
-rspackTest(
-  'should hide stack trace when stackTrace is none',
-  async ({ dev }) => {
-    const rsbuild = await dev();
-    await rsbuild.expectLog(EXPECTED_LOG, { posix: true, strict: true });
-  },
-);
+test('should hide stack trace when stackTrace is none', async ({ dev }) => {
+  const rsbuild = await dev();
+  await rsbuild.expectLog(EXPECTED_LOG, { posix: true, strict: true });
+});

--- a/e2e/cases/browser-logs/unhandled-rejection/index.test.ts
+++ b/e2e/cases/browser-logs/unhandled-rejection/index.test.ts
@@ -1,33 +1,30 @@
-import { rspackTest } from '@e2e/helper';
+import { test } from '@e2e/helper';
 
-rspackTest(
-  'should forward browser unhandled rejection logs to terminal',
-  async ({ dev }) => {
-    const rsbuild = await dev();
-    await rsbuild.expectLog('error   [browser] Uncaught (in promise) 404');
-    await rsbuild.expectLog('error   [browser] Uncaught (in promise) false');
-    await rsbuild.expectLog('error   [browser] Uncaught (in promise) null');
-    await rsbuild.expectLog(
-      'error   [browser] Uncaught (in promise) undefined',
-    );
-    await rsbuild.expectLog('error   [browser] Uncaught (in promise) string');
-    await rsbuild.expectLog(
-      'error   [browser] Uncaught (in promise) {"name":"Custom","message":"custom message"}',
-    );
-    await rsbuild.expectLog(
-      'error   [browser] Uncaught (in promise) Error: reason (src/index.js:7:0)',
-      { posix: true },
-    );
-    await rsbuild.expectLog(
-      'error   [browser] Uncaught (in promise) AbortError: Aborted',
-    );
-    await rsbuild.expectLog(
-      'error   [browser] Uncaught (in promise) Error: Thrown in async (src/index.js:11:0)',
-      { posix: true },
-    );
-    await rsbuild.expectLog(
-      'error   [browser] Uncaught (in promise) AbortError: signal is aborted without reason (src/index.js:16:0)',
-      { posix: true },
-    );
-  },
-);
+test('should forward browser unhandled rejection logs to terminal', async ({
+  dev,
+}) => {
+  const rsbuild = await dev();
+  await rsbuild.expectLog('error   [browser] Uncaught (in promise) 404');
+  await rsbuild.expectLog('error   [browser] Uncaught (in promise) false');
+  await rsbuild.expectLog('error   [browser] Uncaught (in promise) null');
+  await rsbuild.expectLog('error   [browser] Uncaught (in promise) undefined');
+  await rsbuild.expectLog('error   [browser] Uncaught (in promise) string');
+  await rsbuild.expectLog(
+    'error   [browser] Uncaught (in promise) {"name":"Custom","message":"custom message"}',
+  );
+  await rsbuild.expectLog(
+    'error   [browser] Uncaught (in promise) Error: reason (src/index.js:7:0)',
+    { posix: true },
+  );
+  await rsbuild.expectLog(
+    'error   [browser] Uncaught (in promise) AbortError: Aborted',
+  );
+  await rsbuild.expectLog(
+    'error   [browser] Uncaught (in promise) Error: Thrown in async (src/index.js:11:0)',
+    { posix: true },
+  );
+  await rsbuild.expectLog(
+    'error   [browser] Uncaught (in promise) AbortError: signal is aborted without reason (src/index.js:16:0)',
+    { posix: true },
+  );
+});

--- a/e2e/cases/browser-logs/vue-error/index.test.ts
+++ b/e2e/cases/browser-logs/vue-error/index.test.ts
@@ -1,21 +1,21 @@
-import { gotoPage, rspackTest } from '@e2e/helper';
+import { gotoPage, test } from '@e2e/helper';
 
-rspackTest(
-  'should forward Vue runtime error logs to terminal',
-  async ({ devOnly, page }) => {
-    const rsbuild = await devOnly();
+test('should forward Vue runtime error logs to terminal', async ({
+  devOnly,
+  page,
+}) => {
+  const rsbuild = await devOnly();
 
-    await gotoPage(page, rsbuild, '/undefinedError');
-    await rsbuild.expectLog(
-      `error   [browser] Uncaught TypeError: Cannot read properties of undefined (reading 'name') at Proxy.render (src/UndefinedError.vue:2:0)`,
-      { posix: true },
-    );
+  await gotoPage(page, rsbuild, '/undefinedError');
+  await rsbuild.expectLog(
+    `error   [browser] Uncaught TypeError: Cannot read properties of undefined (reading 'name') at Proxy.render (src/UndefinedError.vue:2:0)`,
+    { posix: true },
+  );
 
-    await gotoPage(page, rsbuild, '/eventError');
-    await page.click('button');
-    await rsbuild.expectLog(
-      `error   [browser] Uncaught TypeError: Cannot read properties of null (reading 'someMethod') at handleClick (src/EventError.vue:8:0)`,
-      { posix: true },
-    );
-  },
-);
+  await gotoPage(page, rsbuild, '/eventError');
+  await page.click('button');
+  await rsbuild.expectLog(
+    `error   [browser] Uncaught TypeError: Cannot read properties of null (reading 'someMethod') at handleClick (src/EventError.vue:8:0)`,
+    { posix: true },
+  );
+});

--- a/e2e/cases/cli/base/index.test.ts
+++ b/e2e/cases/cli/base/index.test.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
-import { expect, readDirContents, rspackTest } from '@e2e/helper';
+import { expect, readDirContents, test } from '@e2e/helper';
 
-rspackTest('should run allow to specify base path', async ({ execCliSync }) => {
+test('should run allow to specify base path', async ({ execCliSync }) => {
   execCliSync('build --base /test');
 
   const outputs = await readDirContents(path.join(import.meta.dirname, 'dist'));

--- a/e2e/cases/cli/build-watch-options/index.test.ts
+++ b/e2e/cases/cli/build-watch-options/index.test.ts
@@ -1,34 +1,35 @@
 import path from 'node:path';
-import { expectFileWithContent, rspackTest } from '@e2e/helper';
+import { expectFileWithContent, test } from '@e2e/helper';
 import fse from 'fs-extra';
 
-rspackTest(
-  'should allow to custom watch options for build watch',
-  async ({ execCli, logHelper, copySrcDir }) => {
-    const tempSrc = await copySrcDir();
-    const distIndexFile = path.join(
-      import.meta.dirname,
-      'dist/static/js/index.js',
-    );
-    const fooFile = path.join(tempSrc, 'foo.js');
-    const barFile = path.join(tempSrc, 'bar.js');
+test('should allow to custom watch options for build watch', async ({
+  execCli,
+  logHelper,
+  copySrcDir,
+}) => {
+  const tempSrc = await copySrcDir();
+  const distIndexFile = path.join(
+    import.meta.dirname,
+    'dist/static/js/index.js',
+  );
+  const fooFile = path.join(tempSrc, 'foo.js');
+  const barFile = path.join(tempSrc, 'bar.js');
 
-    execCli('build --watch');
-    const { expectLog, expectNoLog, expectBuildEnd, clearLogs } = logHelper;
+  execCli('build --watch');
+  const { expectLog, expectNoLog, expectBuildEnd, clearLogs } = logHelper;
 
-    await expectBuildEnd();
-    await expectFileWithContent(distIndexFile, 'foo1bar1');
-    clearLogs();
+  await expectBuildEnd();
+  await expectFileWithContent(distIndexFile, 'foo1bar1');
+  clearLogs();
 
-    // should watch foo.js
-    fse.outputFileSync(fooFile, `export const foo = 'foo2';`);
-    await expectLog('building test-temp-src/foo.js', { posix: true });
-    await expectBuildEnd();
-    await expectFileWithContent(distIndexFile, 'foo2bar1');
+  // should watch foo.js
+  fse.outputFileSync(fooFile, `export const foo = 'foo2';`);
+  await expectLog('building test-temp-src/foo.js', { posix: true });
+  await expectBuildEnd();
+  await expectFileWithContent(distIndexFile, 'foo2bar1');
 
-    // should not watch bar.js
-    fse.outputFileSync(barFile, `export const bar = 'bar2';`);
-    await new Promise((resolve) => setTimeout(resolve, 100));
-    expectNoLog('building test-temp-src/bar.js', { posix: true });
-  },
-);
+  // should not watch bar.js
+  fse.outputFileSync(barFile, `export const bar = 'bar2';`);
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  expectNoLog('building test-temp-src/bar.js', { posix: true });
+});

--- a/e2e/cases/cli/build-watch-restart/index.test.ts
+++ b/e2e/cases/cli/build-watch-restart/index.test.ts
@@ -1,54 +1,54 @@
 import path from 'node:path';
-import { expectFileWithContent, rspackTest } from '@e2e/helper';
+import { expectFileWithContent, test } from '@e2e/helper';
 import fse from 'fs-extra';
 
-rspackTest(
-  'should support restart build when config changed',
-  async ({ execCli, logHelper }) => {
-    const indexFile = path.join(import.meta.dirname, 'src/index.js');
-    const distIndexFile = path.join(
-      import.meta.dirname,
-      'dist/static/js/index.js',
-    );
-    const tempConfig = path.join(
-      import.meta.dirname,
-      'test-temp-rsbuild.config.mjs',
-    );
+test('should support restart build when config changed', async ({
+  execCli,
+  logHelper,
+}) => {
+  const indexFile = path.join(import.meta.dirname, 'src/index.js');
+  const distIndexFile = path.join(
+    import.meta.dirname,
+    'dist/static/js/index.js',
+  );
+  const tempConfig = path.join(
+    import.meta.dirname,
+    'test-temp-rsbuild.config.mjs',
+  );
 
-    fse.outputFileSync(indexFile, `console.log('hello!');`);
-    fse.outputFileSync(
-      tempConfig,
-      `export default {
+  fse.outputFileSync(indexFile, `console.log('hello!');`);
+  fse.outputFileSync(
+    tempConfig,
+    `export default {
   output: {
     filenameHash: false,
   },
 };
 `,
-    );
+  );
 
-    execCli(`build --watch -c ${tempConfig}`);
-    const { clearLogs, expectLog, expectBuildEnd } = logHelper;
+  execCli(`build --watch -c ${tempConfig}`);
+  const { clearLogs, expectLog, expectBuildEnd } = logHelper;
 
-    await expectBuildEnd();
-    await expectFileWithContent(distIndexFile, 'hello!');
+  await expectBuildEnd();
+  await expectFileWithContent(distIndexFile, 'hello!');
 
-    fse.outputFileSync(
-      tempConfig,
-      `export default {
+  fse.outputFileSync(
+    tempConfig,
+    `export default {
   // update
   output: {
     filenameHash: false,
   },
 };
 `,
-    );
+  );
 
-    await expectLog('restarting build');
-    await expectFileWithContent(distIndexFile, 'hello!');
+  await expectLog('restarting build');
+  await expectFileWithContent(distIndexFile, 'hello!');
 
-    clearLogs();
-    fse.outputFileSync(indexFile, `console.log('hello2!');`);
-    await expectBuildEnd();
-    await expectFileWithContent(distIndexFile, 'hello2!');
-  },
-);
+  clearLogs();
+  fse.outputFileSync(indexFile, `console.log('hello2!');`);
+  await expectBuildEnd();
+  await expectFileWithContent(distIndexFile, 'hello2!');
+});

--- a/e2e/cases/cli/build-watch/index.test.ts
+++ b/e2e/cases/cli/build-watch/index.test.ts
@@ -1,28 +1,28 @@
 import path from 'node:path';
-import { expectFileWithContent, rspackTest } from '@e2e/helper';
+import { expectFileWithContent, test } from '@e2e/helper';
 import fse from 'fs-extra';
 
-rspackTest(
-  'should support watch mode for build command',
-  async ({ execCli, logHelper }) => {
-    const indexFile = path.join(import.meta.dirname, 'src/index.js');
-    const distIndexFile = path.join(
-      import.meta.dirname,
-      'dist/static/js/index.js',
-    );
+test('should support watch mode for build command', async ({
+  execCli,
+  logHelper,
+}) => {
+  const indexFile = path.join(import.meta.dirname, 'src/index.js');
+  const distIndexFile = path.join(
+    import.meta.dirname,
+    'dist/static/js/index.js',
+  );
 
-    fse.outputFileSync(indexFile, `console.log('hello!');`);
+  fse.outputFileSync(indexFile, `console.log('hello!');`);
 
-    execCli('build --watch');
-    const { expectBuildEnd, clearLogs, expectLog } = logHelper;
+  execCli('build --watch');
+  const { expectBuildEnd, clearLogs, expectLog } = logHelper;
 
-    await expectBuildEnd();
-    await expectFileWithContent(distIndexFile, 'hello!');
-    clearLogs();
+  await expectBuildEnd();
+  await expectFileWithContent(distIndexFile, 'hello!');
+  clearLogs();
 
-    fse.outputFileSync(indexFile, `console.log('hello2!');`);
-    await expectLog('building src/index.js', { posix: true });
-    await expectBuildEnd();
-    await expectFileWithContent(distIndexFile, 'hello2!');
-  },
-);
+  fse.outputFileSync(indexFile, `console.log('hello2!');`);
+  await expectLog('building src/index.js', { posix: true });
+  await expectBuildEnd();
+  await expectFileWithContent(distIndexFile, 'hello2!');
+});

--- a/e2e/cases/cli/build/index.test.ts
+++ b/e2e/cases/cli/build/index.test.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
-import { expect, readDirContents, rspackTest } from '@e2e/helper';
+import { expect, readDirContents, test } from '@e2e/helper';
 
-rspackTest('should run build command correctly', async ({ execCliSync }) => {
+test('should run build command correctly', async ({ execCliSync }) => {
   execCliSync('build');
 
   const outputs = await readDirContents(path.join(import.meta.dirname, 'dist'));

--- a/e2e/cases/cli/config-loader/index.test.ts
+++ b/e2e/cases/cli/config-loader/index.test.ts
@@ -1,42 +1,40 @@
 import path from 'node:path';
-import { expect, readDirContents, rspackTest } from '@e2e/helper';
+import { expect, readDirContents, test } from '@e2e/helper';
 
-rspackTest(
-  'should use Node.js native loader to load config',
-  async ({ execCliSync }) => {
-    if (!process.features.typescript) {
-      return;
-    }
+test('should use Node.js native loader to load config', async ({
+  execCliSync,
+}) => {
+  if (!process.features.typescript) {
+    return;
+  }
 
-    execCliSync('build --config-loader native', {
-      env: {
-        NODE_OPTIONS: '--experimental-strip-types',
-      },
-    });
+  execCliSync('build --config-loader native', {
+    env: {
+      NODE_OPTIONS: '--experimental-strip-types',
+    },
+  });
 
-    const outputs = await readDirContents(
-      path.join(import.meta.dirname, 'dist-custom'),
-    );
-    const outputFiles = Object.keys(outputs);
+  const outputs = await readDirContents(
+    path.join(import.meta.dirname, 'dist-custom'),
+  );
+  const outputFiles = Object.keys(outputs);
 
-    expect(outputFiles.length > 1).toBeTruthy();
-  },
-);
+  expect(outputFiles.length > 1).toBeTruthy();
+});
 
-rspackTest(
-  'should fallback to jiti when config loader set to auto',
-  async ({ execCliSync }) => {
-    execCliSync('build --config-loader auto --config rsbuild.config.auto.mts', {
-      env: {
-        NODE_OPTIONS: '--experimental-strip-types',
-      },
-    });
+test('should fallback to jiti when config loader set to auto', async ({
+  execCliSync,
+}) => {
+  execCliSync('build --config-loader auto --config rsbuild.config.auto.mts', {
+    env: {
+      NODE_OPTIONS: '--experimental-strip-types',
+    },
+  });
 
-    const outputs = await readDirContents(
-      path.join(import.meta.dirname, 'dist-auto'),
-    );
-    const outputFiles = Object.keys(outputs);
+  const outputs = await readDirContents(
+    path.join(import.meta.dirname, 'dist-auto'),
+  );
+  const outputFiles = Object.keys(outputs);
 
-    expect(outputFiles.length > 1).toBeTruthy();
-  },
-);
+  expect(outputFiles.length > 1).toBeTruthy();
+});

--- a/e2e/cases/cli/custom-config/index.test.ts
+++ b/e2e/cases/cli/custom-config/index.test.ts
@@ -1,42 +1,39 @@
 import path from 'node:path';
-import { expect, readDirContents, rspackTest } from '@e2e/helper';
+import { expect, readDirContents, test } from '@e2e/helper';
 
-rspackTest(
-  'should use custom config when using --config option',
-  async ({ execCliSync }) => {
-    execCliSync('build --config ./custom.config.js');
+test('should use custom config when using --config option', async ({
+  execCliSync,
+}) => {
+  execCliSync('build --config ./custom.config.js');
 
-    const outputs = await readDirContents(
-      path.join(import.meta.dirname, 'dist-custom'),
-    );
-    const outputFiles = Object.keys(outputs);
+  const outputs = await readDirContents(
+    path.join(import.meta.dirname, 'dist-custom'),
+  );
+  const outputFiles = Object.keys(outputs);
 
-    expect(outputFiles.length > 1).toBeTruthy();
-  },
-);
+  expect(outputFiles.length > 1).toBeTruthy();
+});
 
-rspackTest(
-  'should support custom config to find absolute path',
-  async ({ execCliSync }) => {
-    const absPath = path.join(import.meta.dirname, 'custom.config.js');
-    execCliSync(`build --config ${absPath}`);
-    const outputs = await readDirContents(
-      path.join(import.meta.dirname, 'dist-custom'),
-    );
-    const outputFiles = Object.keys(outputs);
+test('should support custom config to find absolute path', async ({
+  execCliSync,
+}) => {
+  const absPath = path.join(import.meta.dirname, 'custom.config.js');
+  execCliSync(`build --config ${absPath}`);
+  const outputs = await readDirContents(
+    path.join(import.meta.dirname, 'dist-custom'),
+  );
+  const outputFiles = Object.keys(outputs);
 
-    expect(outputFiles.length > 1).toBeTruthy();
-  },
-);
+  expect(outputFiles.length > 1).toBeTruthy();
+});
 
-rspackTest(
-  'should throw error when custom config not found',
-  async ({ execCliSync }) => {
-    expect(() => {
-      execCliSync('build --config ./custom-not-found.config.js', {
-        // only capture stderr output
-        stdio: ['ignore', 'ignore', 'pipe'],
-      });
-    }).toThrowError(/Cannot find config file: .*custom-not-found.config.js/);
-  },
-);
+test('should throw error when custom config not found', async ({
+  execCliSync,
+}) => {
+  expect(() => {
+    execCliSync('build --config ./custom-not-found.config.js', {
+      // only capture stderr output
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+  }).toThrowError(/Cannot find config file: .*custom-not-found.config.js/);
+});

--- a/e2e/cases/cli/custom-env-dir/index.test.ts
+++ b/e2e/cases/cli/custom-env-dir/index.test.ts
@@ -1,8 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest('should support a custom env directory', async ({ execCliSync }) => {
+test('should support a custom env directory', async ({ execCliSync }) => {
   execCliSync('build --env-dir env');
   const content = fs.readFileSync(
     path.join(import.meta.dirname, 'dist/static/js/index.js'),

--- a/e2e/cases/cli/custom-env-prefix/index.test.ts
+++ b/e2e/cases/cli/custom-env-prefix/index.test.ts
@@ -1,16 +1,15 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should allow to custom env prefix via loadEnv method',
-  async ({ execCliSync }) => {
-    execCliSync('build');
-    const content = fs.readFileSync(
-      path.join(import.meta.dirname, 'dist/static/js/index.js'),
-      'utf-8',
-    );
-    expect(content).not.toContain('jack');
-    expect(content).toContain('rose');
-  },
-);
+test('should allow to custom env prefix via loadEnv method', async ({
+  execCliSync,
+}) => {
+  execCliSync('build');
+  const content = fs.readFileSync(
+    path.join(import.meta.dirname, 'dist/static/js/index.js'),
+    'utf-8',
+  );
+  expect(content).not.toContain('jack');
+  expect(content).toContain('rose');
+});

--- a/e2e/cases/cli/dev/index.test.ts
+++ b/e2e/cases/cli/dev/index.test.ts
@@ -1,23 +1,25 @@
-import { expect, getRandomPort, gotoPage, rspackTest } from '@e2e/helper';
+import { expect, getRandomPort, gotoPage, test } from '@e2e/helper';
 
-rspackTest(
-  'should run dev server via `dev` command',
-  async ({ page, execCli, logHelper }) => {
-    const port = await getRandomPort();
-    execCli(`dev --port ${port}`);
-    await logHelper.expectBuildEnd();
-    await gotoPage(page, { port });
-    await expect(page.locator('#test')).toHaveText('hello');
-  },
-);
+test('should run dev server via `dev` command', async ({
+  page,
+  execCli,
+  logHelper,
+}) => {
+  const port = await getRandomPort();
+  execCli(`dev --port ${port}`);
+  await logHelper.expectBuildEnd();
+  await gotoPage(page, { port });
+  await expect(page.locator('#test')).toHaveText('hello');
+});
 
-rspackTest(
-  'should run dev server via no command',
-  async ({ page, execCli, logHelper }) => {
-    const port = await getRandomPort();
-    execCli(`--port ${port}`);
-    await logHelper.expectBuildEnd();
-    await gotoPage(page, { port });
-    await expect(page.locator('#test')).toHaveText('hello');
-  },
-);
+test('should run dev server via no command', async ({
+  page,
+  execCli,
+  logHelper,
+}) => {
+  const port = await getRandomPort();
+  execCli(`--port ${port}`);
+  await logHelper.expectBuildEnd();
+  await gotoPage(page, { port });
+  await expect(page.locator('#test')).toHaveText('hello');
+});

--- a/e2e/cases/cli/falsy-plugins/index.test.ts
+++ b/e2e/cases/cli/falsy-plugins/index.test.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
-import { expect, readDirContents, rspackTest } from '@e2e/helper';
+import { expect, readDirContents, test } from '@e2e/helper';
 
-rspackTest('should run build command correctly', async ({ execCliSync }) => {
+test('should run build command correctly', async ({ execCliSync }) => {
   execCliSync('build');
 
   const outputs = await readDirContents(path.join(import.meta.dirname, 'dist'));

--- a/e2e/cases/cli/function-config/index.test.ts
+++ b/e2e/cases/cli/function-config/index.test.ts
@@ -1,26 +1,20 @@
 import path from 'node:path';
-import {
-  expect,
-  getFileContent,
-  readDirContents,
-  rspackTest,
-} from '@e2e/helper';
+import { expect, getFileContent, readDirContents, test } from '@e2e/helper';
 import fse from 'fs-extra';
 
 const distDir = path.join(import.meta.dirname, 'dist');
 
-rspackTest(
-  'should support exporting a function from the config file',
-  async ({ execCliSync }) => {
-    await fse.remove(distDir);
-    execCliSync('build');
-    const files = await readDirContents(distDir);
-    const content = getFileContent(files, 'index.js');
-    expect(content.includes('production-production-build')).toBeTruthy();
-  },
-);
+test('should support exporting a function from the config file', async ({
+  execCliSync,
+}) => {
+  await fse.remove(distDir);
+  execCliSync('build');
+  const files = await readDirContents(distDir);
+  const content = getFileContent(files, 'index.js');
+  expect(content.includes('production-production-build')).toBeTruthy();
+});
 
-rspackTest('should specify env as expected', async ({ execCliSync }) => {
+test('should specify env as expected', async ({ execCliSync }) => {
   await fse.remove(distDir);
   execCliSync('build', {
     env: {
@@ -33,7 +27,7 @@ rspackTest('should specify env as expected', async ({ execCliSync }) => {
   expect(content.includes('development-development-build')).toBeTruthy();
 });
 
-rspackTest('should specify env mode as expected', async ({ execCliSync }) => {
+test('should specify env mode as expected', async ({ execCliSync }) => {
   await fse.remove(distDir);
   execCliSync('build --env-mode staging');
   const files = await readDirContents(distDir);

--- a/e2e/cases/cli/inspect/index.test.ts
+++ b/e2e/cases/cli/inspect/index.test.ts
@@ -1,12 +1,12 @@
 import path from 'node:path';
-import { expect, readDirContents, rspackTest } from '@e2e/helper';
+import { expect, readDirContents, test } from '@e2e/helper';
 import fse from 'fs-extra';
 
 const clean = () => {
   fse.removeSync(path.join(import.meta.dirname, 'dist'));
 };
 
-rspackTest('should run inspect command correctly', async ({ execCliSync }) => {
+test('should run inspect command correctly', async ({ execCliSync }) => {
   clean();
 
   execCliSync('inspect');
@@ -29,48 +29,44 @@ rspackTest('should run inspect command correctly', async ({ execCliSync }) => {
   expect(files[rspackConfig!]).toContain("mode: 'development'");
 });
 
-rspackTest(
-  'should run inspect command with mode option correctly',
-  async ({ execCliSync }) => {
-    clean();
+test('should run inspect command with mode option correctly', async ({
+  execCliSync,
+}) => {
+  clean();
 
-    execCliSync('inspect --mode production');
+  execCliSync('inspect --mode production');
 
-    const files = await readDirContents(
-      path.join(import.meta.dirname, 'dist/.rsbuild'),
-    );
-    const fileNames = Object.keys(files);
+  const files = await readDirContents(
+    path.join(import.meta.dirname, 'dist/.rsbuild'),
+  );
+  const fileNames = Object.keys(files);
 
-    const config = fileNames.find((item) =>
-      item.includes('rsbuild.config.mjs'),
-    );
-    expect(config).toBeTruthy();
+  const config = fileNames.find((item) => item.includes('rsbuild.config.mjs'));
+  expect(config).toBeTruthy();
 
-    const rspackConfig = fileNames.find((item) =>
-      item.includes('rspack.config.web.mjs'),
-    );
-    expect(rspackConfig).toBeTruthy();
-    expect(files[rspackConfig!]).toContain("mode: 'production'");
-  },
-);
+  const rspackConfig = fileNames.find((item) =>
+    item.includes('rspack.config.web.mjs'),
+  );
+  expect(rspackConfig).toBeTruthy();
+  expect(files[rspackConfig!]).toContain("mode: 'production'");
+});
 
-rspackTest(
-  'should run inspect command with output option correctly',
-  async ({ execCliSync }) => {
-    clean();
+test('should run inspect command with output option correctly', async ({
+  execCliSync,
+}) => {
+  clean();
 
-    execCliSync('inspect --output foo');
+  execCliSync('inspect --output foo');
 
-    const outputs = await readDirContents(
-      path.join(import.meta.dirname, 'dist/foo'),
-    );
-    const outputFiles = Object.keys(outputs);
+  const outputs = await readDirContents(
+    path.join(import.meta.dirname, 'dist/foo'),
+  );
+  const outputFiles = Object.keys(outputs);
 
-    expect(
-      outputFiles.find((item) => item.includes('rsbuild.config.mjs')),
-    ).toBeTruthy();
-    expect(
-      outputFiles.find((item) => item.includes('rspack.config.web.mjs')),
-    ).toBeTruthy();
-  },
-);
+  expect(
+    outputFiles.find((item) => item.includes('rsbuild.config.mjs')),
+  ).toBeTruthy();
+  expect(
+    outputFiles.find((item) => item.includes('rspack.config.web.mjs')),
+  ).toBeTruthy();
+});

--- a/e2e/cases/cli/load-import-meta-env/index.test.ts
+++ b/e2e/cases/cli/load-import-meta-env/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { expect, rspackTest, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import fse from 'fs-extra';
 
 const localFile = path.join(import.meta.dirname, '.env.local');
@@ -11,47 +11,33 @@ test.beforeEach(async () => {
   await fse.remove(prodLocalFile);
 });
 
-rspackTest(
-  'should load .env config and allow rsbuild.config.ts to read env vars',
-  async ({ execCliSync }) => {
-    execCliSync('build');
-    expect(
-      fs.existsSync(path.join(import.meta.dirname, 'dist/1')),
-    ).toBeTruthy();
-  },
-);
+test('should load .env config and allow rsbuild.config.ts to read env vars', async ({
+  execCliSync,
+}) => {
+  execCliSync('build');
+  expect(fs.existsSync(path.join(import.meta.dirname, 'dist/1'))).toBeTruthy();
+});
 
-rspackTest(
-  'should load .env.local with higher priority',
-  async ({ execCliSync }) => {
-    fse.outputFileSync(localFile, 'FOO=2');
+test('should load .env.local with higher priority', async ({ execCliSync }) => {
+  fse.outputFileSync(localFile, 'FOO=2');
 
-    execCliSync('build');
-    expect(
-      fs.existsSync(path.join(import.meta.dirname, 'dist/2')),
-    ).toBeTruthy();
-  },
-);
+  execCliSync('build');
+  expect(fs.existsSync(path.join(import.meta.dirname, 'dist/2'))).toBeTruthy();
+});
 
-rspackTest(
-  'should load .env.production.local with higher priority',
-  async ({ execCliSync }) => {
-    fse.outputFileSync(localFile, 'FOO=2');
-    fse.outputFileSync(prodLocalFile, 'FOO=3');
+test('should load .env.production.local with higher priority', async ({
+  execCliSync,
+}) => {
+  fse.outputFileSync(localFile, 'FOO=2');
+  fse.outputFileSync(prodLocalFile, 'FOO=3');
 
-    execCliSync('build');
-    expect(
-      fs.existsSync(path.join(import.meta.dirname, 'dist/3')),
-    ).toBeTruthy();
-  },
-);
+  execCliSync('build');
+  expect(fs.existsSync(path.join(import.meta.dirname, 'dist/3'))).toBeTruthy();
+});
 
-rspackTest(
-  'should support specifying env mode via --env-mode',
-  async ({ execCliSync }) => {
-    execCliSync('build --env-mode test');
-    expect(
-      fs.existsSync(path.join(import.meta.dirname, 'dist/5')),
-    ).toBeTruthy();
-  },
-);
+test('should support specifying env mode via --env-mode', async ({
+  execCliSync,
+}) => {
+  execCliSync('build --env-mode test');
+  expect(fs.existsSync(path.join(import.meta.dirname, 'dist/5'))).toBeTruthy();
+});

--- a/e2e/cases/cli/load-node-env/index.test.ts
+++ b/e2e/cases/cli/load-node-env/index.test.ts
@@ -1,14 +1,13 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
 // see: https://github.com/web-infra-dev/rsbuild/issues/2904
-rspackTest(
-  'should load .env config and set NODE_ENV as expected',
-  async ({ execCliSync }) => {
-    execCliSync('build');
-    expect(
-      fs.existsSync(path.join(import.meta.dirname, 'dist/development')),
-    ).toBeTruthy();
-  },
-);
+test('should load .env config and set NODE_ENV as expected', async ({
+  execCliSync,
+}) => {
+  execCliSync('build');
+  expect(
+    fs.existsSync(path.join(import.meta.dirname, 'dist/development')),
+  ).toBeTruthy();
+});

--- a/e2e/cases/cli/load-process-env/index.test.ts
+++ b/e2e/cases/cli/load-process-env/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { expect, rspackTest, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import fse from 'fs-extra';
 
 const localFile = path.join(import.meta.dirname, '.env.local');
@@ -11,45 +11,31 @@ test.beforeEach(async () => {
   await fse.remove(prodLocalFile);
 });
 
-rspackTest(
-  'should load .env config and allow rsbuild.config.ts to read env vars',
-  async ({ execCliSync }) => {
-    execCliSync('build');
-    expect(
-      fs.existsSync(path.join(import.meta.dirname, 'dist/1')),
-    ).toBeTruthy();
-  },
-);
+test('should load .env config and allow rsbuild.config.ts to read env vars', async ({
+  execCliSync,
+}) => {
+  execCliSync('build');
+  expect(fs.existsSync(path.join(import.meta.dirname, 'dist/1'))).toBeTruthy();
+});
 
-rspackTest(
-  'should load .env.local with higher priority',
-  async ({ execCliSync }) => {
-    fse.outputFileSync(localFile, 'FOO=2');
-    execCliSync('build');
-    expect(
-      fs.existsSync(path.join(import.meta.dirname, 'dist/2')),
-    ).toBeTruthy();
-  },
-);
+test('should load .env.local with higher priority', async ({ execCliSync }) => {
+  fse.outputFileSync(localFile, 'FOO=2');
+  execCliSync('build');
+  expect(fs.existsSync(path.join(import.meta.dirname, 'dist/2'))).toBeTruthy();
+});
 
-rspackTest(
-  'should load .env.production.local with higher priority',
-  async ({ execCliSync }) => {
-    fse.outputFileSync(localFile, 'FOO=2');
-    fse.outputFileSync(prodLocalFile, 'FOO=3');
-    execCliSync('build');
-    expect(
-      fs.existsSync(path.join(import.meta.dirname, 'dist/3')),
-    ).toBeTruthy();
-  },
-);
+test('should load .env.production.local with higher priority', async ({
+  execCliSync,
+}) => {
+  fse.outputFileSync(localFile, 'FOO=2');
+  fse.outputFileSync(prodLocalFile, 'FOO=3');
+  execCliSync('build');
+  expect(fs.existsSync(path.join(import.meta.dirname, 'dist/3'))).toBeTruthy();
+});
 
-rspackTest(
-  'should support specifying env mode via --env-mode',
-  async ({ execCliSync }) => {
-    execCliSync('build --env-mode test');
-    expect(
-      fs.existsSync(path.join(import.meta.dirname, 'dist/5')),
-    ).toBeTruthy();
-  },
-);
+test('should support specifying env mode via --env-mode', async ({
+  execCliSync,
+}) => {
+  execCliSync('build --env-mode test');
+  expect(fs.existsSync(path.join(import.meta.dirname, 'dist/5'))).toBeTruthy();
+});

--- a/e2e/cases/cli/log-level/index.test.ts
+++ b/e2e/cases/cli/log-level/index.test.ts
@@ -1,37 +1,34 @@
 import { stripVTControlCharacters as stripAnsi } from 'node:util';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should run build command with log level: info',
-  async ({ execCliSync }) => {
-    const stdout = stripAnsi(execCliSync('build --logLevel info'));
-    expect(stdout).toContain('Rsbuild v');
-    expect(stdout).toContain('build started...');
-    expect(stdout).toContain('built in');
-  },
-);
+test('should run build command with log level: info', async ({
+  execCliSync,
+}) => {
+  const stdout = stripAnsi(execCliSync('build --logLevel info'));
+  expect(stdout).toContain('Rsbuild v');
+  expect(stdout).toContain('build started...');
+  expect(stdout).toContain('built in');
+});
 
-rspackTest(
-  'should run build command with log level: warn',
-  async ({ execCliSync }) => {
-    const stdout = stripAnsi(execCliSync('build --logLevel warn'));
-    expect(stdout).not.toContain('Rsbuild v');
-    expect(stdout).not.toContain('build started...');
-    expect(stdout).not.toContain('built in');
-  },
-);
+test('should run build command with log level: warn', async ({
+  execCliSync,
+}) => {
+  const stdout = stripAnsi(execCliSync('build --logLevel warn'));
+  expect(stdout).not.toContain('Rsbuild v');
+  expect(stdout).not.toContain('build started...');
+  expect(stdout).not.toContain('built in');
+});
 
-rspackTest(
-  'should always print verbose logs when debug mode is enabled',
-  async ({ execCliSync }) => {
-    const stdout = stripAnsi(
-      execCliSync('build --logLevel error', {
-        env: {
-          ...process.env,
-          DEBUG: 'rsbuild',
-        },
-      }),
-    );
-    expect(stdout).toContain('config inspection completed');
-  },
-);
+test('should always print verbose logs when debug mode is enabled', async ({
+  execCliSync,
+}) => {
+  const stdout = stripAnsi(
+    execCliSync('build --logLevel error', {
+      env: {
+        ...process.env,
+        DEBUG: 'rsbuild',
+      },
+    }),
+  );
+  expect(stdout).toContain('config inspection completed');
+});

--- a/e2e/cases/cli/mode/index.test.ts
+++ b/e2e/cases/cli/mode/index.test.ts
@@ -1,42 +1,36 @@
 import path from 'node:path';
-import { expect, readDirContents, rspackTest } from '@e2e/helper';
+import { expect, readDirContents, test } from '@e2e/helper';
 
-rspackTest(
-  'should run build command with --mode option correctly',
-  async ({ execCliSync }) => {
-    execCliSync('build --mode development');
+test('should run build command with --mode option correctly', async ({
+  execCliSync,
+}) => {
+  execCliSync('build --mode development');
 
-    const outputs = await readDirContents(
-      path.join(import.meta.dirname, 'dist'),
-    );
-    const outputFiles = Object.keys(outputs);
+  const outputs = await readDirContents(path.join(import.meta.dirname, 'dist'));
+  const outputFiles = Object.keys(outputs);
 
-    // no filename hash in dev
-    expect(
-      outputFiles.find((item) => item.endsWith('static/js/index.js')),
-    ).toBeTruthy();
-    expect(
-      outputFiles.find((item) => item.endsWith('static/js/index.js.map')),
-    ).toBeTruthy();
-  },
-);
+  // no filename hash in dev
+  expect(
+    outputFiles.find((item) => item.endsWith('static/js/index.js')),
+  ).toBeTruthy();
+  expect(
+    outputFiles.find((item) => item.endsWith('static/js/index.js.map')),
+  ).toBeTruthy();
+});
 
-rspackTest(
-  'should run build command with -m option correctly',
-  async ({ execCliSync }) => {
-    execCliSync('build -m development');
+test('should run build command with -m option correctly', async ({
+  execCliSync,
+}) => {
+  execCliSync('build -m development');
 
-    const outputs = await readDirContents(
-      path.join(import.meta.dirname, 'dist'),
-    );
-    const outputFiles = Object.keys(outputs);
+  const outputs = await readDirContents(path.join(import.meta.dirname, 'dist'));
+  const outputFiles = Object.keys(outputs);
 
-    // no filename hash in dev
-    expect(
-      outputFiles.find((item) => item.endsWith('static/js/index.js')),
-    ).toBeTruthy();
-    expect(
-      outputFiles.find((item) => item.endsWith('static/js/index.js.map')),
-    ).toBeTruthy();
-  },
-);
+  // no filename hash in dev
+  expect(
+    outputFiles.find((item) => item.endsWith('static/js/index.js')),
+  ).toBeTruthy();
+  expect(
+    outputFiles.find((item) => item.endsWith('static/js/index.js.map')),
+  ).toBeTruthy();
+});

--- a/e2e/cases/cli/no-env/index.test.ts
+++ b/e2e/cases/cli/no-env/index.test.ts
@@ -1,8 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest('should disable loading env files', async ({ execCliSync }) => {
+test('should disable loading env files', async ({ execCliSync }) => {
   execCliSync('build --no-env');
   const content = fs.readFileSync(
     path.join(import.meta.dirname, 'dist/static/js/index.js'),

--- a/e2e/cases/cli/node-env/index.test.ts
+++ b/e2e/cases/cli/node-env/index.test.ts
@@ -1,17 +1,16 @@
 import path from 'node:path';
-import { expect, readDirContents, rspackTest } from '@e2e/helper';
+import { expect, readDirContents, test } from '@e2e/helper';
 
-rspackTest(
-  'should set NODE_ENV correctly when running build command',
-  async ({ execCliSync }) => {
-    delete process.env.NODE_ENV;
-    execCliSync('build');
+test('should set NODE_ENV correctly when running build command', async ({
+  execCliSync,
+}) => {
+  delete process.env.NODE_ENV;
+  execCliSync('build');
 
-    const outputs = await readDirContents(
-      path.join(import.meta.dirname, 'dist-prod'),
-    );
-    const outputFiles = Object.keys(outputs);
+  const outputs = await readDirContents(
+    path.join(import.meta.dirname, 'dist-prod'),
+  );
+  const outputFiles = Object.keys(outputs);
 
-    expect(outputFiles.length > 1).toBeTruthy();
-  },
-);
+  expect(outputFiles.length > 1).toBeTruthy();
+});

--- a/e2e/cases/cli/public-env-vars/index.test.ts
+++ b/e2e/cases/cli/public-env-vars/index.test.ts
@@ -1,18 +1,15 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should inject public env vars to client',
-  async ({ execCliSync }) => {
-    execCliSync('build');
+test('should inject public env vars to client', async ({ execCliSync }) => {
+  execCliSync('build');
 
-    const content = fs.readFileSync(
-      path.join(import.meta.dirname, 'dist/static/js/index.js'),
-      'utf-8',
-    );
-    expect(content).not.toContain('jack');
-    expect(content).toContain('"process.env","rose"');
-    expect(content).toContain('"import.meta.env","rose"');
-  },
-);
+  const content = fs.readFileSync(
+    path.join(import.meta.dirname, 'dist/static/js/index.js'),
+    'utf-8',
+  );
+  expect(content).not.toContain('jack');
+  expect(content).toContain('"process.env","rose"');
+  expect(content).toContain('"import.meta.env","rose"');
+});

--- a/e2e/cases/cli/reload-config/index.test.ts
+++ b/e2e/cases/cli/reload-config/index.test.ts
@@ -1,36 +1,36 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { expectFile, getRandomPort, rspackTest } from '@e2e/helper';
+import { expectFile, getRandomPort, test } from '@e2e/helper';
 import fse from 'fs-extra';
 
-rspackTest(
-  'should restart dev server and reload config when config file changed',
-  async ({ execCli }) => {
-    const dist1 = path.join(import.meta.dirname, 'dist');
-    const dist2 = path.join(import.meta.dirname, 'dist-2');
-    const configFile = path.join(import.meta.dirname, 'rsbuild.config.mjs');
+test('should restart dev server and reload config when config file changed', async ({
+  execCli,
+}) => {
+  const dist1 = path.join(import.meta.dirname, 'dist');
+  const dist2 = path.join(import.meta.dirname, 'dist-2');
+  const configFile = path.join(import.meta.dirname, 'rsbuild.config.mjs');
 
-    await fse.remove(dist1);
-    await fse.remove(dist2);
-    await fse.remove(configFile);
+  await fse.remove(dist1);
+  await fse.remove(dist2);
+  await fse.remove(configFile);
 
-    fs.writeFileSync(
-      configFile,
-      `export default {
+  fs.writeFileSync(
+    configFile,
+    `export default {
       dev: {
         writeToDisk: true,
       },
       server: { port: ${await getRandomPort()} }
     };`,
-    );
+  );
 
-    execCli('dev');
+  execCli('dev');
 
-    await expectFile(dist1);
+  await expectFile(dist1);
 
-    fs.writeFileSync(
-      configFile,
-      `export default {
+  fs.writeFileSync(
+    configFile,
+    `export default {
       dev: {
         writeToDisk: true,
       },
@@ -39,8 +39,7 @@ rspackTest(
       },
       server: { port: ${await getRandomPort()} }
     };`,
-    );
+  );
 
-    await expectFile(dist2);
-  },
-);
+  await expectFile(dist2);
+});

--- a/e2e/cases/cli/reload-env/index.test.ts
+++ b/e2e/cases/cli/reload-env/index.test.ts
@@ -1,19 +1,20 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { expectFileWithContent, getRandomPort, rspackTest } from '@e2e/helper';
+import { expectFileWithContent, getRandomPort, test } from '@e2e/helper';
 
-rspackTest(
-  'should restart dev server when .env file is changed',
-  async ({ execCli, logHelper }) => {
-    const dist = path.join(import.meta.dirname, 'dist');
-    const configFile = path.join(import.meta.dirname, 'rsbuild.config.mjs');
-    const envLocalFile = path.join(import.meta.dirname, '.env.local');
-    const distIndex = path.join(dist, 'static/js/index.js');
+test('should restart dev server when .env file is changed', async ({
+  execCli,
+  logHelper,
+}) => {
+  const dist = path.join(import.meta.dirname, 'dist');
+  const configFile = path.join(import.meta.dirname, 'rsbuild.config.mjs');
+  const envLocalFile = path.join(import.meta.dirname, '.env.local');
+  const distIndex = path.join(dist, 'static/js/index.js');
 
-    fs.writeFileSync(envLocalFile, 'PUBLIC_NAME=jack');
-    fs.writeFileSync(
-      configFile,
-      `export default {
+  fs.writeFileSync(envLocalFile, 'PUBLIC_NAME=jack');
+  fs.writeFileSync(
+    configFile,
+    `export default {
       dev: {
         writeToDisk: true,
       },
@@ -22,18 +23,17 @@ rspackTest(
       },
       server: { port: ${await getRandomPort()} }
     };`,
-    );
+  );
 
-    execCli('dev');
-    const { clearLogs, expectLog, expectBuildEnd } = logHelper;
+  execCli('dev');
+  const { clearLogs, expectLog, expectBuildEnd } = logHelper;
 
-    await expectBuildEnd();
-    await expectFileWithContent(distIndex, 'jack');
+  await expectBuildEnd();
+  await expectFileWithContent(distIndex, 'jack');
 
-    clearLogs();
-    fs.writeFileSync(envLocalFile, 'PUBLIC_NAME=rose');
-    await expectLog('restarting server');
-    await expectBuildEnd();
-    await expectFileWithContent(distIndex, 'rose');
-  },
-);
+  clearLogs();
+  fs.writeFileSync(envLocalFile, 'PUBLIC_NAME=rose');
+  await expectLog('restarting server');
+  await expectBuildEnd();
+  await expectFileWithContent(distIndex, 'rose');
+});

--- a/e2e/cases/cli/root/index.test.ts
+++ b/e2e/cases/cli/root/index.test.ts
@@ -1,34 +1,32 @@
 import path from 'node:path';
-import { expect, readDirContents, rspackTest } from '@e2e/helper';
+import { expect, readDirContents, test } from '@e2e/helper';
 
-rspackTest(
-  'should run build command with --root option correctly',
-  async ({ execCliSync }) => {
-    execCliSync('build --root test');
+test('should run build command with --root option correctly', async ({
+  execCliSync,
+}) => {
+  execCliSync('build --root test');
 
-    const outputs = await readDirContents(
-      path.join(import.meta.dirname, 'test', 'dist'),
-    );
-    const outputFiles = Object.keys(outputs);
+  const outputs = await readDirContents(
+    path.join(import.meta.dirname, 'test', 'dist'),
+  );
+  const outputFiles = Object.keys(outputs);
 
-    expect(
-      outputFiles.find((item) => item.endsWith('static/js/index.js')),
-    ).toBeTruthy();
-  },
-);
+  expect(
+    outputFiles.find((item) => item.endsWith('static/js/index.js')),
+  ).toBeTruthy();
+});
 
-rspackTest(
-  'should run build command with -r option correctly',
-  async ({ execCliSync }) => {
-    execCliSync('build -r test');
+test('should run build command with -r option correctly', async ({
+  execCliSync,
+}) => {
+  execCliSync('build -r test');
 
-    const outputs = await readDirContents(
-      path.join(import.meta.dirname, 'test', 'dist'),
-    );
-    const outputFiles = Object.keys(outputs);
+  const outputs = await readDirContents(
+    path.join(import.meta.dirname, 'test', 'dist'),
+  );
+  const outputFiles = Object.keys(outputs);
 
-    expect(
-      outputFiles.find((item) => item.endsWith('static/js/index.js')),
-    ).toBeTruthy();
-  },
-);
+  expect(
+    outputFiles.find((item) => item.endsWith('static/js/index.js')),
+  ).toBeTruthy();
+});

--- a/e2e/cases/cli/shortcuts/index.test.ts
+++ b/e2e/cases/cli/shortcuts/index.test.ts
@@ -1,72 +1,69 @@
-import { rspackTest } from '@e2e/helper';
+import { test } from '@e2e/helper';
 
-rspackTest(
-  'should display shortcuts as expected in dev',
-  async ({ exec, logHelper }) => {
-    const { childProcess } = exec('node ./dev.js');
-    const { expectLog, clearLogs } = logHelper;
+test('should display shortcuts as expected in dev', async ({
+  exec,
+  logHelper,
+}) => {
+  const { childProcess } = exec('node ./dev.js');
+  const { expectLog, clearLogs } = logHelper;
 
-    // help
-    await expectLog('press h + enter to show shortcuts');
-    childProcess.stdin?.write('h\n');
-    await expectLog('u + enter  show urls');
+  // help
+  await expectLog('press h + enter to show shortcuts');
+  childProcess.stdin?.write('h\n');
+  await expectLog('u + enter  show urls');
 
-    // print urls
-    clearLogs();
-    childProcess.stdin?.write('u\n');
-    await expectLog('➜  Local:    http://localhost:');
+  // print urls
+  clearLogs();
+  childProcess.stdin?.write('u\n');
+  await expectLog('➜  Local:    http://localhost:');
 
-    // restart server
-    clearLogs();
-    childProcess.stdin?.write('r\n');
-    await expectLog('restarting server');
-    await expectLog('➜  Local:    http://localhost:');
-  },
-);
+  // restart server
+  clearLogs();
+  childProcess.stdin?.write('r\n');
+  await expectLog('restarting server');
+  await expectLog('➜  Local:    http://localhost:');
+});
 
-rspackTest(
-  'should display shortcuts as expected in preview',
-  async ({ exec, logHelper }) => {
-    const { childProcess } = exec('node ./preview.js');
-    const { expectLog, clearLogs } = logHelper;
+test('should display shortcuts as expected in preview', async ({
+  exec,
+  logHelper,
+}) => {
+  const { childProcess } = exec('node ./preview.js');
+  const { expectLog, clearLogs } = logHelper;
 
-    // help
-    await expectLog('press h + enter to show shortcuts');
-    childProcess.stdin?.write('h\n');
-    await expectLog('u + enter  show urls');
+  // help
+  await expectLog('press h + enter to show shortcuts');
+  childProcess.stdin?.write('h\n');
+  await expectLog('u + enter  show urls');
 
-    // print urls
-    clearLogs();
-    childProcess.stdin?.write('u\n');
-    await expectLog('➜  Local:    http://localhost:');
-  },
-);
+  // print urls
+  clearLogs();
+  childProcess.stdin?.write('u\n');
+  await expectLog('➜  Local:    http://localhost:');
+});
 
-rspackTest(
-  'should support custom shortcuts in dev',
-  async ({ exec, logHelper }) => {
-    const { childProcess } = exec('node ./devCustom.js');
-    const { expectLog, clearLogs } = logHelper;
+test('should support custom shortcuts in dev', async ({ exec, logHelper }) => {
+  const { childProcess } = exec('node ./devCustom.js');
+  const { expectLog, clearLogs } = logHelper;
 
-    await expectLog('press h + enter to show shortcuts');
+  await expectLog('press h + enter to show shortcuts');
 
-    clearLogs();
-    childProcess.stdin?.write('s\n');
-    await expectLog('hello world!');
-  },
-);
+  clearLogs();
+  childProcess.stdin?.write('s\n');
+  await expectLog('hello world!');
+});
 
-rspackTest(
-  'should support custom shortcuts in preview',
-  async ({ exec, logHelper }) => {
-    const { childProcess } = exec('node ./previewCustom.js');
-    const { expectLog, clearLogs } = logHelper;
+test('should support custom shortcuts in preview', async ({
+  exec,
+  logHelper,
+}) => {
+  const { childProcess } = exec('node ./previewCustom.js');
+  const { expectLog, clearLogs } = logHelper;
 
-    // help
-    await expectLog('press h + enter to show shortcuts');
+  // help
+  await expectLog('press h + enter to show shortcuts');
 
-    clearLogs();
-    childProcess.stdin?.write('s\n');
-    await expectLog('hello world!');
-  },
-);
+  clearLogs();
+  childProcess.stdin?.write('s\n');
+  await expectLog('hello world!');
+});

--- a/e2e/cases/cli/specified-environment/index.test.ts
+++ b/e2e/cases/cli/specified-environment/index.test.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { expect, readDirContents, rspackTest, test } from '@e2e/helper';
+import { expect, readDirContents, test } from '@e2e/helper';
 import fse from 'fs-extra';
 
 const distPath = join(import.meta.dirname, 'dist');
@@ -8,36 +8,34 @@ test.beforeEach(async () => {
   await fse.remove(distPath);
 });
 
-rspackTest(
-  'should only build specified environment when using --environment option',
-  async ({ execCliSync }) => {
-    execCliSync('build --environment web2');
+test('should only build specified environment when using --environment option', async ({
+  execCliSync,
+}) => {
+  execCliSync('build --environment web2');
 
-    const files = await readDirContents(distPath);
-    const outputFiles = Object.keys(files);
+  const files = await readDirContents(distPath);
+  const outputFiles = Object.keys(files);
 
-    expect(
-      outputFiles.find((item) => item.includes('web1/index.html')),
-    ).toBeFalsy();
-    expect(
-      outputFiles.find((item) => item.includes('web2/index.html')),
-    ).toBeTruthy();
-  },
-);
+  expect(
+    outputFiles.find((item) => item.includes('web1/index.html')),
+  ).toBeFalsy();
+  expect(
+    outputFiles.find((item) => item.includes('web2/index.html')),
+  ).toBeTruthy();
+});
 
-rspackTest(
-  'should build specified environments when using --environment shorten option',
-  async ({ execCliSync }) => {
-    execCliSync('build --environment web1,web2');
+test('should build specified environments when using --environment shorten option', async ({
+  execCliSync,
+}) => {
+  execCliSync('build --environment web1,web2');
 
-    const files = await readDirContents(distPath);
-    const outputFiles = Object.keys(files);
+  const files = await readDirContents(distPath);
+  const outputFiles = Object.keys(files);
 
-    expect(
-      outputFiles.find((item) => item.includes('web1/index.html')),
-    ).toBeTruthy();
-    expect(
-      outputFiles.find((item) => item.includes('web2/index.html')),
-    ).toBeTruthy();
-  },
-);
+  expect(
+    outputFiles.find((item) => item.includes('web1/index.html')),
+  ).toBeTruthy();
+  expect(
+    outputFiles.find((item) => item.includes('web2/index.html')),
+  ).toBeTruthy();
+});

--- a/e2e/cases/cli/vue/index.test.ts
+++ b/e2e/cases/cli/vue/index.test.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
-import { expect, readDirContents, rspackTest } from '@e2e/helper';
+import { expect, readDirContents, test } from '@e2e/helper';
 
-rspackTest('should build Vue SFC correctly', async ({ execCliSync }) => {
+test('should build Vue SFC correctly', async ({ execCliSync }) => {
   execCliSync('build');
 
   const outputs = await readDirContents(path.join(import.meta.dirname, 'dist'));

--- a/e2e/cases/cli/watch-files-array/index.test.ts
+++ b/e2e/cases/cli/watch-files-array/index.test.ts
@@ -1,33 +1,34 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { expect, getRandomPort, gotoPage, rspackTest } from '@e2e/helper';
+import { expect, getRandomPort, gotoPage, test } from '@e2e/helper';
 
 const tempConfig = path.join(import.meta.dirname, 'test-temp-config.ts');
 
-rspackTest(
-  'should restart dev server when extra config file changed',
-  async ({ page, execCli, logHelper }) => {
-    fs.writeFileSync(tempConfig, 'export default 1;');
+test('should restart dev server when extra config file changed', async ({
+  page,
+  execCli,
+  logHelper,
+}) => {
+  fs.writeFileSync(tempConfig, 'export default 1;');
 
-    const port = await getRandomPort();
-    execCli('dev', {
-      env: {
-        PORT: String(port),
-      },
-    });
-    const { expectBuildEnd, expectLog, clearLogs } = logHelper;
+  const port = await getRandomPort();
+  execCli('dev', {
+    env: {
+      PORT: String(port),
+    },
+  });
+  const { expectBuildEnd, expectLog, clearLogs } = logHelper;
 
-    // initial build
-    await expectBuildEnd();
-    await gotoPage(page, { port });
-    await expect(page.locator('#test')).toHaveText('1');
+  // initial build
+  await expectBuildEnd();
+  await gotoPage(page, { port });
+  await expect(page.locator('#test')).toHaveText('1');
 
-    // restart dev server
-    clearLogs();
-    fs.writeFileSync(tempConfig, 'export default 2;');
-    await expectLog('restarting server');
-    await expectBuildEnd();
-    await gotoPage(page, { port });
-    await expect(page.locator('#test')).toHaveText('2');
-  },
-);
+  // restart dev server
+  clearLogs();
+  fs.writeFileSync(tempConfig, 'export default 2;');
+  await expectLog('restarting server');
+  await expectBuildEnd();
+  await gotoPage(page, { port });
+  await expect(page.locator('#test')).toHaveText('2');
+});

--- a/e2e/cases/cli/watch-files/index.test.ts
+++ b/e2e/cases/cli/watch-files/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { expect, getRandomPort, gotoPage, rspackTest, test } from '@e2e/helper';
+import { expect, getRandomPort, gotoPage, test } from '@e2e/helper';
 
 const tempConfig = path.join(import.meta.dirname, 'test-temp-config.ts');
 
@@ -8,28 +8,29 @@ test.beforeEach(async () => {
   fs.writeFileSync(tempConfig, 'export default 1;');
 });
 
-rspackTest(
-  'should restart dev server when extra config file changed',
-  async ({ page, execCli, logHelper }) => {
-    const port = await getRandomPort();
-    execCli('dev', {
-      env: {
-        PORT: String(port),
-      },
-    });
-    const { clearLogs, expectLog, expectBuildEnd } = logHelper;
+test('should restart dev server when extra config file changed', async ({
+  page,
+  execCli,
+  logHelper,
+}) => {
+  const port = await getRandomPort();
+  execCli('dev', {
+    env: {
+      PORT: String(port),
+    },
+  });
+  const { clearLogs, expectLog, expectBuildEnd } = logHelper;
 
-    // initial build
-    await expectBuildEnd();
-    await gotoPage(page, { port });
-    await expect(page.locator('#test')).toHaveText('1');
+  // initial build
+  await expectBuildEnd();
+  await gotoPage(page, { port });
+  await expect(page.locator('#test')).toHaveText('1');
 
-    // restart dev server
-    clearLogs();
-    fs.writeFileSync(tempConfig, 'export default 2;');
-    await expectLog('restarting server');
-    await expectBuildEnd();
-    await gotoPage(page, { port });
-    await expect(page.locator('#test')).toHaveText('2');
-  },
-);
+  // restart dev server
+  clearLogs();
+  fs.writeFileSync(tempConfig, 'export default 2;');
+  await expectLog('restarting server');
+  await expectBuildEnd();
+  await gotoPage(page, { port });
+  await expect(page.locator('#test')).toHaveText('2');
+});

--- a/e2e/cases/config/bundler-chain/index.test.ts
+++ b/e2e/cases/config/bundler-chain/index.test.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { expect, rspackTest, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
 test('should allow to use tools.bundlerChain to set alias config', async ({
   page,
@@ -46,29 +46,29 @@ test('should allow to use async tools.bundlerChain to set alias config', async (
   await expect(page.innerHTML('#test')).resolves.toBe('Hello Rsbuild! 1');
 });
 
-rspackTest(
-  'should allow to use rspack in tools.bundlerChain',
-  async ({ page, buildPreview }) => {
-    await buildPreview({
-      config: {
-        tools: {
-          bundlerChain: (chain, { rspack }) => {
-            chain.resolve.alias.set(
-              '@common',
-              join(import.meta.dirname, 'src/common'),
-            );
+test('should allow to use rspack in tools.bundlerChain', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview({
+    config: {
+      tools: {
+        bundlerChain: (chain, { rspack }) => {
+          chain.resolve.alias.set(
+            '@common',
+            join(import.meta.dirname, 'src/common'),
+          );
 
-            chain.plugin('extra-define').use(rspack.DefinePlugin, [
-              {
-                ENABLE_TEST: JSON.stringify(true),
-              },
-            ]);
-          },
+          chain.plugin('extra-define').use(rspack.DefinePlugin, [
+            {
+              ENABLE_TEST: JSON.stringify(true),
+            },
+          ]);
         },
       },
-    });
+    },
+  });
 
-    const testEl = page.locator('#test-define');
-    await expect(testEl).toHaveText('aaaaa');
-  },
-);
+  const testEl = page.locator('#test-define');
+  await expect(testEl).toHaveText('aaaaa');
+});

--- a/e2e/cases/config/configure-rspack/index.test.ts
+++ b/e2e/cases/config/configure-rspack/index.test.ts
@@ -1,50 +1,50 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should allow to use tools.rspack to configure Rspack',
-  async ({ page, buildPreview }) => {
-    await buildPreview({
-      config: {
-        tools: {
-          rspack: (config, { rspack }) => {
-            config.plugins.push(
-              new rspack.DefinePlugin({
-                ENABLE_TEST: JSON.stringify(true),
-              }),
-            );
-          },
+test('should allow to use tools.rspack to configure Rspack', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview({
+    config: {
+      tools: {
+        rspack: (config, { rspack }) => {
+          config.plugins.push(
+            new rspack.DefinePlugin({
+              ENABLE_TEST: JSON.stringify(true),
+            }),
+          );
         },
       },
-    });
+    },
+  });
 
-    const testEl = page.locator('#test-el');
-    await expect(testEl).toHaveText('aaaaa');
-  },
-);
+  const testEl = page.locator('#test-el');
+  await expect(testEl).toHaveText('aaaaa');
+});
 
-rspackTest(
-  'should allow to use async tools.rspack to configure Rspack',
-  async ({ page, buildPreview }) => {
-    await buildPreview({
-      config: {
-        tools: {
-          rspack: async (config, { rspack }) => {
-            return new Promise<void>((resolve) => {
-              setTimeout(() => {
-                config.plugins.push(
-                  new rspack.DefinePlugin({
-                    ENABLE_TEST: JSON.stringify(true),
-                  }),
-                );
-                resolve();
-              }, 0);
-            });
-          },
+test('should allow to use async tools.rspack to configure Rspack', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview({
+    config: {
+      tools: {
+        rspack: async (config, { rspack }) => {
+          return new Promise<void>((resolve) => {
+            setTimeout(() => {
+              config.plugins.push(
+                new rspack.DefinePlugin({
+                  ENABLE_TEST: JSON.stringify(true),
+                }),
+              );
+              resolve();
+            }, 0);
+          });
         },
       },
-    });
+    },
+  });
 
-    const testEl = page.locator('#test-el');
-    await expect(testEl).toHaveText('aaaaa');
-  },
-);
+  const testEl = page.locator('#test-el');
+  await expect(testEl).toHaveText('aaaaa');
+});

--- a/e2e/cases/config/debug-mode/index.test.ts
+++ b/e2e/cases/config/debug-mode/index.test.ts
@@ -6,10 +6,7 @@ const getRsbuildConfig = (dist: string) =>
   path.resolve(import.meta.dirname, `./${dist}/.rsbuild/rsbuild.config.mjs`);
 
 const getBundlerConfig = (dist: string) =>
-  path.resolve(
-    import.meta.dirname,
-    `./${dist}/.rsbuild/${process.env.PROVIDE_TYPE || 'rspack'}.config.web.mjs`,
-  );
+  path.resolve(import.meta.dirname, `./${dist}/.rsbuild/rspack.config.web.mjs`);
 
 test('should generate config files in debug mode when build', async ({
   build,

--- a/e2e/cases/config/inspect-config/index.test.ts
+++ b/e2e/cases/config/inspect-config/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path, { join } from 'node:path';
-import { expect, rspackTest, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import type { RsbuildPlugin } from '@rsbuild/core';
 import { createRsbuild } from '@rsbuild/core';
 import fse from 'fs-extra';
@@ -25,143 +25,134 @@ const rsbuildNodeConfig = path.resolve(
 );
 const bundlerConfig = path.resolve(
   import.meta.dirname,
-  `./dist/.rsbuild/${process.env.PROVIDE_TYPE || 'rspack'}.config.web.mjs`,
+  `./dist/.rsbuild/rspack.config.web.mjs`,
 );
 const bundlerNodeConfig = path.resolve(
   import.meta.dirname,
-  `./dist/.rsbuild/${process.env.PROVIDE_TYPE || 'rspack'}.config.node.mjs`,
+  `./dist/.rsbuild/rspack.config.node.mjs`,
 );
 
 const INSPECT_LOG = 'config inspection completed';
 
-rspackTest(
-  'should generate config files when writeToDisk is true',
-  async ({ logHelper }) => {
-    const { expectLog } = logHelper;
+test('should generate config files when writeToDisk is true', async ({
+  logHelper,
+}) => {
+  const { expectLog } = logHelper;
 
-    const rsbuild = await createRsbuild({
-      cwd: import.meta.dirname,
-    });
-    await rsbuild.inspectConfig({
-      writeToDisk: true,
-    });
+  const rsbuild = await createRsbuild({
+    cwd: import.meta.dirname,
+  });
+  await rsbuild.inspectConfig({
+    writeToDisk: true,
+  });
 
-    expect(fs.existsSync(bundlerConfig)).toBeTruthy();
-    expect(fs.existsSync(rsbuildConfig)).toBeTruthy();
-    await expectLog(INSPECT_LOG);
+  expect(fs.existsSync(bundlerConfig)).toBeTruthy();
+  expect(fs.existsSync(rsbuildConfig)).toBeTruthy();
+  await expectLog(INSPECT_LOG);
 
-    await fse.remove(rsbuildConfig);
-    await fse.remove(bundlerConfig);
-  },
-);
+  await fse.remove(rsbuildConfig);
+  await fse.remove(bundlerConfig);
+});
 
-rspackTest(
-  'should generate config files correctly when output is specified',
-  async ({ logHelper }) => {
-    const { expectLog } = logHelper;
+test('should generate config files correctly when output is specified', async ({
+  logHelper,
+}) => {
+  const { expectLog } = logHelper;
 
-    const rsbuild = await createRsbuild({
-      cwd: import.meta.dirname,
-    });
-    await rsbuild.inspectConfig({
-      writeToDisk: true,
-      outputPath: 'foo',
-    });
+  const rsbuild = await createRsbuild({
+    cwd: import.meta.dirname,
+  });
+  await rsbuild.inspectConfig({
+    writeToDisk: true,
+    outputPath: 'foo',
+  });
 
-    const bundlerConfig = path.resolve(
-      import.meta.dirname,
-      `./dist/foo/${process.env.PROVIDE_TYPE || 'rspack'}.config.web.mjs`,
-    );
+  const bundlerConfig = path.resolve(
+    import.meta.dirname,
+    `./dist/foo/rspack.config.web.mjs`,
+  );
 
-    const rsbuildConfig = path.resolve(
-      import.meta.dirname,
-      './dist/foo/rsbuild.config.mjs',
-    );
+  const rsbuildConfig = path.resolve(
+    import.meta.dirname,
+    './dist/foo/rsbuild.config.mjs',
+  );
 
-    expect(fs.existsSync(bundlerConfig)).toBeTruthy();
-    expect(fs.existsSync(rsbuildConfig)).toBeTruthy();
-    await expectLog(INSPECT_LOG);
+  expect(fs.existsSync(bundlerConfig)).toBeTruthy();
+  expect(fs.existsSync(rsbuildConfig)).toBeTruthy();
+  await expectLog(INSPECT_LOG);
 
-    await fse.remove(rsbuildConfig);
-    await fse.remove(bundlerConfig);
-  },
-);
+  await fse.remove(rsbuildConfig);
+  await fse.remove(bundlerConfig);
+});
 
-rspackTest(
-  'should generate bundler config for node when target contains node',
-  async ({ logHelper }) => {
-    const { expectLog } = logHelper;
+test('should generate bundler config for node when target contains node', async ({
+  logHelper,
+}) => {
+  const { expectLog } = logHelper;
 
-    const rsbuild = await createRsbuild({
-      cwd: import.meta.dirname,
-      config: {
-        environments: {
-          web: {},
-          node: {
-            output: {
-              target: 'node',
-            },
+  const rsbuild = await createRsbuild({
+    cwd: import.meta.dirname,
+    config: {
+      environments: {
+        web: {},
+        node: {
+          output: {
+            target: 'node',
           },
         },
       },
-    });
-    await rsbuild.inspectConfig({
-      writeToDisk: true,
-    });
+    },
+  });
+  await rsbuild.inspectConfig({
+    writeToDisk: true,
+  });
 
-    expect(fs.existsSync(rsbuildNodeConfig)).toBeTruthy();
-    expect(fs.existsSync(bundlerConfig)).toBeTruthy();
-    expect(fs.existsSync(bundlerNodeConfig)).toBeTruthy();
-    await expectLog(INSPECT_LOG);
+  expect(fs.existsSync(rsbuildNodeConfig)).toBeTruthy();
+  expect(fs.existsSync(bundlerConfig)).toBeTruthy();
+  expect(fs.existsSync(bundlerNodeConfig)).toBeTruthy();
+  await expectLog(INSPECT_LOG);
 
-    await fse.remove(rsbuildConfig);
-    await fse.remove(rsbuildNodeConfig);
-    await fse.remove(bundlerConfig);
-    await fse.remove(bundlerNodeConfig);
-  },
-);
+  await fse.remove(rsbuildConfig);
+  await fse.remove(rsbuildNodeConfig);
+  await fse.remove(bundlerConfig);
+  await fse.remove(bundlerNodeConfig);
+});
 
-rspackTest(
-  'should not generate config files when writeToDisk is false',
-  async () => {
-    const rsbuild = await createRsbuild({
-      cwd: import.meta.dirname,
-    });
-    await rsbuild.inspectConfig({
-      writeToDisk: false,
-    });
+test('should not generate config files when writeToDisk is false', async () => {
+  const rsbuild = await createRsbuild({
+    cwd: import.meta.dirname,
+  });
+  await rsbuild.inspectConfig({
+    writeToDisk: false,
+  });
 
-    expect(fs.existsSync(rsbuildConfig)).toBeFalsy();
-    expect(fs.existsSync(bundlerConfig)).toBeFalsy();
-  },
-);
+  expect(fs.existsSync(rsbuildConfig)).toBeFalsy();
+  expect(fs.existsSync(bundlerConfig)).toBeFalsy();
+});
 
-rspackTest(
-  'should allow to specify absolute output path',
-  async ({ logHelper }) => {
-    const { expectLog } = logHelper;
+test('should allow to specify absolute output path', async ({ logHelper }) => {
+  const { expectLog } = logHelper;
 
-    const rsbuild = await createRsbuild({
-      cwd: import.meta.dirname,
-    });
-    const outputPath = path.join(import.meta.dirname, 'test-temp-output');
+  const rsbuild = await createRsbuild({
+    cwd: import.meta.dirname,
+  });
+  const outputPath = path.join(import.meta.dirname, 'test-temp-output');
 
-    await rsbuild.inspectConfig({
-      writeToDisk: true,
-      outputPath,
-    });
+  await rsbuild.inspectConfig({
+    writeToDisk: true,
+    outputPath,
+  });
 
-    await expectLog(INSPECT_LOG);
+  await expectLog(INSPECT_LOG);
 
-    expect(
-      fs.existsSync(path.join(outputPath, 'rspack.config.web.mjs')),
-    ).toBeTruthy();
+  expect(
+    fs.existsSync(path.join(outputPath, 'rspack.config.web.mjs')),
+  ).toBeTruthy();
 
-    await fse.remove(rsbuildConfig);
-  },
-);
+  await fse.remove(rsbuildConfig);
+});
 
-rspackTest('should generate extra config files', async ({ logHelper }) => {
+test('should generate extra config files', async ({ logHelper }) => {
   const { expectLog } = logHelper;
 
   const rsbuild = await createRsbuild({
@@ -186,7 +177,7 @@ rspackTest('should generate extra config files', async ({ logHelper }) => {
   await fse.remove(rstestConfig);
 });
 
-rspackTest('should apply plugin correctly', async () => {
+test('should apply plugin correctly', async () => {
   let servePluginApplied = false;
   let buildPluginApplied = false;
 

--- a/e2e/cases/create-rsbuild/basic.test.ts
+++ b/e2e/cases/create-rsbuild/basic.test.ts
@@ -1,21 +1,21 @@
-import { rspackTest } from '@e2e/helper';
+import { test } from '@e2e/helper';
 import { createAndValidate } from './helper';
 
-rspackTest('should create vanilla project as expected', async () => {
+test('should create vanilla project as expected', async () => {
   await createAndValidate(import.meta.dirname, 'vanilla');
 });
 
-rspackTest('should create vanilla-ts project as expected', async () => {
+test('should create vanilla-ts project as expected', async () => {
   await createAndValidate(import.meta.dirname, 'vanilla-ts');
 });
 
-rspackTest('should allow to create project in sub dir', async () => {
+test('should allow to create project in sub dir', async () => {
   await createAndValidate(import.meta.dirname, 'vanilla', {
     name: 'test-temp-dir/rsbuild-project',
   });
 });
 
-rspackTest('should allow to create project in relative dir', async () => {
+test('should allow to create project in relative dir', async () => {
   await createAndValidate(import.meta.dirname, 'vanilla', {
     name: './test-temp-relative-dir',
   });

--- a/e2e/cases/create-rsbuild/jsTemplates.test.ts
+++ b/e2e/cases/create-rsbuild/jsTemplates.test.ts
@@ -1,50 +1,50 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import { createAndValidate } from './helper';
 
-rspackTest('should create react project as expected', async () => {
+test('should create react project as expected', async () => {
   const { pkgJson } = await createAndValidate(import.meta.dirname, 'react');
   expect(pkgJson.dependencies.react).toBeTruthy();
   expect(pkgJson.dependencies['react-dom']).toBeTruthy();
   expect(pkgJson.devDependencies['@rsbuild/plugin-react']).toBeTruthy();
 });
 
-rspackTest('should create react18 project as expected', async () => {
+test('should create react18 project as expected', async () => {
   const { pkgJson } = await createAndValidate(import.meta.dirname, 'react18');
   expect(pkgJson.dependencies.react.startsWith('^18')).toBeTruthy();
   expect(pkgJson.dependencies['react-dom'].startsWith('^18')).toBeTruthy();
   expect(pkgJson.devDependencies['@rsbuild/plugin-react']).toBeTruthy();
 });
 
-rspackTest('should create preact project as expected', async () => {
+test('should create preact project as expected', async () => {
   const { pkgJson } = await createAndValidate(import.meta.dirname, 'preact');
   expect(pkgJson.dependencies.preact).toBeTruthy();
   expect(pkgJson.devDependencies['@rsbuild/plugin-preact']).toBeTruthy();
 });
 
-rspackTest('should create vue3 project as expected', async () => {
+test('should create vue3 project as expected', async () => {
   const { pkgJson } = await createAndValidate(import.meta.dirname, 'vue3');
   expect(pkgJson.dependencies.vue).toBeTruthy();
   expect(pkgJson.devDependencies['@rsbuild/plugin-vue']).toBeTruthy();
 });
 
-rspackTest('should create vue2 project as expected', async () => {
+test('should create vue2 project as expected', async () => {
   const { pkgJson } = await createAndValidate(import.meta.dirname, 'vue2');
   expect(pkgJson.dependencies.vue).toBeTruthy();
   expect(pkgJson.devDependencies['@rsbuild/plugin-vue2']).toBeTruthy();
 });
 
-rspackTest('should create lit project as expected', async () => {
+test('should create lit project as expected', async () => {
   const { pkgJson } = await createAndValidate(import.meta.dirname, 'lit');
   expect(pkgJson.dependencies.lit).toBeTruthy();
 });
 
-rspackTest('should create solid project as expected', async () => {
+test('should create solid project as expected', async () => {
   const { pkgJson } = await createAndValidate(import.meta.dirname, 'solid');
   expect(pkgJson.dependencies['solid-js']).toBeTruthy();
   expect(pkgJson.devDependencies['@rsbuild/plugin-solid']).toBeTruthy();
 });
 
-rspackTest('should create svelte project as expected', async () => {
+test('should create svelte project as expected', async () => {
   const { pkgJson } = await createAndValidate(import.meta.dirname, 'svelte');
   expect(pkgJson.dependencies.svelte).toBeTruthy();
   expect(pkgJson.devDependencies['@rsbuild/plugin-svelte']).toBeTruthy();

--- a/e2e/cases/create-rsbuild/tools.test.ts
+++ b/e2e/cases/create-rsbuild/tools.test.ts
@@ -1,9 +1,9 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import { createAndValidate } from './helper';
 
-rspackTest('should create project with eslint as expected', async () => {
+test('should create project with eslint as expected', async () => {
   const { dir, pkgJson, clean } = await createAndValidate(
     import.meta.dirname,
     'vanilla',
@@ -18,7 +18,7 @@ rspackTest('should create project with eslint as expected', async () => {
   await clean();
 });
 
-rspackTest('should create project with prettier as expected', async () => {
+test('should create project with prettier as expected', async () => {
   const { dir, pkgJson, clean } = await createAndValidate(
     import.meta.dirname,
     'vanilla',
@@ -33,27 +33,24 @@ rspackTest('should create project with prettier as expected', async () => {
   await clean();
 });
 
-rspackTest(
-  'should create project with ESLint and prettier as expected',
-  async () => {
-    const { dir, pkgJson, clean } = await createAndValidate(
-      import.meta.dirname,
-      'vanilla',
-      {
-        name: 'test-temp-eslint-prettier',
-        tools: ['eslint', 'prettier'],
-        clean: false,
-      },
-    );
-    expect(pkgJson.devDependencies.eslint).toBeTruthy();
-    expect(pkgJson.devDependencies.prettier).toBeTruthy();
-    expect(existsSync(join(dir, '.prettierrc'))).toBeTruthy();
-    expect(existsSync(join(dir, 'eslint.config.mjs'))).toBeTruthy();
-    await clean();
-  },
-);
+test('should create project with ESLint and prettier as expected', async () => {
+  const { dir, pkgJson, clean } = await createAndValidate(
+    import.meta.dirname,
+    'vanilla',
+    {
+      name: 'test-temp-eslint-prettier',
+      tools: ['eslint', 'prettier'],
+      clean: false,
+    },
+  );
+  expect(pkgJson.devDependencies.eslint).toBeTruthy();
+  expect(pkgJson.devDependencies.prettier).toBeTruthy();
+  expect(existsSync(join(dir, '.prettierrc'))).toBeTruthy();
+  expect(existsSync(join(dir, 'eslint.config.mjs'))).toBeTruthy();
+  await clean();
+});
 
-rspackTest('should create React project with ESLint as expected', async () => {
+test('should create React project with ESLint as expected', async () => {
   const { dir, pkgJson, clean } = await createAndValidate(
     import.meta.dirname,
     'react-ts',
@@ -69,7 +66,7 @@ rspackTest('should create React project with ESLint as expected', async () => {
   await clean();
 });
 
-rspackTest('should create Vue project with ESLint as expected', async () => {
+test('should create Vue project with ESLint as expected', async () => {
   const { dir, pkgJson, clean } = await createAndValidate(
     import.meta.dirname,
     'vue3-ts',
@@ -85,7 +82,7 @@ rspackTest('should create Vue project with ESLint as expected', async () => {
   await clean();
 });
 
-rspackTest('should create project with biome as expected', async () => {
+test('should create project with biome as expected', async () => {
   const { dir, pkgJson, clean } = await createAndValidate(
     import.meta.dirname,
     'vanilla',

--- a/e2e/cases/create-rsbuild/tsTemplates.test.ts
+++ b/e2e/cases/create-rsbuild/tsTemplates.test.ts
@@ -1,14 +1,14 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import { createAndValidate } from './helper';
 
-rspackTest('should create react-ts project as expected', async () => {
+test('should create react-ts project as expected', async () => {
   const { pkgJson } = await createAndValidate(import.meta.dirname, 'react-ts');
   expect(pkgJson.dependencies.react).toBeTruthy();
   expect(pkgJson.dependencies['react-dom']).toBeTruthy();
   expect(pkgJson.devDependencies['@rsbuild/plugin-react']).toBeTruthy();
 });
 
-rspackTest('should create react18-ts project as expected', async () => {
+test('should create react18-ts project as expected', async () => {
   const { pkgJson } = await createAndValidate(
     import.meta.dirname,
     'react18-ts',
@@ -18,36 +18,36 @@ rspackTest('should create react18-ts project as expected', async () => {
   expect(pkgJson.devDependencies['@rsbuild/plugin-react']).toBeTruthy();
 });
 
-rspackTest('should create preact-ts project as expected', async () => {
+test('should create preact-ts project as expected', async () => {
   const { pkgJson } = await createAndValidate(import.meta.dirname, 'preact-ts');
   expect(pkgJson.dependencies.preact).toBeTruthy();
   expect(pkgJson.devDependencies['@rsbuild/plugin-preact']).toBeTruthy();
 });
 
-rspackTest('should create vue3-ts project as expected', async () => {
+test('should create vue3-ts project as expected', async () => {
   const { pkgJson } = await createAndValidate(import.meta.dirname, 'vue3-ts');
   expect(pkgJson.dependencies.vue).toBeTruthy();
   expect(pkgJson.devDependencies['@rsbuild/plugin-vue']).toBeTruthy();
 });
 
-rspackTest('should create vue2-ts project as expected', async () => {
+test('should create vue2-ts project as expected', async () => {
   const { pkgJson } = await createAndValidate(import.meta.dirname, 'vue2-ts');
   expect(pkgJson.dependencies.vue).toBeTruthy();
   expect(pkgJson.devDependencies['@rsbuild/plugin-vue2']).toBeTruthy();
 });
 
-rspackTest('should create lit-ts project as expected', async () => {
+test('should create lit-ts project as expected', async () => {
   const { pkgJson } = await createAndValidate(import.meta.dirname, 'lit-ts');
   expect(pkgJson.dependencies.lit).toBeTruthy();
 });
 
-rspackTest('should create solid-ts project as expected', async () => {
+test('should create solid-ts project as expected', async () => {
   const { pkgJson } = await createAndValidate(import.meta.dirname, 'solid-ts');
   expect(pkgJson.dependencies['solid-js']).toBeTruthy();
   expect(pkgJson.devDependencies['@rsbuild/plugin-solid']).toBeTruthy();
 });
 
-rspackTest('should create svelte-ts project as expected', async () => {
+test('should create svelte-ts project as expected', async () => {
   const { pkgJson } = await createAndValidate(import.meta.dirname, 'svelte-ts');
   expect(pkgJson.dependencies.svelte).toBeTruthy();
   expect(pkgJson.devDependencies['@rsbuild/plugin-svelte']).toBeTruthy();

--- a/e2e/cases/css/css-layers/index.test.ts
+++ b/e2e/cases/css/css-layers/index.test.ts
@@ -1,18 +1,15 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest(
-  'should bundle CSS layers as expected in build',
-  async ({ build }) => {
-    const rsbuild = await build();
-    const files = rsbuild.getDistFiles();
-    const content = getFileContent(files, 'index.css');
-    expect(content).toEqual(
-      '@layer a{.a{color:red}}@layer b{.b{color:green}}@layer c{@layer{.c-sub{color:#00f}.c-sub2{color:green}}.c{color:#00f}}',
-    );
-  },
-);
+test('should bundle CSS layers as expected in build', async ({ build }) => {
+  const rsbuild = await build();
+  const files = rsbuild.getDistFiles();
+  const content = getFileContent(files, 'index.css');
+  expect(content).toEqual(
+    '@layer a{.a{color:red}}@layer b{.b{color:green}}@layer c{@layer{.c-sub{color:#00f}.c-sub2{color:green}}.c{color:#00f}}',
+  );
+});
 
-rspackTest('should bundle CSS layers as expected in dev', async ({ dev }) => {
+test('should bundle CSS layers as expected in dev', async ({ dev }) => {
   const rsbuild = await dev();
   const files = rsbuild.getDistFiles();
   const content = getFileContent(files, 'index.css');

--- a/e2e/cases/css/css-modules-composes/index.test.ts
+++ b/e2e/cases/css/css-modules-composes/index.test.ts
@@ -1,34 +1,30 @@
 import path from 'node:path';
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest(
-  'should compile CSS Modules composes correctly',
-  async ({ build }) => {
-    const rsbuild = await build();
-    const files = rsbuild.getDistFiles();
-    const content = getFileContent(files, 'index.css');
-    expect(content).toMatch(
-      /.*\{color:#ff0;background:red\}.*\{background:#00f\}/,
-    );
-  },
-);
+test('should compile CSS Modules composes correctly', async ({ build }) => {
+  const rsbuild = await build();
+  const files = rsbuild.getDistFiles();
+  const content = getFileContent(files, 'index.css');
+  expect(content).toMatch(
+    /.*\{color:#ff0;background:red\}.*\{background:#00f\}/,
+  );
+});
 
-rspackTest(
-  'should compile CSS Modules composes with external correctly',
-  async ({ build }) => {
-    const rsbuild = await build({
-      config: {
-        source: {
-          entry: {
-            external: path.resolve(import.meta.dirname, './src/external.js'),
-          },
+test('should compile CSS Modules composes with external correctly', async ({
+  build,
+}) => {
+  const rsbuild = await build({
+    config: {
+      source: {
+        entry: {
+          external: path.resolve(import.meta.dirname, './src/external.js'),
         },
       },
-    });
-    const files = rsbuild.getDistFiles();
-    const content = getFileContent(files, 'external.css');
-    expect(content).toMatch(
-      /.*\{color:#000;background:#0ff\}.*\{background:green\}/,
-    );
-  },
-);
+    },
+  });
+  const files = rsbuild.getDistFiles();
+  const content = getFileContent(files, 'external.css');
+  expect(content).toMatch(
+    /.*\{color:#000;background:#0ff\}.*\{background:green\}/,
+  );
+});

--- a/e2e/cases/css/css-modules-export-locals/index.test.ts
+++ b/e2e/cases/css/css-modules-export-locals/index.test.ts
@@ -1,9 +1,4 @@
-import {
-  type BuildResult,
-  expect,
-  getFileContent,
-  rspackTest,
-} from '@e2e/helper';
+import { type BuildResult, expect, getFileContent, test } from '@e2e/helper';
 
 declare global {
   interface Window {
@@ -19,125 +14,125 @@ const expectCSSContext = async (rsbuild: BuildResult) => {
   );
 };
 
-rspackTest(
-  'should compile CSS Modules with exportLocalsConvention camelCaseOnly',
-  async ({ page, buildPreview }) => {
-    const rsbuild = await buildPreview({
-      config: {
-        output: {
-          cssModules: {
-            exportLocalsConvention: 'camelCaseOnly',
-          },
+test('should compile CSS Modules with exportLocalsConvention camelCaseOnly', async ({
+  page,
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview({
+    config: {
+      output: {
+        cssModules: {
+          exportLocalsConvention: 'camelCaseOnly',
         },
       },
-    });
+    },
+  });
 
-    await expectCSSContext(rsbuild);
+  await expectCSSContext(rsbuild);
 
-    const styles = await page.evaluate(() => window.styles);
-    expect(Object.keys(styles)).toEqual([
-      'theDashClass',
-      'theCamelClass',
-      'theUnderscoreClass',
-    ]);
-  },
-);
+  const styles = await page.evaluate(() => window.styles);
+  expect(Object.keys(styles)).toEqual([
+    'theDashClass',
+    'theCamelClass',
+    'theUnderscoreClass',
+  ]);
+});
 
-rspackTest(
-  'should compile CSS Modules with exportLocalsConvention camelCase',
-  async ({ page, buildPreview }) => {
-    const rsbuild = await buildPreview({
-      config: {
-        output: {
-          cssModules: {
-            exportLocalsConvention: 'camelCase',
-          },
+test('should compile CSS Modules with exportLocalsConvention camelCase', async ({
+  page,
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview({
+    config: {
+      output: {
+        cssModules: {
+          exportLocalsConvention: 'camelCase',
         },
       },
-    });
+    },
+  });
 
-    await expectCSSContext(rsbuild);
+  await expectCSSContext(rsbuild);
 
-    const styles = await page.evaluate(() => window.styles);
-    expect(Object.keys(styles)).toEqual([
-      'the-dash-class',
-      'theDashClass',
-      'theCamelClass',
-      'the_underscore_class',
-      'theUnderscoreClass',
-    ]);
-  },
-);
+  const styles = await page.evaluate(() => window.styles);
+  expect(Object.keys(styles)).toEqual([
+    'the-dash-class',
+    'theDashClass',
+    'theCamelClass',
+    'the_underscore_class',
+    'theUnderscoreClass',
+  ]);
+});
 
-rspackTest(
-  'should compile CSS Modules with exportLocalsConvention dashes',
-  async ({ page, buildPreview }) => {
-    const rsbuild = await buildPreview({
-      config: {
-        output: {
-          cssModules: {
-            exportLocalsConvention: 'dashes',
-          },
+test('should compile CSS Modules with exportLocalsConvention dashes', async ({
+  page,
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview({
+    config: {
+      output: {
+        cssModules: {
+          exportLocalsConvention: 'dashes',
         },
       },
-    });
+    },
+  });
 
-    await expectCSSContext(rsbuild);
+  await expectCSSContext(rsbuild);
 
-    const styles = await page.evaluate(() => window.styles);
-    expect(Object.keys(styles)).toEqual([
-      'the-dash-class',
-      'theDashClass',
-      'theCamelClass',
-      'the_underscore_class',
-    ]);
-  },
-);
+  const styles = await page.evaluate(() => window.styles);
+  expect(Object.keys(styles)).toEqual([
+    'the-dash-class',
+    'theDashClass',
+    'theCamelClass',
+    'the_underscore_class',
+  ]);
+});
 
-rspackTest(
-  'should compile CSS Modules with exportLocalsConvention dashesOnly',
-  async ({ page, buildPreview }) => {
-    const rsbuild = await buildPreview({
-      config: {
-        output: {
-          cssModules: {
-            exportLocalsConvention: 'dashesOnly',
-          },
+test('should compile CSS Modules with exportLocalsConvention dashesOnly', async ({
+  page,
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview({
+    config: {
+      output: {
+        cssModules: {
+          exportLocalsConvention: 'dashesOnly',
         },
       },
-    });
+    },
+  });
 
-    await expectCSSContext(rsbuild);
+  await expectCSSContext(rsbuild);
 
-    const styles = await page.evaluate(() => window.styles);
-    expect(Object.keys(styles)).toEqual([
-      'theDashClass',
-      'theCamelClass',
-      'the_underscore_class',
-    ]);
-  },
-);
+  const styles = await page.evaluate(() => window.styles);
+  expect(Object.keys(styles)).toEqual([
+    'theDashClass',
+    'theCamelClass',
+    'the_underscore_class',
+  ]);
+});
 
-rspackTest(
-  'should compile CSS Modules with exportLocalsConvention asIs',
-  async ({ page, buildPreview }) => {
-    const rsbuild = await buildPreview({
-      config: {
-        output: {
-          cssModules: {
-            exportLocalsConvention: 'asIs',
-          },
+test('should compile CSS Modules with exportLocalsConvention asIs', async ({
+  page,
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview({
+    config: {
+      output: {
+        cssModules: {
+          exportLocalsConvention: 'asIs',
         },
       },
-    });
+    },
+  });
 
-    await expectCSSContext(rsbuild);
+  await expectCSSContext(rsbuild);
 
-    const styles = await page.evaluate(() => window.styles);
-    expect(Object.keys(styles)).toEqual([
-      'the-dash-class',
-      'theCamelClass',
-      'the_underscore_class',
-    ]);
-  },
-);
+  const styles = await page.evaluate(() => window.styles);
+  expect(Object.keys(styles)).toEqual([
+    'the-dash-class',
+    'theCamelClass',
+    'the_underscore_class',
+  ]);
+});

--- a/e2e/cases/css/css-modules-exports-global/index.test.ts
+++ b/e2e/cases/css/css-modules-exports-global/index.test.ts
@@ -1,31 +1,31 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest(
-  'should exports global in CSS Modules correctly in dev build',
-  async ({ page, dev }) => {
-    await dev();
+test('should exports global in CSS Modules correctly in dev build', async ({
+  page,
+  dev,
+}) => {
+  await dev();
 
-    const test1Locator = page.locator('#test1');
-    await expect(test1Locator).toHaveCSS('color', 'rgb(255, 0, 0)');
+  const test1Locator = page.locator('#test1');
+  await expect(test1Locator).toHaveCSS('color', 'rgb(255, 0, 0)');
 
-    const test2Locator = page.locator('#test2');
-    await expect(test2Locator).toHaveCSS('color', 'rgb(0, 0, 255)');
-  },
-);
+  const test2Locator = page.locator('#test2');
+  await expect(test2Locator).toHaveCSS('color', 'rgb(0, 0, 255)');
+});
 
-rspackTest(
-  'should exports global in CSS Modules correctly in build',
-  async ({ page, buildPreview }) => {
-    const rsbuild = await buildPreview();
+test('should exports global in CSS Modules correctly in build', async ({
+  page,
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview();
 
-    const test1Locator = page.locator('#test1');
-    await expect(test1Locator).toHaveCSS('color', 'rgb(255, 0, 0)');
+  const test1Locator = page.locator('#test1');
+  await expect(test1Locator).toHaveCSS('color', 'rgb(255, 0, 0)');
 
-    const test2Locator = page.locator('#test2');
-    await expect(test2Locator).toHaveCSS('color', 'rgb(0, 0, 255)');
+  const test2Locator = page.locator('#test2');
+  await expect(test2Locator).toHaveCSS('color', 'rgb(0, 0, 255)');
 
-    const files = rsbuild.getDistFiles();
-    const content = getFileContent(files, 'index.css');
-    expect(content).toMatch(/\.foo-\w{6}{color:red}\.bar{color:#00f}/);
-  },
-);
+  const files = rsbuild.getDistFiles();
+  const content = getFileContent(files, 'index.css');
+  expect(content).toMatch(/\.foo-\w{6}{color:red}\.bar{color:#00f}/);
+});

--- a/e2e/cases/css/css-modules-named-export/index.test.ts
+++ b/e2e/cases/css/css-modules-named-export/index.test.ts
@@ -1,18 +1,18 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest(
-  'should compile CSS Modules with named exports correctly',
-  async ({ page, buildPreview }) => {
-    const rsbuild = await buildPreview();
-    const files = rsbuild.getDistFiles();
-    const content = getFileContent(files, 'index.css');
+test('should compile CSS Modules with named exports correctly', async ({
+  page,
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview();
+  const files = rsbuild.getDistFiles();
+  const content = getFileContent(files, 'index.css');
 
-    expect(content).toMatch(
-      /\.classA-\w{6}{color:red}\.classB-\w{6}{color:#00f}\.classC-\w{6}{color:#ff0}/,
-    );
+  expect(content).toMatch(
+    /\.classA-\w{6}{color:red}\.classB-\w{6}{color:#00f}\.classC-\w{6}{color:#ff0}/,
+  );
 
-    const root = page.locator('#root');
-    const text = await root.innerHTML();
-    expect(text).toMatch(/classA-\w{6} classB-\w{6} classC-\w{6}/);
-  },
-);
+  const root = page.locator('#root');
+  const text = await root.innerHTML();
+  expect(text).toMatch(/classA-\w{6} classB-\w{6} classC-\w{6}/);
+});

--- a/e2e/cases/css/css-modules/index.test.ts
+++ b/e2e/cases/css/css-modules/index.test.ts
@@ -1,75 +1,71 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest(
-  'should compile CSS Modules with default configuration',
-  async ({ build }) => {
-    const rsbuild = await build();
-    const files = rsbuild.getDistFiles();
-    const content = getFileContent(files, 'index.css');
-    expect(content).toMatch(
-      /\.the-a-class{color:red}\.the-b-class-\w{6}{color:#00f}\.the-c-class-\w{6}{color:#ff0}\.the-d-class{color:green}/,
-    );
-  },
-);
+test('should compile CSS Modules with default configuration', async ({
+  build,
+}) => {
+  const rsbuild = await build();
+  const files = rsbuild.getDistFiles();
+  const content = getFileContent(files, 'index.css');
+  expect(content).toMatch(
+    /\.the-a-class{color:red}\.the-b-class-\w{6}{color:#00f}\.the-c-class-\w{6}{color:#ff0}\.the-d-class{color:green}/,
+  );
+});
 
-rspackTest(
-  'should compile CSS Modules with custom auto configuration',
-  async ({ build }) => {
-    const rsbuild = await build({
-      config: {
-        output: {
-          cssModules: {
-            auto: (resource) => {
-              return resource.includes('.scss');
-            },
+test('should compile CSS Modules with custom auto configuration', async ({
+  build,
+}) => {
+  const rsbuild = await build({
+    config: {
+      output: {
+        cssModules: {
+          auto: (resource) => {
+            return resource.includes('.scss');
           },
         },
       },
-    });
-    const files = rsbuild.getDistFiles();
-    const content = getFileContent(files, 'index.css');
-    expect(content).toMatch(
-      /.the-a-class{color:red}.the-b-class-\w{6}{color:#00f}.the-c-class{color:#ff0}.the-d-class{color:green}/,
-    );
-  },
-);
+    },
+  });
+  const files = rsbuild.getDistFiles();
+  const content = getFileContent(files, 'index.css');
+  expect(content).toMatch(
+    /.the-a-class{color:red}.the-b-class-\w{6}{color:#00f}.the-c-class{color:#ff0}.the-d-class{color:green}/,
+  );
+});
 
-rspackTest(
-  'should compile CSS Modules with custom localIdentName pattern',
-  async ({ build }) => {
-    const rsbuild = await build({
-      config: {
-        output: {
-          cssModules: {
-            localIdentName: '[hash:base64:8]',
-          },
+test('should compile CSS Modules with custom localIdentName pattern', async ({
+  build,
+}) => {
+  const rsbuild = await build({
+    config: {
+      output: {
+        cssModules: {
+          localIdentName: '[hash:base64:8]',
         },
       },
-    });
-    const files = rsbuild.getDistFiles();
-    const content = getFileContent(files, 'index.css');
-    expect(content).toMatch(
-      /\.the-a-class{color:red}\.\w{8}{color:#00f}\.\w{8}{color:#ff0}\.the-d-class{color:green}/,
-    );
-  },
-);
+    },
+  });
+  const files = rsbuild.getDistFiles();
+  const content = getFileContent(files, 'index.css');
+  expect(content).toMatch(
+    /\.the-a-class{color:red}\.\w{8}{color:#00f}\.\w{8}{color:#ff0}\.the-d-class{color:green}/,
+  );
+});
 
-rspackTest(
-  'should compile CSS Modules with custom hash digest format',
-  async ({ build }) => {
-    const rsbuild = await build({
-      config: {
-        output: {
-          cssModules: {
-            localIdentName: '[hash:hex:4]',
-          },
+test('should compile CSS Modules with custom hash digest format', async ({
+  build,
+}) => {
+  const rsbuild = await build({
+    config: {
+      output: {
+        cssModules: {
+          localIdentName: '[hash:hex:4]',
         },
       },
-    });
-    const files = rsbuild.getDistFiles();
-    const content = getFileContent(files, 'index.css');
-    expect(content).toMatch(
-      /\.the-a-class{color:red}\.\w{4}{color:#00f}\.\w{4}{color:#ff0}\.the-d-class{color:green}/,
-    );
-  },
-);
+    },
+  });
+  const files = rsbuild.getDistFiles();
+  const content = getFileContent(files, 'index.css');
+  expect(content).toMatch(
+    /\.the-a-class{color:red}\.\w{4}{color:#00f}\.\w{4}{color:#ff0}\.the-d-class{color:green}/,
+  );
+});

--- a/e2e/cases/css/enable-experiments-css/index.test.ts
+++ b/e2e/cases/css/enable-experiments-css/index.test.ts
@@ -1,36 +1,32 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 const COMPILE_WARNING = 'Compile Warning';
 
-rspackTest(
-  'should allow to enable Rspack experiments.css',
-  async ({ build }) => {
-    const rsbuild = await build();
-    const files = rsbuild.getDistFiles();
-    const content = getFileContent(files, 'index.css');
+test('should allow to enable Rspack experiments.css', async ({ build }) => {
+  const rsbuild = await build();
+  const files = rsbuild.getDistFiles();
+  const content = getFileContent(files, 'index.css');
 
-    expect(content).toEqual('body{color:red}');
-    // should have no warnings
-    rsbuild.expectNoLog(COMPILE_WARNING);
-  },
-);
+  expect(content).toEqual('body{color:red}');
+  // should have no warnings
+  rsbuild.expectNoLog(COMPILE_WARNING);
+});
 
-rspackTest(
-  'should allow to enable Rspack experiments.css with style-loader',
-  async ({ build }) => {
-    const rsbuild = await build({
-      config: {
-        output: {
-          injectStyles: true,
-        },
+test('should allow to enable Rspack experiments.css with style-loader', async ({
+  build,
+}) => {
+  const rsbuild = await build({
+    config: {
+      output: {
+        injectStyles: true,
       },
-    });
+    },
+  });
 
-    const files = rsbuild.getDistFiles();
-    const content = getFileContent(files, 'index.js');
-    expect(content).toContain('color:red');
+  const files = rsbuild.getDistFiles();
+  const content = getFileContent(files, 'index.js');
+  expect(content).toContain('color:red');
 
-    // should have no warnings
-    rsbuild.expectNoLog(COMPILE_WARNING);
-  },
-);
+  // should have no warnings
+  rsbuild.expectNoLog(COMPILE_WARNING);
+});

--- a/e2e/cases/css/export-type-string/index.test.ts
+++ b/e2e/cases/css/export-type-string/index.test.ts
@@ -1,11 +1,12 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should allow to configure `cssLoader.exportType` as `string` in development',
-  async ({ page, dev }) => {
-    await dev();
+test('should allow to configure `cssLoader.exportType` as `string` in development', async ({
+  page,
+  dev,
+}) => {
+  await dev();
 
-    expect(await page.evaluate('window.a')).toBe(`.the-a-class {
+  expect(await page.evaluate('window.a')).toBe(`.the-a-class {
   color: red;
 }
 
@@ -14,20 +15,20 @@ rspackTest(
 }
 `);
 
-    expect(
-      (await page.evaluate<string>('window.b')).includes(
-        '.src-b-module__the-b-class',
-      ),
-    ).toBeTruthy();
-  },
-);
+  expect(
+    (await page.evaluate<string>('window.b')).includes(
+      '.src-b-module__the-b-class',
+    ),
+  ).toBeTruthy();
+});
 
-rspackTest(
-  'should allow to configure `cssLoader.exportType` as `string` in production',
-  async ({ page, buildPreview }) => {
-    await buildPreview();
+test('should allow to configure `cssLoader.exportType` as `string` in production', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview();
 
-    expect(await page.evaluate('window.a')).toBe(`.the-a-class {
+  expect(await page.evaluate('window.a')).toBe(`.the-a-class {
   color: red;
 }
 
@@ -36,8 +37,7 @@ rspackTest(
 }
 `);
 
-    expect(
-      (await page.evaluate<string>('window.b')).includes('.the-b-class-'),
-    ).toBeTruthy();
-  },
-);
+  expect(
+    (await page.evaluate<string>('window.b')).includes('.the-b-class-'),
+  ).toBeTruthy();
+});

--- a/e2e/cases/css/import-common-css/index.test.ts
+++ b/e2e/cases/css/import-common-css/index.test.ts
@@ -1,6 +1,6 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest('should compile common CSS import correctly', async ({ build }) => {
+test('should compile common CSS import correctly', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
   const indexCss = getFileContent(files, 'index.css');

--- a/e2e/cases/css/import-loaders/index.test.ts
+++ b/e2e/cases/css/import-loaders/index.test.ts
@@ -1,13 +1,12 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest(
-  'should compile CSS Modules which depends on importLoaders correctly',
-  async ({ build }) => {
-    const rsbuild = await build();
-    const files = rsbuild.getDistFiles();
-    const content = getFileContent(files, 'index.css');
-    expect(content).toEqual(
-      '.class-foo-yQ8Tl7+.hello-class-foo{background-color:red}.class-bar-TVH2T6 .hello-class-bar{background-color:#00f}',
-    );
-  },
-);
+test('should compile CSS Modules which depends on importLoaders correctly', async ({
+  build,
+}) => {
+  const rsbuild = await build();
+  const files = rsbuild.getDistFiles();
+  const content = getFileContent(files, 'index.css');
+  expect(content).toEqual(
+    '.class-foo-yQ8Tl7+.hello-class-foo{background-color:red}.class-bar-TVH2T6 .hello-class-bar{background-color:#00f}',
+  );
+});

--- a/e2e/cases/css/inject-styles-lightningcss/index.test.ts
+++ b/e2e/cases/css/inject-styles-lightningcss/index.test.ts
@@ -1,20 +1,19 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest(
-  'should use lightningcss-loader to transform and minify CSS when injectStyles is true',
-  async ({ build }) => {
-    const rsbuild = await build();
+test('should use lightningcss-loader to transform and minify CSS when injectStyles is true', async ({
+  build,
+}) => {
+  const rsbuild = await build();
 
-    // injectStyles worked
-    const files = rsbuild.getDistFiles();
+  // injectStyles worked
+  const files = rsbuild.getDistFiles();
 
-    // should inline minified CSS
-    const indexJs = getFileContent(files, 'index.js');
+  // should inline minified CSS
+  const indexJs = getFileContent(files, 'index.js');
 
-    expect(
-      indexJs.includes(
-        '@media (-webkit-min-device-pixel-ratio:2),(min-resolution:2dppx){.item{-webkit-user-select:none;user-select:none;background:linear-gradient(#fff,#000);transition:all .5s}}',
-      ),
-    ).toBeTruthy();
-  },
-);
+  expect(
+    indexJs.includes(
+      '@media (-webkit-min-device-pixel-ratio:2),(min-resolution:2dppx){.item{-webkit-user-select:none;user-select:none;background:linear-gradient(#fff,#000);transition:all .5s}}',
+    ),
+  ).toBeTruthy();
+});

--- a/e2e/cases/css/inject-styles/index.test.ts
+++ b/e2e/cases/css/inject-styles/index.test.ts
@@ -1,96 +1,97 @@
 import { join } from 'node:path';
-import { expect, findFile, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, findFile, getFileContent, test } from '@e2e/helper';
 
-rspackTest(
-  'should inline style when `injectStyles` is enabled',
-  async ({ page, buildPreview }) => {
-    const rsbuild = await buildPreview();
+test('should inline style when `injectStyles` is enabled', async ({
+  page,
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview();
 
-    // injectStyles worked
-    const files = rsbuild.getDistFiles();
-    expect(() => findFile(files, '.css')).toThrowError();
+  // injectStyles worked
+  const files = rsbuild.getDistFiles();
+  expect(() => findFile(files, '.css')).toThrowError();
 
-    // should inline minified CSS
-    const indexJs = getFileContent(files, 'index.js');
+  // should inline minified CSS
+  const indexJs = getFileContent(files, 'index.js');
 
-    expect(indexJs.includes('html,body{margin:0;padding:0}')).toBeTruthy();
-    expect(
-      indexJs.includes(
-        '.description{text-align:center;font-size:16px;line-height:1.5}',
-      ),
-    ).toBeTruthy();
+  expect(indexJs.includes('html,body{margin:0;padding:0}')).toBeTruthy();
+  expect(
+    indexJs.includes(
+      '.description{text-align:center;font-size:16px;line-height:1.5}',
+    ),
+  ).toBeTruthy();
 
-    // scss worked
-    const header = page.locator('#header');
-    await expect(header).toHaveCSS('font-size', '20px');
+  // scss worked
+  const header = page.locator('#header');
+  await expect(header).toHaveCSS('font-size', '20px');
 
-    // less worked
-    const title = page.locator('#title');
-    await expect(title).toHaveCSS('font-size', '20px');
-  },
-);
+  // less worked
+  const title = page.locator('#title');
+  await expect(title).toHaveCSS('font-size', '20px');
+});
 
-rspackTest(
-  'HMR should work well when `injectStyles` is enabled',
-  async ({ page, dev, editFile, copySrcDir }) => {
-    const tempSrc = await copySrcDir();
+test('HMR should work well when `injectStyles` is enabled', async ({
+  page,
+  dev,
+  editFile,
+  copySrcDir,
+}) => {
+  const tempSrc = await copySrcDir();
 
-    await dev({
-      config: {
-        source: {
-          entry: {
-            index: join(tempSrc, 'index.ts'),
-          },
+  await dev({
+    config: {
+      source: {
+        entry: {
+          index: join(tempSrc, 'index.ts'),
         },
       },
-    });
+    },
+  });
 
-    // scss worked
-    const header = page.locator('#header');
-    await expect(header).toHaveCSS('font-size', '20px');
+  // scss worked
+  const header = page.locator('#header');
+  await expect(header).toHaveCSS('font-size', '20px');
 
-    // less worked
-    const title = page.locator('#title');
-    await expect(title).toHaveCSS('font-size', '20px');
+  // less worked
+  const title = page.locator('#title');
+  await expect(title).toHaveCSS('font-size', '20px');
 
-    const locatorKeep = page.locator('#test-keep');
-    const keepNum = await locatorKeep.innerHTML();
+  const locatorKeep = page.locator('#test-keep');
+  const keepNum = await locatorKeep.innerHTML();
 
-    await editFile(join(tempSrc, 'App.module.less'), (code) =>
-      code.replace('20px', '40px'),
-    );
+  await editFile(join(tempSrc, 'App.module.less'), (code) =>
+    code.replace('20px', '40px'),
+  );
 
-    // CSS HMR works well
-    await expect(title).toHaveCSS('font-size', '40px');
+  // CSS HMR works well
+  await expect(title).toHaveCSS('font-size', '40px');
 
-    // #test-keep should unchanged when CSS HMR
-    expect(await locatorKeep.innerHTML()).toBe(keepNum);
-  },
-);
+  // #test-keep should unchanged when CSS HMR
+  expect(await locatorKeep.innerHTML()).toBe(keepNum);
+});
 
-rspackTest(
-  'should allow to disable CSS minification when `injectStyles` is enabled',
-  async ({ build }) => {
-    const rsbuild = await build({
-      config: {
-        output: {
-          minify: false,
-        },
+test('should allow to disable CSS minification when `injectStyles` is enabled', async ({
+  build,
+}) => {
+  const rsbuild = await build({
+    config: {
+      output: {
+        minify: false,
       },
-    });
+    },
+  });
 
-    // injectStyles worked
-    const files = rsbuild.getDistFiles();
-    expect(() => findFile(files, '.css')).toThrowError();
+  // injectStyles worked
+  const files = rsbuild.getDistFiles();
+  expect(() => findFile(files, '.css')).toThrowError();
 
-    // should inline CSS
-    const indexJs = getFileContent(files, 'index.js');
+  // should inline CSS
+  const indexJs = getFileContent(files, 'index.js');
 
-    expect(
-      indexJs.includes(`html, body {
+  expect(
+    indexJs.includes(`html, body {
   margin: 0;
   padding: 0;
 }`),
-    ).toBeTruthy();
-  },
-);
+  ).toBeTruthy();
+});

--- a/e2e/cases/css/inline-query-node-target/index.test.ts
+++ b/e2e/cases/css/inline-query-node-target/index.test.ts
@@ -1,28 +1,26 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should transform inlined CSS via lightningcss if target is node in dev',
-  async ({ devOnly }) => {
-    await devOnly();
+test('should transform inlined CSS via lightningcss if target is node in dev', async ({
+  devOnly,
+}) => {
+  await devOnly();
 
-    // @ts-ignore
-    const { style } = await import('./dist-dev/index.js');
-    expect(style).toContain(`.foo {
+  // @ts-ignore
+  const { style } = await import('./dist-dev/index.js');
+  expect(style).toContain(`.foo {
   -webkit-transition: all .5s;
   transition: all .5s;
 }`);
-  },
-);
+});
 
-rspackTest(
-  'should transform inlined CSS via lightningcss if target is node in build',
-  async ({ build }) => {
-    await build();
+test('should transform inlined CSS via lightningcss if target is node in build', async ({
+  build,
+}) => {
+  await build();
 
-    // @ts-ignore
-    const { style } = await import('./dist-build/index.js');
-    expect(style).toContain(
-      '.foo{-webkit-transition:all .5s;transition:all .5s}',
-    );
-  },
-);
+  // @ts-ignore
+  const { style } = await import('./dist-build/index.js');
+  expect(style).toContain(
+    '.foo{-webkit-transition:all .5s;transition:all .5s}',
+  );
+});

--- a/e2e/cases/css/inline-query/index.test.ts
+++ b/e2e/cases/css/inline-query/index.test.ts
@@ -1,44 +1,42 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should allow to import inline CSS files in dev',
-  async ({ page, dev }) => {
-    await dev();
+test('should allow to import inline CSS files in dev', async ({
+  page,
+  dev,
+}) => {
+  await dev();
 
-    for (const key of ['aInline1', 'aInline2', 'aInline3', 'aInline4']) {
-      const inline: string = await page.evaluate(`window.${key}`);
-      expect(
-        inline.includes('.header-class') && inline.includes('color: red'),
-      ).toBe(true);
-    }
-
-    const bInline: string = await page.evaluate('window.bInline');
-    const bStyles: Record<string, string> =
-      await page.evaluate('window.bStyles');
-
+  for (const key of ['aInline1', 'aInline2', 'aInline3', 'aInline4']) {
+    const inline: string = await page.evaluate(`window.${key}`);
     expect(
-      bInline.includes('.title-class') && bInline.includes('font-size: 14px'),
+      inline.includes('.header-class') && inline.includes('color: red'),
     ).toBe(true);
-    expect(bStyles['title-class']).toBeTruthy();
-  },
-);
+  }
 
-rspackTest(
-  'should allow to import inline CSS files in build',
-  async ({ page, buildPreview }) => {
-    await buildPreview();
+  const bInline: string = await page.evaluate('window.bInline');
+  const bStyles: Record<string, string> = await page.evaluate('window.bStyles');
 
-    for (const key of ['aInline1', 'aInline2', 'aInline3', 'aInline4']) {
-      const inline: string = await page.evaluate(`window.${key}`);
-      expect(inline.includes('.header-class{color:red}')).toBe(true);
-    }
+  expect(
+    bInline.includes('.title-class') && bInline.includes('font-size: 14px'),
+  ).toBe(true);
+  expect(bStyles['title-class']).toBeTruthy();
+});
 
-    const bStyles: Record<string, string> =
-      await page.evaluate('window.bStyles');
+test('should allow to import inline CSS files in build', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview();
 
-    expect(await page.evaluate('window.bInline')).toBe(
-      '.title-class{font-size:14px}',
-    );
-    expect(bStyles['title-class']).toBeTruthy();
-  },
-);
+  for (const key of ['aInline1', 'aInline2', 'aInline3', 'aInline4']) {
+    const inline: string = await page.evaluate(`window.${key}`);
+    expect(inline.includes('.header-class{color:red}')).toBe(true);
+  }
+
+  const bStyles: Record<string, string> = await page.evaluate('window.bStyles');
+
+  expect(await page.evaluate('window.bInline')).toBe(
+    '.title-class{font-size:14px}',
+  );
+  expect(bStyles['title-class']).toBeTruthy();
+});

--- a/e2e/cases/css/lightningcss-disabled/index.test.ts
+++ b/e2e/cases/css/lightningcss-disabled/index.test.ts
@@ -1,14 +1,13 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest(
-  'should allow to disable the built-in lightningcss loader',
-  async ({ build }) => {
-    const rsbuild = await build();
-    const files = rsbuild.getDistFiles();
+test('should allow to disable the built-in lightningcss loader', async ({
+  build,
+}) => {
+  const rsbuild = await build();
+  const files = rsbuild.getDistFiles();
 
-    const content = getFileContent(files, '.css');
+  const content = getFileContent(files, '.css');
 
-    expect(content).not.toContain('-webkit-');
-    expect(content).not.toContain('-ms-');
-  },
-);
+  expect(content).not.toContain('-webkit-');
+  expect(content).not.toContain('-ms-');
+});

--- a/e2e/cases/css/lightningcss-prefixes/index.test.ts
+++ b/e2e/cases/css/lightningcss-prefixes/index.test.ts
@@ -1,28 +1,27 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest(
-  'should add vendor prefixes by current browserslist',
-  async ({ build }) => {
-    const rsbuild = await build();
-    const files = rsbuild.getDistFiles();
+test('should add vendor prefixes by current browserslist', async ({
+  build,
+}) => {
+  const rsbuild = await build();
+  const files = rsbuild.getDistFiles();
 
-    const content = getFileContent(files, '.css');
+  const content = getFileContent(files, '.css');
 
-    expect(content).toEqual(
-      '@media (-webkit-min-device-pixel-ratio:2),(min-resolution:2dppx){.item{-webkit-user-select:none;-ms-user-select:none;user-select:none;background:-webkit-linear-gradient(#000,#fff);background:linear-gradient(#fff,#000);-webkit-transition:all .5s;transition:all .5s}}',
-    );
-  },
-);
+  expect(content).toEqual(
+    '@media (-webkit-min-device-pixel-ratio:2),(min-resolution:2dppx){.item{-webkit-user-select:none;-ms-user-select:none;user-select:none;background:-webkit-linear-gradient(#000,#fff);background:linear-gradient(#fff,#000);-webkit-transition:all .5s;transition:all .5s}}',
+  );
+});
 
-rspackTest(
-  'should add vendor prefixes by current browserslist in dev',
-  async ({ dev }) => {
-    const rsbuild = await dev();
+test('should add vendor prefixes by current browserslist in dev', async ({
+  dev,
+}) => {
+  const rsbuild = await dev();
 
-    const distFiles = rsbuild.getDistFiles();
-    const content = getFileContent(distFiles, 'css/index.css');
-    expect(content).toContain(
-      `@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 2dppx) {
+  const distFiles = rsbuild.getDistFiles();
+  const content = getFileContent(distFiles, 'css/index.css');
+  expect(content).toContain(
+    `@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 2dppx) {
   .item {
     -webkit-user-select: none;
     -ms-user-select: none;
@@ -33,6 +32,5 @@ rspackTest(
     transition: all .5s;
   }
 }`,
-    );
-  },
-);
+  );
+});

--- a/e2e/cases/css/multi-css/index.test.ts
+++ b/e2e/cases/css/multi-css/index.test.ts
@@ -1,6 +1,6 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest('should emit multiple CSS files correctly', async ({ build }) => {
+test('should emit multiple CSS files correctly', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
   expect(getFileContent(files, 'entry1.css')).toContain('#entry1{color:red}');

--- a/e2e/cases/css/nested-npm-import/index.test.ts
+++ b/e2e/cases/css/nested-npm-import/index.test.ts
@@ -1,8 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest('should compile nested npm import correctly', async ({ build }) => {
+test('should compile nested npm import correctly', async ({ build }) => {
   fs.cpSync(
     path.resolve(import.meta.dirname, '_node_modules'),
     path.resolve(import.meta.dirname, 'node_modules'),

--- a/e2e/cases/css/postcss-config-ts/index.test.ts
+++ b/e2e/cases/css/postcss-config-ts/index.test.ts
@@ -1,6 +1,6 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest('should load postcss.config.ts correctly', async ({ build }) => {
+test('should load postcss.config.ts correctly', async ({ build }) => {
   const rsbuild = await build();
 
   const files = rsbuild.getDistFiles();

--- a/e2e/cases/css/relative-import/index.test.ts
+++ b/e2e/cases/css/relative-import/index.test.ts
@@ -1,15 +1,10 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest(
-  'should compile CSS relative imports correctly',
-  async ({ build }) => {
-    const rsbuild = await build();
-    const files = rsbuild.getDistFiles();
+test('should compile CSS relative imports correctly', async ({ build }) => {
+  const rsbuild = await build();
+  const files = rsbuild.getDistFiles();
 
-    const content = getFileContent(files, '.css');
+  const content = getFileContent(files, '.css');
 
-    expect(content).toContain(
-      '.foo{color:red}.bar{color:#00f}.baz{color:green}',
-    );
-  },
-);
+  expect(content).toContain('.foo{color:red}.bar{color:#00f}.baz{color:green}');
+});

--- a/e2e/cases/css/resolve-alias/index.test.ts
+++ b/e2e/cases/css/resolve-alias/index.test.ts
@@ -1,6 +1,6 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest('should compile CSS with alias correctly', async ({ build }) => {
+test('should compile CSS with alias correctly', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
 

--- a/e2e/cases/css/resolve-ts-paths/index.test.ts
+++ b/e2e/cases/css/resolve-ts-paths/index.test.ts
@@ -1,14 +1,11 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest(
-  'should resolve ts paths correctly in SCSS file',
-  async ({ build }) => {
-    const rsbuild = await build();
+test('should resolve ts paths correctly in SCSS file', async ({ build }) => {
+  const rsbuild = await build();
 
-    const files = rsbuild.getDistFiles();
+  const files = rsbuild.getDistFiles();
 
-    const content = getFileContent(files, '.css');
+  const content = getFileContent(files, '.css');
 
-    expect(content).toContain('background-image:url(/static/image/icon');
-  },
-);
+  expect(content).toContain('background-image:url(/static/image/icon');
+});

--- a/e2e/cases/diagnostic/add-compilation-errors/index.test.ts
+++ b/e2e/cases/diagnostic/add-compilation-errors/index.test.ts
@@ -1,21 +1,20 @@
-import { enableDebugMode, rspackTest } from '@e2e/helper';
+import { enableDebugMode, test } from '@e2e/helper';
 
 const ERROR_MESSAGE = 'Something went wrong';
 const ERROR_STACK = / at/;
 
-rspackTest('should print `compilation.errors` by default', async ({ dev }) => {
+test('should print `compilation.errors` by default', async ({ dev }) => {
   const rsbuild = await dev();
   await rsbuild.expectLog(ERROR_MESSAGE);
   rsbuild.expectNoLog(ERROR_STACK);
 });
 
-rspackTest(
-  'should print `compilation.errors` with stack trace in debug mode',
-  async ({ dev }) => {
-    const restore = enableDebugMode();
-    const rsbuild = await dev();
-    await rsbuild.expectLog(ERROR_MESSAGE);
-    await rsbuild.expectLog(ERROR_STACK);
-    restore();
-  },
-);
+test('should print `compilation.errors` with stack trace in debug mode', async ({
+  dev,
+}) => {
+  const restore = enableDebugMode();
+  const rsbuild = await dev();
+  await rsbuild.expectLog(ERROR_MESSAGE);
+  await rsbuild.expectLog(ERROR_STACK);
+  restore();
+});

--- a/e2e/cases/diagnostic/build-failed-time/index.test.ts
+++ b/e2e/cases/diagnostic/build-failed-time/index.test.ts
@@ -1,13 +1,13 @@
-import { rspackTest } from '@e2e/helper';
+import { test } from '@e2e/helper';
 
 const EXPECTED_LOG = /build failed in [\d.]+ s/;
 
-rspackTest('should print build failed time in dev', async ({ devOnly }) => {
+test('should print build failed time in dev', async ({ devOnly }) => {
   const rsbuild = await devOnly();
   await rsbuild.expectLog(EXPECTED_LOG);
 });
 
-rspackTest('should print build failed time in build', async ({ build }) => {
+test('should print build failed time in build', async ({ build }) => {
   const rsbuild = await build({
     catchBuildError: true,
   });

--- a/e2e/cases/diagnostic/build-time/index.test.ts
+++ b/e2e/cases/diagnostic/build-time/index.test.ts
@@ -1,13 +1,13 @@
-import { rspackTest } from '@e2e/helper';
+import { test } from '@e2e/helper';
 
 const EXPECTED_LOG = /built in [\d.]+ s/;
 
-rspackTest('should print build time in dev', async ({ devOnly }) => {
+test('should print build time in dev', async ({ devOnly }) => {
   const rsbuild = await devOnly();
   await rsbuild.expectLog(EXPECTED_LOG);
 });
 
-rspackTest('should print build time in build', async ({ build }) => {
+test('should print build time in build', async ({ build }) => {
   const rsbuild = await build();
   await rsbuild.expectLog(EXPECTED_LOG);
 });

--- a/e2e/cases/diagnostic/disable-stats-errors/index.test.ts
+++ b/e2e/cases/diagnostic/disable-stats-errors/index.test.ts
@@ -1,21 +1,19 @@
-import { rspackTest } from '@e2e/helper';
+import { test } from '@e2e/helper';
 
 const EXPECTED_LOG = `Build failed. No errors reported since Rspack's "stats.errors" is disabled.`;
 
-rspackTest(
-  'should print a hint if stats.errors is disabled after a dev failure',
-  async ({ dev }) => {
-    const rsbuild = await dev();
-    await rsbuild.expectLog(EXPECTED_LOG);
-  },
-);
+test('should print a hint if stats.errors is disabled after a dev failure', async ({
+  dev,
+}) => {
+  const rsbuild = await dev();
+  await rsbuild.expectLog(EXPECTED_LOG);
+});
 
-rspackTest(
-  'should print a hint if stats.errors is disabled after a build failure',
-  async ({ build }) => {
-    const rsbuild = await build({
-      catchBuildError: true,
-    });
-    await rsbuild.expectLog(EXPECTED_LOG);
-  },
-);
+test('should print a hint if stats.errors is disabled after a build failure', async ({
+  build,
+}) => {
+  const rsbuild = await build({
+    catchBuildError: true,
+  });
+  await rsbuild.expectLog(EXPECTED_LOG);
+});

--- a/e2e/cases/diagnostic/import-traces-lazy-compilation/index.test.ts
+++ b/e2e/cases/diagnostic/import-traces-lazy-compilation/index.test.ts
@@ -1,13 +1,12 @@
-import { rspackTest } from '@e2e/helper';
+import { test } from '@e2e/helper';
 
 const EXPECTED_LOG = `Import traces (entry → error):
   ./src/index.js
   ./src/dynamic.js ×`;
 
-rspackTest(
-  'should exclude lazy compilation identifier from import traces',
-  async ({ dev }) => {
-    const rsbuild = await dev();
-    await rsbuild.expectLog(EXPECTED_LOG);
-  },
-);
+test('should exclude lazy compilation identifier from import traces', async ({
+  dev,
+}) => {
+  const rsbuild = await dev();
+  await rsbuild.expectLog(EXPECTED_LOG);
+});

--- a/e2e/cases/diagnostic/import-traces-vue/index.test.ts
+++ b/e2e/cases/diagnostic/import-traces-vue/index.test.ts
@@ -1,16 +1,16 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
 const EXPECTED_LOG = `Import traces (entry → error):
   ./src/index.js
   ./src/App.vue
   ./src/App.vue.css?vue&type=style`;
 
-rspackTest('should print Vue SFC import traces in dev', async ({ dev }) => {
+test('should print Vue SFC import traces in dev', async ({ dev }) => {
   const rsbuild = await dev();
   await rsbuild.expectLog(EXPECTED_LOG);
 });
 
-rspackTest('should print Vue SFC import traces in build', async ({ build }) => {
+test('should print Vue SFC import traces in build', async ({ build }) => {
   const rsbuild = await build({
     catchBuildError: true,
   });

--- a/e2e/cases/diagnostic/no-deprecation-logs/index.test.ts
+++ b/e2e/cases/diagnostic/no-deprecation-logs/index.test.ts
@@ -1,14 +1,14 @@
-import { rspackTest } from '@e2e/helper';
+import { test } from '@e2e/helper';
 
 const DEPRECATION_LOG = /deprecated|deprecation/i;
 
-rspackTest('should not print deprecation logs in dev', async ({ devOnly }) => {
+test('should not print deprecation logs in dev', async ({ devOnly }) => {
   const rsbuild = await devOnly();
   await rsbuild.expectBuildEnd();
   rsbuild.expectNoLog(DEPRECATION_LOG);
 });
 
-rspackTest('should not print deprecation logs in build', async ({ build }) => {
+test('should not print deprecation logs in build', async ({ build }) => {
   const rsbuild = await build();
   await rsbuild.expectBuildEnd();
   rsbuild.expectNoLog(DEPRECATION_LOG);

--- a/e2e/cases/diagnostic/process-undefined/index.test.ts
+++ b/e2e/cases/diagnostic/process-undefined/index.test.ts
@@ -1,11 +1,10 @@
-import { rspackTest } from '@e2e/helper';
+import { test } from '@e2e/helper';
 
-rspackTest(
-  'should print help message if undefined process.env.* is accessed in dev',
-  async ({ dev }) => {
-    const rsbuild = await dev();
-    await rsbuild.expectLog(
-      'To access `process.env.*`, define them in a `.env` file with the `PUBLIC_` prefix.',
-    );
-  },
-);
+test('should print help message if undefined process.env.* is accessed in dev', async ({
+  dev,
+}) => {
+  const rsbuild = await dev();
+  await rsbuild.expectLog(
+    'To access `process.env.*`, define them in a `.env` file with the `PUBLIC_` prefix.',
+  );
+});

--- a/e2e/cases/environments/disable-hmr/index.test.ts
+++ b/e2e/cases/environments/disable-hmr/index.test.ts
@@ -1,23 +1,22 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should allow to disable HMR and live reload for a specified environment',
-  async ({ devOnly }) => {
-    const rsbuild = await devOnly();
+test('should allow to disable HMR and live reload for a specified environment', async ({
+  devOnly,
+}) => {
+  const rsbuild = await devOnly();
 
-    const files = rsbuild.getDistFiles();
-    const filenames = Object.keys(files);
+  const files = rsbuild.getDistFiles();
+  const filenames = Object.keys(files);
 
-    const fooJs = filenames.find((filename) =>
-      filename.includes('dist/static/js/foo.js'),
-    );
-    const barJs = filenames.find((filename) =>
-      filename.includes('dist/static/js/bar.js'),
-    );
-    const fooContent = files[fooJs!];
-    const barContent = files[barJs!];
+  const fooJs = filenames.find((filename) =>
+    filename.includes('dist/static/js/foo.js'),
+  );
+  const barJs = filenames.find((filename) =>
+    filename.includes('dist/static/js/bar.js'),
+  );
+  const fooContent = files[fooJs!];
+  const barContent = files[barJs!];
 
-    expect(fooContent.includes('dist/client/hmr.js')).toBeTruthy();
-    expect(barContent.includes('dist/client/hmr.js')).toBeFalsy();
-  },
-);
+  expect(fooContent.includes('dist/client/hmr.js')).toBeTruthy();
+  expect(barContent.includes('dist/client/hmr.js')).toBeFalsy();
+});

--- a/e2e/cases/environments/hmr/index.test.ts
+++ b/e2e/cases/environments/hmr/index.test.ts
@@ -1,75 +1,78 @@
 import { join } from 'node:path';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 
-rspackTest(
-  'should perform multiple environments HMR',
-  async ({ dev, page, context, editFile, copySrcDir }) => {
-    const tempSrc = await copySrcDir();
+test('should perform multiple environments HMR', async ({
+  dev,
+  page,
+  context,
+  editFile,
+  copySrcDir,
+}) => {
+  const tempSrc = await copySrcDir();
 
-    const rsbuild = await dev({
-      config: {
-        plugins: [pluginReact()],
-        environments: {
-          web: {
-            source: {
-              entry: {
-                index: join(tempSrc, 'index.ts'),
-              },
+  const rsbuild = await dev({
+    config: {
+      plugins: [pluginReact()],
+      environments: {
+        web: {
+          source: {
+            entry: {
+              index: join(tempSrc, 'index.ts'),
             },
           },
-          web1: {
-            dev: {
-              // When generating outputs for multiple web environments,
-              // if assetPrefix is not added, file search conflicts will occur.
-              assetPrefix: 'auto',
+        },
+        web1: {
+          dev: {
+            // When generating outputs for multiple web environments,
+            // if assetPrefix is not added, file search conflicts will occur.
+            assetPrefix: 'auto',
+          },
+          source: {
+            entry: {
+              main: join(tempSrc, 'web1.js'),
             },
-            source: {
-              entry: {
-                main: join(tempSrc, 'web1.js'),
-              },
-            },
-            output: {
-              distPath: {
-                root: 'dist/web1',
-                html: 'html1',
-              },
+          },
+          output: {
+            distPath: {
+              root: 'dist/web1',
+              html: 'html1',
             },
           },
         },
       },
-    });
+    },
+  });
 
-    const web1Page = await context.newPage();
+  const web1Page = await context.newPage();
 
-    await web1Page.goto(`http://localhost:${rsbuild.port}/web1/html1/main`);
+  await web1Page.goto(`http://localhost:${rsbuild.port}/web1/html1/main`);
 
-    const locator1 = web1Page.locator('#test');
-    await expect(locator1).toHaveText('Hello Rsbuild (web1)!');
+  const locator1 = web1Page.locator('#test');
+  await expect(locator1).toHaveText('Hello Rsbuild (web1)!');
 
-    const locator = page.locator('#test');
-    await expect(locator).toHaveText('Hello Rsbuild!');
-    await expect(locator).toHaveCSS('color', 'rgb(255, 0, 0)');
+  const locator = page.locator('#test');
+  await expect(locator).toHaveText('Hello Rsbuild!');
+  await expect(locator).toHaveCSS('color', 'rgb(255, 0, 0)');
 
-    const locatorKeep = page.locator('#test-keep');
-    const keepNum = await locatorKeep.innerHTML();
+  const locatorKeep = page.locator('#test-keep');
+  const keepNum = await locatorKeep.innerHTML();
 
-    // web1 live reload correctly and should not trigger index update
-    await editFile(join(tempSrc, 'web1.js'), (code) =>
-      code.replace('(web1)', '(web1-new)'),
-    );
+  // web1 live reload correctly and should not trigger index update
+  await editFile(join(tempSrc, 'web1.js'), (code) =>
+    code.replace('(web1)', '(web1-new)'),
+  );
 
-    await expect(locator1).toHaveText('Hello Rsbuild (web1)!');
-    expect(await locatorKeep.innerHTML()).toBe(keepNum);
+  await expect(locator1).toHaveText('Hello Rsbuild (web1)!');
+  expect(await locatorKeep.innerHTML()).toBe(keepNum);
 
-    // index HMR correctly
-    await editFile(join(tempSrc, 'App.tsx'), (code) =>
-      code.replace('Hello Rsbuild', 'Hello Test'),
-    );
+  // index HMR correctly
+  await editFile(join(tempSrc, 'App.tsx'), (code) =>
+    code.replace('Hello Rsbuild', 'Hello Test'),
+  );
 
-    await expect(locator).toHaveText('Hello Test!');
+  await expect(locator).toHaveText('Hello Test!');
 
-    // #test-keep should remain unchanged when app.tsx HMR
-    expect(await locatorKeep.innerHTML()).toBe(keepNum);
-  },
-);
+  // #test-keep should remain unchanged when app.tsx HMR
+  expect(await locatorKeep.innerHTML()).toBe(keepNum);
+});

--- a/e2e/cases/environments/vue-react-plugins/index.test.ts
+++ b/e2e/cases/environments/vue-react-plugins/index.test.ts
@@ -1,21 +1,18 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should build basic Vue jsx correctly',
-  async ({ page, buildPreview }) => {
-    const rsbuild = await buildPreview();
+test('should build basic Vue jsx correctly', async ({ page, buildPreview }) => {
+  const rsbuild = await buildPreview();
 
-    const reactUrl = new URL(`http://localhost:${rsbuild.port}/react`);
+  const reactUrl = new URL(`http://localhost:${rsbuild.port}/react`);
 
-    await page.goto(reactUrl.href);
+  await page.goto(reactUrl.href);
 
-    await expect(page.locator('#test')).toHaveText('Hello Rsbuild!');
+  await expect(page.locator('#test')).toHaveText('Hello Rsbuild!');
 
-    const vueUrl = new URL(`http://localhost:${rsbuild.port}/vue`);
+  const vueUrl = new URL(`http://localhost:${rsbuild.port}/vue`);
 
-    await page.goto(vueUrl.href);
+  await page.goto(vueUrl.href);
 
-    const button1 = page.locator('#button1');
-    await expect(button1).toHaveText('A: 0');
-  },
-);
+  const button1 = page.locator('#button1');
+  await expect(button1).toHaveText('A: 0');
+});

--- a/e2e/cases/hmr/basic/index.test.ts
+++ b/e2e/cases/hmr/basic/index.test.ts
@@ -1,40 +1,42 @@
 import { join } from 'node:path';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should perform HMR and preserve state',
-  async ({ page, dev, editFile, copySrcDir }) => {
-    const tempSrc = await copySrcDir();
+test('should perform HMR and preserve state', async ({
+  page,
+  dev,
+  editFile,
+  copySrcDir,
+}) => {
+  const tempSrc = await copySrcDir();
 
-    await dev({
-      config: {
-        source: {
-          entry: {
-            index: join(tempSrc, 'index.ts'),
-          },
+  await dev({
+    config: {
+      source: {
+        entry: {
+          index: join(tempSrc, 'index.ts'),
         },
       },
-    });
+    },
+  });
 
-    const locator = page.locator('#test');
-    await expect(locator).toHaveText('Hello Rsbuild!');
-    await expect(locator).toHaveCSS('color', 'rgb(255, 0, 0)');
+  const locator = page.locator('#test');
+  await expect(locator).toHaveText('Hello Rsbuild!');
+  await expect(locator).toHaveCSS('color', 'rgb(255, 0, 0)');
 
-    const locatorKeep = page.locator('#test-keep');
-    const keepNum = await locatorKeep.innerHTML();
+  const locatorKeep = page.locator('#test-keep');
+  const keepNum = await locatorKeep.innerHTML();
 
-    await editFile(join(tempSrc, 'App.tsx'), (code) =>
-      code.replace('Hello Rsbuild', 'Hello Test'),
-    );
+  await editFile(join(tempSrc, 'App.tsx'), (code) =>
+    code.replace('Hello Rsbuild', 'Hello Test'),
+  );
 
-    await expect(locator).toHaveText('Hello Test!');
-    // #test-keep should remain unchanged when app.tsx HMR
-    expect(await locatorKeep.innerHTML()).toBe(keepNum);
+  await expect(locator).toHaveText('Hello Test!');
+  // #test-keep should remain unchanged when app.tsx HMR
+  expect(await locatorKeep.innerHTML()).toBe(keepNum);
 
-    await editFile(
-      join(tempSrc, 'App.css'),
-      () => `#test { color: rgb(0, 0, 255); }`,
-    );
-    await expect(locator).toHaveCSS('color', 'rgb(0, 0, 255)');
-  },
-);
+  await editFile(
+    join(tempSrc, 'App.css'),
+    () => `#test { color: rgb(0, 0, 255); }`,
+  );
+  await expect(locator).toHaveCSS('color', 'rgb(0, 0, 255)');
+});

--- a/e2e/cases/hmr/client-host/index.test.ts
+++ b/e2e/cases/hmr/client-host/index.test.ts
@@ -1,33 +1,35 @@
 import { join } from 'node:path';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'HMR should work when setting dev.port and dev.client.host',
-  async ({ page, dev, editFile, copySrcDir }) => {
-    const tempSrc = await copySrcDir();
+test('HMR should work when setting dev.port and dev.client.host', async ({
+  page,
+  dev,
+  editFile,
+  copySrcDir,
+}) => {
+  const tempSrc = await copySrcDir();
 
-    await dev({
-      config: {
-        source: {
-          entry: {
-            index: join(tempSrc, 'index.ts'),
-          },
-        },
-        dev: {
-          client: {
-            host: '',
-          },
+  await dev({
+    config: {
+      source: {
+        entry: {
+          index: join(tempSrc, 'index.ts'),
         },
       },
-    });
+      dev: {
+        client: {
+          host: '',
+        },
+      },
+    },
+  });
 
-    const locator = page.locator('#test');
-    await expect(locator).toHaveText('Hello Rsbuild!');
+  const locator = page.locator('#test');
+  await expect(locator).toHaveText('Hello Rsbuild!');
 
-    await editFile(join(tempSrc, 'App.tsx'), (code) =>
-      code.replace('Hello Rsbuild', 'Hello Test'),
-    );
+  await editFile(join(tempSrc, 'App.tsx'), (code) =>
+    code.replace('Hello Rsbuild', 'Hello Test'),
+  );
 
-    await expect(locator).toHaveText('Hello Test!');
-  },
-);
+  await expect(locator).toHaveText('Hello Test!');
+});

--- a/e2e/cases/hmr/client-multiple-environment/index.test.ts
+++ b/e2e/cases/hmr/client-multiple-environment/index.test.ts
@@ -1,15 +1,14 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should allow to set different dev.client for multiple environments',
-  async ({ dev }) => {
-    const rsbuild = await dev();
+test('should allow to set different dev.client for multiple environments', async ({
+  dev,
+}) => {
+  const rsbuild = await dev();
 
-    const files = rsbuild.getDistFiles();
-    const filenames = Object.keys(files);
-    const fooJs = filenames.find((name) => name.endsWith('foo.js'));
-    const barJs = filenames.find((name) => name.endsWith('bar.js'));
-    expect(files[fooJs!].includes('"host": "http://foo.com"')).toBeTruthy();
-    expect(files[barJs!].includes('"host": "http://bar.com"')).toBeTruthy();
-  },
-);
+  const files = rsbuild.getDistFiles();
+  const filenames = Object.keys(files);
+  const fooJs = filenames.find((name) => name.endsWith('foo.js'));
+  const barJs = filenames.find((name) => name.endsWith('bar.js'));
+  expect(files[fooJs!].includes('"host": "http://foo.com"')).toBeTruthy();
+  expect(files[barJs!].includes('"host": "http://bar.com"')).toBeTruthy();
+});

--- a/e2e/cases/hmr/client-port-placeholder/index.test.ts
+++ b/e2e/cases/hmr/client-port-placeholder/index.test.ts
@@ -1,33 +1,35 @@
 import { join } from 'node:path';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'HMR should work when dev.client.port is `<port>`',
-  async ({ page, dev, editFile, copySrcDir }) => {
-    const tempSrc = await copySrcDir();
+test('HMR should work when dev.client.port is `<port>`', async ({
+  page,
+  dev,
+  editFile,
+  copySrcDir,
+}) => {
+  const tempSrc = await copySrcDir();
 
-    await dev({
-      config: {
-        source: {
-          entry: {
-            index: join(tempSrc, 'index.ts'),
-          },
-        },
-        dev: {
-          client: {
-            port: '<port>',
-          },
+  await dev({
+    config: {
+      source: {
+        entry: {
+          index: join(tempSrc, 'index.ts'),
         },
       },
-    });
+      dev: {
+        client: {
+          port: '<port>',
+        },
+      },
+    },
+  });
 
-    const locator = page.locator('#test');
-    await expect(locator).toHaveText('Hello Rsbuild!');
+  const locator = page.locator('#test');
+  await expect(locator).toHaveText('Hello Rsbuild!');
 
-    await editFile(join(tempSrc, 'App.tsx'), (code) =>
-      code.replace('Hello Rsbuild', 'Hello Test'),
-    );
+  await editFile(join(tempSrc, 'App.tsx'), (code) =>
+    code.replace('Hello Rsbuild', 'Hello Test'),
+  );
 
-    await expect(locator).toHaveText('Hello Test!');
-  },
-);
+  await expect(locator).toHaveText('Hello Test!');
+});

--- a/e2e/cases/hmr/error-recovery/index.test.ts
+++ b/e2e/cases/hmr/error-recovery/index.test.ts
@@ -1,40 +1,42 @@
 import { join } from 'node:path';
-import { expect, MODULE_BUILD_FAILED_LOG, rspackTest } from '@e2e/helper';
+import { expect, MODULE_BUILD_FAILED_LOG, test } from '@e2e/helper';
 
-rspackTest(
-  'HMR should work after fixing compilation error',
-  async ({ page, dev, editFile, copySrcDir }) => {
-    const tempSrc = await copySrcDir();
+test('HMR should work after fixing compilation error', async ({
+  page,
+  dev,
+  editFile,
+  copySrcDir,
+}) => {
+  const tempSrc = await copySrcDir();
 
-    const rsbuild = await dev({
-      config: {
-        source: {
-          entry: {
-            index: join(tempSrc, 'index.ts'),
-          },
+  const rsbuild = await dev({
+    config: {
+      source: {
+        entry: {
+          index: join(tempSrc, 'index.ts'),
         },
       },
-    });
+    },
+  });
 
-    const locator = page.locator('#test');
-    await expect(locator).toHaveText('Hello Rsbuild!');
+  const locator = page.locator('#test');
+  await expect(locator).toHaveText('Hello Rsbuild!');
 
-    await editFile(join(tempSrc, 'App.tsx'), (code) =>
-      code.replace(
-        '<div id="test">Hello Rsbuild!</div>',
-        '<div id="test">Hello Rsbuild!</div',
-      ),
-    );
+  await editFile(join(tempSrc, 'App.tsx'), (code) =>
+    code.replace(
+      '<div id="test">Hello Rsbuild!</div>',
+      '<div id="test">Hello Rsbuild!</div',
+    ),
+  );
 
-    await rsbuild.expectLog(MODULE_BUILD_FAILED_LOG);
+  await rsbuild.expectLog(MODULE_BUILD_FAILED_LOG);
 
-    await editFile(join(tempSrc, 'App.tsx'), (code) =>
-      code.replace(
-        '<div id="test">Hello Rsbuild!</div',
-        '<div id="test">Hello Rsbuild2!</div>',
-      ),
-    );
+  await editFile(join(tempSrc, 'App.tsx'), (code) =>
+    code.replace(
+      '<div id="test">Hello Rsbuild!</div',
+      '<div id="test">Hello Rsbuild2!</div>',
+    ),
+  );
 
-    await expect(locator).toHaveText('Hello Rsbuild2!');
-  },
-);
+  await expect(locator).toHaveText('Hello Rsbuild2!');
+});

--- a/e2e/cases/hmr/esm/index.test.ts
+++ b/e2e/cases/hmr/esm/index.test.ts
@@ -1,40 +1,42 @@
 import { join } from 'node:path';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should perform HMR and preserve state when `output.module` is enabled',
-  async ({ page, dev, editFile, copySrcDir }) => {
-    const tempSrc = await copySrcDir();
+test('should perform HMR and preserve state when `output.module` is enabled', async ({
+  page,
+  dev,
+  editFile,
+  copySrcDir,
+}) => {
+  const tempSrc = await copySrcDir();
 
-    await dev({
-      config: {
-        source: {
-          entry: {
-            index: join(tempSrc, 'index.ts'),
-          },
+  await dev({
+    config: {
+      source: {
+        entry: {
+          index: join(tempSrc, 'index.ts'),
         },
       },
-    });
+    },
+  });
 
-    const locator = page.locator('#test');
-    await expect(locator).toHaveText('Hello Rsbuild!');
-    await expect(locator).toHaveCSS('color', 'rgb(255, 0, 0)');
+  const locator = page.locator('#test');
+  await expect(locator).toHaveText('Hello Rsbuild!');
+  await expect(locator).toHaveCSS('color', 'rgb(255, 0, 0)');
 
-    const locatorKeep = page.locator('#test-keep');
-    const keepNum = await locatorKeep.innerHTML();
+  const locatorKeep = page.locator('#test-keep');
+  const keepNum = await locatorKeep.innerHTML();
 
-    await editFile(join(tempSrc, 'App.tsx'), (code) =>
-      code.replace('Hello Rsbuild', 'Hello Test'),
-    );
+  await editFile(join(tempSrc, 'App.tsx'), (code) =>
+    code.replace('Hello Rsbuild', 'Hello Test'),
+  );
 
-    await expect(locator).toHaveText('Hello Test!');
-    // #test-keep should remain unchanged when app.tsx HMR
-    expect(await locatorKeep.innerHTML()).toBe(keepNum);
+  await expect(locator).toHaveText('Hello Test!');
+  // #test-keep should remain unchanged when app.tsx HMR
+  expect(await locatorKeep.innerHTML()).toBe(keepNum);
 
-    await editFile(
-      join(tempSrc, 'App.css'),
-      () => `#test { color: rgb(0, 0, 255); }`,
-    );
-    await expect(locator).toHaveCSS('color', 'rgb(0, 0, 255)');
-  },
-);
+  await editFile(
+    join(tempSrc, 'App.css'),
+    () => `#test { color: rgb(0, 0, 255); }`,
+  );
+  await expect(locator).toHaveCSS('color', 'rgb(0, 0, 255)');
+});

--- a/e2e/cases/hmr/live-reload/index.test.ts
+++ b/e2e/cases/hmr/live-reload/index.test.ts
@@ -1,49 +1,53 @@
 import path from 'node:path';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should fallback to live-reload when dev.hmr is false',
-  async ({ page, dev, editFile, copySrcDir }) => {
-    const tempSrc = await copySrcDir();
-    const appFile = path.join(tempSrc, 'App.jsx');
-    await dev({
-      config: {
-        source: {
-          entry: {
-            index: path.join(tempSrc, 'index.js'),
-          },
+test('should fallback to live-reload when dev.hmr is false', async ({
+  page,
+  dev,
+  editFile,
+  copySrcDir,
+}) => {
+  const tempSrc = await copySrcDir();
+  const appFile = path.join(tempSrc, 'App.jsx');
+  await dev({
+    config: {
+      source: {
+        entry: {
+          index: path.join(tempSrc, 'index.js'),
         },
       },
-    });
+    },
+  });
 
-    const testEl = page.locator('#test');
-    await expect(testEl).toHaveText('Hello Rsbuild!');
-    await editFile(appFile, (code) => code.replace('Rsbuild', 'Live Reload'));
-    await expect(testEl).toHaveText('Hello Live Reload!');
-  },
-);
+  const testEl = page.locator('#test');
+  await expect(testEl).toHaveText('Hello Rsbuild!');
+  await editFile(appFile, (code) => code.replace('Rsbuild', 'Live Reload'));
+  await expect(testEl).toHaveText('Hello Live Reload!');
+});
 
-rspackTest(
-  'should not reload page when live-reload is disabled',
-  async ({ page, dev, editFile, copySrcDir }) => {
-    const tempSrc = await copySrcDir();
-    const appFile = path.join(tempSrc, 'App.jsx');
-    await dev({
-      config: {
-        source: {
-          entry: {
-            index: path.join(tempSrc, 'index.js'),
-          },
-        },
-        dev: {
-          liveReload: false,
+test('should not reload page when live-reload is disabled', async ({
+  page,
+  dev,
+  editFile,
+  copySrcDir,
+}) => {
+  const tempSrc = await copySrcDir();
+  const appFile = path.join(tempSrc, 'App.jsx');
+  await dev({
+    config: {
+      source: {
+        entry: {
+          index: path.join(tempSrc, 'index.js'),
         },
       },
-    });
+      dev: {
+        liveReload: false,
+      },
+    },
+  });
 
-    const test = page.locator('#test');
-    await expect(test).toHaveText('Hello Rsbuild!');
-    await editFile(appFile, (code) => code.replace('Rsbuild', 'Live Reload'));
-    await expect(test).toHaveText('Hello Rsbuild!');
-  },
-);
+  const test = page.locator('#test');
+  await expect(test).toHaveText('Hello Rsbuild!');
+  await editFile(appFile, (code) => code.replace('Rsbuild', 'Live Reload'));
+  await expect(test).toHaveText('Hello Rsbuild!');
+});

--- a/e2e/cases/hmr/log-level/index.test.ts
+++ b/e2e/cases/hmr/log-level/index.test.ts
@@ -1,143 +1,153 @@
 import { join } from 'node:path';
-import { expect, HMR_CONNECTED_LOG, rspackTest } from '@e2e/helper';
+import { expect, HMR_CONNECTED_LOG, test } from '@e2e/helper';
 
-rspackTest(
-  'should respect dev.client.logLevel when set to warn',
-  async ({ page, dev, logHelper, copySrcDir }) => {
-    const tempSrc = await copySrcDir();
-    const { addLog, expectNoLog } = logHelper;
+test('should respect dev.client.logLevel when set to warn', async ({
+  page,
+  dev,
+  logHelper,
+  copySrcDir,
+}) => {
+  const tempSrc = await copySrcDir();
+  const { addLog, expectNoLog } = logHelper;
 
-    page.on('console', (consoleMessage) => {
-      addLog(consoleMessage.text());
-    });
+  page.on('console', (consoleMessage) => {
+    addLog(consoleMessage.text());
+  });
 
-    await dev({
-      config: {
-        dev: {
-          client: {
-            logLevel: 'warn',
-          },
-        },
-        source: {
-          entry: {
-            index: join(tempSrc, 'index.tsx'),
-          },
+  await dev({
+    config: {
+      dev: {
+        client: {
+          logLevel: 'warn',
         },
       },
-    });
-
-    const locator = page.locator('#test');
-    await expect(locator).toHaveText('Hello Rsbuild');
-
-    expectNoLog(HMR_CONNECTED_LOG);
-  },
-);
-
-rspackTest(
-  'should show info logs when dev.client.logLevel is info (default)',
-  async ({ page, dev, logHelper, copySrcDir }) => {
-    const tempSrc = await copySrcDir();
-    const { expectLog, addLog } = logHelper;
-
-    page.on('console', (consoleMessage) => {
-      addLog(consoleMessage.text());
-    });
-
-    await dev({
-      config: {
-        source: {
-          entry: {
-            index: join(tempSrc, 'index.tsx'),
-          },
+      source: {
+        entry: {
+          index: join(tempSrc, 'index.tsx'),
         },
       },
-    });
+    },
+  });
 
-    await expectLog(HMR_CONNECTED_LOG);
-  },
-);
+  const locator = page.locator('#test');
+  await expect(locator).toHaveText('Hello Rsbuild');
 
-rspackTest(
-  'should inherit root logLevel when dev.client.logLevel is not set',
-  async ({ page, dev, logHelper, copySrcDir }) => {
-    const tempSrc = await copySrcDir();
-    const { addLog, expectNoLog } = logHelper;
+  expectNoLog(HMR_CONNECTED_LOG);
+});
 
-    page.on('console', (consoleMessage) => {
-      addLog(consoleMessage.text());
-    });
+test('should show info logs when dev.client.logLevel is info (default)', async ({
+  page,
+  dev,
+  logHelper,
+  copySrcDir,
+}) => {
+  const tempSrc = await copySrcDir();
+  const { expectLog, addLog } = logHelper;
 
-    await dev({
-      config: {
-        logLevel: 'error',
-        source: {
-          entry: {
-            index: join(tempSrc, 'index.tsx'),
-          },
+  page.on('console', (consoleMessage) => {
+    addLog(consoleMessage.text());
+  });
+
+  await dev({
+    config: {
+      source: {
+        entry: {
+          index: join(tempSrc, 'index.tsx'),
         },
       },
-    });
+    },
+  });
 
-    const locator = page.locator('#test');
-    await expect(locator).toHaveText('Hello Rsbuild');
-    expectNoLog(HMR_CONNECTED_LOG);
-  },
-);
+  await expectLog(HMR_CONNECTED_LOG);
+});
 
-rspackTest(
-  'should suppress all logs when dev.client.logLevel is silent',
-  async ({ page, dev, logHelper, copySrcDir }) => {
-    const tempSrc = await copySrcDir();
-    const { addLog, expectNoLog } = logHelper;
+test('should inherit root logLevel when dev.client.logLevel is not set', async ({
+  page,
+  dev,
+  logHelper,
+  copySrcDir,
+}) => {
+  const tempSrc = await copySrcDir();
+  const { addLog, expectNoLog } = logHelper;
 
-    page.on('console', (consoleMessage) => {
-      addLog(consoleMessage.text());
-    });
+  page.on('console', (consoleMessage) => {
+    addLog(consoleMessage.text());
+  });
 
-    await dev({
-      config: {
-        dev: {
-          client: {
-            logLevel: 'silent',
-          },
-        },
-        source: {
-          entry: {
-            index: join(tempSrc, 'index.tsx'),
-          },
+  await dev({
+    config: {
+      logLevel: 'error',
+      source: {
+        entry: {
+          index: join(tempSrc, 'index.tsx'),
         },
       },
-    });
+    },
+  });
 
-    const locator = page.locator('#test');
-    await expect(locator).toHaveText('Hello Rsbuild');
-    expectNoLog('[rsbuild]');
-  },
-);
+  const locator = page.locator('#test');
+  await expect(locator).toHaveText('Hello Rsbuild');
+  expectNoLog(HMR_CONNECTED_LOG);
+});
 
-rspackTest(
-  'should inherit silent mode from root logLevel',
-  async ({ page, dev, logHelper, copySrcDir }) => {
-    const tempSrc = await copySrcDir();
-    const { addLog, expectNoLog } = logHelper;
+test('should suppress all logs when dev.client.logLevel is silent', async ({
+  page,
+  dev,
+  logHelper,
+  copySrcDir,
+}) => {
+  const tempSrc = await copySrcDir();
+  const { addLog, expectNoLog } = logHelper;
 
-    page.on('console', (consoleMessage) => {
-      addLog(consoleMessage.text());
-    });
+  page.on('console', (consoleMessage) => {
+    addLog(consoleMessage.text());
+  });
 
-    await dev({
-      config: {
-        logLevel: 'silent',
-        source: {
-          entry: {
-            index: join(tempSrc, 'index.tsx'),
-          },
+  await dev({
+    config: {
+      dev: {
+        client: {
+          logLevel: 'silent',
         },
       },
-    });
+      source: {
+        entry: {
+          index: join(tempSrc, 'index.tsx'),
+        },
+      },
+    },
+  });
 
-    const locator = page.locator('#test');
-    await expect(locator).toHaveText('Hello Rsbuild');
-    expectNoLog('[rsbuild]');
-  },
-);
+  const locator = page.locator('#test');
+  await expect(locator).toHaveText('Hello Rsbuild');
+  expectNoLog('[rsbuild]');
+});
+
+test('should inherit silent mode from root logLevel', async ({
+  page,
+  dev,
+  logHelper,
+  copySrcDir,
+}) => {
+  const tempSrc = await copySrcDir();
+  const { addLog, expectNoLog } = logHelper;
+
+  page.on('console', (consoleMessage) => {
+    addLog(consoleMessage.text());
+  });
+
+  await dev({
+    config: {
+      logLevel: 'silent',
+      source: {
+        entry: {
+          index: join(tempSrc, 'index.tsx'),
+        },
+      },
+    },
+  });
+
+  const locator = page.locator('#test');
+  await expect(locator).toHaveText('Hello Rsbuild');
+  expectNoLog('[rsbuild]');
+});

--- a/e2e/cases/hmr/multiple-connection/index.test.ts
+++ b/e2e/cases/hmr/multiple-connection/index.test.ts
@@ -1,45 +1,48 @@
 import { join } from 'node:path';
-import { expect, gotoPage, rspackTest } from '@e2e/helper';
+import { expect, gotoPage, test } from '@e2e/helper';
 
-rspackTest(
-  'should allow to create multiple HMR connections',
-  async ({ page: page1, context, devOnly, editFile, copySrcDir }) => {
-    const tempSrc = await copySrcDir();
+test('should allow to create multiple HMR connections', async ({
+  page: page1,
+  context,
+  devOnly,
+  editFile,
+  copySrcDir,
+}) => {
+  const tempSrc = await copySrcDir();
 
-    const rsbuild = await devOnly({
-      config: {
-        source: {
-          entry: {
-            index: join(tempSrc, 'index.ts'),
-          },
+  const rsbuild = await devOnly({
+    config: {
+      source: {
+        entry: {
+          index: join(tempSrc, 'index.ts'),
         },
       },
-    });
+    },
+  });
 
-    const page2 = await context.newPage();
-    await gotoPage(page1, rsbuild);
-    await gotoPage(page2, rsbuild);
+  const page2 = await context.newPage();
+  await gotoPage(page1, rsbuild);
+  await gotoPage(page2, rsbuild);
 
-    const locator1 = page1.locator('#test');
-    const locator2 = page2.locator('#test');
+  const locator1 = page1.locator('#test');
+  const locator2 = page2.locator('#test');
 
-    await expect(locator1).toHaveText('Hello Rsbuild!');
-    await expect(locator2).toHaveText('Hello Rsbuild!');
+  await expect(locator1).toHaveText('Hello Rsbuild!');
+  await expect(locator2).toHaveText('Hello Rsbuild!');
 
-    const locatorKeep1 = page1.locator('#test-keep');
-    const locatorKeep2 = page2.locator('#test-keep');
-    const keepNum1 = await locatorKeep1.innerHTML();
-    const keepNum2 = await locatorKeep2.innerHTML();
+  const locatorKeep1 = page1.locator('#test-keep');
+  const locatorKeep2 = page2.locator('#test-keep');
+  const keepNum1 = await locatorKeep1.innerHTML();
+  const keepNum2 = await locatorKeep2.innerHTML();
 
-    await editFile(join(tempSrc, 'App.tsx'), (code) =>
-      code.replace('Hello Rsbuild', 'Hello Test'),
-    );
+  await editFile(join(tempSrc, 'App.tsx'), (code) =>
+    code.replace('Hello Rsbuild', 'Hello Test'),
+  );
 
-    await expect(locator1).toHaveText('Hello Test!');
-    await expect(locator2).toHaveText('Hello Test!');
+  await expect(locator1).toHaveText('Hello Test!');
+  await expect(locator2).toHaveText('Hello Test!');
 
-    // #test-keep should remain unchanged when app.tsx HMR
-    expect(await locatorKeep1.innerHTML()).toBe(keepNum1);
-    expect(await locatorKeep2.innerHTML()).toBe(keepNum2);
-  },
-);
+  // #test-keep should remain unchanged when app.tsx HMR
+  expect(await locatorKeep1.innerHTML()).toBe(keepNum1);
+  expect(await locatorKeep2.innerHTML()).toBe(keepNum2);
+});

--- a/e2e/cases/hmr/multiple-environment-shared-module/index.test.ts
+++ b/e2e/cases/hmr/multiple-environment-shared-module/index.test.ts
@@ -1,63 +1,65 @@
 import { join } from 'node:path';
-import { expect, gotoPage, rspackTest } from '@e2e/helper';
+import { expect, gotoPage, test } from '@e2e/helper';
 
-rspackTest(
-  'should perform HMR for multiple environments with shared module',
-  async ({ page, devOnly, editFile, copySrcDir }) => {
-    const tempSrc = await copySrcDir();
+test('should perform HMR for multiple environments with shared module', async ({
+  page,
+  devOnly,
+  editFile,
+  copySrcDir,
+}) => {
+  const tempSrc = await copySrcDir();
 
-    const rsbuild = await devOnly({
-      config: {
-        environments: {
-          foo: {
-            source: {
-              entry: {
-                foo: join(tempSrc, 'foo.js'),
-              },
+  const rsbuild = await devOnly({
+    config: {
+      environments: {
+        foo: {
+          source: {
+            entry: {
+              foo: join(tempSrc, 'foo.js'),
             },
           },
-          bar: {
-            source: {
-              entry: {
-                bar: join(tempSrc, 'bar.js'),
-              },
+        },
+        bar: {
+          source: {
+            entry: {
+              bar: join(tempSrc, 'bar.js'),
             },
           },
         },
       },
-    });
+    },
+  });
 
-    const expectValue = async (value: string) => {
-      const locator = page.locator('body');
-      await expect(locator).toHaveText(value);
-    };
+  const expectValue = async (value: string) => {
+    const locator = page.locator('body');
+    await expect(locator).toHaveText(value);
+  };
 
-    await gotoPage(page, rsbuild, 'foo');
-    await expectValue('foo:hello');
-    await gotoPage(page, rsbuild, 'bar');
-    await expectValue('bar:hello');
+  await gotoPage(page, rsbuild, 'foo');
+  await expectValue('foo:hello');
+  await gotoPage(page, rsbuild, 'bar');
+  await expectValue('bar:hello');
 
-    // edit shared module
-    await editFile(join(tempSrc, 'shared.js'), (code) =>
-      code.replace('hello', 'world'),
-    );
-    await gotoPage(page, rsbuild, 'foo');
-    await expectValue('foo:world');
-    await gotoPage(page, rsbuild, 'bar');
-    await expectValue('bar:world');
+  // edit shared module
+  await editFile(join(tempSrc, 'shared.js'), (code) =>
+    code.replace('hello', 'world'),
+  );
+  await gotoPage(page, rsbuild, 'foo');
+  await expectValue('foo:world');
+  await gotoPage(page, rsbuild, 'bar');
+  await expectValue('bar:world');
 
-    // edit foo entry module
-    await editFile(join(tempSrc, 'foo.js'), (code) =>
-      code.replace('foo', 'foo2'),
-    );
-    await gotoPage(page, rsbuild, 'foo');
-    await expectValue('foo2:world');
+  // edit foo entry module
+  await editFile(join(tempSrc, 'foo.js'), (code) =>
+    code.replace('foo', 'foo2'),
+  );
+  await gotoPage(page, rsbuild, 'foo');
+  await expectValue('foo2:world');
 
-    // edit bar entry module
-    await editFile(join(tempSrc, 'bar.js'), (code) =>
-      code.replace('bar', 'bar2'),
-    );
-    await gotoPage(page, rsbuild, 'bar');
-    await expectValue('bar2:world');
-  },
-);
+  // edit bar entry module
+  await editFile(join(tempSrc, 'bar.js'), (code) =>
+    code.replace('bar', 'bar2'),
+  );
+  await gotoPage(page, rsbuild, 'bar');
+  await expectValue('bar2:world');
+});

--- a/e2e/cases/hmr/rebuild-logs/index.test.ts
+++ b/e2e/cases/hmr/rebuild-logs/index.test.ts
@@ -1,57 +1,60 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should print changed files in logs',
-  async ({ page, dev, editFile, copySrcDir }) => {
-    const tempSrc = await copySrcDir();
+test('should print changed files in logs', async ({
+  page,
+  dev,
+  editFile,
+  copySrcDir,
+}) => {
+  const tempSrc = await copySrcDir();
 
-    const rsbuild = await dev({
-      config: {
-        source: {
-          entry: {
-            index: join(tempSrc, 'index.ts'),
-          },
+  const rsbuild = await dev({
+    config: {
+      source: {
+        entry: {
+          index: join(tempSrc, 'index.ts'),
         },
       },
-    });
+    },
+  });
 
-    const locator = page.locator('#test');
-    await expect(locator).toHaveText('Hello Rsbuild!');
+  const locator = page.locator('#test');
+  await expect(locator).toHaveText('Hello Rsbuild!');
 
-    await editFile(join(tempSrc, 'App.tsx'), (code) =>
-      code.replace('Hello Rsbuild!', 'Hello Rsbuild2!'),
-    );
+  await editFile(join(tempSrc, 'App.tsx'), (code) =>
+    code.replace('Hello Rsbuild!', 'Hello Rsbuild2!'),
+  );
 
-    await rsbuild.expectLog('building test-temp-src/App.tsx', { posix: true });
-  },
-);
+  await rsbuild.expectLog('building test-temp-src/App.tsx', { posix: true });
+});
 
-rspackTest(
-  'should print removed files in logs',
-  async ({ page, dev, copySrcDir }) => {
-    const tempSrc = await copySrcDir();
+test('should print removed files in logs', async ({
+  page,
+  dev,
+  copySrcDir,
+}) => {
+  const tempSrc = await copySrcDir();
 
-    const rsbuild = await dev({
-      config: {
-        source: {
-          entry: {
-            index: join(tempSrc, 'index.ts'),
-          },
+  const rsbuild = await dev({
+    config: {
+      source: {
+        entry: {
+          index: join(tempSrc, 'index.ts'),
         },
       },
-    });
+    },
+  });
 
-    const locator = page.locator('#test');
-    await expect(locator).toHaveText('Hello Rsbuild!');
+  const locator = page.locator('#test');
+  await expect(locator).toHaveText('Hello Rsbuild!');
 
-    const appPath = join(tempSrc, 'App.tsx');
+  const appPath = join(tempSrc, 'App.tsx');
 
-    await fs.promises.unlink(appPath);
+  await fs.promises.unlink(appPath);
 
-    await rsbuild.expectLog('building removed test-temp-src/App.tsx', {
-      posix: true,
-    });
-  },
-);
+  await rsbuild.expectLog('building removed test-temp-src/App.tsx', {
+    posix: true,
+  });
+});

--- a/e2e/cases/hmr/reconnect/index.test.ts
+++ b/e2e/cases/hmr/reconnect/index.test.ts
@@ -1,36 +1,39 @@
 import { join } from 'node:path';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should reconnect WebSocket server as expected',
-  async ({ page, dev, devOnly, editFile, copySrcDir }) => {
-    const tempSrc = await copySrcDir();
+test('should reconnect WebSocket server as expected', async ({
+  page,
+  dev,
+  devOnly,
+  editFile,
+  copySrcDir,
+}) => {
+  const tempSrc = await copySrcDir();
 
-    const entry = {
-      index: join(tempSrc, 'index.ts'),
-    };
+  const entry = {
+    index: join(tempSrc, 'index.ts'),
+  };
 
-    const rsbuild = await dev({
-      config: {
-        source: { entry },
-      },
-    });
+  const rsbuild = await dev({
+    config: {
+      source: { entry },
+    },
+  });
 
-    const locator = page.locator('#test');
-    await expect(locator).toHaveText('Hello Rsbuild!');
+  const locator = page.locator('#test');
+  await expect(locator).toHaveText('Hello Rsbuild!');
 
-    const { port } = rsbuild;
+  const { port } = rsbuild;
 
-    await devOnly({
-      config: {
-        server: { port },
-        source: { entry },
-      },
-    });
+  await devOnly({
+    config: {
+      server: { port },
+      source: { entry },
+    },
+  });
 
-    await editFile(join(tempSrc, 'App.tsx'), (code) =>
-      code.replace('Hello Rsbuild', 'Hello Test'),
-    );
-    await expect(locator).toHaveText('Hello Test!');
-  },
-);
+  await editFile(join(tempSrc, 'App.tsx'), (code) =>
+    code.replace('Hello Rsbuild', 'Hello Test'),
+  );
+  await expect(locator).toHaveText('Hello Test!');
+});

--- a/e2e/cases/hmr/remove-module/index.test.ts
+++ b/e2e/cases/hmr/remove-module/index.test.ts
@@ -1,36 +1,38 @@
 import { join } from 'node:path';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import fse from 'fs-extra';
 
-rspackTest(
-  'should recover after a missing module is restored',
-  async ({ page, dev, logHelper, copySrcDir }) => {
-    const tempSrc = await copySrcDir();
+test('should recover after a missing module is restored', async ({
+  page,
+  dev,
+  logHelper,
+  copySrcDir,
+}) => {
+  const tempSrc = await copySrcDir();
 
-    await dev({
-      config: {
-        source: {
-          entry: {
-            index: join(tempSrc, 'index.js'),
-          },
+  await dev({
+    config: {
+      source: {
+        entry: {
+          index: join(tempSrc, 'index.js'),
         },
       },
-    });
+    },
+  });
 
-    const button = page.locator('#button');
-    await expect(button).toHaveText('count: 0');
-    await button.click();
-    await expect(button).toHaveText('count: 1');
+  const button = page.locator('#button');
+  await expect(button).toHaveText('count: 0');
+  await button.click();
+  await expect(button).toHaveText('count: 1');
 
-    await fse.remove(join(tempSrc, 'Button.jsx'));
-    await logHelper.expectLog(`Can't resolve './Button'`);
+  await fse.remove(join(tempSrc, 'Button.jsx'));
+  await logHelper.expectLog(`Can't resolve './Button'`);
 
-    logHelper.clearLogs();
-    await fse.copy(
-      join(import.meta.dirname, 'src/Button.jsx'),
-      join(tempSrc, 'Button.jsx'),
-    );
-    await logHelper.expectBuildEnd();
-    await expect(page.locator('#button')).toHaveText('count: 0');
-  },
-);
+  logHelper.clearLogs();
+  await fse.copy(
+    join(import.meta.dirname, 'src/Button.jsx'),
+    join(tempSrc, 'Button.jsx'),
+  );
+  await logHelper.expectBuildEnd();
+  await expect(page.locator('#button')).toHaveText('count: 0');
+});

--- a/e2e/cases/hmr/unaffected-environment/index.test.ts
+++ b/e2e/cases/hmr/unaffected-environment/index.test.ts
@@ -1,48 +1,51 @@
 import { join } from 'node:path';
-import { expect, gotoPage, rspackTest } from '@e2e/helper';
+import { expect, gotoPage, test } from '@e2e/helper';
 
-rspackTest(
-  'should not affect other unchanged environments during HMR',
-  async ({ page: page1, devOnly, editFile, copySrcDir, context }) => {
-    const tempSrc = await copySrcDir();
+test('should not affect other unchanged environments during HMR', async ({
+  page: page1,
+  devOnly,
+  editFile,
+  copySrcDir,
+  context,
+}) => {
+  const tempSrc = await copySrcDir();
 
-    const rsbuild = await devOnly({
-      config: {
-        environments: {
-          foo: {
-            source: {
-              entry: {
-                foo: join(tempSrc, 'foo.js'),
-              },
+  const rsbuild = await devOnly({
+    config: {
+      environments: {
+        foo: {
+          source: {
+            entry: {
+              foo: join(tempSrc, 'foo.js'),
             },
           },
-          bar: {
-            source: {
-              entry: {
-                bar: join(tempSrc, 'bar.js'),
-              },
+        },
+        bar: {
+          source: {
+            entry: {
+              bar: join(tempSrc, 'bar.js'),
             },
           },
         },
       },
-    });
+    },
+  });
 
-    const page2 = await context.newPage();
-    await gotoPage(page1, rsbuild, 'foo');
-    await gotoPage(page2, rsbuild, 'bar');
+  const page2 = await context.newPage();
+  await gotoPage(page1, rsbuild, 'foo');
+  await gotoPage(page2, rsbuild, 'bar');
 
-    // initial state
-    await expect(page1.locator('body')).toHaveText('hello world');
-    const button = page2.locator('#button');
-    await expect(button).toHaveText('count: 0');
-    await button.click();
-    await expect(button).toHaveText('count: 1');
+  // initial state
+  await expect(page1.locator('body')).toHaveText('hello world');
+  const button = page2.locator('#button');
+  await expect(button).toHaveText('count: 0');
+  await button.click();
+  await expect(button).toHaveText('count: 1');
 
-    // edit foo.js
-    await editFile(join(tempSrc, 'foo.js'), (code) =>
-      code.replace('hello world', 'changed'),
-    );
-    await expect(page1.locator('body')).toHaveText('changed');
-    await expect(page2.locator('#button')).toHaveText('count: 1');
-  },
-);
+  // edit foo.js
+  await editFile(join(tempSrc, 'foo.js'), (code) =>
+    code.replace('hello world', 'changed'),
+  );
+  await expect(page1.locator('body')).toHaveText('changed');
+  await expect(page2.locator('#button')).toHaveText('count: 1');
+});

--- a/e2e/cases/html/html-loader/index.test.ts
+++ b/e2e/cases/html/html-loader/index.test.ts
@@ -1,39 +1,33 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should allow to use html-loader in development',
-  async ({ dev }) => {
-    const rsbuild = await dev();
+test('should allow to use html-loader in development', async ({ dev }) => {
+  const rsbuild = await dev();
 
-    const files = rsbuild.getDistFiles();
-    const filenames = Object.keys(files);
+  const files = rsbuild.getDistFiles();
+  const filenames = Object.keys(files);
 
-    expect(
-      filenames.some((filename) =>
-        filename.includes('dist/static/image/image.png'),
-      ),
-    ).toBeTruthy();
+  expect(
+    filenames.some((filename) =>
+      filename.includes('dist/static/image/image.png'),
+    ),
+  ).toBeTruthy();
 
-    const htmlFile = filenames.find((filename) => filename.endsWith('.html'));
-    expect(files[htmlFile!]).toContain('<img src="/static/image/image.png"');
-  },
-);
+  const htmlFile = filenames.find((filename) => filename.endsWith('.html'));
+  expect(files[htmlFile!]).toContain('<img src="/static/image/image.png"');
+});
 
-rspackTest(
-  'should allow to use html-loader in production',
-  async ({ build }) => {
-    const rsbuild = await build();
+test('should allow to use html-loader in production', async ({ build }) => {
+  const rsbuild = await build();
 
-    const files = rsbuild.getDistFiles();
-    const filenames = Object.keys(files);
+  const files = rsbuild.getDistFiles();
+  const filenames = Object.keys(files);
 
-    expect(
-      filenames.some((filename) =>
-        filename.includes('dist/static/image/image.png'),
-      ),
-    ).toBeTruthy();
+  expect(
+    filenames.some((filename) =>
+      filename.includes('dist/static/image/image.png'),
+    ),
+  ).toBeTruthy();
 
-    const htmlFile = filenames.find((filename) => filename.endsWith('.html'));
-    expect(files[htmlFile!]).toContain('<img src="/static/image/image.png"');
-  },
-);
+  const htmlFile = filenames.find((filename) => filename.endsWith('.html'));
+  expect(files[htmlFile!]).toContain('<img src="/static/image/image.png"');
+});

--- a/e2e/cases/html/html-tags/function-usage/index.test.ts
+++ b/e2e/cases/html/html-tags/function-usage/index.test.ts
@@ -1,20 +1,12 @@
-import {
-  expect,
-  getFileContent,
-  normalizeNewlines,
-  rspackTest,
-} from '@e2e/helper';
+import { expect, getFileContent, normalizeNewlines, test } from '@e2e/helper';
 
-rspackTest(
-  'should inject tags with function usage correctly',
-  async ({ build }) => {
-    const rsbuild = await build();
-    const files = rsbuild.getDistFiles();
+test('should inject tags with function usage correctly', async ({ build }) => {
+  const rsbuild = await build();
+  const files = rsbuild.getDistFiles();
 
-    const indexHtml = getFileContent(files, 'index.html');
+  const indexHtml = getFileContent(files, 'index.html');
 
-    expect(normalizeNewlines(indexHtml)).toEqual(
-      `<!DOCTYPE html><html><head><script src="/foo.js"></script><script src="/bar.js"></script><script src="/baz.js"></script><title>Rsbuild App</title><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><script defer src="/static/js/index.js"></script></head><body><div id="root"></div></body></html>`,
-    );
-  },
-);
+  expect(normalizeNewlines(indexHtml)).toEqual(
+    `<!DOCTYPE html><html><head><script src="/foo.js"></script><script src="/bar.js"></script><script src="/baz.js"></script><title>Rsbuild App</title><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><script defer src="/static/js/index.js"></script></head><body><div id="root"></div></body></html>`,
+  );
+});

--- a/e2e/cases/html/inject/index.test.ts
+++ b/e2e/cases/html/inject/index.test.ts
@@ -1,11 +1,5 @@
 import path from 'node:path';
-import {
-  expect,
-  getFileContent,
-  normalizeNewlines,
-  rspackTest,
-  test,
-} from '@e2e/helper';
+import { expect, getFileContent, normalizeNewlines, test } from '@e2e/helper';
 import { pluginRem } from '@rsbuild/plugin-rem';
 
 test('should preserve the expected script injection order', async ({
@@ -37,7 +31,7 @@ test('should preserve the expected script injection order', async ({
   expect(html.indexOf('/js/index')).toBe(html.lastIndexOf('/js/index'));
 });
 
-rspackTest('should set inject via function correctly', async ({ build }) => {
+test('should set inject via function correctly', async ({ build }) => {
   const rsbuild = await build({
     config: {
       source: {

--- a/e2e/cases/html/meta/index.test.ts
+++ b/e2e/cases/html/meta/index.test.ts
@@ -1,18 +1,13 @@
-import {
-  expect,
-  getFileContent,
-  normalizeNewlines,
-  rspackTest,
-} from '@e2e/helper';
+import { expect, getFileContent, normalizeNewlines, test } from '@e2e/helper';
 
-rspackTest(
-  'should not inject charset meta if template already contains it',
-  async ({ build }) => {
-    const rsbuild = await build();
-    const files = rsbuild.getDistFiles();
+test('should not inject charset meta if template already contains it', async ({
+  build,
+}) => {
+  const rsbuild = await build();
+  const files = rsbuild.getDistFiles();
 
-    const html = getFileContent(files, 'index.html');
-    expect(normalizeNewlines(html)).toEqual(`<!doctype html>
+  const html = getFileContent(files, 'index.html');
+  expect(normalizeNewlines(html)).toEqual(`<!doctype html>
 <html>
   <head>
     <title>Page Title</title>
@@ -23,5 +18,4 @@ rspackTest(
   </body>
 </html>
 `);
-  },
-);
+});

--- a/e2e/cases/html/minify/index.test.ts
+++ b/e2e/cases/html/minify/index.test.ts
@@ -1,17 +1,14 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest(
-  'should minify template success when inlineScripts & inlineStyles',
-  async ({ buildPreview }) => {
-    const rsbuild = await buildPreview();
+test('should minify template success when inlineScripts & inlineStyles', async ({
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview();
 
-    const files = rsbuild.getDistFiles();
+  const files = rsbuild.getDistFiles();
 
-    const content = getFileContent(files, '.html');
+  const content = getFileContent(files, '.html');
 
-    expect(content.includes('html,body{margin:0;padding:0}')).toBeTruthy();
-    expect(
-      /let \w+=document\.createElement\("div"\)/.test(content),
-    ).toBeTruthy();
-  },
-);
+  expect(content.includes('html,body{margin:0;padding:0}')).toBeTruthy();
+  expect(/let \w+=document\.createElement\("div"\)/.test(content)).toBeTruthy();
+});

--- a/e2e/cases/html/script-loading/index.test.ts
+++ b/e2e/cases/html/script-loading/index.test.ts
@@ -1,6 +1,6 @@
-import { expect, getFileContent, rspackTest, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest('should apply defer by default', async ({ build }) => {
+test('should apply defer by default', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
   const html = getFileContent(files, 'index.html');

--- a/e2e/cases/html/template-cache/index.test.ts
+++ b/e2e/cases/html/template-cache/index.test.ts
@@ -1,63 +1,65 @@
 import { join } from 'node:path';
-import { expect, rspackTest, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import type { RsbuildPlugin } from '@rsbuild/core';
 
 // https://github.com/web-infra-dev/rsbuild/issues/5176
-rspackTest(
-  'should not re-compile templates when the template is not changed',
-  async ({ dev, page, editFile, copySrcDir }) => {
-    // Failed to run this case on Windows
-    if (process.platform === 'win32') {
-      test.skip();
-    }
+test('should not re-compile templates when the template is not changed', async ({
+  dev,
+  page,
+  editFile,
+  copySrcDir,
+}) => {
+  // Failed to run this case on Windows
+  if (process.platform === 'win32') {
+    test.skip();
+  }
 
-    let count = 0;
+  let count = 0;
 
-    const tempSrc = await copySrcDir();
+  const tempSrc = await copySrcDir();
 
-    await dev({
-      config: {
-        root: tempSrc,
-        source: {
-          entry: {
-            index: './index.js',
-            bar: './bar.js',
-          },
+  await dev({
+    config: {
+      root: tempSrc,
+      source: {
+        entry: {
+          index: './index.js',
+          bar: './bar.js',
         },
-        html: {
-          template: ({ entryName }) => `./${entryName}.html`,
-        },
-        plugins: [
-          {
-            name: 'test-plugin',
-            setup(api) {
-              api.transform({ test: /\.html$/ }, ({ code }) => {
-                count++;
-                return `export default \`${code}\`;`;
-              });
-            },
-          } satisfies RsbuildPlugin,
-        ],
       },
-    });
+      html: {
+        template: ({ entryName }) => `./${entryName}.html`,
+      },
+      plugins: [
+        {
+          name: 'test-plugin',
+          setup(api) {
+            api.transform({ test: /\.html$/ }, ({ code }) => {
+              count++;
+              return `export default \`${code}\`;`;
+            });
+          },
+        } satisfies RsbuildPlugin,
+      ],
+    },
+  });
 
-    await expect(page.locator('#root')).toHaveText('foo');
-    expect(count).toEqual(2);
+  await expect(page.locator('#root')).toHaveText('foo');
+  expect(count).toEqual(2);
 
-    // Re-compile the template when the template is changed
-    await editFile(join(tempSrc, 'index.html'), (code) =>
-      code.replace('foo', 'foo2'),
-    );
-    await expect(page.locator('#root')).toHaveText('foo2');
-    // The count will be 4 as the childCompiler in html-rspack-plugin
-    // will compile all the templates
-    expect(count).toEqual(4);
+  // Re-compile the template when the template is changed
+  await editFile(join(tempSrc, 'index.html'), (code) =>
+    code.replace('foo', 'foo2'),
+  );
+  await expect(page.locator('#root')).toHaveText('foo2');
+  // The count will be 4 as the childCompiler in html-rspack-plugin
+  // will compile all the templates
+  expect(count).toEqual(4);
 
-    await editFile(join(tempSrc, 'index.js'), (code) =>
-      code.replace('foo', 'foo3'),
-    );
-    await expect(page.locator('#content')).toHaveText('foo3');
-    // The count should not change if the templates are not changed
-    expect(count).toEqual(4);
-  },
-);
+  await editFile(join(tempSrc, 'index.js'), (code) =>
+    code.replace('foo', 'foo3'),
+  );
+  await expect(page.locator('#content')).toHaveText('foo3');
+  // The count should not change if the templates are not changed
+  expect(count).toEqual(4);
+});

--- a/e2e/cases/html/template-no-head/index.test.ts
+++ b/e2e/cases/html/template-no-head/index.test.ts
@@ -1,15 +1,14 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 // https://github.com/web-infra-dev/rsbuild/issues/4924
-rspackTest(
-  'should inject tags to HTML template without <head> tag',
-  async ({ build }) => {
-    const rsbuild = await build();
-    const files = rsbuild.getDistFiles();
+test('should inject tags to HTML template without <head> tag', async ({
+  build,
+}) => {
+  const rsbuild = await build();
+  const files = rsbuild.getDistFiles();
 
-    const indexHtml = getFileContent(files, 'index.html');
-    expect(indexHtml).toContain(
-      '<!doctype html><head><title>Rsbuild App</title><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><script defer src=',
-    );
-  },
-);
+  const indexHtml = getFileContent(files, 'index.html');
+  expect(indexHtml).toContain(
+    '<!doctype html><head><title>Rsbuild App</title><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><script defer src=',
+  );
+});

--- a/e2e/cases/javascript-api/build-and-load-env/index.test.ts
+++ b/e2e/cases/javascript-api/build-and-load-env/index.test.ts
@@ -1,6 +1,6 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest('should not load env by default', async ({ build }) => {
+test('should not load env by default', async ({ build }) => {
   await build({
     loadEnv: false,
   });
@@ -8,20 +8,19 @@ rspackTest('should not load env by default', async ({ build }) => {
   expect(process.env.PUBLIC_BAR).toBe(undefined);
 });
 
-rspackTest(
-  'should allow to call `build` with `loadEnv` options',
-  async ({ build }) => {
-    const result = await build({
-      loadEnv: {
-        mode: 'prod',
-      },
-    });
+test('should allow to call `build` with `loadEnv` options', async ({
+  build,
+}) => {
+  const result = await build({
+    loadEnv: {
+      mode: 'prod',
+    },
+  });
 
-    expect(process.env.PUBLIC_FOO).toBe('foo');
-    expect(process.env.PUBLIC_BAR).toBe('bar');
+  expect(process.env.PUBLIC_FOO).toBe('foo');
+  expect(process.env.PUBLIC_BAR).toBe('bar');
 
-    await result.close();
-    expect(process.env.PUBLIC_FOO).toBe(undefined);
-    expect(process.env.PUBLIC_BAR).toBe(undefined);
-  },
-);
+  await result.close();
+  expect(process.env.PUBLIC_FOO).toBe(undefined);
+  expect(process.env.PUBLIC_BAR).toBe(undefined);
+});

--- a/e2e/cases/javascript-api/build/index.test.ts
+++ b/e2e/cases/javascript-api/build/index.test.ts
@@ -1,14 +1,11 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should allow to call `build` and get stats object',
-  async ({ build }) => {
-    const result = await build();
+test('should allow to call `build` and get stats object', async ({ build }) => {
+  const result = await build();
 
-    await result.close();
+  await result.close();
 
-    const statsJson = result.stats?.toJson({ all: true });
-    expect(statsJson?.name).toBe('web');
-    expect(statsJson?.assets?.length).toBeGreaterThan(0);
-  },
-);
+  const statsJson = result.stats?.toJson({ all: true });
+  expect(statsJson?.name).toBe('web');
+  expect(statsJson?.assets?.length).toBeGreaterThan(0);
+});

--- a/e2e/cases/javascript-api/caller-name/index.test.ts
+++ b/e2e/cases/javascript-api/caller-name/index.test.ts
@@ -1,23 +1,22 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should allow to set caller name and use it in plugins',
-  async ({ build }) => {
-    let callerName = '';
-    await build({
-      callerName: 'foo',
-      config: {
-        plugins: [
-          {
-            name: 'foo',
-            setup(api) {
-              callerName = api.context.callerName;
-            },
+test('should allow to set caller name and use it in plugins', async ({
+  build,
+}) => {
+  let callerName = '';
+  await build({
+    callerName: 'foo',
+    config: {
+      plugins: [
+        {
+          name: 'foo',
+          setup(api) {
+            callerName = api.context.callerName;
           },
-        ],
-      },
-    });
+        },
+      ],
+    },
+  });
 
-    expect(callerName).toBe('foo');
-  },
-);
+  expect(callerName).toBe('foo');
+});

--- a/e2e/cases/javascript-api/custom-logger/index.test.ts
+++ b/e2e/cases/javascript-api/custom-logger/index.test.ts
@@ -1,6 +1,6 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest('should allow to customize logger', async ({ build }) => {
+test('should allow to customize logger', async ({ build }) => {
   const rsbuild = await build();
   expect(
     rsbuild.logs.find((item) => item.includes('[READY] built in')),

--- a/e2e/cases/javascript-api/get-stats/index.test.ts
+++ b/e2e/cases/javascript-api/get-stats/index.test.ts
@@ -1,29 +1,26 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import { createRsbuild } from '@rsbuild/core';
 
-rspackTest(
-  'should allow to call `getStats` to get stats after creating dev server',
-  async () => {
-    const rsbuild = await createRsbuild({
-      cwd: import.meta.dirname,
-      config: {
-        environments: {
-          node: {
-            output: {
-              target: 'node',
-            },
+test('should allow to call `getStats` to get stats after creating dev server', async () => {
+  const rsbuild = await createRsbuild({
+    cwd: import.meta.dirname,
+    config: {
+      environments: {
+        node: {
+          output: {
+            target: 'node',
           },
         },
       },
-    });
+    },
+  });
 
-    const server = await rsbuild.createDevServer();
-    const stats = await server.environments.node.getStats();
-    expect(
-      typeof stats.toJson({
-        all: false,
-      }),
-    ).toBe('object');
-    await server.close();
-  },
-);
+  const server = await rsbuild.createDevServer();
+  const stats = await server.environments.node.getStats();
+  expect(
+    typeof stats.toJson({
+      all: false,
+    }),
+  ).toBe('object');
+  await server.close();
+});

--- a/e2e/cases/javascript-api/instance-api/index.test.ts
+++ b/e2e/cases/javascript-api/instance-api/index.test.ts
@@ -1,41 +1,35 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import { createRsbuild, type RsbuildPlugin } from '@rsbuild/core';
 
-rspackTest(
-  'should allow to call `modifyRsbuildConfig` via Rsbuild instance',
-  async () => {
-    const rsbuild = await createRsbuild({
-      cwd: import.meta.dirname,
-    });
-    rsbuild.modifyRsbuildConfig((config) => {
-      config.mode = 'none';
-    });
+test('should allow to call `modifyRsbuildConfig` via Rsbuild instance', async () => {
+  const rsbuild = await createRsbuild({
+    cwd: import.meta.dirname,
+  });
+  rsbuild.modifyRsbuildConfig((config) => {
+    config.mode = 'none';
+  });
 
-    const result = await rsbuild.inspectConfig();
-    expect(result.origin.rsbuildConfig.mode).toBe('none');
-  },
-);
+  const result = await rsbuild.inspectConfig();
+  expect(result.origin.rsbuildConfig.mode).toBe('none');
+});
 
-rspackTest(
-  'should allow to call `modifyEnvironmentConfig` via Rsbuild instance',
-  async () => {
-    const rsbuild = await createRsbuild({
-      cwd: import.meta.dirname,
-    });
-    rsbuild.modifyRsbuildConfig((config) => {
-      config.mode = 'development';
-    });
-    rsbuild.modifyEnvironmentConfig((config) => {
-      config.mode = 'none';
-    });
+test('should allow to call `modifyEnvironmentConfig` via Rsbuild instance', async () => {
+  const rsbuild = await createRsbuild({
+    cwd: import.meta.dirname,
+  });
+  rsbuild.modifyRsbuildConfig((config) => {
+    config.mode = 'development';
+  });
+  rsbuild.modifyEnvironmentConfig((config) => {
+    config.mode = 'none';
+  });
 
-    const result = await rsbuild.inspectConfig();
-    expect(result.origin.rsbuildConfig.mode).toBe('development');
-    expect(result.origin.environmentConfigs.web.mode).toBe('none');
-  },
-);
+  const result = await rsbuild.inspectConfig();
+  expect(result.origin.rsbuildConfig.mode).toBe('development');
+  expect(result.origin.environmentConfigs.web.mode).toBe('none');
+});
 
-rspackTest('should allow to call `expose` via Rsbuild instance', async () => {
+test('should allow to call `expose` via Rsbuild instance', async () => {
   const rsbuild = await createRsbuild({
     cwd: import.meta.dirname,
   });

--- a/e2e/cases/javascript-api/load-env/index.test.ts
+++ b/e2e/cases/javascript-api/load-env/index.test.ts
@@ -1,7 +1,7 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import { loadEnv } from '@rsbuild/core';
 
-rspackTest('should load env files correctly', () => {
+test('should load env files correctly', () => {
   const env = loadEnv({
     cwd: import.meta.dirname,
     mode: 'staging',
@@ -42,7 +42,7 @@ rspackTest('should load env files correctly', () => {
   expect(process.env.REACT_NAME).toEqual(undefined);
 });
 
-rspackTest('should not modify process.env if processEnv is provided', () => {
+test('should not modify process.env if processEnv is provided', () => {
   delete process.env.REACT_NAME;
 
   const targetEnv: Record<string, string> = {};

--- a/e2e/cases/javascript-api/register-plugin/index.test.ts
+++ b/e2e/cases/javascript-api/register-plugin/index.test.ts
@@ -1,26 +1,21 @@
 import path from 'node:path';
-import { expect, readDirContents, rspackTest } from '@e2e/helper';
+import { expect, readDirContents, test } from '@e2e/helper';
 import { pluginVue } from '@rsbuild/plugin-vue';
 
-rspackTest(
-  'should register plugins correctly when using JavaScript API',
-  async ({ build }) => {
-    await build({
-      config: {
-        plugins: [pluginVue()],
-      },
-    });
+test('should register plugins correctly when using JavaScript API', async ({
+  build,
+}) => {
+  await build({
+    config: {
+      plugins: [pluginVue()],
+    },
+  });
 
-    const outputs = await readDirContents(
-      path.join(import.meta.dirname, 'dist'),
-    );
-    const outputFiles = Object.keys(outputs);
+  const outputs = await readDirContents(path.join(import.meta.dirname, 'dist'));
+  const outputFiles = Object.keys(outputs);
 
-    expect(
-      outputFiles.find((item) => item.includes('index.html')),
-    ).toBeTruthy();
-    expect(
-      outputFiles.find((item) => item.includes('static/js/index.')),
-    ).toBeTruthy();
-  },
-);
+  expect(outputFiles.find((item) => item.includes('index.html'))).toBeTruthy();
+  expect(
+    outputFiles.find((item) => item.includes('static/js/index.')),
+  ).toBeTruthy();
+});

--- a/e2e/cases/javascript-api/sock-write/index.test.ts
+++ b/e2e/cases/javascript-api/sock-write/index.test.ts
@@ -1,29 +1,28 @@
-import { expectPoll, gotoPage, rspackTest } from '@e2e/helper';
+import { expectPoll, gotoPage, test } from '@e2e/helper';
 import { createRsbuild } from '@rsbuild/core';
 
-rspackTest(
-  'should allow to call `sockWrite` after creating dev server',
-  async ({ page }) => {
-    let count = 0;
-    const rsbuild = await createRsbuild({
-      cwd: import.meta.dirname,
-    });
+test('should allow to call `sockWrite` after creating dev server', async ({
+  page,
+}) => {
+  let count = 0;
+  const rsbuild = await createRsbuild({
+    cwd: import.meta.dirname,
+  });
 
-    const server = await rsbuild.createDevServer();
+  const server = await rsbuild.createDevServer();
 
-    server.middlewares.use((_req, _res, next) => {
-      count++;
-      next();
-    });
+  server.middlewares.use((_req, _res, next) => {
+    count++;
+    next();
+  });
 
-    await server.listen();
-    await gotoPage(page, server);
-    expectPoll(() => count > 0).toBeTruthy();
+  await server.listen();
+  await gotoPage(page, server);
+  expectPoll(() => count > 0).toBeTruthy();
 
-    const previousCount = count;
-    server.sockWrite('static-changed');
-    expectPoll(() => count > previousCount).toBeTruthy();
+  const previousCount = count;
+  server.sockWrite('static-changed');
+  expectPoll(() => count > previousCount).toBeTruthy();
 
-    await server.close();
-  },
-);
+  await server.close();
+});

--- a/e2e/cases/lazy-compilation/add-initial-chunk/index.test.ts
+++ b/e2e/cases/lazy-compilation/add-initial-chunk/index.test.ts
@@ -1,16 +1,16 @@
-import { expect, rspackTest, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
 // https://github.com/web-infra-dev/rspack/issues/6633
-rspackTest(
-  'should render pages correctly when using lazy compilation and add new initial chunk',
-  async ({ page, dev }) => {
-    // TODO: fixme on Windows
-    if (process.platform === 'win32') {
-      test.skip();
-    }
+test('should render pages correctly when using lazy compilation and add new initial chunk', async ({
+  page,
+  dev,
+}) => {
+  // TODO: fixme on Windows
+  if (process.platform === 'win32') {
+    test.skip();
+  }
 
-    await dev();
+  await dev();
 
-    await expect(page.locator('#test')).toHaveText('Hello World!');
-  },
-);
+  await expect(page.locator('#test')).toHaveText('Hello World!');
+});

--- a/e2e/cases/lazy-compilation/basic/index.test.ts
+++ b/e2e/cases/lazy-compilation/basic/index.test.ts
@@ -1,68 +1,68 @@
-import { expect, gotoPage, rspackTest } from '@e2e/helper';
+import { expect, gotoPage, test } from '@e2e/helper';
 
 const BUILD_PAGE1 = 'building src/page1/index.js';
 const BUILD_PAGE2 = 'building src/page2/index.js';
 
-rspackTest(
-  'should render pages correctly when using lazy compilation',
-  async ({ page, dev }) => {
-    const rsbuild = await dev({
-      config: {
-        dev: {
+test('should render pages correctly when using lazy compilation', async ({
+  page,
+  dev,
+}) => {
+  const rsbuild = await dev({
+    config: {
+      dev: {
+        lazyCompilation: true,
+      },
+    },
+  });
+
+  // initial build
+  await rsbuild.expectBuildEnd();
+  rsbuild.clearLogs();
+
+  // build page1
+  await gotoPage(page, rsbuild, 'page1');
+  await rsbuild.expectLog(BUILD_PAGE1, { posix: true });
+  await rsbuild.expectBuildEnd();
+  await expect(page.locator('#test')).toHaveText('Page 1');
+  rsbuild.expectNoLog(BUILD_PAGE2, { posix: true });
+  rsbuild.clearLogs();
+
+  // build page2
+  await gotoPage(page, rsbuild, 'page2');
+  await rsbuild.expectLog(BUILD_PAGE2, { posix: true });
+  await rsbuild.expectBuildEnd();
+  await expect(page.locator('#test')).toHaveText('Page 2');
+});
+
+test('should allow to configure `tools.rspack.lazyCompilation`', async ({
+  page,
+  dev,
+}) => {
+  const rsbuild = await dev({
+    config: {
+      tools: {
+        rspack: {
           lazyCompilation: true,
         },
       },
-    });
+    },
+  });
 
-    // initial build
-    await rsbuild.expectBuildEnd();
-    rsbuild.clearLogs();
+  // initial build
+  await rsbuild.expectBuildEnd();
+  rsbuild.clearLogs();
 
-    // build page1
-    await gotoPage(page, rsbuild, 'page1');
-    await rsbuild.expectLog(BUILD_PAGE1, { posix: true });
-    await rsbuild.expectBuildEnd();
-    await expect(page.locator('#test')).toHaveText('Page 1');
-    rsbuild.expectNoLog(BUILD_PAGE2, { posix: true });
-    rsbuild.clearLogs();
+  // build page1
+  await gotoPage(page, rsbuild, 'page1');
+  await rsbuild.expectLog(BUILD_PAGE1, { posix: true });
+  await rsbuild.expectBuildEnd();
+  await expect(page.locator('#test')).toHaveText('Page 1');
+  rsbuild.expectNoLog(BUILD_PAGE2, { posix: true });
+  rsbuild.clearLogs();
 
-    // build page2
-    await gotoPage(page, rsbuild, 'page2');
-    await rsbuild.expectLog(BUILD_PAGE2, { posix: true });
-    await rsbuild.expectBuildEnd();
-    await expect(page.locator('#test')).toHaveText('Page 2');
-  },
-);
-
-rspackTest(
-  'should allow to configure `tools.rspack.lazyCompilation`',
-  async ({ page, dev }) => {
-    const rsbuild = await dev({
-      config: {
-        tools: {
-          rspack: {
-            lazyCompilation: true,
-          },
-        },
-      },
-    });
-
-    // initial build
-    await rsbuild.expectBuildEnd();
-    rsbuild.clearLogs();
-
-    // build page1
-    await gotoPage(page, rsbuild, 'page1');
-    await rsbuild.expectLog(BUILD_PAGE1, { posix: true });
-    await rsbuild.expectBuildEnd();
-    await expect(page.locator('#test')).toHaveText('Page 1');
-    rsbuild.expectNoLog(BUILD_PAGE2, { posix: true });
-    rsbuild.clearLogs();
-
-    // build page2
-    await gotoPage(page, rsbuild, 'page2');
-    await rsbuild.expectLog(BUILD_PAGE2, { posix: true });
-    await rsbuild.expectBuildEnd();
-    await expect(page.locator('#test')).toHaveText('Page 2');
-  },
-);
+  // build page2
+  await gotoPage(page, rsbuild, 'page2');
+  await rsbuild.expectLog(BUILD_PAGE2, { posix: true });
+  await rsbuild.expectBuildEnd();
+  await expect(page.locator('#test')).toHaveText('Page 2');
+});

--- a/e2e/cases/lazy-compilation/dynamic-import/index.test.ts
+++ b/e2e/cases/lazy-compilation/dynamic-import/index.test.ts
@@ -1,22 +1,22 @@
-import { expect, gotoPage, rspackTest } from '@e2e/helper';
+import { expect, gotoPage, test } from '@e2e/helper';
 
 const BUILD_FOO = 'building src/foo.js';
 
-rspackTest(
-  'should lazy compile dynamic imported modules',
-  async ({ page, devOnly }) => {
-    const rsbuild = await devOnly();
+test('should lazy compile dynamic imported modules', async ({
+  page,
+  devOnly,
+}) => {
+  const rsbuild = await devOnly();
 
-    // initial build
-    await rsbuild.expectBuildEnd();
-    rsbuild.expectNoLog(BUILD_FOO, { posix: true });
-    rsbuild.clearLogs();
+  // initial build
+  await rsbuild.expectBuildEnd();
+  rsbuild.expectNoLog(BUILD_FOO, { posix: true });
+  rsbuild.clearLogs();
 
-    // build foo.js
-    await gotoPage(page, rsbuild, 'index');
-    await rsbuild.expectLog(BUILD_FOO, { posix: true });
-    await rsbuild.expectBuildEnd();
-    const value = await page.evaluate(() => window.foo);
-    expect(value).toBe(42);
-  },
-);
+  // build foo.js
+  await gotoPage(page, rsbuild, 'index');
+  await rsbuild.expectLog(BUILD_FOO, { posix: true });
+  await rsbuild.expectBuildEnd();
+  const value = await page.evaluate(() => window.foo);
+  expect(value).toBe(42);
+});

--- a/e2e/cases/lazy-compilation/port-placeholder/index.test.ts
+++ b/e2e/cases/lazy-compilation/port-placeholder/index.test.ts
@@ -1,23 +1,23 @@
-import { expect, gotoPage, rspackTest } from '@e2e/helper';
+import { expect, gotoPage, test } from '@e2e/helper';
 
-rspackTest(
-  'should replace port placeholder with actual port',
-  async ({ page, devOnly }) => {
-    const rsbuild = await devOnly();
+test('should replace port placeholder with actual port', async ({
+  page,
+  devOnly,
+}) => {
+  const rsbuild = await devOnly();
 
-    // initial build
-    await rsbuild.expectBuildEnd();
-    rsbuild.clearLogs();
+  // initial build
+  await rsbuild.expectBuildEnd();
+  rsbuild.clearLogs();
 
-    // build page1
-    await gotoPage(page, rsbuild, 'page1');
-    await rsbuild.expectBuildEnd();
-    await expect(page.locator('#test')).toHaveText('Page 1');
-    rsbuild.clearLogs();
+  // build page1
+  await gotoPage(page, rsbuild, 'page1');
+  await rsbuild.expectBuildEnd();
+  await expect(page.locator('#test')).toHaveText('Page 1');
+  rsbuild.clearLogs();
 
-    // build page2
-    await gotoPage(page, rsbuild, 'page2');
-    await rsbuild.expectBuildEnd();
-    await expect(page.locator('#test')).toHaveText('Page 2');
-  },
-);
+  // build page2
+  await gotoPage(page, rsbuild, 'page2');
+  await rsbuild.expectBuildEnd();
+  await expect(page.locator('#test')).toHaveText('Page 2');
+});

--- a/e2e/cases/manifest/filter/index.test.ts
+++ b/e2e/cases/manifest/filter/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, getFileContent, rspackTest, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 test('should allow to filter files in manifest', async ({ build }) => {
   const rsbuild = await build({
@@ -32,38 +32,35 @@ test('should allow to filter files in manifest', async ({ build }) => {
   });
 });
 
-rspackTest(
-  'should allow to include license files in manifest',
-  async ({ build }) => {
-    const rsbuild = await build({
-      config: {
-        output: {
-          manifest: {
-            filter: () => true,
-          },
-          filenameHash: false,
+test('should allow to include license files in manifest', async ({ build }) => {
+  const rsbuild = await build({
+    config: {
+      output: {
+        manifest: {
+          filter: () => true,
         },
-        performance: {
-          chunkSplit: {
-            strategy: 'all-in-one',
-          },
+        filenameHash: false,
+      },
+      performance: {
+        chunkSplit: {
+          strategy: 'all-in-one',
         },
       },
-    });
+    },
+  });
 
-    const files = rsbuild.getDistFiles();
+  const files = rsbuild.getDistFiles();
 
-    const manifestContent = getFileContent(files, 'manifest.json');
-    const manifest = JSON.parse(manifestContent);
+  const manifestContent = getFileContent(files, 'manifest.json');
+  const manifest = JSON.parse(manifestContent);
 
-    expect(Object.keys(manifest.allFiles).length).toBe(3);
+  expect(Object.keys(manifest.allFiles).length).toBe(3);
 
-    expect(manifest.entries.index).toMatchObject({
-      initial: {
-        js: ['/static/js/index.js'],
-      },
-      html: ['/index.html'],
-      assets: ['/static/js/index.js.LICENSE.txt'],
-    });
-  },
-);
+  expect(manifest.entries.index).toMatchObject({
+    initial: {
+      js: ['/static/js/index.js'],
+    },
+    html: ['/index.html'],
+    assets: ['/static/js/index.js.LICENSE.txt'],
+  });
+});

--- a/e2e/cases/manifest/integrity/index.test.ts
+++ b/e2e/cases/manifest/integrity/index.test.ts
@@ -1,32 +1,28 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 import type { ManifestData } from '@rsbuild/core';
 
-rspackTest(
-  'should generate manifest file with integrity in build',
-  async ({ build }) => {
-    const rsbuild = await build();
-    const files = rsbuild.getDistFiles();
-    const manifestContent = getFileContent(files, 'manifest.json');
-    const manifest = JSON.parse(manifestContent) as ManifestData;
-    manifest.allFiles.forEach((item) => {
-      if (item.endsWith('.js')) {
-        expect(manifest.integrity[item]).toBeTruthy();
-      }
-    });
-  },
-);
+test('should generate manifest file with integrity in build', async ({
+  build,
+}) => {
+  const rsbuild = await build();
+  const files = rsbuild.getDistFiles();
+  const manifestContent = getFileContent(files, 'manifest.json');
+  const manifest = JSON.parse(manifestContent) as ManifestData;
+  manifest.allFiles.forEach((item) => {
+    if (item.endsWith('.js')) {
+      expect(manifest.integrity[item]).toBeTruthy();
+    }
+  });
+});
 
-rspackTest(
-  'should generate manifest file with integrity in dev',
-  async ({ dev }) => {
-    const rsbuild = await dev();
-    const files = rsbuild.getDistFiles();
-    const manifestContent = getFileContent(files, 'manifest.json');
-    const manifest = JSON.parse(manifestContent) as ManifestData;
-    manifest.allFiles.forEach((item) => {
-      if (item.endsWith('.js')) {
-        expect(manifest.integrity[item]).toBeTruthy();
-      }
-    });
-  },
-);
+test('should generate manifest file with integrity in dev', async ({ dev }) => {
+  const rsbuild = await dev();
+  const files = rsbuild.getDistFiles();
+  const manifestContent = getFileContent(files, 'manifest.json');
+  const manifest = JSON.parse(manifestContent) as ManifestData;
+  manifest.allFiles.forEach((item) => {
+    if (item.endsWith('.js')) {
+      expect(manifest.integrity[item]).toBeTruthy();
+    }
+  });
+});

--- a/e2e/cases/mode/basic/index.test.ts
+++ b/e2e/cases/mode/basic/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, getFileContent, rspackTest, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 test('should allow to set development mode when building', async ({
   build,
@@ -42,31 +42,30 @@ test('should allow to set none mode when building', async ({ build }) => {
   expect(indexJs).toContain('// this is a comment');
 });
 
-rspackTest(
-  'should allow to set production mode when starting dev server',
-  async ({ dev }) => {
-    const rsbuild = await dev({
-      config: {
-        mode: 'production',
-      },
-    });
+test('should allow to set production mode when starting dev server', async ({
+  dev,
+}) => {
+  const rsbuild = await dev({
+    config: {
+      mode: 'production',
+    },
+  });
 
-    const files = rsbuild.getDistFiles({ sourceMaps: true });
+  const files = rsbuild.getDistFiles({ sourceMaps: true });
 
-    // should have filename hash in build
-    const indexJs = getFileContent(
-      files,
-      (key) => /static\/js\/index\.\w+\.js/.test(key),
-      { ignoreHash: false },
-    );
+  // should have filename hash in build
+  const indexJs = getFileContent(
+    files,
+    (key) => /static\/js\/index\.\w+\.js/.test(key),
+    { ignoreHash: false },
+  );
 
-    // should replace `process.env.NODE_ENV` with `'production'`
-    expect(indexJs).toContain('this is production mode!');
+  // should replace `process.env.NODE_ENV` with `'production'`
+  expect(indexJs).toContain('this is production mode!');
 
-    // should remove comments
-    expect(indexJs).not.toContain('// this is a comment');
+  // should remove comments
+  expect(indexJs).not.toContain('// this is a comment');
 
-    // should not have JavaScript source map
-    expect(() => getFileContent(files, '.js.map')).toThrow();
-  },
-);
+  // should not have JavaScript source map
+  expect(() => getFileContent(files, '.js.map')).toThrow();
+});

--- a/e2e/cases/mode/define/index.test.ts
+++ b/e2e/cases/mode/define/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, rspackTest, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
 declare global {
   interface Window {
@@ -147,7 +147,7 @@ test('should define vars in none mode correctly', async ({
   );
 });
 
-rspackTest('should allow to disable NODE_ENV injection', async ({ build }) => {
+test('should allow to disable NODE_ENV injection', async ({ build }) => {
   const rsbuild = await build({
     config: {
       mode: 'production',

--- a/e2e/cases/module-federation/v1-basic/index.test.ts
+++ b/e2e/cases/module-federation/v1-basic/index.test.ts
@@ -1,6 +1,6 @@
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { expect, getRandomPort, gotoPage, rspackTest } from '@e2e/helper';
+import { expect, getRandomPort, gotoPage, test } from '@e2e/helper';
 import type { RsbuildConfig } from '@rsbuild/core';
 import { pluginCheckSyntax } from '@rsbuild/plugin-check-syntax';
 
@@ -19,7 +19,7 @@ export default Button;`,
   );
 };
 
-rspackTest('should run module federation in dev', async ({ page, devOnly }) => {
+test('should run module federation in dev', async ({ page, devOnly }) => {
   writeButtonCode();
 
   const remotePort = await getRandomPort();
@@ -42,142 +42,136 @@ rspackTest('should run module federation in dev', async ({ page, devOnly }) => {
   await expect(page.locator('#button')).toHaveText('Button from remote');
 });
 
-rspackTest(
-  'should allow to set `server.cors` config',
-  async ({ request, devOnly }) => {
-    writeButtonCode();
+test('should allow to set `server.cors` config', async ({
+  request,
+  devOnly,
+}) => {
+  writeButtonCode();
 
-    const remotePort = await getRandomPort();
-    process.env.REMOTE_PORT = remotePort.toString();
+  const remotePort = await getRandomPort();
+  process.env.REMOTE_PORT = remotePort.toString();
 
-    const remoteApp = await devOnly({
-      cwd: remote,
-    });
-    const hostApp = await devOnly({
-      cwd: host,
-    });
+  const remoteApp = await devOnly({
+    cwd: remote,
+  });
+  const hostApp = await devOnly({
+    cwd: host,
+  });
 
-    // Check CORS headers
-    const remoteResponse = await request.get(
-      `http://127.0.0.1:${remoteApp.port}`,
-    );
-    expect(remoteResponse.headers()['access-control-allow-origin']).toEqual(
-      'https://localhost',
-    );
+  // Check CORS headers
+  const remoteResponse = await request.get(
+    `http://127.0.0.1:${remoteApp.port}`,
+  );
+  expect(remoteResponse.headers()['access-control-allow-origin']).toEqual(
+    'https://localhost',
+  );
 
-    const hostResponse = await request.get(`http://127.0.0.1:${hostApp.port}`);
-    expect(hostResponse.headers()['access-control-allow-origin']).toEqual(
-      'https://localhost',
-    );
-  },
-);
+  const hostResponse = await request.get(`http://127.0.0.1:${hostApp.port}`);
+  expect(hostResponse.headers()['access-control-allow-origin']).toEqual(
+    'https://localhost',
+  );
+});
 
-rspackTest(
-  'should run module federation in dev with server.base',
-  async ({ page, devOnly }) => {
-    writeButtonCode();
+test('should run module federation in dev with server.base', async ({
+  page,
+  devOnly,
+}) => {
+  writeButtonCode();
 
-    const remotePort = await getRandomPort();
+  const remotePort = await getRandomPort();
 
-    process.env.REMOTE_PORT = remotePort.toString();
+  process.env.REMOTE_PORT = remotePort.toString();
 
-    const remoteApp = await devOnly({
-      cwd: remote,
-      config: {
-        server: {
-          base: '/remote',
-        },
+  const remoteApp = await devOnly({
+    cwd: remote,
+    config: {
+      server: {
+        base: '/remote',
       },
-    });
-    const hostApp = await devOnly({
-      cwd: host,
-      config: {
-        server: {
-          base: '/host',
-        },
+    },
+  });
+  const hostApp = await devOnly({
+    cwd: host,
+    config: {
+      server: {
+        base: '/host',
       },
-    });
+    },
+  });
 
-    await gotoPage(page, remoteApp);
-    await expect(page.locator('#title')).toHaveText('Remote');
-    await expect(page.locator('#button')).toHaveText('Button from remote');
+  await gotoPage(page, remoteApp);
+  await expect(page.locator('#title')).toHaveText('Remote');
+  await expect(page.locator('#button')).toHaveText('Button from remote');
 
-    await gotoPage(page, hostApp);
-    await expect(page.locator('#title')).toHaveText('Host');
-    await expect(page.locator('#button')).toHaveText('Button from remote');
-  },
-);
+  await gotoPage(page, hostApp);
+  await expect(page.locator('#title')).toHaveText('Host');
+  await expect(page.locator('#button')).toHaveText('Button from remote');
+});
 
-rspackTest(
-  'should allow remote module to perform HMR',
-  async ({ page, devOnly }) => {
-    writeButtonCode();
+test('should allow remote module to perform HMR', async ({ page, devOnly }) => {
+  writeButtonCode();
 
-    const remotePort = await getRandomPort();
+  const remotePort = await getRandomPort();
 
-    process.env.REMOTE_PORT = remotePort.toString();
+  process.env.REMOTE_PORT = remotePort.toString();
 
-    const remoteApp = await devOnly({
-      cwd: remote,
-    });
-    const hostApp = await devOnly({
-      cwd: host,
-    });
+  const remoteApp = await devOnly({
+    cwd: remote,
+  });
+  const hostApp = await devOnly({
+    cwd: host,
+  });
 
-    await gotoPage(page, remoteApp);
-    await expect(page.locator('#title')).toHaveText('Remote');
-    await expect(page.locator('#button')).toHaveText('Button from remote');
+  await gotoPage(page, remoteApp);
+  await expect(page.locator('#title')).toHaveText('Remote');
+  await expect(page.locator('#button')).toHaveText('Button from remote');
 
-    await gotoPage(page, hostApp);
-    await expect(page.locator('#title')).toHaveText('Host');
-    await expect(page.locator('#button')).toHaveText('Button from remote');
+  await gotoPage(page, hostApp);
+  await expect(page.locator('#title')).toHaveText('Host');
+  await expect(page.locator('#button')).toHaveText('Button from remote');
 
-    writeButtonCode('Button from remote (HMR)');
-    await expect(page.locator('#button')).toHaveText(
-      'Button from remote (HMR)',
-    );
-  },
-);
+  writeButtonCode('Button from remote (HMR)');
+  await expect(page.locator('#button')).toHaveText('Button from remote (HMR)');
+});
 
-rspackTest(
-  'should transform module federation runtime with SWC',
-  async ({ build }) => {
-    writeButtonCode();
+test('should transform module federation runtime with SWC', async ({
+  build,
+}) => {
+  writeButtonCode();
 
-    const remotePort = await getRandomPort();
+  const remotePort = await getRandomPort();
 
-    process.env.REMOTE_PORT = remotePort.toString();
+  process.env.REMOTE_PORT = remotePort.toString();
 
-    const config: RsbuildConfig = {
-      output: {
-        sourceMap: true,
-        overrideBrowserslist: ['Chrome >= 51'],
+  const config: RsbuildConfig = {
+    output: {
+      sourceMap: true,
+      overrideBrowserslist: ['Chrome >= 51'],
+    },
+    performance: {
+      chunkSplit: {
+        strategy: 'all-in-one',
       },
-      performance: {
-        chunkSplit: {
-          strategy: 'all-in-one',
-        },
-      },
-      plugins: [
-        pluginCheckSyntax({
-          // MF runtime contains dynamic import, which can not pass syntax checking
-          exclude: [/@module-federation[\\/]runtime/],
-        }),
-      ],
-    };
-
-    await expect(
-      build({
-        cwd: remote,
-        config,
+    },
+    plugins: [
+      pluginCheckSyntax({
+        // MF runtime contains dynamic import, which can not pass syntax checking
+        exclude: [/@module-federation[\\/]runtime/],
       }),
-    ).resolves.toBeTruthy();
+    ],
+  };
 
-    await expect(
-      build({
-        cwd: host,
-        config,
-      }),
-    ).resolves.toBeTruthy();
-  },
-);
+  await expect(
+    build({
+      cwd: remote,
+      config,
+    }),
+  ).resolves.toBeTruthy();
+
+  await expect(
+    build({
+      cwd: host,
+      config,
+    }),
+  ).resolves.toBeTruthy();
+});

--- a/e2e/cases/module-federation/v1-without-entry/index.test.ts
+++ b/e2e/cases/module-federation/v1-without-entry/index.test.ts
@@ -1,9 +1,9 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest('should start MF app in dev without entry', async ({ devOnly }) => {
+test('should start MF app in dev without entry', async ({ devOnly }) => {
   await expect(devOnly()).resolves.toBeTruthy();
 });
 
-rspackTest('should build MF app without entry', async ({ build }) => {
+test('should build MF app without entry', async ({ build }) => {
   await expect(build()).resolves.toBeTruthy();
 });

--- a/e2e/cases/module-federation/v2-basic/index.test.ts
+++ b/e2e/cases/module-federation/v2-basic/index.test.ts
@@ -1,6 +1,6 @@
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { expect, getRandomPort, gotoPage, rspackTest } from '@e2e/helper';
+import { expect, getRandomPort, gotoPage, test } from '@e2e/helper';
 import type { RsbuildConfig } from '@rsbuild/core';
 import { pluginCheckSyntax } from '@rsbuild/plugin-check-syntax';
 
@@ -19,7 +19,7 @@ export default Button;`,
   );
 };
 
-rspackTest('should run module federation in dev', async ({ page, devOnly }) => {
+test('should run module federation in dev', async ({ page, devOnly }) => {
   writeButtonCode();
 
   const remotePort = await getRandomPort();
@@ -43,38 +43,33 @@ rspackTest('should run module federation in dev', async ({ page, devOnly }) => {
   await expect(page.locator('#button')).toHaveText('Button from remote');
 });
 
-rspackTest(
-  'should allow remote module to perform HMR',
-  async ({ page, devOnly }) => {
-    writeButtonCode();
+test('should allow remote module to perform HMR', async ({ page, devOnly }) => {
+  writeButtonCode();
 
-    const remotePort = await getRandomPort();
+  const remotePort = await getRandomPort();
 
-    process.env.REMOTE_PORT = remotePort.toString();
+  process.env.REMOTE_PORT = remotePort.toString();
 
-    const remoteApp = await devOnly({
-      cwd: remote,
-    });
-    const hostApp = await devOnly({
-      cwd: host,
-    });
+  const remoteApp = await devOnly({
+    cwd: remote,
+  });
+  const hostApp = await devOnly({
+    cwd: host,
+  });
 
-    await gotoPage(page, remoteApp);
-    await expect(page.locator('#title')).toHaveText('Remote');
-    await expect(page.locator('#button')).toHaveText('Button from remote');
+  await gotoPage(page, remoteApp);
+  await expect(page.locator('#title')).toHaveText('Remote');
+  await expect(page.locator('#button')).toHaveText('Button from remote');
 
-    await gotoPage(page, hostApp);
-    await expect(page.locator('#title')).toHaveText('Host');
-    await expect(page.locator('#button')).toHaveText('Button from remote');
+  await gotoPage(page, hostApp);
+  await expect(page.locator('#title')).toHaveText('Host');
+  await expect(page.locator('#button')).toHaveText('Button from remote');
 
-    writeButtonCode('Button from remote (HMR)');
-    await expect(page.locator('#button')).toHaveText(
-      'Button from remote (HMR)',
-    );
-  },
-);
+  writeButtonCode('Button from remote (HMR)');
+  await expect(page.locator('#button')).toHaveText('Button from remote (HMR)');
+});
 
-rspackTest('should downgrade syntax as expected', async ({ build }) => {
+test('should downgrade syntax as expected', async ({ build }) => {
   writeButtonCode();
 
   const remotePort = await getRandomPort();

--- a/e2e/cases/module-federation/v2-without-entry/index.test.ts
+++ b/e2e/cases/module-federation/v2-without-entry/index.test.ts
@@ -1,9 +1,9 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest('should start MF app in dev without entry', async ({ devOnly }) => {
+test('should start MF app in dev without entry', async ({ devOnly }) => {
   await expect(devOnly()).resolves.toBeTruthy();
 });
 
-rspackTest('should build MF app without entry', async ({ build }) => {
+test('should build MF app without entry', async ({ build }) => {
   await expect(build()).resolves.toBeTruthy();
 });

--- a/e2e/cases/module/glob-import/index.test.ts
+++ b/e2e/cases/module/glob-import/index.test.ts
@@ -1,20 +1,20 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should glob import components in dev build correctly',
-  async ({ page, dev }) => {
-    await dev();
+test('should glob import components in dev build correctly', async ({
+  page,
+  dev,
+}) => {
+  await dev();
 
-    await expect(page.locator('#header')).toHaveText('Header');
-    await expect(page.locator('#footer')).toHaveText('Footer');
-  },
-);
+  await expect(page.locator('#header')).toHaveText('Header');
+  await expect(page.locator('#footer')).toHaveText('Footer');
+});
 
-rspackTest(
-  'should glob import components in build correctly',
-  async ({ page, buildPreview }) => {
-    await buildPreview();
-    await expect(page.locator('#header')).toHaveText('Header');
-    await expect(page.locator('#footer')).toHaveText('Footer');
-  },
-);
+test('should glob import components in build correctly', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview();
+  await expect(page.locator('#header')).toHaveText('Header');
+  await expect(page.locator('#footer')).toHaveText('Footer');
+});

--- a/e2e/cases/node-addons/cjs/index.test.ts
+++ b/e2e/cases/node-addons/cjs/index.test.ts
@@ -1,65 +1,63 @@
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import { join } from 'node:path';
-import { expect, findFile, rspackTest } from '@e2e/helper';
+import { expect, findFile, test } from '@e2e/helper';
 import fse from 'fs-extra';
 
 const require = createRequire(import.meta.url);
 
-rspackTest(
-  'should compile Node addons correctly for CJS output',
-  async ({ build }) => {
-    const rsbuild = await build();
-    const files = rsbuild.getDistFiles();
-    const addonFile = findFile(files, 'test.darwin.node');
-    expect(fs.existsSync(addonFile)).toBeTruthy();
+test('should compile Node addons correctly for CJS output', async ({
+  build,
+}) => {
+  const rsbuild = await build();
+  const files = rsbuild.getDistFiles();
+  const addonFile = findFile(files, 'test.darwin.node');
+  expect(fs.existsSync(addonFile)).toBeTruthy();
 
-    // the `test.darwin.node` is only compatible with darwin
-    if (process.platform === 'darwin') {
-      const { addon } = require('./dist/index.cjs');
-      expect(typeof addon.readLength).toEqual('function');
-    }
-  },
-);
+  // the `test.darwin.node` is only compatible with darwin
+  if (process.platform === 'darwin') {
+    const { addon } = require('./dist/index.cjs');
+    expect(typeof addon.readLength).toEqual('function');
+  }
+});
 
-rspackTest(
-  'should compile Node addons in the node_modules for CJS output',
-  async ({ build }) => {
-    const pkgDir = join(import.meta.dirname, 'node_modules', 'node-addon-pkg');
+test('should compile Node addons in the node_modules for CJS output', async ({
+  build,
+}) => {
+  const pkgDir = join(import.meta.dirname, 'node_modules', 'node-addon-pkg');
 
-    await fse.remove(pkgDir);
+  await fse.remove(pkgDir);
 
-    fse.outputJSONSync(join(pkgDir, 'package.json'), {
-      name: 'node-addon-pkg',
-      main: 'src/index.js',
-    });
-    fse.outputFileSync(
-      join(pkgDir, 'src', 'index.js'),
-      `import addon from './other.node'; export default addon;`,
-    );
-    fse.ensureDirSync(join(pkgDir, 'src'));
-    fs.copyFileSync(
-      join(import.meta.dirname, 'src', 'test.darwin.node'),
-      join(pkgDir, 'src', 'other.node'),
-    );
+  fse.outputJSONSync(join(pkgDir, 'package.json'), {
+    name: 'node-addon-pkg',
+    main: 'src/index.js',
+  });
+  fse.outputFileSync(
+    join(pkgDir, 'src', 'index.js'),
+    `import addon from './other.node'; export default addon;`,
+  );
+  fse.ensureDirSync(join(pkgDir, 'src'));
+  fs.copyFileSync(
+    join(import.meta.dirname, 'src', 'test.darwin.node'),
+    join(pkgDir, 'src', 'other.node'),
+  );
 
-    const rsbuild = await build({
-      config: {
-        source: {
-          entry: {
-            index: './src/other.js',
-          },
+  const rsbuild = await build({
+    config: {
+      source: {
+        entry: {
+          index: './src/other.js',
         },
       },
-    });
+    },
+  });
 
-    const files = rsbuild.getDistFiles();
-    const addonFile = findFile(files, 'other.node');
-    expect(fs.existsSync(addonFile)).toBeTruthy();
+  const files = rsbuild.getDistFiles();
+  const addonFile = findFile(files, 'other.node');
+  expect(fs.existsSync(addonFile)).toBeTruthy();
 
-    if (process.platform === 'darwin') {
-      const { addon } = require('./dist/index.cjs');
-      expect(typeof addon.readLength).toEqual('function');
-    }
-  },
-);
+  if (process.platform === 'darwin') {
+    const { addon } = require('./dist/index.cjs');
+    expect(typeof addon.readLength).toEqual('function');
+  }
+});

--- a/e2e/cases/node-addons/esm/index.test.ts
+++ b/e2e/cases/node-addons/esm/index.test.ts
@@ -1,62 +1,60 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
-import { expect, findFile, rspackTest } from '@e2e/helper';
+import { expect, findFile, test } from '@e2e/helper';
 import fse from 'fs-extra';
 
-rspackTest(
-  'should compile Node addons correctly for ESM output',
-  async ({ build }) => {
-    const rsbuild = await build();
-    const files = rsbuild.getDistFiles();
-    const addonFile = findFile(files, 'test.darwin.node');
-    expect(fs.existsSync(addonFile)).toBeTruthy();
+test('should compile Node addons correctly for ESM output', async ({
+  build,
+}) => {
+  const rsbuild = await build();
+  const files = rsbuild.getDistFiles();
+  const addonFile = findFile(files, 'test.darwin.node');
+  expect(fs.existsSync(addonFile)).toBeTruthy();
 
-    // the `test.darwin.node` is only compatible with darwin
-    if (process.platform === 'darwin') {
-      const { addon } = await import('./dist/index.js' as string);
-      expect(typeof addon.readLength).toEqual('function');
-    }
-  },
-);
+  // the `test.darwin.node` is only compatible with darwin
+  if (process.platform === 'darwin') {
+    const { addon } = await import('./dist/index.js' as string);
+    expect(typeof addon.readLength).toEqual('function');
+  }
+});
 
-rspackTest(
-  'should compile Node addons in the node_modules for ESM output',
-  async ({ build }) => {
-    const pkgDir = join(import.meta.dirname, 'node_modules', 'node-addon-pkg');
+test('should compile Node addons in the node_modules for ESM output', async ({
+  build,
+}) => {
+  const pkgDir = join(import.meta.dirname, 'node_modules', 'node-addon-pkg');
 
-    await fse.remove(pkgDir);
+  await fse.remove(pkgDir);
 
-    fse.outputJSONSync(join(pkgDir, 'package.json'), {
-      name: 'node-addon-pkg',
-      main: 'src/index.js',
-    });
-    fse.outputFileSync(
-      join(pkgDir, 'src', 'index.js'),
-      `import addon from './other.node'; export default addon;`,
-    );
-    fse.ensureDirSync(join(pkgDir, 'src'));
-    fs.copyFileSync(
-      join(import.meta.dirname, 'src', 'test.darwin.node'),
-      join(pkgDir, 'src', 'other.node'),
-    );
+  fse.outputJSONSync(join(pkgDir, 'package.json'), {
+    name: 'node-addon-pkg',
+    main: 'src/index.js',
+  });
+  fse.outputFileSync(
+    join(pkgDir, 'src', 'index.js'),
+    `import addon from './other.node'; export default addon;`,
+  );
+  fse.ensureDirSync(join(pkgDir, 'src'));
+  fs.copyFileSync(
+    join(import.meta.dirname, 'src', 'test.darwin.node'),
+    join(pkgDir, 'src', 'other.node'),
+  );
 
-    const rsbuild = await build({
-      config: {
-        source: {
-          entry: {
-            index: './src/other.js',
-          },
+  const rsbuild = await build({
+    config: {
+      source: {
+        entry: {
+          index: './src/other.js',
         },
       },
-    });
+    },
+  });
 
-    const files = rsbuild.getDistFiles();
-    const addonFile = findFile(files, 'other.node');
-    expect(fs.existsSync(addonFile)).toBeTruthy();
+  const files = rsbuild.getDistFiles();
+  const addonFile = findFile(files, 'other.node');
+  expect(fs.existsSync(addonFile)).toBeTruthy();
 
-    if (process.platform === 'darwin') {
-      const { addon } = await import('./dist/index.js' as string);
-      expect(typeof addon.readLength).toEqual('function');
-    }
-  },
-);
+  if (process.platform === 'darwin') {
+    const { addon } = await import('./dist/index.js' as string);
+    expect(typeof addon.readLength).toEqual('function');
+  }
+});

--- a/e2e/cases/optimization/css-minify-always/index.test.ts
+++ b/e2e/cases/optimization/css-minify-always/index.test.ts
@@ -1,6 +1,6 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest('should minimize CSS correctly by default', async ({ build }) => {
+test('should minimize CSS correctly by default', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
 

--- a/e2e/cases/optimization/css-minify-inherit/index.test.ts
+++ b/e2e/cases/optimization/css-minify-inherit/index.test.ts
@@ -1,22 +1,22 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should let lightningcss minimizer inherit from tools.lightningcssLoader',
-  async ({ dev, build }) => {
-    const rsbuild = await dev();
-    const devFiles = rsbuild.getDistFiles();
-    const devContent =
-      devFiles[
-        Object.keys(devFiles).find((file) => file.endsWith('css/index.css'))!
-      ];
-    expect(devContent).toContain('margin-inline-end: 100px;');
+test('should let lightningcss minimizer inherit from tools.lightningcssLoader', async ({
+  dev,
+  build,
+}) => {
+  const rsbuild = await dev();
+  const devFiles = rsbuild.getDistFiles();
+  const devContent =
+    devFiles[
+      Object.keys(devFiles).find((file) => file.endsWith('css/index.css'))!
+    ];
+  expect(devContent).toContain('margin-inline-end: 100px;');
 
-    const rsbuild2 = await build();
-    const buildFiles = rsbuild2.getDistFiles();
-    const buildContent =
-      buildFiles[
-        Object.keys(buildFiles).find((file) => file.endsWith('css/index.css'))!
-      ];
-    expect(buildContent).toContain('margin-inline-end:100px');
-  },
-);
+  const rsbuild2 = await build();
+  const buildFiles = rsbuild2.getDistFiles();
+  const buildContent =
+    buildFiles[
+      Object.keys(buildFiles).find((file) => file.endsWith('css/index.css'))!
+    ];
+  expect(buildContent).toContain('margin-inline-end:100px');
+});

--- a/e2e/cases/optimization/css-minify-options/index.test.ts
+++ b/e2e/cases/optimization/css-minify-options/index.test.ts
@@ -1,6 +1,6 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest('should allow to custom CSS minify options', async ({ build }) => {
+test('should allow to custom CSS minify options', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
   const content = getFileContent(files, '.css');

--- a/e2e/cases/optimization/css-minify/index.test.ts
+++ b/e2e/cases/optimization/css-minify/index.test.ts
@@ -1,6 +1,6 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest('should allow to minify CSS in dev', async ({ dev }) => {
+test('should allow to minify CSS in dev', async ({ dev }) => {
   const rsbuild = await dev();
   const files = rsbuild.getDistFiles();
 

--- a/e2e/cases/optimization/inline-const/index.test.ts
+++ b/e2e/cases/optimization/inline-const/index.test.ts
@@ -1,21 +1,18 @@
-import { expect, rspackTest, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should inline the constants in build',
-  async ({ page, buildPreview }) => {
-    const rsbuild = await buildPreview();
-    await page.waitForFunction(() => window.testDog);
-    expect(await page.evaluate(() => window.testFish)).toBe('fish,FISH');
-    expect(await page.evaluate(() => window.testCat)).toBe('cat,CAT');
-    expect(await page.evaluate(() => window.testDog)).toBe('dog,DOG');
-    expect(await page.evaluate(() => window.testNamespace)).toBe('0,1');
+test('should inline the constants in build', async ({ page, buildPreview }) => {
+  const rsbuild = await buildPreview();
+  await page.waitForFunction(() => window.testDog);
+  expect(await page.evaluate(() => window.testFish)).toBe('fish,FISH');
+  expect(await page.evaluate(() => window.testCat)).toBe('cat,CAT');
+  expect(await page.evaluate(() => window.testDog)).toBe('dog,DOG');
+  expect(await page.evaluate(() => window.testNamespace)).toBe('0,1');
 
-    const indexJs = await rsbuild.getIndexBundle();
-    expect(indexJs).toContain('window.testFish="fish,FISH"');
-    expect(indexJs).toContain('window.testCat="cat,CAT"');
-    expect(indexJs).toContain('window.testNamespace="0,1"');
-  },
-);
+  const indexJs = await rsbuild.getIndexBundle();
+  expect(indexJs).toContain('window.testFish="fish,FISH"');
+  expect(indexJs).toContain('window.testCat="cat,CAT"');
+  expect(indexJs).toContain('window.testNamespace="0,1"');
+});
 
 test('should import the constants as expected in dev', async ({
   page,

--- a/e2e/cases/optimization/js-minify-always/index.test.ts
+++ b/e2e/cases/optimization/js-minify-always/index.test.ts
@@ -1,6 +1,6 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest('should allow to minify JS in dev', async ({ dev }) => {
+test('should allow to minify JS in dev', async ({ dev }) => {
   const rsbuild = await dev();
   const files = rsbuild.getDistFiles();
   const content = getFileContent(files, '.js');

--- a/e2e/cases/output/charset-zh-filename/index.test.ts
+++ b/e2e/cases/output/charset-zh-filename/index.test.ts
@@ -1,16 +1,16 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
 const expected = '你好';
 
-rspackTest('should resolve Chinese filename in dev', async ({ page, dev }) => {
+test('should resolve Chinese filename in dev', async ({ page, dev }) => {
   await dev();
   expect(await page.evaluate('window.test')).toBe(expected);
 });
 
-rspackTest(
-  'should resolve Chinese filename in build',
-  async ({ page, buildPreview }) => {
-    await buildPreview();
-    expect(await page.evaluate('window.test')).toBe(expected);
-  },
-);
+test('should resolve Chinese filename in build', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview();
+  expect(await page.evaluate('window.test')).toBe(expected);
+});

--- a/e2e/cases/output/charset/index.test.ts
+++ b/e2e/cases/output/charset/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, getFileContent, rspackTest, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 const utf8Str = `你好 world! I'm 🦀`;
 const asciiStr = `\\u{4F60}\\u{597D} world! I'm \\u{1F980}`;
@@ -13,29 +13,26 @@ const expectedObject = {
   '𝒩': 'a',
 };
 
-rspackTest(
-  'should set output.charset to ascii in dev',
-  async ({ page, dev }) => {
-    const rsbuild = await dev({
-      config: {
-        output: {
-          charset: 'ascii',
-        },
+test('should set output.charset to ascii in dev', async ({ page, dev }) => {
+  const rsbuild = await dev({
+    config: {
+      output: {
+        charset: 'ascii',
       },
-    });
+    },
+  });
 
-    expect(await page.evaluate('window.testA')).toBe(utf8Str);
-    expect(await page.evaluate('window.testB')).toStrictEqual(expectedObject);
+  expect(await page.evaluate('window.testA')).toBe(utf8Str);
+  expect(await page.evaluate('window.testB')).toStrictEqual(expectedObject);
 
-    const files = rsbuild.getDistFiles();
-    const content = getFileContent(
-      files,
-      (name) => name.endsWith('.js') && name.includes('static/js/index'),
-    );
+  const files = rsbuild.getDistFiles();
+  const content = getFileContent(
+    files,
+    (name) => name.endsWith('.js') && name.includes('static/js/index'),
+  );
 
-    expect(content.includes(asciiStr)).toBeTruthy();
-  },
-);
+  expect(content.includes(asciiStr)).toBeTruthy();
+});
 
 test('should set output.charset to ascii in build', async ({
   page,

--- a/e2e/cases/output/legal-comments/index.test.ts
+++ b/e2e/cases/output/legal-comments/index.test.ts
@@ -1,13 +1,7 @@
-import {
-  expect,
-  findFile,
-  getFileContent,
-  rspackTest,
-  test,
-} from '@e2e/helper';
+import { expect, findFile, getFileContent, test } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 
-rspackTest('legalComments linked (default)', async ({ page, buildPreview }) => {
+test('legalComments linked (default)', async ({ page, buildPreview }) => {
   const rsbuild = await buildPreview({
     config: {
       plugins: [pluginReact()],

--- a/e2e/cases/overlay/error-recovery/index.test.ts
+++ b/e2e/cases/overlay/error-recovery/index.test.ts
@@ -1,36 +1,34 @@
 import { join } from 'node:path';
-import {
-  expect,
-  MODULE_BUILD_FAILED_LOG,
-  OVERLAY_ID,
-  rspackTest,
-} from '@e2e/helper';
+import { expect, MODULE_BUILD_FAILED_LOG, OVERLAY_ID, test } from '@e2e/helper';
 
-rspackTest(
-  'should hide overlay after resolving error',
-  async ({ page, dev, editFile, logHelper, copySrcDir }) => {
-    const tempSrc = await copySrcDir();
-    await dev({
-      config: {
-        source: {
-          entry: {
-            index: join(tempSrc, 'index.jsx'),
-          },
+test('should hide overlay after resolving error', async ({
+  page,
+  dev,
+  editFile,
+  logHelper,
+  copySrcDir,
+}) => {
+  const tempSrc = await copySrcDir();
+  await dev({
+    config: {
+      source: {
+        entry: {
+          index: join(tempSrc, 'index.jsx'),
         },
       },
-    });
+    },
+  });
 
-    await editFile(join(tempSrc, 'App.jsx'), (code) =>
-      code.replace('</div>', '</a>'),
-    );
-    await logHelper.expectLog(MODULE_BUILD_FAILED_LOG);
-    await expect(page.locator(OVERLAY_ID)).toBeAttached();
+  await editFile(join(tempSrc, 'App.jsx'), (code) =>
+    code.replace('</div>', '</a>'),
+  );
+  await logHelper.expectLog(MODULE_BUILD_FAILED_LOG);
+  await expect(page.locator(OVERLAY_ID)).toBeAttached();
 
-    logHelper.clearLogs();
-    await editFile(join(tempSrc, 'App.jsx'), (code) =>
-      code.replace('</a>', '</div>'),
-    );
-    await logHelper.expectBuildEnd();
-    await expect(page.locator(OVERLAY_ID)).not.toBeAttached();
-  },
-);
+  logHelper.clearLogs();
+  await editFile(join(tempSrc, 'App.jsx'), (code) =>
+    code.replace('</a>', '</div>'),
+  );
+  await logHelper.expectBuildEnd();
+  await expect(page.locator(OVERLAY_ID)).not.toBeAttached();
+});

--- a/e2e/cases/overlay/runtime-errors/index.test.ts
+++ b/e2e/cases/overlay/runtime-errors/index.test.ts
@@ -1,49 +1,52 @@
 import { join } from 'node:path';
-import { expect, HMR_CONNECTED_LOG, OVERLAY_ID, rspackTest } from '@e2e/helper';
+import { expect, HMR_CONNECTED_LOG, OVERLAY_ID, test } from '@e2e/helper';
 
-rspackTest(
-  'should show runtime errors on overlay',
-  async ({ page, dev, editFile, logHelper, copySrcDir }) => {
-    const tempSrc = await copySrcDir();
+test('should show runtime errors on overlay', async ({
+  page,
+  dev,
+  editFile,
+  logHelper,
+  copySrcDir,
+}) => {
+  const tempSrc = await copySrcDir();
 
-    page.on('console', (consoleMessage) => {
-      logHelper.addLog(consoleMessage.text());
-    });
+  page.on('console', (consoleMessage) => {
+    logHelper.addLog(consoleMessage.text());
+  });
 
-    await dev({
-      config: {
-        source: {
-          entry: {
-            index: join(tempSrc, 'index.jsx'),
-          },
+  await dev({
+    config: {
+      source: {
+        entry: {
+          index: join(tempSrc, 'index.jsx'),
         },
       },
-    });
+    },
+  });
 
-    await logHelper.expectLog(HMR_CONNECTED_LOG);
+  await logHelper.expectLog(HMR_CONNECTED_LOG);
 
-    const errorOverlay = page.locator(OVERLAY_ID);
-    await expect(errorOverlay.locator('.title')).not.toBeAttached();
+  const errorOverlay = page.locator(OVERLAY_ID);
+  await expect(errorOverlay.locator('.title')).not.toBeAttached();
 
-    // Introduce a runtime error
-    await editFile(join(tempSrc, 'App.jsx'), (code) =>
-      code.replace(
-        'return <div>Hello</div>',
-        `
+  // Introduce a runtime error
+  await editFile(join(tempSrc, 'App.jsx'), (code) =>
+    code.replace(
+      'return <div>Hello</div>',
+      `
   throw new Error('Runtime error occurred');
   return <div>Hello</div>`,
-      ),
-    );
-    await logHelper.expectLog('Runtime error occurred');
+    ),
+  );
+  await logHelper.expectLog('Runtime error occurred');
 
-    // expect overlay to show runtime error
-    await expect(errorOverlay.locator('.title')).toHaveText('Runtime errors');
-    await expect(
-      errorOverlay.getByText('Uncaught Error: Runtime error occurred'),
-    ).toBeAttached();
+  // expect overlay to show runtime error
+  await expect(errorOverlay.locator('.title')).toHaveText('Runtime errors');
+  await expect(
+    errorOverlay.getByText('Uncaught Error: Runtime error occurred'),
+  ).toBeAttached();
 
-    // expect stack trace to be shown fully
-    await expect(errorOverlay.getByText('at App')).toBeAttached();
-    await expect(errorOverlay.getByText('at renderWithHooks')).toBeAttached();
-  },
-);
+  // expect stack trace to be shown fully
+  await expect(errorOverlay.getByText('at App')).toBeAttached();
+  await expect(errorOverlay.getByText('at renderWithHooks')).toBeAttached();
+});

--- a/e2e/cases/performance/external-helpers/index.test.ts
+++ b/e2e/cases/performance/external-helpers/index.test.ts
@@ -1,6 +1,6 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest('should externalHelpers by default', async ({ build }) => {
+test('should externalHelpers by default', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles({ sourceMaps: true });
   const content = getFileContent(files, 'static/js/index.js.map');

--- a/e2e/cases/performance/resource-hints-prefetch/index.test.ts
+++ b/e2e/cases/performance/resource-hints-prefetch/index.test.ts
@@ -1,11 +1,5 @@
 import { join } from 'node:path';
-import {
-  expect,
-  findFile,
-  getFileContent,
-  rspackTest,
-  test,
-} from '@e2e/helper';
+import { expect, findFile, getFileContent, test } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 const fixtures = import.meta.dirname;
@@ -226,66 +220,64 @@ test('should generate prefetch link by config (distinguish html)', async ({
   expect(content2.match(/rel="prefetch"/g)?.length).toBe(3);
 });
 
-rspackTest(
-  'should not generate prefetch link for inlined assets',
-  async ({ build }) => {
-    const rsbuild = await build({
-      config: {
-        plugins: [pluginReact()],
-        source: {
-          entry: {
-            main: join(fixtures, 'src/page1/index.ts'),
-          },
-        },
-        output: {
-          inlineScripts: true,
-          inlineStyles: true,
-        },
-        performance: {
-          prefetch: true,
+test('should not generate prefetch link for inlined assets', async ({
+  build,
+}) => {
+  const rsbuild = await build({
+    config: {
+      plugins: [pluginReact()],
+      source: {
+        entry: {
+          main: join(fixtures, 'src/page1/index.ts'),
         },
       },
-    });
+      output: {
+        inlineScripts: true,
+        inlineStyles: true,
+      },
+      performance: {
+        prefetch: true,
+      },
+    },
+  });
 
-    const files = rsbuild.getDistFiles();
-    const content = getFileContent(files, '.html');
+  const files = rsbuild.getDistFiles();
+  const content = getFileContent(files, '.html');
 
-    // image.png
-    expect(content.match(/rel="prefetch"/g)?.length).toBe(1);
-  },
-);
+  // image.png
+  expect(content.match(/rel="prefetch"/g)?.length).toBe(1);
+});
 
-rspackTest(
-  'should not generate prefetch link for inlined assets with test option',
-  async ({ build }) => {
-    const rsbuild = await build({
-      config: {
-        plugins: [pluginReact()],
-        source: {
-          entry: {
-            main: join(fixtures, 'src/page1/index.ts'),
-          },
-        },
-        output: {
-          inlineScripts: {
-            enable: 'auto',
-            test: /\.js$/,
-          },
-          inlineStyles: {
-            enable: 'auto',
-            test: /\.css$/,
-          },
-        },
-        performance: {
-          prefetch: true,
+test('should not generate prefetch link for inlined assets with test option', async ({
+  build,
+}) => {
+  const rsbuild = await build({
+    config: {
+      plugins: [pluginReact()],
+      source: {
+        entry: {
+          main: join(fixtures, 'src/page1/index.ts'),
         },
       },
-    });
+      output: {
+        inlineScripts: {
+          enable: 'auto',
+          test: /\.js$/,
+        },
+        inlineStyles: {
+          enable: 'auto',
+          test: /\.css$/,
+        },
+      },
+      performance: {
+        prefetch: true,
+      },
+    },
+  });
 
-    const files = rsbuild.getDistFiles();
-    const content = getFileContent(files, '.html');
+  const files = rsbuild.getDistFiles();
+  const content = getFileContent(files, '.html');
 
-    // image.png
-    expect(content.match(/rel="prefetch"/g)?.length).toBe(1);
-  },
-);
+  // image.png
+  expect(content.match(/rel="prefetch"/g)?.length).toBe(1);
+});

--- a/e2e/cases/performance/resource-hints-preload/index.test.ts
+++ b/e2e/cases/performance/resource-hints-preload/index.test.ts
@@ -1,11 +1,5 @@
 import { join } from 'node:path';
-import {
-  expect,
-  findFile,
-  getFileContent,
-  rspackTest,
-  test,
-} from '@e2e/helper';
+import { expect, findFile, getFileContent, test } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 const fixtures = import.meta.dirname;
@@ -222,66 +216,64 @@ test('should generate preload link with include array', async ({ build }) => {
   ).toBeTruthy();
 });
 
-rspackTest(
-  'should not generate preload link for inlined assets',
-  async ({ build }) => {
-    const rsbuild = await build({
-      config: {
-        plugins: [pluginReact()],
-        source: {
-          entry: {
-            main: join(fixtures, 'src/page1/index.ts'),
-          },
-        },
-        output: {
-          inlineScripts: true,
-          inlineStyles: true,
-        },
-        performance: {
-          preload: true,
+test('should not generate preload link for inlined assets', async ({
+  build,
+}) => {
+  const rsbuild = await build({
+    config: {
+      plugins: [pluginReact()],
+      source: {
+        entry: {
+          main: join(fixtures, 'src/page1/index.ts'),
         },
       },
-    });
+      output: {
+        inlineScripts: true,
+        inlineStyles: true,
+      },
+      performance: {
+        preload: true,
+      },
+    },
+  });
 
-    const files = rsbuild.getDistFiles();
-    const content = getFileContent(files, '.html');
+  const files = rsbuild.getDistFiles();
+  const content = getFileContent(files, '.html');
 
-    // image.png
-    expect(content.match(/rel="preload" as="/g)?.length).toBe(1);
-  },
-);
+  // image.png
+  expect(content.match(/rel="preload" as="/g)?.length).toBe(1);
+});
 
-rspackTest(
-  'should not generate preload link for inlined assets with test option',
-  async ({ build }) => {
-    const rsbuild = await build({
-      config: {
-        plugins: [pluginReact()],
-        source: {
-          entry: {
-            main: join(fixtures, 'src/page1/index.ts'),
-          },
-        },
-        output: {
-          inlineScripts: {
-            enable: 'auto',
-            test: /\.js$/,
-          },
-          inlineStyles: {
-            enable: 'auto',
-            test: /\.css$/,
-          },
-        },
-        performance: {
-          preload: true,
+test('should not generate preload link for inlined assets with test option', async ({
+  build,
+}) => {
+  const rsbuild = await build({
+    config: {
+      plugins: [pluginReact()],
+      source: {
+        entry: {
+          main: join(fixtures, 'src/page1/index.ts'),
         },
       },
-    });
+      output: {
+        inlineScripts: {
+          enable: 'auto',
+          test: /\.js$/,
+        },
+        inlineStyles: {
+          enable: 'auto',
+          test: /\.css$/,
+        },
+      },
+      performance: {
+        preload: true,
+      },
+    },
+  });
 
-    const files = rsbuild.getDistFiles();
-    const content = getFileContent(files, '.html');
+  const files = rsbuild.getDistFiles();
+  const content = getFileContent(files, '.html');
 
-    // image.png
-    expect(content.match(/rel="preload" as="/g)?.length).toBe(1);
-  },
-);
+  // image.png
+  expect(content.match(/rel="preload" as="/g)?.length).toBe(1);
+});

--- a/e2e/cases/plugin-api/async-plugin/index.test.ts
+++ b/e2e/cases/plugin-api/async-plugin/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import type { RsbuildPlugin } from '@rsbuild/core';
 
 const asyncPlugin = async (): Promise<RsbuildPlugin> => {
@@ -22,16 +22,16 @@ const asyncPlugin = async (): Promise<RsbuildPlugin> => {
   };
 };
 
-rspackTest(
-  'should allow to register async plugin in plugins field',
-  async ({ page, buildPreview }) => {
-    await buildPreview({
-      config: {
-        plugins: [asyncPlugin()],
-      },
-    });
+test('should allow to register async plugin in plugins field', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview({
+    config: {
+      plugins: [asyncPlugin()],
+    },
+  });
 
-    const testEl = page.locator('#test-el');
-    await expect(testEl).toHaveText('aaaaa');
-  },
-);
+  const testEl = page.locator('#test-el');
+  await expect(testEl).toHaveText('aaaaa');
+});

--- a/e2e/cases/plugin-api/plugin-after-build-hook/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-after-build-hook/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import { createRsbuild, type RsbuildPlugin } from '@rsbuild/core';
 import fse from 'fs-extra';
 
@@ -30,29 +30,26 @@ const plugin: RsbuildPlugin = {
   },
 };
 
-rspackTest(
-  'should run onAfterBuild hooks correctly when have multiple targets',
-  async () => {
-    await fse.remove(distFile);
+test('should run onAfterBuild hooks correctly when have multiple targets', async () => {
+  await fse.remove(distFile);
 
-    const rsbuild = await createRsbuild({
-      cwd: import.meta.dirname,
-      config: {
-        plugins: [plugin],
-        environments: {
-          web: {},
-          node: {
-            output: {
-              target: 'node',
-            },
+  const rsbuild = await createRsbuild({
+    cwd: import.meta.dirname,
+    config: {
+      plugins: [plugin],
+      environments: {
+        web: {},
+        node: {
+          output: {
+            target: 'node',
           },
         },
       },
-    });
+    },
+  });
 
-    await rsbuild.build();
-    write('2');
+  await rsbuild.build();
+  write('2');
 
-    expect(fs.readFileSync(distFile, 'utf-8').split(',')).toEqual(['1', '2']);
-  },
-);
+  expect(fs.readFileSync(distFile, 'utf-8').split(',')).toEqual(['1', '2']);
+});

--- a/e2e/cases/plugin-api/plugin-apply-function/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-apply-function/index.test.ts
@@ -1,23 +1,23 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should apply plugin as expected when running dev server',
-  async ({ page, dev }) => {
-    await dev();
+test('should apply plugin as expected when running dev server', async ({
+  page,
+  dev,
+}) => {
+  await dev();
 
-    const body = page.locator('body');
-    await expect(body).toHaveText('serve-plugin');
-    await expect(body).not.toHaveText('build-plugin');
-  },
-);
+  const body = page.locator('body');
+  await expect(body).toHaveText('serve-plugin');
+  await expect(body).not.toHaveText('build-plugin');
+});
 
-rspackTest(
-  'should apply plugin as expected when running build',
-  async ({ page, buildPreview }) => {
-    await buildPreview();
+test('should apply plugin as expected when running build', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview();
 
-    const body = page.locator('body');
-    await expect(body).toHaveText('build-plugin');
-    await expect(body).not.toHaveText('serve-plugin');
-  },
-);
+  const body = page.locator('body');
+  await expect(body).toHaveText('build-plugin');
+  await expect(body).not.toHaveText('serve-plugin');
+});

--- a/e2e/cases/plugin-api/plugin-apply/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-apply/index.test.ts
@@ -1,23 +1,23 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should apply plugin as expected when running dev server',
-  async ({ page, dev }) => {
-    await dev();
+test('should apply plugin as expected when running dev server', async ({
+  page,
+  dev,
+}) => {
+  await dev();
 
-    const body = page.locator('body');
-    await expect(body).toHaveText('serve-plugin');
-    await expect(body).not.toHaveText('build-plugin');
-  },
-);
+  const body = page.locator('body');
+  await expect(body).toHaveText('serve-plugin');
+  await expect(body).not.toHaveText('build-plugin');
+});
 
-rspackTest(
-  'should apply plugin as expected when running build',
-  async ({ page, buildPreview }) => {
-    await buildPreview();
+test('should apply plugin as expected when running build', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview();
 
-    const body = page.locator('body');
-    await expect(body).toHaveText('build-plugin');
-    await expect(body).not.toHaveText('serve-plugin');
-  },
-);
+  const body = page.locator('body');
+  await expect(body).toHaveText('build-plugin');
+  await expect(body).not.toHaveText('serve-plugin');
+});

--- a/e2e/cases/plugin-api/plugin-expose/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-expose/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import { createRsbuild, type RsbuildPlugin } from '@rsbuild/core';
 
 type ParentAPI = {
@@ -28,7 +28,7 @@ const pluginParent2: RsbuildPlugin = {
   },
 };
 
-rspackTest('should allow plugin to expose and consume API', async () => {
+test('should allow plugin to expose and consume API', async () => {
   const pluginChild: RsbuildPlugin = {
     name: 'plugin-child',
     setup(api) {
@@ -46,7 +46,7 @@ rspackTest('should allow plugin to expose and consume API', async () => {
   await rsbuild.build();
 });
 
-rspackTest('should override the previous exposed API', async () => {
+test('should override the previous exposed API', async () => {
   const pluginChild: RsbuildPlugin = {
     name: 'plugin-child',
     setup(api) {

--- a/e2e/cases/plugin-api/plugin-hooks-environment/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-hooks-environment/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import type { RsbuildPlugin } from '@rsbuild/core';
 
 const createPlugin = () => {
@@ -80,128 +80,126 @@ const createPlugin = () => {
   return { plugin, names };
 };
 
-rspackTest(
-  'should run plugin hooks correctly when running build with multiple environments',
-  async ({ build }) => {
-    const { plugin, names } = createPlugin();
-    await build({
-      config: {
-        plugins: [plugin],
-        environments: {
-          web: {},
-          node: {},
-        },
+test('should run plugin hooks correctly when running build with multiple environments', async ({
+  build,
+}) => {
+  const { plugin, names } = createPlugin();
+  await build({
+    config: {
+      plugins: [plugin],
+      environments: {
+        web: {},
+        node: {},
       },
-    });
+    },
+  });
 
-    // Test environment hook is always called twice
-    expect(names.filter((name) => name.includes(' web')).length).toBe(
-      names.filter((name) => name.includes(' node')).length,
-    );
+  // Test environment hook is always called twice
+  expect(names.filter((name) => name.includes(' web')).length).toBe(
+    names.filter((name) => name.includes(' node')).length,
+  );
 
-    // The execution order between different Environments of the same hook is not fixed
-    // Therefore, we only test the execution order of a single Environment
-    expect(names.filter((name) => !name.includes(' node'))).toEqual([
-      'ModifyRsbuildConfig',
-      'ModifyEnvironmentConfig web',
-      'ModifyBundlerChain web',
-      'ModifyBundlerConfig web',
-      'BeforeCreateCompiler',
-      'AfterCreateCompiler',
-      'BeforeBuild',
-      'BeforeEnvironmentCompile web',
-      'ModifyHTMLTags web',
-      'ModifyHTML web',
-      'AfterEnvironmentCompile web',
-      'AfterBuild',
-    ]);
+  // The execution order between different Environments of the same hook is not fixed
+  // Therefore, we only test the execution order of a single Environment
+  expect(names.filter((name) => !name.includes(' node'))).toEqual([
+    'ModifyRsbuildConfig',
+    'ModifyEnvironmentConfig web',
+    'ModifyBundlerChain web',
+    'ModifyBundlerConfig web',
+    'BeforeCreateCompiler',
+    'AfterCreateCompiler',
+    'BeforeBuild',
+    'BeforeEnvironmentCompile web',
+    'ModifyHTMLTags web',
+    'ModifyHTML web',
+    'AfterEnvironmentCompile web',
+    'AfterBuild',
+  ]);
 
-    expect(names.filter((name) => !name.includes(' web'))).toEqual([
-      'ModifyRsbuildConfig',
-      'ModifyEnvironmentConfig node',
-      'ModifyBundlerChain node',
-      'ModifyBundlerConfig node',
-      'BeforeCreateCompiler',
-      'AfterCreateCompiler',
-      'BeforeBuild',
-      'BeforeEnvironmentCompile node',
-      'ModifyHTMLTags node',
-      'ModifyHTML node',
-      'AfterEnvironmentCompile node',
-      'AfterBuild',
-    ]);
-  },
-);
+  expect(names.filter((name) => !name.includes(' web'))).toEqual([
+    'ModifyRsbuildConfig',
+    'ModifyEnvironmentConfig node',
+    'ModifyBundlerChain node',
+    'ModifyBundlerConfig node',
+    'BeforeCreateCompiler',
+    'AfterCreateCompiler',
+    'BeforeBuild',
+    'BeforeEnvironmentCompile node',
+    'ModifyHTMLTags node',
+    'ModifyHTML node',
+    'AfterEnvironmentCompile node',
+    'AfterBuild',
+  ]);
+});
 
-rspackTest(
-  'should run plugin hooks correctly when running startDevServer with multiple environments',
-  async ({ dev }) => {
-    const { plugin, names } = createPlugin();
-    const rsbuild = await dev({
-      config: {
-        plugins: [plugin],
-        environments: {
-          web: {},
-          node: {},
-        },
+test('should run plugin hooks correctly when running startDevServer with multiple environments', async ({
+  dev,
+}) => {
+  const { plugin, names } = createPlugin();
+  const rsbuild = await dev({
+    config: {
+      plugins: [plugin],
+      environments: {
+        web: {},
+        node: {},
       },
-    });
+    },
+  });
 
-    await rsbuild.close();
+  await rsbuild.close();
 
-    expect(names.filter((name) => name.includes(' web')).length).toBe(
-      names.filter((name) => name.includes(' node')).length,
-    );
+  expect(names.filter((name) => name.includes(' web')).length).toBe(
+    names.filter((name) => name.includes(' node')).length,
+  );
 
-    expect(names.filter((name) => name.includes('DevServer'))).toEqual([
-      'BeforeStartDevServer',
-      'AfterStartDevServer',
-      'CloseDevServer',
-    ]);
+  expect(names.filter((name) => name.includes('DevServer'))).toEqual([
+    'BeforeStartDevServer',
+    'AfterStartDevServer',
+    'CloseDevServer',
+  ]);
 
-    // compile is async, so the execution order of AfterStartDevServer and the compile hooks is uncertain
-    expect(
-      names.filter(
-        (name) => !name.includes(' node') && name !== 'AfterStartDevServer',
-      ),
-    ).toEqual([
-      'ModifyRsbuildConfig',
-      'ModifyEnvironmentConfig web',
-      'BeforeStartDevServer',
-      'ModifyBundlerChain web',
-      'ModifyBundlerConfig web',
-      'BeforeCreateCompiler',
-      'AfterCreateCompiler',
-      'BeforeDevCompile',
-      'BeforeEnvironmentCompile web',
-      'ModifyHTMLTags web',
-      'ModifyHTML web',
-      'AfterEnvironmentCompile web',
-      'AfterDevCompile',
-      'DevCompileDone',
-      'CloseDevServer',
-    ]);
+  // compile is async, so the execution order of AfterStartDevServer and the compile hooks is uncertain
+  expect(
+    names.filter(
+      (name) => !name.includes(' node') && name !== 'AfterStartDevServer',
+    ),
+  ).toEqual([
+    'ModifyRsbuildConfig',
+    'ModifyEnvironmentConfig web',
+    'BeforeStartDevServer',
+    'ModifyBundlerChain web',
+    'ModifyBundlerConfig web',
+    'BeforeCreateCompiler',
+    'AfterCreateCompiler',
+    'BeforeDevCompile',
+    'BeforeEnvironmentCompile web',
+    'ModifyHTMLTags web',
+    'ModifyHTML web',
+    'AfterEnvironmentCompile web',
+    'AfterDevCompile',
+    'DevCompileDone',
+    'CloseDevServer',
+  ]);
 
-    expect(
-      names.filter(
-        (name) => !name.includes(' web') && name !== 'AfterStartDevServer',
-      ),
-    ).toEqual([
-      'ModifyRsbuildConfig',
-      'ModifyEnvironmentConfig node',
-      'BeforeStartDevServer',
-      'ModifyBundlerChain node',
-      'ModifyBundlerConfig node',
-      'BeforeCreateCompiler',
-      'AfterCreateCompiler',
-      'BeforeDevCompile',
-      'BeforeEnvironmentCompile node',
-      'ModifyHTMLTags node',
-      'ModifyHTML node',
-      'AfterEnvironmentCompile node',
-      'AfterDevCompile',
-      'DevCompileDone',
-      'CloseDevServer',
-    ]);
-  },
-);
+  expect(
+    names.filter(
+      (name) => !name.includes(' web') && name !== 'AfterStartDevServer',
+    ),
+  ).toEqual([
+    'ModifyRsbuildConfig',
+    'ModifyEnvironmentConfig node',
+    'BeforeStartDevServer',
+    'ModifyBundlerChain node',
+    'ModifyBundlerConfig node',
+    'BeforeCreateCompiler',
+    'AfterCreateCompiler',
+    'BeforeDevCompile',
+    'BeforeEnvironmentCompile node',
+    'ModifyHTMLTags node',
+    'ModifyHTML node',
+    'AfterEnvironmentCompile node',
+    'AfterDevCompile',
+    'DevCompileDone',
+    'CloseDevServer',
+  ]);
+});

--- a/e2e/cases/plugin-api/plugin-hooks-environment/rebuild.test.ts
+++ b/e2e/cases/plugin-api/plugin-hooks-environment/rebuild.test.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import type { RsbuildPlugin } from '@rsbuild/core';
 import fse from 'fs-extra';
 
@@ -21,49 +21,48 @@ const createPlugin = () => {
   return { plugin, names };
 };
 
-rspackTest(
-  'should run onBeforeDevCompile hook correctly when rebuild in dev with multiple environments',
-  async ({ dev }) => {
-    const indexJs = join(import.meta.dirname, 'test-temp-src', 'index.js');
-    await fse.outputFile(indexJs, "console.log('1');");
+test('should run onBeforeDevCompile hook correctly when rebuild in dev with multiple environments', async ({
+  dev,
+}) => {
+  const indexJs = join(import.meta.dirname, 'test-temp-src', 'index.js');
+  await fse.outputFile(indexJs, "console.log('1');");
 
-    const { plugin, names } = createPlugin();
+  const { plugin, names } = createPlugin();
 
-    const rsbuild = await dev({
-      config: {
-        plugins: [plugin],
-        environments: {
-          web: {},
-          node: {
-            source: {
-              entry: {
-                index: './test-temp-src/index.js',
-              },
+  const rsbuild = await dev({
+    config: {
+      plugins: [plugin],
+      environments: {
+        web: {},
+        node: {
+          source: {
+            entry: {
+              index: './test-temp-src/index.js',
             },
           },
         },
       },
-    });
+    },
+  });
 
-    // initial build
-    await rsbuild.expectBuildEnd();
-    expect(names.includes('BeforeDevCompile')).toBeTruthy();
-    expect(names.includes('BeforeEnvironmentCompile node')).toBeTruthy();
-    expect(names.includes('BeforeEnvironmentCompile web')).toBeTruthy();
+  // initial build
+  await rsbuild.expectBuildEnd();
+  expect(names.includes('BeforeDevCompile')).toBeTruthy();
+  expect(names.includes('BeforeEnvironmentCompile node')).toBeTruthy();
+  expect(names.includes('BeforeEnvironmentCompile web')).toBeTruthy();
 
-    // clear state
-    rsbuild.clearLogs();
-    names.length = 0;
+  // clear state
+  rsbuild.clearLogs();
+  names.length = 0;
 
-    // rebuild
-    await fse.outputFile(indexJs, "console.log('2');");
-    await rsbuild.expectLog('building test-temp-src');
-    await rsbuild.expectBuildEnd();
+  // rebuild
+  await fse.outputFile(indexJs, "console.log('2');");
+  await rsbuild.expectLog('building test-temp-src');
+  await rsbuild.expectBuildEnd();
 
-    expect(names).toEqual([
-      'BeforeDevCompile',
-      // only recompile the node environment which is affected by the file change
-      'BeforeEnvironmentCompile node',
-    ]);
-  },
-);
+  expect(names).toEqual([
+    'BeforeDevCompile',
+    // only recompile the node environment which is affected by the file change
+    'BeforeEnvironmentCompile node',
+  ]);
+});

--- a/e2e/cases/plugin-api/plugin-hooks-watch/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-hooks-watch/index.test.ts
@@ -1,50 +1,49 @@
 import { join } from 'node:path';
-import { expect, recordPluginHooks, rspackTest } from '@e2e/helper';
+import { expect, recordPluginHooks, test } from '@e2e/helper';
 import fse from 'fs-extra';
 
-rspackTest(
-  'should run plugin hooks correctly when running build with watch',
-  async ({ build }) => {
-    const cwd = import.meta.dirname;
-    const filePath = join(cwd, 'test-temp-src', 'index.js');
-    await fse.outputFile(filePath, "console.log('1');");
+test('should run plugin hooks correctly when running build with watch', async ({
+  build,
+}) => {
+  const cwd = import.meta.dirname;
+  const filePath = join(cwd, 'test-temp-src', 'index.js');
+  await fse.outputFile(filePath, "console.log('1');");
 
-    const { plugin, hooks } = recordPluginHooks();
-    const rsbuild = await build({
-      watch: true,
-      config: {
-        plugins: [plugin],
-      },
-    });
+  const { plugin, hooks } = recordPluginHooks();
+  const rsbuild = await build({
+    watch: true,
+    config: {
+      plugins: [plugin],
+    },
+  });
 
-    // initial build
-    await rsbuild.expectBuildEnd();
-    rsbuild.clearLogs();
+  // initial build
+  await rsbuild.expectBuildEnd();
+  rsbuild.clearLogs();
 
-    // rebuild
-    await fse.outputFile(filePath, "console.log('2');");
-    await rsbuild.expectLog('building test-temp-src');
-    await rsbuild.expectBuildEnd();
+  // rebuild
+  await fse.outputFile(filePath, "console.log('2');");
+  await rsbuild.expectLog('building test-temp-src');
+  await rsbuild.expectBuildEnd();
 
-    expect(hooks.slice(0, 17)).toEqual([
-      'ModifyRsbuildConfig',
-      'ModifyEnvironmentConfig',
-      'ModifyBundlerChain',
-      'ModifyBundlerConfig',
-      'BeforeCreateCompiler',
-      'AfterCreateCompiler',
-      'BeforeBuild',
-      'BeforeEnvironmentCompile',
-      'ModifyHTMLTags',
-      'ModifyHTML',
-      'AfterEnvironmentCompile',
-      'AfterBuild',
-      // The below hooks should be called when rebuilding
-      'BeforeBuild',
-      'BeforeEnvironmentCompile',
-      'ModifyHTMLTags',
-      'ModifyHTML',
-      'AfterEnvironmentCompile',
-    ]);
-  },
-);
+  expect(hooks.slice(0, 17)).toEqual([
+    'ModifyRsbuildConfig',
+    'ModifyEnvironmentConfig',
+    'ModifyBundlerChain',
+    'ModifyBundlerConfig',
+    'BeforeCreateCompiler',
+    'AfterCreateCompiler',
+    'BeforeBuild',
+    'BeforeEnvironmentCompile',
+    'ModifyHTMLTags',
+    'ModifyHTML',
+    'AfterEnvironmentCompile',
+    'AfterBuild',
+    // The below hooks should be called when rebuilding
+    'BeforeBuild',
+    'BeforeEnvironmentCompile',
+    'ModifyHTMLTags',
+    'ModifyHTML',
+    'AfterEnvironmentCompile',
+  ]);
+});

--- a/e2e/cases/plugin-api/plugin-hooks/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-hooks/index.test.ts
@@ -1,128 +1,122 @@
-import { expect, recordPluginHooks, rspackTest } from '@e2e/helper';
+import { expect, recordPluginHooks, test } from '@e2e/helper';
 import { createRsbuild } from '@rsbuild/core';
 
-rspackTest(
-  'should run plugin hooks correctly when running build',
-  async ({ build }) => {
-    const { plugin, hooks } = recordPluginHooks();
-    const rsbuild = await build({
-      config: {
-        plugins: [plugin],
-      },
-    });
+test('should run plugin hooks correctly when running build', async ({
+  build,
+}) => {
+  const { plugin, hooks } = recordPluginHooks();
+  const rsbuild = await build({
+    config: {
+      plugins: [plugin],
+    },
+  });
 
-    await rsbuild.close();
+  await rsbuild.close();
 
-    expect(hooks).toEqual([
-      'ModifyRsbuildConfig',
-      'ModifyEnvironmentConfig',
-      'ModifyBundlerChain',
-      'ModifyBundlerConfig',
-      'BeforeCreateCompiler',
-      'AfterCreateCompiler',
-      'BeforeBuild',
-      'BeforeEnvironmentCompile',
-      'ModifyHTMLTags',
-      'ModifyHTML',
-      'AfterEnvironmentCompile',
-      'AfterBuild',
-      'CloseBuild',
-    ]);
-  },
-);
+  expect(hooks).toEqual([
+    'ModifyRsbuildConfig',
+    'ModifyEnvironmentConfig',
+    'ModifyBundlerChain',
+    'ModifyBundlerConfig',
+    'BeforeCreateCompiler',
+    'AfterCreateCompiler',
+    'BeforeBuild',
+    'BeforeEnvironmentCompile',
+    'ModifyHTMLTags',
+    'ModifyHTML',
+    'AfterEnvironmentCompile',
+    'AfterBuild',
+    'CloseBuild',
+  ]);
+});
 
-rspackTest(
-  'should run plugin hooks correctly when running build and mode is development',
-  async ({ build }) => {
-    const { plugin, hooks } = recordPluginHooks();
-    const rsbuild = await build({
-      config: {
-        mode: 'development',
-        plugins: [plugin],
-      },
-    });
+test('should run plugin hooks correctly when running build and mode is development', async ({
+  build,
+}) => {
+  const { plugin, hooks } = recordPluginHooks();
+  const rsbuild = await build({
+    config: {
+      mode: 'development',
+      plugins: [plugin],
+    },
+  });
 
-    await rsbuild.close();
+  await rsbuild.close();
 
-    expect(hooks).toEqual([
-      'ModifyRsbuildConfig',
-      'ModifyEnvironmentConfig',
-      'ModifyBundlerChain',
-      'ModifyBundlerConfig',
-      'BeforeCreateCompiler',
-      'AfterCreateCompiler',
-      'BeforeBuild',
-      'BeforeEnvironmentCompile',
-      'ModifyHTMLTags',
-      'ModifyHTML',
-      'AfterEnvironmentCompile',
-      'AfterBuild',
-      'CloseBuild',
-    ]);
-  },
-);
+  expect(hooks).toEqual([
+    'ModifyRsbuildConfig',
+    'ModifyEnvironmentConfig',
+    'ModifyBundlerChain',
+    'ModifyBundlerConfig',
+    'BeforeCreateCompiler',
+    'AfterCreateCompiler',
+    'BeforeBuild',
+    'BeforeEnvironmentCompile',
+    'ModifyHTMLTags',
+    'ModifyHTML',
+    'AfterEnvironmentCompile',
+    'AfterBuild',
+    'CloseBuild',
+  ]);
+});
 
-rspackTest(
-  'should run plugin hooks correctly when running startDevServer',
-  async ({ dev }) => {
-    const { plugin, hooks } = recordPluginHooks();
-    const rsbuild = await dev({
-      config: {
-        plugins: [plugin],
-      },
-    });
+test('should run plugin hooks correctly when running startDevServer', async ({
+  dev,
+}) => {
+  const { plugin, hooks } = recordPluginHooks();
+  const rsbuild = await dev({
+    config: {
+      plugins: [plugin],
+    },
+  });
 
-    await rsbuild.close();
+  await rsbuild.close();
 
-    expect(hooks.filter((name) => name.includes('DevServer'))).toEqual([
-      'BeforeStartDevServer',
-      'AfterStartDevServer',
-      'CloseDevServer',
-    ]);
+  expect(hooks.filter((name) => name.includes('DevServer'))).toEqual([
+    'BeforeStartDevServer',
+    'AfterStartDevServer',
+    'CloseDevServer',
+  ]);
 
-    // compile is async, so the execution order of AfterStartDevServer and the compile hooks is uncertain
-    expect(hooks.filter((name) => name !== 'AfterStartDevServer')).toEqual([
-      'ModifyRsbuildConfig',
-      'ModifyEnvironmentConfig',
-      'BeforeStartDevServer',
-      'ModifyBundlerChain',
-      'ModifyBundlerConfig',
-      'BeforeCreateCompiler',
-      'AfterCreateCompiler',
-      'BeforeDevCompile',
-      'BeforeEnvironmentCompile',
-      'ModifyHTMLTags',
-      'ModifyHTML',
-      'AfterEnvironmentCompile',
-      'AfterDevCompile',
-      'DevCompileDone',
-      'CloseDevServer',
-    ]);
-  },
-);
+  // compile is async, so the execution order of AfterStartDevServer and the compile hooks is uncertain
+  expect(hooks.filter((name) => name !== 'AfterStartDevServer')).toEqual([
+    'ModifyRsbuildConfig',
+    'ModifyEnvironmentConfig',
+    'BeforeStartDevServer',
+    'ModifyBundlerChain',
+    'ModifyBundlerConfig',
+    'BeforeCreateCompiler',
+    'AfterCreateCompiler',
+    'BeforeDevCompile',
+    'BeforeEnvironmentCompile',
+    'ModifyHTMLTags',
+    'ModifyHTML',
+    'AfterEnvironmentCompile',
+    'AfterDevCompile',
+    'DevCompileDone',
+    'CloseDevServer',
+  ]);
+});
 
-rspackTest(
-  'should run plugin hooks correctly when running preview',
-  async () => {
-    const { plugin, hooks } = recordPluginHooks();
-    const rsbuild = await createRsbuild({
-      cwd: import.meta.dirname,
-      config: {
-        plugins: [plugin],
-      },
-    });
+test('should run plugin hooks correctly when running preview', async () => {
+  const { plugin, hooks } = recordPluginHooks();
+  const rsbuild = await createRsbuild({
+    cwd: import.meta.dirname,
+    config: {
+      plugins: [plugin],
+    },
+  });
 
-    const result = await rsbuild.preview({
-      checkDistDir: false,
-    });
+  const result = await rsbuild.preview({
+    checkDistDir: false,
+  });
 
-    await result.server.close();
+  await result.server.close();
 
-    expect(hooks).toEqual([
-      'ModifyRsbuildConfig',
-      'ModifyEnvironmentConfig',
-      'BeforeStartProdServer',
-      'AfterStartProdServer',
-    ]);
-  },
-);
+  expect(hooks).toEqual([
+    'ModifyRsbuildConfig',
+    'ModifyEnvironmentConfig',
+    'BeforeStartProdServer',
+    'AfterStartProdServer',
+  ]);
+});

--- a/e2e/cases/plugin-api/plugin-modify-html/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-modify-html/index.test.ts
@@ -1,7 +1,7 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 import type { RsbuildPlugin } from '@rsbuild/core';
 
-rspackTest('should allow plugin to modify HTML content', async ({ build }) => {
+test('should allow plugin to modify HTML content', async ({ build }) => {
   const myPlugin: RsbuildPlugin = {
     name: 'my-plugin',
     setup(api) {
@@ -30,35 +30,34 @@ rspackTest('should allow plugin to modify HTML content', async ({ build }) => {
   expect(html.includes('<div>assets: 2</div>')).toBeTruthy();
 });
 
-rspackTest(
-  'should run modifyHTML hook after modifyHTMLTags hook',
-  async ({ build }) => {
-    const myPlugin: RsbuildPlugin = {
-      name: 'my-plugin',
-      setup(api) {
-        api.modifyHTMLTags((tags) => {
-          tags.bodyTags.push({
-            tag: 'div',
-            children: 'foo',
-          });
-          return tags;
+test('should run modifyHTML hook after modifyHTMLTags hook', async ({
+  build,
+}) => {
+  const myPlugin: RsbuildPlugin = {
+    name: 'my-plugin',
+    setup(api) {
+      api.modifyHTMLTags((tags) => {
+        tags.bodyTags.push({
+          tag: 'div',
+          children: 'foo',
         });
-        api.modifyHTML((html) => {
-          return html.replace('foo', 'bar');
-        });
-      },
-    };
+        return tags;
+      });
+      api.modifyHTML((html) => {
+        return html.replace('foo', 'bar');
+      });
+    },
+  };
 
-    const rsbuild = await build({
-      config: {
-        plugins: [myPlugin],
-      },
-    });
+  const rsbuild = await build({
+    config: {
+      plugins: [myPlugin],
+    },
+  });
 
-    const files = rsbuild.getDistFiles();
-    const html = getFileContent(files, 'index.html');
+  const files = rsbuild.getDistFiles();
+  const html = getFileContent(files, 'index.html');
 
-    expect(html.includes('foo')).toBeFalsy();
-    expect(html.includes('bar')).toBeTruthy();
-  },
-);
+  expect(html.includes('foo')).toBeFalsy();
+  expect(html.includes('bar')).toBeTruthy();
+});

--- a/e2e/cases/plugin-api/plugin-modify-tags-meta/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-modify-tags-meta/index.test.ts
@@ -1,17 +1,16 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest(
-  'should allow plugin to modify HTML tags with metadata',
-  async ({ build }) => {
-    const rsbuild = await build();
+test('should allow plugin to modify HTML tags with metadata', async ({
+  build,
+}) => {
+  const rsbuild = await build();
 
-    const files = rsbuild.getDistFiles();
-    const html = getFileContent(files, 'index.html');
+  const files = rsbuild.getDistFiles();
+  const html = getFileContent(files, 'index.html');
 
-    expect(
-      html.includes(
-        '<script src="https://example.com/script.js" id="foo"></script>',
-      ),
-    ).toBeTruthy();
-  },
-);
+  expect(
+    html.includes(
+      '<script src="https://example.com/script.js" id="foo"></script>',
+    ),
+  ).toBeTruthy();
+});

--- a/e2e/cases/plugin-api/plugin-modify-tags/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-modify-tags/index.test.ts
@@ -1,6 +1,6 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest('should allow plugin to modify HTML tags', async ({ build }) => {
+test('should allow plugin to modify HTML tags', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
   const html = getFileContent(files, 'index.html');

--- a/e2e/cases/plugin-api/plugin-on-exit-hook/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-on-exit-hook/index.test.ts
@@ -1,12 +1,12 @@
 import { exec } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import fse from 'fs-extra';
 
 const distFile = path.join(import.meta.dirname, 'node_modules/hooksTempFile');
 
-rspackTest('should run onExit hook before process exit', async () => {
+test('should run onExit hook before process exit', async () => {
   await fse.remove(distFile);
 
   await new Promise<void>((resolve, reject) => {

--- a/e2e/cases/plugin-api/plugin-process-assets-by-environments/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-process-assets-by-environments/index.test.ts
@@ -1,18 +1,17 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import type { RsbuildPluginAPI } from '@rsbuild/core';
 
-rspackTest(
-  'should allow plugin to process assets by environments',
-  async ({ build }) => {
-    const rsbuild = await build();
-    expect(existsSync(join(rsbuild.distPath, 'static/index.js'))).toBeFalsy();
-    expect(existsSync(join(rsbuild.distPath, 'server/index.js'))).toBeTruthy();
-  },
-);
+test('should allow plugin to process assets by environments', async ({
+  build,
+}) => {
+  const rsbuild = await build();
+  expect(existsSync(join(rsbuild.distPath, 'static/index.js'))).toBeFalsy();
+  expect(existsSync(join(rsbuild.distPath, 'server/index.js'))).toBeTruthy();
+});
 
-rspackTest('should filter environments correctly', async ({ build }) => {
+test('should filter environments correctly', async ({ build }) => {
   const rsbuild = await build({
     config: {
       plugins: [

--- a/e2e/cases/plugin-api/plugin-process-assets-by-targets/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-process-assets-by-targets/index.test.ts
@@ -1,6 +1,6 @@
-import { expect, findFile, rspackTest } from '@e2e/helper';
+import { expect, findFile, test } from '@e2e/helper';
 
-rspackTest('should process assets when target is web', async ({ build }) => {
+test('should process assets when target is web', async ({ build }) => {
   const rsbuild = await build({
     config: {
       output: {
@@ -13,19 +13,16 @@ rspackTest('should process assets when target is web', async ({ build }) => {
   expect(() => findFile(files, 'index.js')).toThrow();
 });
 
-rspackTest(
-  'should not process assets when target is not web',
-  async ({ build }) => {
-    const rsbuild = await build({
-      config: {
-        output: {
-          target: 'web-worker',
-        },
+test('should not process assets when target is not web', async ({ build }) => {
+  const rsbuild = await build({
+    config: {
+      output: {
+        target: 'web-worker',
       },
-    });
+    },
+  });
 
-    const files = rsbuild.getDistFiles();
-    const indexJs = findFile(files, 'index.js');
-    expect(indexJs).toBeTruthy();
-  },
-);
+  const files = rsbuild.getDistFiles();
+  const indexJs = findFile(files, 'index.js');
+  expect(indexJs).toBeTruthy();
+});

--- a/e2e/cases/plugin-api/plugin-process-assets-with-html-child-compiler/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-process-assets-with-html-child-compiler/index.test.ts
@@ -1,6 +1,6 @@
-import { expect, findFile, rspackTest } from '@e2e/helper';
+import { expect, findFile, test } from '@e2e/helper';
 
-rspackTest('should allow plugin to process assets', async ({ build }) => {
+test('should allow plugin to process assets', async ({ build }) => {
   const rsbuild = await build();
 
   const files = rsbuild.getDistFiles();

--- a/e2e/cases/plugin-api/plugin-process-assets/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-process-assets/index.test.ts
@@ -1,6 +1,6 @@
-import { expect, findFile, rspackTest } from '@e2e/helper';
+import { expect, findFile, test } from '@e2e/helper';
 
-rspackTest('should allow plugin to process assets', async ({ build }) => {
+test('should allow plugin to process assets', async ({ build }) => {
   const rsbuild = await build();
 
   const files = rsbuild.getDistFiles();

--- a/e2e/cases/plugin-api/plugin-transform-buffer/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-transform-buffer/index.test.ts
@@ -1,15 +1,14 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest(
-  'should allow plugin to transform code with Buffer return',
-  async ({ build }) => {
-    const rsbuild = await build();
+test('should allow plugin to transform code with Buffer return', async ({
+  build,
+}) => {
+  const rsbuild = await build();
 
-    const files = rsbuild.getDistFiles();
-    const indexJs = getFileContent(files, 'index.js');
-    const indexCss = getFileContent(files, 'index.css');
+  const files = rsbuild.getDistFiles();
+  const indexJs = getFileContent(files, 'index.js');
+  const indexCss = getFileContent(files, 'index.css');
 
-    expect(indexJs.includes('world')).toBeTruthy();
-    expect(indexCss.includes('#00f')).toBeTruthy();
-  },
-);
+  expect(indexJs.includes('world')).toBeTruthy();
+  expect(indexCss.includes('#00f')).toBeTruthy();
+});

--- a/e2e/cases/plugin-api/plugin-transform-enforce/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-transform-enforce/index.test.ts
@@ -1,10 +1,9 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should allow plugin to specify the execution order via `enforce`',
-  async ({ build }) => {
-    const rsbuild = await build();
-    const indexJs = await rsbuild.getIndexBundle();
-    expect(indexJs).toContain('with enforce: pre');
-  },
-);
+test('should allow plugin to specify the execution order via `enforce`', async ({
+  build,
+}) => {
+  const rsbuild = await build();
+  const indexJs = await rsbuild.getIndexBundle();
+  expect(indexJs).toContain('with enforce: pre');
+});

--- a/e2e/cases/plugin-api/plugin-transform-error-handle/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-transform-error-handle/index.test.ts
@@ -1,6 +1,6 @@
-import { rspackTest } from '@e2e/helper';
+import { test } from '@e2e/helper';
 
-rspackTest('should handle transform error in dev', async ({ devOnly }) => {
+test('should handle transform error in dev', async ({ devOnly }) => {
   const rsbuild = await devOnly();
 
   await rsbuild.expectLog(

--- a/e2e/cases/plugin-api/plugin-transform-import-attributes/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-transform-import-attributes/index.test.ts
@@ -1,10 +1,9 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should allow plugin to transform code with import attributes',
-  async ({ build }) => {
-    const rsbuild = await build();
-    const indexJs = await rsbuild.getIndexBundle();
-    expect(indexJs).toContain('with import attributes');
-  },
-);
+test('should allow plugin to transform code with import attributes', async ({
+  build,
+}) => {
+  const rsbuild = await build();
+  const indexJs = await rsbuild.getIndexBundle();
+  expect(indexJs).toContain('with import attributes');
+});

--- a/e2e/cases/plugin-api/plugin-transform-import-module/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-transform-import-module/index.test.ts
@@ -1,12 +1,11 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest(
-  'should allow plugin to transform code and call `importModule`',
-  async ({ build }) => {
-    const rsbuild = await build();
-    const files = rsbuild.getDistFiles();
-    const indexCss = getFileContent(files, 'index.css');
+test('should allow plugin to transform code and call `importModule`', async ({
+  build,
+}) => {
+  const rsbuild = await build();
+  const files = rsbuild.getDistFiles();
+  const indexCss = getFileContent(files, 'index.css');
 
-    expect(indexCss.includes('#00f')).toBeTruthy();
-  },
-);
+  expect(indexCss.includes('#00f')).toBeTruthy();
+});

--- a/e2e/cases/plugin-api/plugin-transform-merge-source-map/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-transform-merge-source-map/index.test.ts
@@ -5,7 +5,7 @@ import {
   getDistFiles,
   getFileContent,
   mapSourceMapPositions,
-  rspackTest,
+  test,
 } from '@e2e/helper';
 
 const expectSourceMap = async (files: Record<string, string>) => {
@@ -47,22 +47,20 @@ const expectSourceMap = async (files: Record<string, string>) => {
   ]);
 };
 
-rspackTest(
-  'should merge source map when plugin transforms code in build',
-  async ({ build }) => {
-    const rsbuild = await build();
-    const files = rsbuild.getDistFiles({ sourceMaps: true });
+test('should merge source map when plugin transforms code in build', async ({
+  build,
+}) => {
+  const rsbuild = await build();
+  const files = rsbuild.getDistFiles({ sourceMaps: true });
 
-    await expectSourceMap(files);
-  },
-);
+  await expectSourceMap(files);
+});
 
-rspackTest(
-  'should merge source map when plugin transforms code in dev',
-  async ({ dev }) => {
-    const rsbuild = await dev();
-    const files = await getDistFiles(rsbuild.distPath, true);
+test('should merge source map when plugin transforms code in dev', async ({
+  dev,
+}) => {
+  const rsbuild = await dev();
+  const files = await getDistFiles(rsbuild.distPath, true);
 
-    await expectSourceMap(files);
-  },
-);
+  await expectSourceMap(files);
+});

--- a/e2e/cases/plugin-api/plugin-transform-mime-type/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-transform-mime-type/index.test.ts
@@ -1,10 +1,9 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should allow plugin to match data uri modules with `mimetype`',
-  async ({ build }) => {
-    const rsbuild = await build();
-    const indexJs = await rsbuild.getIndexBundle();
-    expect(indexJs).toContain('data-uri-bar');
-  },
-);
+test('should allow plugin to match data uri modules with `mimetype`', async ({
+  build,
+}) => {
+  const rsbuild = await build();
+  const indexJs = await rsbuild.getIndexBundle();
+  expect(indexJs).toContain('data-uri-bar');
+});

--- a/e2e/cases/plugin-api/plugin-transform-order/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-transform-order/index.test.ts
@@ -1,10 +1,9 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should allow plugin to specify the execution order via `order`',
-  async ({ build }) => {
-    const rsbuild = await build();
-    const indexJs = await rsbuild.getIndexBundle();
-    expect(indexJs).toContain('with order: pre');
-  },
-);
+test('should allow plugin to specify the execution order via `order`', async ({
+  build,
+}) => {
+  const rsbuild = await build();
+  const indexJs = await rsbuild.getIndexBundle();
+  expect(indexJs).toContain('with order: pre');
+});

--- a/e2e/cases/plugin-api/plugin-transform/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-transform/index.test.ts
@@ -1,6 +1,6 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest('should allow plugin to transform code', async ({ build }) => {
+test('should allow plugin to transform code', async ({ build }) => {
   const rsbuild = await build();
 
   const files = rsbuild.getDistFiles();

--- a/e2e/cases/plugin-babel/basic/index.test.ts
+++ b/e2e/cases/plugin-babel/basic/index.test.ts
@@ -1,45 +1,45 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import { pluginBabel } from '@rsbuild/plugin-babel';
 import { myBabelPlugin } from './plugins/myBabelPlugin.ts';
 
-rspackTest(
-  'should run babel with babel plugin correctly',
-  async ({ page, buildPreview }) => {
-    await buildPreview({
-      config: {
-        plugins: [
-          pluginBabel({
-            babelLoaderOptions: (_, { addPlugins }) => {
-              addPlugins([myBabelPlugin]);
-            },
-          }),
-        ],
+test('should run babel with babel plugin correctly', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview({
+    config: {
+      plugins: [
+        pluginBabel({
+          babelLoaderOptions: (_, { addPlugins }) => {
+            addPlugins([myBabelPlugin]);
+          },
+        }),
+      ],
+    },
+  });
+
+  expect(await page.evaluate('window.b')).toBe(10);
+});
+
+test('should allow to exclude file from babel transformation', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview({
+    config: {
+      source: {
+        exclude: [/aa/],
       },
-    });
+      plugins: [
+        pluginBabel({
+          babelLoaderOptions: (_, { addPlugins }) => {
+            addPlugins([myBabelPlugin]);
+          },
+        }),
+      ],
+    },
+  });
 
-    expect(await page.evaluate('window.b')).toBe(10);
-  },
-);
-
-rspackTest(
-  'should allow to exclude file from babel transformation',
-  async ({ page, buildPreview }) => {
-    await buildPreview({
-      config: {
-        source: {
-          exclude: [/aa/],
-        },
-        plugins: [
-          pluginBabel({
-            babelLoaderOptions: (_, { addPlugins }) => {
-              addPlugins([myBabelPlugin]);
-            },
-          }),
-        ],
-      },
-    });
-
-    expect(await page.evaluate('window.b')).toBe(10);
-    expect(await page.evaluate('window.bb')).toBeUndefined();
-  },
-);
+  expect(await page.evaluate('window.b')).toBe(10);
+  expect(await page.evaluate('window.bb')).toBeUndefined();
+});

--- a/e2e/cases/plugin-babel/decorator/index.test.ts
+++ b/e2e/cases/plugin-babel/decorator/index.test.ts
@@ -1,37 +1,37 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import { pluginBabel } from '@rsbuild/plugin-babel';
 
-rspackTest(
-  'should support legacy decorators and source.decorators.version in TypeScript',
-  async ({ page, buildPreview }) => {
-    await buildPreview({
-      config: {
-        plugins: [pluginBabel()],
-      },
-    });
+test('should support legacy decorators and source.decorators.version in TypeScript', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview({
+    config: {
+      plugins: [pluginBabel()],
+    },
+  });
 
-    expect(await page.evaluate('window.aaa')).toBe('hello');
-    expect(await page.evaluate('window.bbb')).toBe('world');
-    expect(await page.evaluate('window.FooService')).toBeTruthy();
-  },
-);
+  expect(await page.evaluate('window.aaa')).toBe('hello');
+  expect(await page.evaluate('window.bbb')).toBe('world');
+  expect(await page.evaluate('window.FooService')).toBeTruthy();
+});
 
-rspackTest(
-  'should support legacy decorators and source.decorators.version in JavaScript',
-  async ({ page, buildPreview }) => {
-    await buildPreview({
-      config: {
-        plugins: [pluginBabel()],
-        source: {
-          entry: {
-            index: './src/jsIndex.js',
-          },
+test('should support legacy decorators and source.decorators.version in JavaScript', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview({
+    config: {
+      plugins: [pluginBabel()],
+      source: {
+        entry: {
+          index: './src/jsIndex.js',
         },
       },
-    });
+    },
+  });
 
-    expect(await page.evaluate('window.aaa')).toBe('hello');
-    expect(await page.evaluate('window.bbb')).toBe('world');
-    expect(await page.evaluate('window.FooService')).toBeTruthy();
-  },
-);
+  expect(await page.evaluate('window.aaa')).toBe('hello');
+  expect(await page.evaluate('window.bbb')).toBe('world');
+  expect(await page.evaluate('window.FooService')).toBeTruthy();
+});

--- a/e2e/cases/plugin-less/inline-query/index.test.ts
+++ b/e2e/cases/plugin-less/inline-query/index.test.ts
@@ -1,37 +1,35 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should allow to import inline Less files in dev',
-  async ({ page, dev }) => {
-    await dev();
+test('should allow to import inline Less files in dev', async ({
+  page,
+  dev,
+}) => {
+  await dev();
 
-    const aInline: string = await page.evaluate('window.aInline');
-    const bInline: string = await page.evaluate('window.bInline');
-    const bStyles: Record<string, string> =
-      await page.evaluate('window.bStyles');
+  const aInline: string = await page.evaluate('window.aInline');
+  const bInline: string = await page.evaluate('window.bInline');
+  const bStyles: Record<string, string> = await page.evaluate('window.bStyles');
 
-    expect(
-      aInline.includes('.header-class') && aInline.includes('color: red'),
-    ).toBe(true);
-    expect(
-      bInline.includes('.title-class') && bInline.includes('font-size: 14px'),
-    ).toBe(true);
-    expect(bStyles['title-class']).toBeTruthy();
-  },
-);
+  expect(
+    aInline.includes('.header-class') && aInline.includes('color: red'),
+  ).toBe(true);
+  expect(
+    bInline.includes('.title-class') && bInline.includes('font-size: 14px'),
+  ).toBe(true);
+  expect(bStyles['title-class']).toBeTruthy();
+});
 
-rspackTest(
-  'should allow to import inline Less files in build',
-  async ({ page, buildPreview }) => {
-    await buildPreview();
+test('should allow to import inline Less files in build', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview();
 
-    const aInline: string = await page.evaluate('window.aInline');
-    const bInline: string = await page.evaluate('window.bInline');
-    const bStyles: Record<string, string> =
-      await page.evaluate('window.bStyles');
+  const aInline: string = await page.evaluate('window.aInline');
+  const bInline: string = await page.evaluate('window.bInline');
+  const bStyles: Record<string, string> = await page.evaluate('window.bStyles');
 
-    expect(aInline).toBe('.header-class{color:red}');
-    expect(bInline).toBe('.title-class{font-size:14px}');
-    expect(bStyles['title-class']).toBeTruthy();
-  },
-);
+  expect(aInline).toBe('.header-class{color:red}');
+  expect(bInline).toBe('.title-class{font-size:14px}');
+  expect(bStyles['title-class']).toBeTruthy();
+});

--- a/e2e/cases/plugin-less/parallel/index.test.ts
+++ b/e2e/cases/plugin-less/parallel/index.test.ts
@@ -1,23 +1,22 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest(
-  'should compile less with `parallel` option in build',
-  async ({ build }) => {
-    const rsbuild = await build();
-    const files = rsbuild.getDistFiles();
-    const cssContent = getFileContent(files, '.css');
-    expect(cssContent).toEqual(
-      'body{background-color:red;font-size:16px}div{font-size:14px}h1{font-size:18px;font-weight:700}p{font-size:15px}',
-    );
-  },
-);
+test('should compile less with `parallel` option in build', async ({
+  build,
+}) => {
+  const rsbuild = await build();
+  const files = rsbuild.getDistFiles();
+  const cssContent = getFileContent(files, '.css');
+  expect(cssContent).toEqual(
+    'body{background-color:red;font-size:16px}div{font-size:14px}h1{font-size:18px;font-weight:700}p{font-size:15px}',
+  );
+});
 
-rspackTest(
-  'should compile less with `parallel` option in dev',
-  async ({ page, dev }) => {
-    await dev();
-    const body = page.locator('body');
-    await expect(body).toHaveCSS('background-color', 'rgb(255, 0, 0)');
-    await expect(body).toHaveCSS('font-size', '16px');
-  },
-);
+test('should compile less with `parallel` option in dev', async ({
+  page,
+  dev,
+}) => {
+  await dev();
+  const body = page.locator('body');
+  await expect(body).toHaveCSS('background-color', 'rgb(255, 0, 0)');
+  await expect(body).toHaveCSS('font-size', '16px');
+});

--- a/e2e/cases/plugin-less/plugin-hints/index.test.ts
+++ b/e2e/cases/plugin-less/plugin-hints/index.test.ts
@@ -1,6 +1,6 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest('should print Less plugin hints as expected', async ({ build }) => {
+test('should print Less plugin hints as expected', async ({ build }) => {
   const rsbuild = await build({
     catchBuildError: true,
   });

--- a/e2e/cases/plugin-preact/basic/index.test.ts
+++ b/e2e/cases/plugin-preact/basic/index.test.ts
@@ -1,25 +1,22 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should render basic Preact component in dev',
-  async ({ page, dev }) => {
-    await dev();
+test('should render basic Preact component in dev', async ({ page, dev }) => {
+  await dev();
 
-    const button = page.locator('#button');
-    await expect(button).toHaveText('count: 0');
-    await button.click();
-    await expect(button).toHaveText('count: 1');
-  },
-);
+  const button = page.locator('#button');
+  await expect(button).toHaveText('count: 0');
+  await button.click();
+  await expect(button).toHaveText('count: 1');
+});
 
-rspackTest(
-  'should render basic Preact component in build',
-  async ({ page, buildPreview }) => {
-    await buildPreview();
+test('should render basic Preact component in build', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview();
 
-    const button = page.locator('#button');
-    await expect(button).toHaveText('count: 0');
-    await button.click();
-    await expect(button).toHaveText('count: 1');
-  },
-);
+  const button = page.locator('#button');
+  await expect(button).toHaveText('count: 0');
+  await button.click();
+  await expect(button).toHaveText('count: 1');
+});

--- a/e2e/cases/plugin-preact/prefresh-context/index.test.ts
+++ b/e2e/cases/plugin-preact/prefresh-context/index.test.ts
@@ -1,51 +1,52 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { expect, rspackTest, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'HMR should work properly with `createContext`',
-  async ({ page, dev, editFile }) => {
-    // Prefresh does not work as expected on Windows
-    if (process.platform === 'win32') {
-      test.skip();
-    }
+test('HMR should work properly with `createContext`', async ({
+  page,
+  dev,
+  editFile,
+}) => {
+  // Prefresh does not work as expected on Windows
+  if (process.platform === 'win32') {
+    test.skip();
+  }
 
-    const root = import.meta.dirname;
-    const compFilePath = path.join(root, 'src/test-temp-B.jsx');
-    const compSourceCode = `const B = (props) => {
+  const root = import.meta.dirname;
+  const compFilePath = path.join(root, 'src/test-temp-B.jsx');
+  const compSourceCode = `const B = (props) => {
   return <div id="B">B: {props.count}</div>;
 };
 
 export default B;
 `;
 
-    fs.writeFileSync(compFilePath, compSourceCode, 'utf-8');
+  fs.writeFileSync(compFilePath, compSourceCode, 'utf-8');
 
-    await dev();
+  await dev();
 
-    const a = page.locator('#A');
-    const b = page.locator('#B');
+  const a = page.locator('#A');
+  const b = page.locator('#B');
 
-    await expect(a).toHaveText('A: 0');
-    await expect(b).toHaveText('B: 0');
+  await expect(a).toHaveText('A: 0');
+  await expect(b).toHaveText('B: 0');
 
-    await a.click({ clickCount: 5 });
-    await expect(a).toHaveText('A: 5');
-    await expect(b).toHaveText('B: 5');
+  await a.click({ clickCount: 5 });
+  await expect(a).toHaveText('A: 5');
+  await expect(b).toHaveText('B: 5');
 
-    // simulate a change to component B's source code
-    await editFile(compFilePath, (code) => code.replace('B:', 'Beep:'));
+  // simulate a change to component B's source code
+  await editFile(compFilePath, (code) => code.replace('B:', 'Beep:'));
 
-    await page.waitForFunction(() => {
-      const aText = document.querySelector('#A')?.textContent;
-      const bText = document.querySelector('#B')?.textContent;
+  await page.waitForFunction(() => {
+    const aText = document.querySelector('#A')?.textContent;
+    const bText = document.querySelector('#B')?.textContent;
 
-      return (
-        // the state (count) of A should be kept
-        aText === 'A: 5' &&
-        // content of B changed to `Beep: 5` means HMR has taken effect
-        bText === 'Beep: 5'
-      );
-    });
-  },
-);
+    return (
+      // the state (count) of A should be kept
+      aText === 'A: 5' &&
+      // content of B changed to `Beep: 5` means HMR has taken effect
+      bText === 'Beep: 5'
+    );
+  });
+});

--- a/e2e/cases/plugin-preact/prefresh-disabled/index.test.ts
+++ b/e2e/cases/plugin-preact/prefresh-disabled/index.test.ts
@@ -1,8 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest('HMR should work properly', async ({ page, dev, editFile }) => {
+test('HMR should work properly', async ({ page, dev, editFile }) => {
   const root = import.meta.dirname;
   const compFilePath = path.join(root, 'src/test-temp-B.jsx');
   const compSourceCode = `const B = (props) => {

--- a/e2e/cases/plugin-preact/prefresh/index.test.ts
+++ b/e2e/cases/plugin-preact/prefresh/index.test.ts
@@ -1,8 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { expect, rspackTest, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest('HMR should work properly', async ({ page, dev, editFile }) => {
+test('HMR should work properly', async ({ page, dev, editFile }) => {
   // Prefresh does not work as expected on Windows
   if (process.platform === 'win32') {
     test.skip();

--- a/e2e/cases/plugin-react/basic/index.test.ts
+++ b/e2e/cases/plugin-react/basic/index.test.ts
@@ -1,25 +1,22 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should render basic React component in dev',
-  async ({ page, dev }) => {
-    await dev();
+test('should render basic React component in dev', async ({ page, dev }) => {
+  await dev();
 
-    const button = page.locator('#button');
-    await expect(button).toHaveText('count: 0');
-    await button.click();
-    await expect(button).toHaveText('count: 1');
-  },
-);
+  const button = page.locator('#button');
+  await expect(button).toHaveText('count: 0');
+  await button.click();
+  await expect(button).toHaveText('count: 1');
+});
 
-rspackTest(
-  'should render basic React component in build',
-  async ({ page, buildPreview }) => {
-    await buildPreview();
+test('should render basic React component in build', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview();
 
-    const button = page.locator('#button');
-    await expect(button).toHaveText('count: 0');
-    await button.click();
-    await expect(button).toHaveText('count: 1');
-  },
-);
+  const button = page.locator('#button');
+  await expect(button).toHaveText('count: 0');
+  await button.click();
+  await expect(button).toHaveText('count: 1');
+});

--- a/e2e/cases/plugin-react/disable-fast-refresh/index.test.ts
+++ b/e2e/cases/plugin-react/disable-fast-refresh/index.test.ts
@@ -1,28 +1,30 @@
 import { join } from 'node:path';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'HMR should work when Fast Refresh is disabled',
-  async ({ page, dev, editFile, copySrcDir }) => {
-    const tempSrc = await copySrcDir();
+test('HMR should work when Fast Refresh is disabled', async ({
+  page,
+  dev,
+  editFile,
+  copySrcDir,
+}) => {
+  const tempSrc = await copySrcDir();
 
-    await dev({
-      config: {
-        source: {
-          entry: {
-            index: join(tempSrc, 'index.ts'),
-          },
+  await dev({
+    config: {
+      source: {
+        entry: {
+          index: join(tempSrc, 'index.ts'),
         },
       },
-    });
+    },
+  });
 
-    const locator = page.locator('#test');
-    await expect(locator).toHaveText('Hello Rsbuild!');
-    await expect(locator).toHaveCSS('color', 'rgb(255, 0, 0)');
+  const locator = page.locator('#test');
+  await expect(locator).toHaveText('Hello Rsbuild!');
+  await expect(locator).toHaveCSS('color', 'rgb(255, 0, 0)');
 
-    await editFile(join(tempSrc, 'App.tsx'), (code) =>
-      code.replace('Hello Rsbuild', 'Hello Test'),
-    );
-    await expect(locator).toHaveText('Hello Test!');
-  },
-);
+  await editFile(join(tempSrc, 'App.tsx'), (code) =>
+    code.replace('Hello Rsbuild', 'Hello Test'),
+  );
+  await expect(locator).toHaveText('Hello Test!');
+});

--- a/e2e/cases/plugin-react/jsx-runtime-classic/index.test.ts
+++ b/e2e/cases/plugin-react/jsx-runtime-classic/index.test.ts
@@ -1,19 +1,19 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should render element with classic JSX runtime in build',
-  async ({ page, buildPreview }) => {
-    await buildPreview();
-    const testEl = page.locator('#test');
-    await expect(testEl).toHaveText('Hello Rsbuild!');
-  },
-);
+test('should render element with classic JSX runtime in build', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview();
+  const testEl = page.locator('#test');
+  await expect(testEl).toHaveText('Hello Rsbuild!');
+});
 
-rspackTest(
-  'should render element with classic JSX runtime in dev',
-  async ({ page, dev }) => {
-    await dev();
-    const testEl = page.locator('#test');
-    await expect(testEl).toHaveText('Hello Rsbuild!');
-  },
-);
+test('should render element with classic JSX runtime in dev', async ({
+  page,
+  dev,
+}) => {
+  await dev();
+  const testEl = page.locator('#test');
+  await expect(testEl).toHaveText('Hello Rsbuild!');
+});

--- a/e2e/cases/plugin-react/jsx-runtime-preserve/index.test.ts
+++ b/e2e/cases/plugin-react/jsx-runtime-preserve/index.test.ts
@@ -1,6 +1,6 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest('should preserve JSX after build', async ({ build }) => {
+test('should preserve JSX after build', async ({ build }) => {
   const result = await build();
   const content = await result.getIndexBundle();
   expect(content.includes('<div id="test">Hello Rsbuild!</div>')).toBeTruthy();

--- a/e2e/cases/plugin-react/react-compiler-babel/index.test.ts
+++ b/e2e/cases/plugin-react/react-compiler-babel/index.test.ts
@@ -1,28 +1,25 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should render basic React component in dev',
-  async ({ page, dev }) => {
-    await dev();
+test('should render basic React component in dev', async ({ page, dev }) => {
+  await dev();
 
-    const button = page.locator('#button');
-    await expect(button).toHaveText('count: 0');
-    await button.click();
-    await expect(button).toHaveText('count: 1');
-  },
-);
+  const button = page.locator('#button');
+  await expect(button).toHaveText('count: 0');
+  await button.click();
+  await expect(button).toHaveText('count: 1');
+});
 
-rspackTest(
-  'should render basic React component in build',
-  async ({ page, buildPreview }) => {
-    const rsbuild = await buildPreview();
+test('should render basic React component in build', async ({
+  page,
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview();
 
-    const button = page.locator('#button');
-    await expect(button).toHaveText('count: 0');
-    await button.click();
-    await expect(button).toHaveText('count: 1');
+  const button = page.locator('#button');
+  await expect(button).toHaveText('count: 0');
+  await button.click();
+  await expect(button).toHaveText('count: 1');
 
-    const index = await rsbuild.getIndexBundle();
-    expect(index).toContain('memo_cache_sentinel');
-  },
-);
+  const index = await rsbuild.getIndexBundle();
+  expect(index).toContain('memo_cache_sentinel');
+});

--- a/e2e/cases/plugin-sass/inline-query/index.test.ts
+++ b/e2e/cases/plugin-sass/inline-query/index.test.ts
@@ -1,37 +1,35 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should allow to import inline Sass files in dev',
-  async ({ page, dev }) => {
-    await dev();
+test('should allow to import inline Sass files in dev', async ({
+  page,
+  dev,
+}) => {
+  await dev();
 
-    const aInline: string = await page.evaluate('window.aInline');
-    const bInline: string = await page.evaluate('window.bInline');
-    const bStyles: Record<string, string> =
-      await page.evaluate('window.bStyles');
+  const aInline: string = await page.evaluate('window.aInline');
+  const bInline: string = await page.evaluate('window.bInline');
+  const bStyles: Record<string, string> = await page.evaluate('window.bStyles');
 
-    expect(
-      aInline.includes('.header-class') && aInline.includes('color: red'),
-    ).toBe(true);
-    expect(
-      bInline.includes('.title-class') && bInline.includes('font-size: 14px'),
-    ).toBe(true);
-    expect(bStyles['title-class']).toBeTruthy();
-  },
-);
+  expect(
+    aInline.includes('.header-class') && aInline.includes('color: red'),
+  ).toBe(true);
+  expect(
+    bInline.includes('.title-class') && bInline.includes('font-size: 14px'),
+  ).toBe(true);
+  expect(bStyles['title-class']).toBeTruthy();
+});
 
-rspackTest(
-  'should allow to import inline Sass files in build',
-  async ({ page, buildPreview }) => {
-    await buildPreview();
+test('should allow to import inline Sass files in build', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview();
 
-    const aInline: string = await page.evaluate('window.aInline');
-    const bInline: string = await page.evaluate('window.bInline');
-    const bStyles: Record<string, string> =
-      await page.evaluate('window.bStyles');
+  const aInline: string = await page.evaluate('window.aInline');
+  const bInline: string = await page.evaluate('window.bInline');
+  const bStyles: Record<string, string> = await page.evaluate('window.bStyles');
 
-    expect(aInline).toBe('.header-class{color:red}');
-    expect(bInline).toBe('.title-class{font-size:14px}');
-    expect(bStyles['title-class']).toBeTruthy();
-  },
-);
+  expect(aInline).toBe('.header-class{color:red}');
+  expect(bInline).toBe('.title-class{font-size:14px}');
+  expect(bStyles['title-class']).toBeTruthy();
+});

--- a/e2e/cases/plugin-sass/plugin-hints/index.test.ts
+++ b/e2e/cases/plugin-sass/plugin-hints/index.test.ts
@@ -1,6 +1,6 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest('should print Sass plugin hints as expected', async ({ build }) => {
+test('should print Sass plugin hints as expected', async ({ build }) => {
   const rsbuild = await build({
     catchBuildError: true,
   });

--- a/e2e/cases/plugin-solid/hmr/index.test.ts
+++ b/e2e/cases/plugin-solid/hmr/index.test.ts
@@ -1,8 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest('HMR should work properly', async ({ page, dev, editFile }) => {
+test('HMR should work properly', async ({ page, dev, editFile }) => {
   const root = import.meta.dirname;
   const compFilePath = path.join(root, 'src/test-temp-B.jsx');
   const compSourceCode = `const B = (props) => {

--- a/e2e/cases/plugin-solid/index.test.ts
+++ b/e2e/cases/plugin-solid/index.test.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import type { BuildOptions, BuildResult } from '@e2e/helper';
-import { expect, gotoPage, rspackTest } from '@e2e/helper';
+import { expect, gotoPage, test } from '@e2e/helper';
 import { pluginBabel } from '@rsbuild/plugin-babel';
 import { pluginSolid } from '@rsbuild/plugin-solid';
 import { pluginStylus } from '@rsbuild/plugin-stylus';
@@ -28,50 +28,44 @@ const buildFixture = (
   });
 };
 
-rspackTest(
-  'should build basic solid component properly',
-  async ({ page, build }) => {
-    const rsbuild = await buildFixture(build, 'basic');
+test('should build basic solid component properly', async ({ page, build }) => {
+  const rsbuild = await buildFixture(build, 'basic');
 
-    await gotoPage(page, rsbuild);
+  await gotoPage(page, rsbuild);
 
-    const button = page.locator('#button');
-    await expect(button).toHaveText('count: 0');
+  const button = page.locator('#button');
+  await expect(button).toHaveText('count: 0');
 
-    await button.click();
-    await expect(button).toHaveText('count: 1');
-  },
-);
+  await button.click();
+  await expect(button).toHaveText('count: 1');
+});
 
-rspackTest(
-  'should build solid component with typescript',
-  async ({ page, build }) => {
-    const rsbuild = await buildFixture(build, 'ts');
+test('should build solid component with typescript', async ({
+  page,
+  build,
+}) => {
+  const rsbuild = await buildFixture(build, 'ts');
 
-    await gotoPage(page, rsbuild);
+  await gotoPage(page, rsbuild);
 
-    const button = page.locator('#button');
-    await expect(button).toHaveText('count: 0');
+  const button = page.locator('#button');
+  await expect(button).toHaveText('count: 0');
 
-    await button.click();
-    await expect(button).toHaveText('count: 1');
-  },
-);
+  await button.click();
+  await expect(button).toHaveText('count: 1');
+});
 
 // test cases for CSS preprocessors
 for (const name of ['less', 'scss', 'stylus']) {
-  rspackTest(
-    `should build solid component with ${name}`,
-    async ({ page, build }) => {
-      const rsbuild = await buildFixture(build, name);
+  test(`should build solid component with ${name}`, async ({ page, build }) => {
+    const rsbuild = await buildFixture(build, name);
 
-      await gotoPage(page, rsbuild);
+    await gotoPage(page, rsbuild);
 
-      const title = page.locator('#title');
+    const title = page.locator('#title');
 
-      await expect(title).toHaveText('Hello World!');
-      // use the text color to assert the compilation result
-      await expect(title).toHaveCSS('color', 'rgb(255, 62, 0)');
-    },
-  );
+    await expect(title).toHaveText('Hello World!');
+    // use the text color to assert the compilation result
+    await expect(title).toHaveCSS('color', 'rgb(255, 62, 0)');
+  });
 }

--- a/e2e/cases/plugin-solid/ref/index.test.ts
+++ b/e2e/cases/plugin-solid/ref/index.test.ts
@@ -1,7 +1,7 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
 // https://github.com/web-infra-dev/rsbuild/issues/1963
-rspackTest('Solid ref should work', async ({ page, dev }) => {
+test('Solid ref should work', async ({ page, dev }) => {
   await dev();
 
   const test = page.locator('#test');

--- a/e2e/cases/plugin-stylus/basic/index.test.ts
+++ b/e2e/cases/plugin-stylus/basic/index.test.ts
@@ -1,6 +1,6 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest('should compile stylus correctly', async ({ build }) => {
+test('should compile stylus correctly', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
 

--- a/e2e/cases/plugin-stylus/environment/index.test.ts
+++ b/e2e/cases/plugin-stylus/environment/index.test.ts
@@ -1,14 +1,13 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest(
-  'should allow to configure Stylus plugin for specific environment',
-  async ({ build }) => {
-    const rsbuild = await build();
-    const files = rsbuild.getDistFiles();
-    const content = getFileContent(files, '.css');
+test('should allow to configure Stylus plugin for specific environment', async ({
+  build,
+}) => {
+  const rsbuild = await build();
+  const files = rsbuild.getDistFiles();
+  const content = getFileContent(files, '.css');
 
-    expect(content).toMatch(
-      /body{color:red;font:14px Arial,sans-serif}\.title-class-\w{6}{font-size:14px}/,
-    );
-  },
-);
+  expect(content).toMatch(
+    /body{color:red;font:14px Arial,sans-serif}\.title-class-\w{6}{font-size:14px}/,
+  );
+});

--- a/e2e/cases/plugin-stylus/inline-query/index.test.ts
+++ b/e2e/cases/plugin-stylus/inline-query/index.test.ts
@@ -1,37 +1,35 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should allow to import inline Stylus files in dev',
-  async ({ page, dev }) => {
-    await dev();
+test('should allow to import inline Stylus files in dev', async ({
+  page,
+  dev,
+}) => {
+  await dev();
 
-    const aInline: string = await page.evaluate('window.aInline');
-    const bInline: string = await page.evaluate('window.bInline');
-    const bStyles: Record<string, string> =
-      await page.evaluate('window.bStyles');
+  const aInline: string = await page.evaluate('window.aInline');
+  const bInline: string = await page.evaluate('window.bInline');
+  const bStyles: Record<string, string> = await page.evaluate('window.bStyles');
 
-    expect(
-      aInline.includes('.header-class') && aInline.includes('color: red'),
-    ).toBe(true);
-    expect(
-      bInline.includes('.title-class') && bInline.includes('font-size: 14px'),
-    ).toBe(true);
-    expect(bStyles['title-class']).toBeTruthy();
-  },
-);
+  expect(
+    aInline.includes('.header-class') && aInline.includes('color: red'),
+  ).toBe(true);
+  expect(
+    bInline.includes('.title-class') && bInline.includes('font-size: 14px'),
+  ).toBe(true);
+  expect(bStyles['title-class']).toBeTruthy();
+});
 
-rspackTest(
-  'should allow to import inline Stylus files in build',
-  async ({ page, buildPreview }) => {
-    await buildPreview();
+test('should allow to import inline Stylus files in build', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview();
 
-    const aInline: string = await page.evaluate('window.aInline');
-    const bInline: string = await page.evaluate('window.bInline');
-    const bStyles: Record<string, string> =
-      await page.evaluate('window.bStyles');
+  const aInline: string = await page.evaluate('window.aInline');
+  const bInline: string = await page.evaluate('window.bInline');
+  const bStyles: Record<string, string> = await page.evaluate('window.bStyles');
 
-    expect(aInline).toBe('.header-class{color:red}');
-    expect(bInline).toBe('.title-class{font-size:14px}');
-    expect(bStyles['title-class']).toBeTruthy();
-  },
-);
+  expect(aInline).toBe('.header-class{color:red}');
+  expect(bInline).toBe('.title-class{font-size:14px}');
+  expect(bStyles['title-class']).toBeTruthy();
+});

--- a/e2e/cases/plugin-stylus/plugin-hints/index.test.ts
+++ b/e2e/cases/plugin-stylus/plugin-hints/index.test.ts
@@ -1,15 +1,12 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should print Stylus plugin hints as expected',
-  async ({ build }) => {
-    const rsbuild = await build({
-      catchBuildError: true,
-    });
+test('should print Stylus plugin hints as expected', async ({ build }) => {
+  const rsbuild = await build({
+    catchBuildError: true,
+  });
 
-    expect(rsbuild.buildError).toBeTruthy();
-    await rsbuild.expectLog(
-      'To enable support for Stylus, use "@rsbuild/plugin-stylus"',
-    );
-  },
-);
+  expect(rsbuild.buildError).toBeTruthy();
+  await rsbuild.expectLog(
+    'To enable support for Stylus, use "@rsbuild/plugin-stylus"',
+  );
+});

--- a/e2e/cases/plugin-stylus/rem/index.test.ts
+++ b/e2e/cases/plugin-stylus/rem/index.test.ts
@@ -1,6 +1,6 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest('should compile stylus and rem correctly', async ({ build }) => {
+test('should compile stylus and rem correctly', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
   const content = getFileContent(files, '.css');

--- a/e2e/cases/plugin-svelte/basic/index.test.ts
+++ b/e2e/cases/plugin-svelte/basic/index.test.ts
@@ -1,19 +1,19 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should compile basic svelte component properly in build',
-  async ({ page, buildPreview }) => {
-    await buildPreview();
-    const title = page.locator('#title');
-    await expect(title).toHaveText('Hello world!');
-  },
-);
+test('should compile basic svelte component properly in build', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview();
+  const title = page.locator('#title');
+  await expect(title).toHaveText('Hello world!');
+});
 
-rspackTest(
-  'should compile basic svelte component properly in dev',
-  async ({ page, dev }) => {
-    await dev();
-    const title = page.locator('#title');
-    await expect(title).toHaveText('Hello world!');
-  },
-);
+test('should compile basic svelte component properly in dev', async ({
+  page,
+  dev,
+}) => {
+  await dev();
+  const title = page.locator('#title');
+  await expect(title).toHaveText('Hello world!');
+});

--- a/e2e/cases/plugin-svelte/hmr/index.test.ts
+++ b/e2e/cases/plugin-svelte/hmr/index.test.ts
@@ -1,8 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest('HMR should work properly', async ({ page, dev, editFile }) => {
+test('HMR should work properly', async ({ page, dev, editFile }) => {
   const cwd = import.meta.dirname;
   const bPath = path.join(cwd, 'src/test-temp-B.svelte');
   fs.writeFileSync(

--- a/e2e/cases/plugin-svelte/less/index.test.ts
+++ b/e2e/cases/plugin-svelte/less/index.test.ts
@@ -1,23 +1,23 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should compile svelte component with less in build',
-  async ({ page, buildPreview }) => {
-    await buildPreview();
-    const title = page.locator('#title');
-    await expect(title).toHaveText('Hello world!');
-    // use the text color to assert the compilation result
-    await expect(title).toHaveCSS('color', 'rgb(255, 62, 0)');
-  },
-);
+test('should compile svelte component with less in build', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview();
+  const title = page.locator('#title');
+  await expect(title).toHaveText('Hello world!');
+  // use the text color to assert the compilation result
+  await expect(title).toHaveCSS('color', 'rgb(255, 62, 0)');
+});
 
-rspackTest(
-  'should compile svelte component with less in dev',
-  async ({ page, dev }) => {
-    await dev();
-    const title = page.locator('#title');
-    await expect(title).toHaveText('Hello world!');
-    // use the text color to assert the compilation result
-    await expect(title).toHaveCSS('color', 'rgb(255, 62, 0)');
-  },
-);
+test('should compile svelte component with less in dev', async ({
+  page,
+  dev,
+}) => {
+  await dev();
+  const title = page.locator('#title');
+  await expect(title).toHaveText('Hello world!');
+  // use the text color to assert the compilation result
+  await expect(title).toHaveCSS('color', 'rgb(255, 62, 0)');
+});

--- a/e2e/cases/plugin-svelte/scss/index.test.ts
+++ b/e2e/cases/plugin-svelte/scss/index.test.ts
@@ -1,23 +1,23 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should compile svelte component with sass in build',
-  async ({ page, buildPreview }) => {
-    await buildPreview();
-    const title = page.locator('#title');
-    await expect(title).toHaveText('Hello world!');
-    // use the text color to assert the compilation result
-    await expect(title).toHaveCSS('color', 'rgb(255, 62, 0)');
-  },
-);
+test('should compile svelte component with sass in build', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview();
+  const title = page.locator('#title');
+  await expect(title).toHaveText('Hello world!');
+  // use the text color to assert the compilation result
+  await expect(title).toHaveCSS('color', 'rgb(255, 62, 0)');
+});
 
-rspackTest(
-  'should compile svelte component with sass in dev',
-  async ({ page, dev }) => {
-    await dev();
-    const title = page.locator('#title');
-    await expect(title).toHaveText('Hello world!');
-    // use the text color to assert the compilation result
-    await expect(title).toHaveCSS('color', 'rgb(255, 62, 0)');
-  },
-);
+test('should compile svelte component with sass in dev', async ({
+  page,
+  dev,
+}) => {
+  await dev();
+  const title = page.locator('#title');
+  await expect(title).toHaveText('Hello world!');
+  // use the text color to assert the compilation result
+  await expect(title).toHaveCSS('color', 'rgb(255, 62, 0)');
+});

--- a/e2e/cases/plugin-svelte/stylus/index.test.ts
+++ b/e2e/cases/plugin-svelte/stylus/index.test.ts
@@ -1,23 +1,23 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should compile svelte component with stylus in build',
-  async ({ page, buildPreview }) => {
-    await buildPreview();
-    const title = page.locator('#title');
-    await expect(title).toHaveText('Hello world!');
-    // use the text color to assert the compilation result
-    await expect(title).toHaveCSS('color', 'rgb(255, 62, 0)');
-  },
-);
+test('should compile svelte component with stylus in build', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview();
+  const title = page.locator('#title');
+  await expect(title).toHaveText('Hello world!');
+  // use the text color to assert the compilation result
+  await expect(title).toHaveCSS('color', 'rgb(255, 62, 0)');
+});
 
-rspackTest(
-  'should compile svelte component with stylus in dev',
-  async ({ page, dev }) => {
-    await dev();
-    const title = page.locator('#title');
-    await expect(title).toHaveText('Hello world!');
-    // use the text color to assert the compilation result
-    await expect(title).toHaveCSS('color', 'rgb(255, 62, 0)');
-  },
-);
+test('should compile svelte component with stylus in dev', async ({
+  page,
+  dev,
+}) => {
+  await dev();
+  const title = page.locator('#title');
+  await expect(title).toHaveText('Hello world!');
+  // use the text color to assert the compilation result
+  await expect(title).toHaveCSS('color', 'rgb(255, 62, 0)');
+});

--- a/e2e/cases/plugin-svelte/transpile/index.test.ts
+++ b/e2e/cases/plugin-svelte/transpile/index.test.ts
@@ -1,8 +1,7 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should transpile .svelte files to ES2015 as expected',
-  async ({ build }) => {
-    expect(build()).resolves.toBeTruthy();
-  },
-);
+test('should transpile .svelte files to ES2015 as expected', async ({
+  build,
+}) => {
+  expect(build()).resolves.toBeTruthy();
+});

--- a/e2e/cases/plugin-svelte/ts/index.test.ts
+++ b/e2e/cases/plugin-svelte/ts/index.test.ts
@@ -1,16 +1,16 @@
-import { expect, gotoPage, rspackTest } from '@e2e/helper';
+import { expect, gotoPage, test } from '@e2e/helper';
 
-rspackTest(
-  'should build svelte component with typescript',
-  async ({ page, buildPreview }) => {
-    const rsbuild = await buildPreview();
+test('should build svelte component with typescript', async ({
+  page,
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview();
 
-    await gotoPage(page, rsbuild);
+  await gotoPage(page, rsbuild);
 
-    const title = page.locator('#title');
-    await expect(title).toHaveText('Hello world!');
+  const title = page.locator('#title');
+  await expect(title).toHaveText('Hello world!');
 
-    const count = page.locator('#count');
-    await expect(count).toHaveText('Count: 2');
-  },
-);
+  const count = page.locator('#count');
+  await expect(count).toHaveText('Count: 2');
+});

--- a/e2e/cases/plugin-vue/sfc-basic/index.test.ts
+++ b/e2e/cases/plugin-vue/sfc-basic/index.test.ts
@@ -1,16 +1,13 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should build basic Vue SFC correctly',
-  async ({ page, buildPreview }) => {
-    await buildPreview();
+test('should build basic Vue SFC correctly', async ({ page, buildPreview }) => {
+  await buildPreview();
 
-    const button1 = page.locator('#button1');
-    const button2 = page.locator('#button2');
-    const list1 = page.locator('.list1');
+  const button1 = page.locator('#button1');
+  const button2 = page.locator('#button2');
+  const list1 = page.locator('.list1');
 
-    await expect(button1).toHaveText('A: 0');
-    await expect(button2).toHaveText('B: 0');
-    await expect(list1).toHaveCount(3);
-  },
-);
+  await expect(button1).toHaveText('A: 0');
+  await expect(button2).toHaveText('B: 0');
+  await expect(list1).toHaveCount(3);
+});

--- a/e2e/cases/plugin-vue/sfc-build-error/index.test.ts
+++ b/e2e/cases/plugin-vue/sfc-build-error/index.test.ts
@@ -1,22 +1,19 @@
-import { rspackTest } from '@e2e/helper';
+import { test } from '@e2e/helper';
 
 const EXPECTED_FILE =
   /File: \.\/src\/App\.vue\.js\?vue&type=script&lang=js:1:1-\d+/;
 const EXPECTED_ERROR = `× ESModulesLinkingError: export 'default' (reexported as 'default') was not found`;
 
-rspackTest('should display Vue compilation error in dev', async ({ dev }) => {
+test('should display Vue compilation error in dev', async ({ dev }) => {
   const rsbuild = await dev();
   await rsbuild.expectLog(EXPECTED_FILE, { strict: true });
   await rsbuild.expectLog(EXPECTED_ERROR);
 });
 
-rspackTest(
-  'should display Vue compilation error in build',
-  async ({ build }) => {
-    const rsbuild = await build({
-      catchBuildError: true,
-    });
-    await rsbuild.expectLog(EXPECTED_FILE, { strict: true });
-    await rsbuild.expectLog(EXPECTED_ERROR);
-  },
-);
+test('should display Vue compilation error in build', async ({ build }) => {
+  const rsbuild = await build({
+    catchBuildError: true,
+  });
+  await rsbuild.expectLog(EXPECTED_FILE, { strict: true });
+  await rsbuild.expectLog(EXPECTED_ERROR);
+});

--- a/e2e/cases/plugin-vue/sfc-css-modules-custom/index.test.ts
+++ b/e2e/cases/plugin-vue/sfc-css-modules-custom/index.test.ts
@@ -1,31 +1,31 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should allow to custom CSS Modules inject name in dev build',
-  async ({ page, dev }) => {
-    await dev();
+test('should allow to custom CSS Modules inject name in dev build', async ({
+  page,
+  dev,
+}) => {
+  await dev();
 
-    const test1 = page.locator('#test1');
-    const test2 = page.locator('#test2');
-    const test3 = page.locator('#test3');
+  const test1 = page.locator('#test1');
+  const test2 = page.locator('#test2');
+  const test3 = page.locator('#test3');
 
-    await expect(test1).toHaveCSS('color', 'rgb(255, 0, 0)');
-    await expect(test2).toHaveCSS('color', 'rgb(0, 0, 255)');
-    await expect(test3).toHaveCSS('color', 'rgb(0, 128, 0)');
-  },
-);
+  await expect(test1).toHaveCSS('color', 'rgb(255, 0, 0)');
+  await expect(test2).toHaveCSS('color', 'rgb(0, 0, 255)');
+  await expect(test3).toHaveCSS('color', 'rgb(0, 128, 0)');
+});
 
-rspackTest(
-  'should allow to custom CSS Modules inject name in build',
-  async ({ page, buildPreview }) => {
-    await buildPreview();
+test('should allow to custom CSS Modules inject name in build', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview();
 
-    const test1 = page.locator('#test1');
-    const test2 = page.locator('#test2');
-    const test3 = page.locator('#test3');
+  const test1 = page.locator('#test1');
+  const test2 = page.locator('#test2');
+  const test3 = page.locator('#test3');
 
-    await expect(test1).toHaveCSS('color', 'rgb(255, 0, 0)');
-    await expect(test2).toHaveCSS('color', 'rgb(0, 0, 255)');
-    await expect(test3).toHaveCSS('color', 'rgb(0, 128, 0)');
-  },
-);
+  await expect(test1).toHaveCSS('color', 'rgb(255, 0, 0)');
+  await expect(test2).toHaveCSS('color', 'rgb(0, 0, 255)');
+  await expect(test3).toHaveCSS('color', 'rgb(0, 128, 0)');
+});

--- a/e2e/cases/plugin-vue/sfc-css-modules-ssr/index.test.ts
+++ b/e2e/cases/plugin-vue/sfc-css-modules-ssr/index.test.ts
@@ -1,25 +1,23 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest(
-  'should build Vue SFC with CSS Modules correctly in dev build for node target',
-  async ({ dev }) => {
-    const rsbuild = await dev();
+test('should build Vue SFC with CSS Modules correctly in dev build for node target', async ({
+  dev,
+}) => {
+  const rsbuild = await dev();
 
-    const files = rsbuild.getDistFiles();
-    const indexJs = getFileContent(files, 'index.js');
-    expect(indexJs).toMatch(/`src-App__red-\w{6}`/);
-    expect(indexJs).toMatch(/`src-App__blue-\w{6}`/);
-  },
-);
+  const files = rsbuild.getDistFiles();
+  const indexJs = getFileContent(files, 'index.js');
+  expect(indexJs).toMatch(/`src-App__red-\w{6}`/);
+  expect(indexJs).toMatch(/`src-App__blue-\w{6}`/);
+});
 
-rspackTest(
-  'should build Vue SFC with CSS Modules correctly in build for node target',
-  async ({ buildPreview }) => {
-    const rsbuild = await buildPreview();
+test('should build Vue SFC with CSS Modules correctly in build for node target', async ({
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview();
 
-    const files = rsbuild.getDistFiles();
-    const indexJs = getFileContent(files, 'index.js');
-    expect(indexJs).toMatch(/"red-\w{6}"/);
-    expect(indexJs).toMatch(/"blue-\w{6}"/);
-  },
-);
+  const files = rsbuild.getDistFiles();
+  const indexJs = getFileContent(files, 'index.js');
+  expect(indexJs).toMatch(/"red-\w{6}"/);
+  expect(indexJs).toMatch(/"blue-\w{6}"/);
+});

--- a/e2e/cases/plugin-vue/sfc-css-modules/index.test.ts
+++ b/e2e/cases/plugin-vue/sfc-css-modules/index.test.ts
@@ -1,31 +1,31 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should build Vue SFC with CSS Modules correctly in dev build',
-  async ({ page, dev }) => {
-    await dev();
+test('should build Vue SFC with CSS Modules correctly in dev build', async ({
+  page,
+  dev,
+}) => {
+  await dev();
 
-    const test1 = page.locator('#test1');
-    const test2 = page.locator('#test2');
-    const test3 = page.locator('#test3');
+  const test1 = page.locator('#test1');
+  const test2 = page.locator('#test2');
+  const test3 = page.locator('#test3');
 
-    await expect(test1).toHaveCSS('color', 'rgb(255, 0, 0)');
-    await expect(test2).toHaveCSS('color', 'rgb(0, 0, 255)');
-    await expect(test3).toHaveCSS('color', 'rgb(0, 128, 0)');
-  },
-);
+  await expect(test1).toHaveCSS('color', 'rgb(255, 0, 0)');
+  await expect(test2).toHaveCSS('color', 'rgb(0, 0, 255)');
+  await expect(test3).toHaveCSS('color', 'rgb(0, 128, 0)');
+});
 
-rspackTest(
-  'should build Vue SFC with CSS Modules correctly in build',
-  async ({ page, buildPreview }) => {
-    await buildPreview();
+test('should build Vue SFC with CSS Modules correctly in build', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview();
 
-    const test1 = page.locator('#test1');
-    const test2 = page.locator('#test2');
-    const test3 = page.locator('#test3');
+  const test1 = page.locator('#test1');
+  const test2 = page.locator('#test2');
+  const test3 = page.locator('#test3');
 
-    await expect(test1).toHaveCSS('color', 'rgb(255, 0, 0)');
-    await expect(test2).toHaveCSS('color', 'rgb(0, 0, 255)');
-    await expect(test3).toHaveCSS('color', 'rgb(0, 128, 0)');
-  },
-);
+  await expect(test1).toHaveCSS('color', 'rgb(255, 0, 0)');
+  await expect(test2).toHaveCSS('color', 'rgb(0, 0, 255)');
+  await expect(test3).toHaveCSS('color', 'rgb(0, 128, 0)');
+});

--- a/e2e/cases/plugin-vue/sfc-in-node-modules/index.test.ts
+++ b/e2e/cases/plugin-vue/sfc-in-node-modules/index.test.ts
@@ -1,28 +1,27 @@
 import path from 'node:path';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import fse from 'fs-extra';
 
-rspackTest(
-  'should transpile Vue SFC in node_modules correctly',
-  async ({ build }) => {
-    fse.outputFileSync(
-      path.resolve(import.meta.dirname, 'node_modules/foo/package.json'),
-      JSON.stringify({
-        name: 'foo',
-        version: '1.0.0',
-        main: 'index.vue',
-      }),
-    );
-    fse.outputFileSync(
-      path.resolve(import.meta.dirname, 'node_modules/foo/index.vue'),
-      '<template><div :test="window?.foo" /></template>',
-    );
+test('should transpile Vue SFC in node_modules correctly', async ({
+  build,
+}) => {
+  fse.outputFileSync(
+    path.resolve(import.meta.dirname, 'node_modules/foo/package.json'),
+    JSON.stringify({
+      name: 'foo',
+      version: '1.0.0',
+      main: 'index.vue',
+    }),
+  );
+  fse.outputFileSync(
+    path.resolve(import.meta.dirname, 'node_modules/foo/index.vue'),
+    '<template><div :test="window?.foo" /></template>',
+  );
 
-    const rsbuild = await build();
+  const rsbuild = await build();
 
-    const content = await rsbuild.getIndexBundle();
-    expect(content).not.toContain('window?.foo');
-    // should transpile optional chaining
-    expect(content).toContain('test:null==');
-  },
-);
+  const content = await rsbuild.getIndexBundle();
+  expect(content).not.toContain('window?.foo');
+  // should transpile optional chaining
+  expect(content).toContain('test:null==');
+});

--- a/e2e/cases/plugin-vue/sfc-lang-pcss/index.test.ts
+++ b/e2e/cases/plugin-vue/sfc-lang-pcss/index.test.ts
@@ -1,10 +1,10 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should build Vue SFC with lang="postcss" correctly',
-  async ({ page, buildPreview }) => {
-    await buildPreview();
-    const button = page.locator('#button');
-    await expect(button).toHaveCSS('color', 'rgb(255, 0, 0)');
-  },
-);
+test('should build Vue SFC with lang="postcss" correctly', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview();
+  const button = page.locator('#button');
+  await expect(button).toHaveCSS('color', 'rgb(255, 0, 0)');
+});

--- a/e2e/cases/plugin-vue/sfc-lang-postcss/index.test.ts
+++ b/e2e/cases/plugin-vue/sfc-lang-postcss/index.test.ts
@@ -1,11 +1,11 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should build Vue SFC with lang="postcss" correctly',
-  async ({ page, buildPreview }) => {
-    await buildPreview();
+test('should build Vue SFC with lang="postcss" correctly', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview();
 
-    const button = page.locator('#button');
-    await expect(button).toHaveCSS('color', 'rgb(255, 0, 0)');
-  },
-);
+  const button = page.locator('#button');
+  await expect(button).toHaveCSS('color', 'rgb(255, 0, 0)');
+});

--- a/e2e/cases/plugin-vue/sfc-lang-ts/index.test.ts
+++ b/e2e/cases/plugin-vue/sfc-lang-ts/index.test.ts
@@ -1,11 +1,11 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should build Vue SFC with lang="ts" correctly',
-  async ({ page, buildPreview }) => {
-    await buildPreview();
+test('should build Vue SFC with lang="ts" correctly', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview();
 
-    const button = page.locator('#button');
-    await expect(button).toHaveText('count: 0 foo: bar');
-  },
-);
+  const button = page.locator('#button');
+  await expect(button).toHaveText('count: 0 foo: bar');
+});

--- a/e2e/cases/plugin-vue/sfc-style/index.test.ts
+++ b/e2e/cases/plugin-vue/sfc-style/index.test.ts
@@ -1,14 +1,11 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should build Vue SFC style correctly',
-  async ({ page, buildPreview }) => {
-    await buildPreview();
+test('should build Vue SFC style correctly', async ({ page, buildPreview }) => {
+  await buildPreview();
 
-    const button = page.locator('#button');
-    await expect(button).toHaveCSS('color', 'rgb(255, 0, 0)');
+  const button = page.locator('#button');
+  await expect(button).toHaveCSS('color', 'rgb(255, 0, 0)');
 
-    const body = page.locator('body');
-    await expect(body).toHaveCSS('background-color', 'rgb(0, 0, 255)');
-  },
-);
+  const body = page.locator('body');
+  await expect(body).toHaveCSS('background-color', 'rgb(0, 0, 255)');
+});

--- a/e2e/cases/plugin-vue/with-react/index.test.ts
+++ b/e2e/cases/plugin-vue/with-react/index.test.ts
@@ -1,16 +1,16 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should allow to build Vue SFC when pluginReact is also used',
-  async ({ page, buildPreview }) => {
-    await buildPreview();
+test('should allow to build Vue SFC when pluginReact is also used', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview();
 
-    const button1 = page.locator('#button1');
-    const button2 = page.locator('#button2');
-    const list1 = page.locator('.list1');
+  const button1 = page.locator('#button1');
+  const button2 = page.locator('#button2');
+  const list1 = page.locator('.list1');
 
-    await expect(button1).toHaveText('A: 0');
-    await expect(button2).toHaveText('B: 0');
-    await expect(list1).toHaveCount(3);
-  },
-);
+  await expect(button1).toHaveText('A: 0');
+  await expect(button2).toHaveText('B: 0');
+  await expect(list1).toHaveCount(3);
+});

--- a/e2e/cases/polyfill/core-js-basic/index.test.ts
+++ b/e2e/cases/polyfill/core-js-basic/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, rspackTest, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import { getPolyfillContent } from '../helper';
 
 const EXPECT_VALUE = {
@@ -34,32 +34,32 @@ test('should add polyfill when set polyfill entry (default)', async ({
   expect(content.includes('object.has-own.js')).toBeTruthy();
 });
 
-rspackTest(
-  'should add polyfill when set polyfill usage',
-  async ({ page, buildPreview }) => {
-    const rsbuild = await buildPreview({
-      config: {
-        output: {
-          polyfill: 'usage',
-          sourceMap: {
-            js: 'source-map',
-          },
+test('should add polyfill when set polyfill usage', async ({
+  page,
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview({
+    config: {
+      output: {
+        polyfill: 'usage',
+        sourceMap: {
+          js: 'source-map',
         },
       },
-    });
+    },
+  });
 
-    page.on('pageerror', (err) => {
-      console.log('page err', err);
-    });
+  page.on('pageerror', (err) => {
+    console.log('page err', err);
+  });
 
-    expect(await page.evaluate('window.a')).toEqual(EXPECT_VALUE);
+  expect(await page.evaluate('window.a')).toEqual(EXPECT_VALUE);
 
-    const files = rsbuild.getDistFiles({ sourceMaps: true });
+  const files = rsbuild.getDistFiles({ sourceMaps: true });
 
-    const content = getPolyfillContent(files);
+  const content = getPolyfillContent(files);
 
-    // should only polyfill some usage api
-    expect(content.includes('object.group-by.js')).toBeTruthy();
-    expect(content.includes('object.has-own.js')).toBeFalsy();
-  },
-);
+  // should only polyfill some usage api
+  expect(content.includes('object.group-by.js')).toBeTruthy();
+  expect(content.includes('object.has-own.js')).toBeFalsy();
+});

--- a/e2e/cases/polyfill/core-js-browserslist/index.test.ts
+++ b/e2e/cases/polyfill/core-js-browserslist/index.test.ts
@@ -1,25 +1,23 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import { getPolyfillContent } from '../helper';
 
-rspackTest(
-  'should read browserslist for development env correctly',
-  async ({ dev }) => {
-    const rsbuild = await dev();
+test('should read browserslist for development env correctly', async ({
+  dev,
+}) => {
+  const rsbuild = await dev();
 
-    const files = rsbuild.getDistFiles({ sourceMaps: true });
-    const content = getPolyfillContent(files);
+  const files = rsbuild.getDistFiles({ sourceMaps: true });
+  const content = getPolyfillContent(files);
 
-    expect(content.includes('es.string.replace-all')).toBeFalsy();
-  },
-);
+  expect(content.includes('es.string.replace-all')).toBeFalsy();
+});
 
-rspackTest(
-  'should read browserslist for production env correctly',
-  async ({ build }) => {
-    const rsbuild = await build();
-    const files = rsbuild.getDistFiles({ sourceMaps: true });
-    const content = getPolyfillContent(files);
+test('should read browserslist for production env correctly', async ({
+  build,
+}) => {
+  const rsbuild = await build();
+  const files = rsbuild.getDistFiles({ sourceMaps: true });
+  const content = getPolyfillContent(files);
 
-    expect(content.includes('es.string.replace-all')).toBeTruthy();
-  },
-);
+  expect(content.includes('es.string.replace-all')).toBeTruthy();
+});

--- a/e2e/cases/polyfill/dirname-filename-node/index.test.ts
+++ b/e2e/cases/polyfill/dirname-filename-node/index.test.ts
@@ -1,13 +1,12 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should not polyfill dirname and filename in node target when output.module is enabled',
-  async ({ build }) => {
-    const rsbuild = await build();
-    const content = await rsbuild.getIndexBundle();
-    expect(content).toContain(`"__dirname",__dirname`);
-    expect(content).toContain(`"__filename",__filename`);
-    expect(content).toContain(`"import.meta.dirname",import.meta.dirname`);
-    expect(content).toContain(`"import.meta.filename",import.meta.filename`);
-  },
-);
+test('should not polyfill dirname and filename in node target when output.module is enabled', async ({
+  build,
+}) => {
+  const rsbuild = await build();
+  const content = await rsbuild.getIndexBundle();
+  expect(content).toContain(`"__dirname",__dirname`);
+  expect(content).toContain(`"__filename",__filename`);
+  expect(content).toContain(`"import.meta.dirname",import.meta.dirname`);
+  expect(content).toContain(`"import.meta.filename",import.meta.filename`);
+});

--- a/e2e/cases/polyfill/dirname-filename-web/index.test.ts
+++ b/e2e/cases/polyfill/dirname-filename-web/index.test.ts
@@ -1,15 +1,15 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should not polyfill dirname and filename in web target when output.module is enabled',
-  async ({ page, buildPreview }) => {
-    await buildPreview();
-    const values = await page.evaluate('window.testValues');
-    expect(values).toEqual({
-      dirname: 'undefined',
-      filename: 'undefined',
-      importMetaDirname: 'undefined',
-      importMetaFilename: 'undefined',
-    });
-  },
-);
+test('should not polyfill dirname and filename in web target when output.module is enabled', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview();
+  const values = await page.evaluate('window.testValues');
+  expect(values).toEqual({
+    dirname: 'undefined',
+    filename: 'undefined',
+    importMetaDirname: 'undefined',
+    importMetaFilename: 'undefined',
+  });
+});

--- a/e2e/cases/print-file-size/diff/index.test.ts
+++ b/e2e/cases/print-file-size/diff/index.test.ts
@@ -1,100 +1,103 @@
 import { join } from 'node:path';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import fse from 'fs-extra';
 import { extractFileSizeLogs } from '../helper';
 
-rspackTest(
-  'should print file size diff as expected',
-  async ({ cwd, build, editFile, copySrcDir }) => {
-    const cacheDir = join(cwd, 'node_modules/.cache');
-    await fse.remove(cacheDir);
-    const srcDir = await copySrcDir();
-    const config = {
-      source: {
-        entry: {
-          index: join(srcDir, 'index.js'),
-        },
+test('should print file size diff as expected', async ({
+  cwd,
+  build,
+  editFile,
+  copySrcDir,
+}) => {
+  const cacheDir = join(cwd, 'node_modules/.cache');
+  await fse.remove(cacheDir);
+  const srcDir = await copySrcDir();
+  const config = {
+    source: {
+      entry: {
+        index: join(srcDir, 'index.js'),
       },
-    };
+    },
+  };
 
-    const rsbuild1 = await build({ config });
-    expect(extractFileSizeLogs(rsbuild1.logs)).toEqual(`
+  const rsbuild1 = await build({ config });
+  expect(extractFileSizeLogs(rsbuild1.logs)).toEqual(`
 File (web)                         Size      Gzip
 dist/static/js/index.[[hash]].js   X.X kB   X.X kB
 dist/index.html                    X.X kB   X.X kB
                           Total:   X.X kB   X.X kB`);
-    rsbuild1.clearLogs();
+  rsbuild1.clearLogs();
 
-    editFile(
-      join(srcDir, 'index.js'),
-      () => `import "./App.css";
+  editFile(
+    join(srcDir, 'index.js'),
+    () => `import "./App.css";
 import React from 'react';
 import ReactDOM from 'react-dom';
 console.log(React);
 console.log(ReactDOM);
 `,
-    );
+  );
 
-    const rsbuild2 = await build({ config });
-    expect(extractFileSizeLogs(rsbuild2.logs)).toEqual(`
+  const rsbuild2 = await build({ config });
+  expect(extractFileSizeLogs(rsbuild2.logs)).toEqual(`
 File (web)                           Size                 Gzip
 dist/static/css/index.[[hash]].css   X.X kB (+X.X kB)   X.X kB (+X.X kB)
 dist/index.html                      X.X kB (+X.X kB)   X.X kB (+X.X kB)
 dist/static/js/index.[[hash]].js     X.X kB (+X.X kB)   X.X kB (+X.X kB)
 dist/static/js/vendor.[[hash]].js    X.X kB (+X.X kB)   X.X kB (+X.X kB)
                             Total:   X.X kB (+X.X kB)   X.X kB (+X.X kB)`);
-    rsbuild2.clearLogs();
+  rsbuild2.clearLogs();
 
-    editFile(join(srcDir, 'index.js'), () => `import "./App.css";`);
+  editFile(join(srcDir, 'index.js'), () => `import "./App.css";`);
 
-    const rsbuild3 = await build({ config });
-    expect(extractFileSizeLogs(rsbuild3.logs)).toEqual(`
+  const rsbuild3 = await build({ config });
+  expect(extractFileSizeLogs(rsbuild3.logs)).toEqual(`
 File (web)                           Size                 Gzip
 dist/static/js/index.[[hash]].js     X.X kB (-X.X kB)   X.X kB (-X.X kB)
 dist/static/css/index.[[hash]].css   X.X kB              X.X kB
 dist/index.html                      X.X kB (-X.X kB)   X.X kB (-X.X kB)
                             Total:   X.X kB (-X.X kB)   X.X kB (-X.X kB)`);
-  },
-);
+});
 
-rspackTest(
-  'should not print gzip total diff when change is below threshold',
-  async ({ cwd, build, copySrcDir }) => {
-    const cacheDir = join(cwd, 'node_modules/.cache');
-    await fse.remove(cacheDir);
-    const srcDir = await copySrcDir();
-    const config = {
-      source: {
-        entry: {
-          index: join(srcDir, 'index.js'),
-        },
+test('should not print gzip total diff when change is below threshold', async ({
+  cwd,
+  build,
+  copySrcDir,
+}) => {
+  const cacheDir = join(cwd, 'node_modules/.cache');
+  await fse.remove(cacheDir);
+  const srcDir = await copySrcDir();
+  const config = {
+    source: {
+      entry: {
+        index: join(srcDir, 'index.js'),
       },
-    };
+    },
+  };
 
-    const rsbuild1 = await build({ config });
+  const rsbuild1 = await build({ config });
 
-    const snapshotDir = join(rsbuild1.instance.context.cachePath, 'rsbuild');
-    const snapshotFile = (await fse.readdir(snapshotDir)).find((filename) =>
-      filename.startsWith('file-sizes'),
-    );
-    expect(snapshotFile).toBeTruthy();
+  const snapshotDir = join(rsbuild1.instance.context.cachePath, 'rsbuild');
+  const snapshotFile = (await fse.readdir(snapshotDir)).find((filename) =>
+    filename.startsWith('file-sizes'),
+  );
+  expect(snapshotFile).toBeTruthy();
 
-    const snapshotPath = join(snapshotDir, snapshotFile!);
-    const snapshots = await fse.readJSON(snapshotPath);
-    const environmentName = Object.keys(snapshots)[0];
+  const snapshotPath = join(snapshotDir, snapshotFile!);
+  const snapshots = await fse.readJSON(snapshotPath);
+  const environmentName = Object.keys(snapshots)[0];
 
-    expect(snapshots[environmentName].totalGzipSize).toBeGreaterThan(5);
-    snapshots[environmentName].totalGzipSize -= 5;
-    await fse.writeJSON(snapshotPath, snapshots, { spaces: 2 });
+  expect(snapshots[environmentName].totalGzipSize).toBeGreaterThan(5);
+  snapshots[environmentName].totalGzipSize -= 5;
+  await fse.writeJSON(snapshotPath, snapshots, { spaces: 2 });
 
-    rsbuild1.clearLogs();
+  rsbuild1.clearLogs();
 
-    const rsbuild2 = await build({ config });
+  const rsbuild2 = await build({ config });
 
-    expect(extractFileSizeLogs(rsbuild2.logs)).toEqual(`
+  expect(extractFileSizeLogs(rsbuild2.logs)).toEqual(`
 File (web)                         Size      Gzip
 dist/static/js/index.[[hash]].js   X.X kB   X.X kB
 dist/index.html                    X.X kB   X.X kB
                           Total:   X.X kB   X.X kB`);
-  },
-);
+});

--- a/e2e/cases/profiling/enable-rsdoctor/index.test.ts
+++ b/e2e/cases/profiling/enable-rsdoctor/index.test.ts
@@ -1,93 +1,90 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import { createRsbuild, type Rspack } from '@rsbuild/core';
 import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
 import { matchPlugin } from '@scripts/test-helper';
 
 const RSDOCTOR_LOG = '@rsdoctor/rspack-plugin enabled';
 
-rspackTest(
-  'should register Rsdoctor plugin when process.env.RSDOCTOR is true',
-  async ({ logHelper }) => {
-    const { expectLog } = logHelper;
-    process.env.RSDOCTOR = 'true';
+test('should register Rsdoctor plugin when process.env.RSDOCTOR is true', async ({
+  logHelper,
+}) => {
+  const { expectLog } = logHelper;
+  process.env.RSDOCTOR = 'true';
 
-    const rsbuild = await createRsbuild({
-      cwd: import.meta.dirname,
-    });
+  const rsbuild = await createRsbuild({
+    cwd: import.meta.dirname,
+  });
 
-    const compiler = await rsbuild.createCompiler();
+  const compiler = await rsbuild.createCompiler();
 
-    await expectLog(RSDOCTOR_LOG);
+  await expectLog(RSDOCTOR_LOG);
 
-    expect(
-      matchPlugin(
-        compiler.options as Rspack.Configuration,
-        'RsdoctorRspackPlugin',
-      ),
-    ).toBeTruthy();
+  expect(
+    matchPlugin(
+      compiler.options as Rspack.Configuration,
+      'RsdoctorRspackPlugin',
+    ),
+  ).toBeTruthy();
 
-    process.env.RSDOCTOR = '';
-  },
-);
+  process.env.RSDOCTOR = '';
+});
 
-rspackTest(
-  'should not register Rsdoctor plugin when process.env.RSDOCTOR is false',
-  async ({ logHelper }) => {
-    const { expectNoLog } = logHelper;
-    process.env.RSDOCTOR = 'false';
+test('should not register Rsdoctor plugin when process.env.RSDOCTOR is false', async ({
+  logHelper,
+}) => {
+  const { expectNoLog } = logHelper;
+  process.env.RSDOCTOR = 'false';
 
-    const rsbuild = await createRsbuild({
-      cwd: import.meta.dirname,
-    });
+  const rsbuild = await createRsbuild({
+    cwd: import.meta.dirname,
+  });
 
-    const compiler = await rsbuild.createCompiler();
+  const compiler = await rsbuild.createCompiler();
 
-    expectNoLog(RSDOCTOR_LOG);
+  expectNoLog(RSDOCTOR_LOG);
 
-    expect(
-      matchPlugin(
-        compiler.options as Rspack.Configuration,
-        'RsdoctorRspackPlugin',
-      ),
-    ).toBeFalsy();
+  expect(
+    matchPlugin(
+      compiler.options as Rspack.Configuration,
+      'RsdoctorRspackPlugin',
+    ),
+  ).toBeFalsy();
 
-    process.env.RSDOCTOR = '';
-  },
-);
+  process.env.RSDOCTOR = '';
+});
 
-rspackTest(
-  'should not register Rsdoctor plugin when process.env.RSDOCTOR is true and the plugin has been registered',
-  async ({ logHelper }) => {
-    const { expectNoLog } = logHelper;
+test('should not register Rsdoctor plugin when process.env.RSDOCTOR is true and the plugin has been registered', async ({
+  logHelper,
+}) => {
+  const { expectNoLog } = logHelper;
 
-    process.env.RSDOCTOR = 'true';
+  process.env.RSDOCTOR = 'true';
 
-    const rsbuild = await createRsbuild({
-      cwd: import.meta.dirname,
-      config: {
-        tools: {
-          rspack: {
-            plugins: [
-              new RsdoctorRspackPlugin({
-                disableClientServer: true,
-              }),
-            ],
-          },
+  const rsbuild = await createRsbuild({
+    cwd: import.meta.dirname,
+    config: {
+      tools: {
+        rspack: {
+          plugins: [
+            new RsdoctorRspackPlugin({
+              disableClientServer: true,
+            }),
+          ],
         },
       },
-    });
+    },
+  });
 
-    const compiler = await rsbuild.createCompiler();
+  const compiler = await rsbuild.createCompiler();
 
-    expect(
-      matchPlugin(
-        compiler.options as Rspack.Configuration,
-        'RsdoctorRspackPlugin',
-      ),
-    ).toBeTruthy();
+  expect(
+    matchPlugin(
+      compiler.options as Rspack.Configuration,
+      'RsdoctorRspackPlugin',
+    ),
+  ).toBeTruthy();
 
-    expectNoLog(RSDOCTOR_LOG);
+  expectNoLog(RSDOCTOR_LOG);
 
-    process.env.RSDOCTOR = '';
-  },
-);
+  process.env.RSDOCTOR = '';
+});

--- a/e2e/cases/profiling/rspack-profile/index.test.ts
+++ b/e2e/cases/profiling/rspack-profile/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
-import { expect, rspackTest, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import fse from 'fs-extra';
 
 test.afterAll(() => {
@@ -20,34 +20,34 @@ const getProfilePath = (logs: string[]) =>
     ?.split(PROFILE_LOG)[1]
     ?.trim();
 
-rspackTest(
-  'should generate rspack profile as expected in dev',
-  async ({ exec, logHelper }) => {
-    exec('node ./dev.js', {
-      env: {
-        RSPACK_PROFILE: 'OVERVIEW',
-      },
-    });
-    const { logs, expectLog } = logHelper;
+test('should generate rspack profile as expected in dev', async ({
+  exec,
+  logHelper,
+}) => {
+  exec('node ./dev.js', {
+    env: {
+      RSPACK_PROFILE: 'OVERVIEW',
+    },
+  });
+  const { logs, expectLog } = logHelper;
 
-    await expectLog(PROFILE_LOG);
-    const profileFile = getProfilePath(logs);
-    expect(fs.existsSync(profileFile!)).toBeTruthy();
-  },
-);
+  await expectLog(PROFILE_LOG);
+  const profileFile = getProfilePath(logs);
+  expect(fs.existsSync(profileFile!)).toBeTruthy();
+});
 
-rspackTest(
-  'should generate rspack profile as expected in build',
-  async ({ execCli, logHelper }) => {
-    execCli('build', {
-      env: {
-        RSPACK_PROFILE: 'OVERVIEW',
-      },
-    });
-    const { logs, expectLog } = logHelper;
+test('should generate rspack profile as expected in build', async ({
+  execCli,
+  logHelper,
+}) => {
+  execCli('build', {
+    env: {
+      RSPACK_PROFILE: 'OVERVIEW',
+    },
+  });
+  const { logs, expectLog } = logHelper;
 
-    await expectLog(PROFILE_LOG);
-    const profileFile = getProfilePath(logs);
-    expect(fs.existsSync(profileFile!)).toBeTruthy();
-  },
-);
+  await expectLog(PROFILE_LOG);
+  const profileFile = getProfilePath(logs);
+  expect(fs.existsSync(profileFile!)).toBeTruthy();
+});

--- a/e2e/cases/resolve/jsconfig-paths/index.test.ts
+++ b/e2e/cases/resolve/jsconfig-paths/index.test.ts
@@ -1,44 +1,44 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'tsconfig paths should work and override the alias config',
-  async ({ page, buildPreview }) => {
-    await buildPreview({
-      config: {
-        resolve: {
-          alias: {
-            '@common': './src/common2',
-          },
-        },
-        source: {
-          tsconfigPath: './jsconfig.json',
+test('tsconfig paths should work and override the alias config', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview({
+    config: {
+      resolve: {
+        alias: {
+          '@common': './src/common2',
         },
       },
-    });
-
-    const foo = page.locator('#foo');
-    await expect(foo).toHaveText('tsconfig paths worked');
-  },
-);
-
-rspackTest(
-  'tsconfig paths should not work when aliasStrategy is "prefer-alias"',
-  async ({ page, buildPreview }) => {
-    await buildPreview({
-      config: {
-        resolve: {
-          alias: {
-            '@/common': './src/common2',
-          },
-          aliasStrategy: 'prefer-alias',
-        },
-        source: {
-          tsconfigPath: './jsconfig.json',
-        },
+      source: {
+        tsconfigPath: './jsconfig.json',
       },
-    });
+    },
+  });
 
-    const foo = page.locator('#foo');
-    await expect(foo).toHaveText('resolve.alias worked');
-  },
-);
+  const foo = page.locator('#foo');
+  await expect(foo).toHaveText('tsconfig paths worked');
+});
+
+test('tsconfig paths should not work when aliasStrategy is "prefer-alias"', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview({
+    config: {
+      resolve: {
+        alias: {
+          '@/common': './src/common2',
+        },
+        aliasStrategy: 'prefer-alias',
+      },
+      source: {
+        tsconfigPath: './jsconfig.json',
+      },
+    },
+  });
+
+  const foo = page.locator('#foo');
+  await expect(foo).toHaveText('resolve.alias worked');
+});

--- a/e2e/cases/resolve/tsconfig-paths-references/index.test.ts
+++ b/e2e/cases/resolve/tsconfig-paths-references/index.test.ts
@@ -1,19 +1,19 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'tsconfig paths should work with references',
-  async ({ page, buildPreview }) => {
-    await buildPreview({
-      config: {
-        resolve: {
-          alias: {
-            '@common': './src/common2',
-          },
+test('tsconfig paths should work with references', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview({
+    config: {
+      resolve: {
+        alias: {
+          '@common': './src/common2',
         },
       },
-    });
+    },
+  });
 
-    const foo = page.locator('#foo');
-    await expect(foo).toHaveText('tsconfig paths worked');
-  },
-);
+  const foo = page.locator('#foo');
+  await expect(foo).toHaveText('tsconfig paths worked');
+});

--- a/e2e/cases/resolve/tsconfig-paths-reload/index.test.ts
+++ b/e2e/cases/resolve/tsconfig-paths-reload/index.test.ts
@@ -1,39 +1,34 @@
 import { join } from 'node:path';
-import {
-  expect,
-  expectFile,
-  getRandomPort,
-  gotoPage,
-  rspackTest,
-} from '@e2e/helper';
+import { expect, expectFile, getRandomPort, gotoPage, test } from '@e2e/helper';
 import fse from 'fs-extra';
 import { tempConfig } from './rsbuild.config';
 
-rspackTest(
-  'should watch tsconfig.json and reload the server when it changes',
-  async ({ page, editFile, execCli }) => {
-    if (process.platform === 'win32') {
-      return;
-    }
+test('should watch tsconfig.json and reload the server when it changes', async ({
+  page,
+  editFile,
+  execCli,
+}) => {
+  if (process.platform === 'win32') {
+    return;
+  }
 
-    const dist = join(import.meta.dirname, 'dist');
+  const dist = join(import.meta.dirname, 'dist');
 
-    await fse.remove(dist);
-    await fse.remove(tempConfig);
-    await fse.copy(join(import.meta.dirname, 'tsconfig.json'), tempConfig);
+  await fse.remove(dist);
+  await fse.remove(tempConfig);
+  await fse.copy(join(import.meta.dirname, 'tsconfig.json'), tempConfig);
 
-    const port = await getRandomPort();
-    execCli('dev', {
-      env: {
-        PORT: String(port),
-      },
-    });
+  const port = await getRandomPort();
+  execCli('dev', {
+    env: {
+      PORT: String(port),
+    },
+  });
 
-    await expectFile(dist);
-    await gotoPage(page, { port });
-    await expect(page.locator('#content')).toHaveText('foo');
+  await expectFile(dist);
+  await gotoPage(page, { port });
+  await expect(page.locator('#content')).toHaveText('foo');
 
-    await editFile(tempConfig, (code) => code.replace('foo', 'bar'));
-    await expect(page.locator('#content')).toHaveText('bar');
-  },
-);
+  await editFile(tempConfig, (code) => code.replace('foo', 'bar'));
+  await expect(page.locator('#content')).toHaveText('bar');
+});

--- a/e2e/cases/security/nonce-basic/index.test.ts
+++ b/e2e/cases/security/nonce-basic/index.test.ts
@@ -1,6 +1,6 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest('should apply nonce to script and style tags', async ({ build }) => {
+test('should apply nonce to script and style tags', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
   const html = getFileContent(files, 'index.html');
@@ -8,7 +8,7 @@ rspackTest('should apply nonce to script and style tags', async ({ build }) => {
   expect(html).toContain(`<style nonce="CSP_NONCE_PLACEHOLDER">body{`);
 });
 
-rspackTest('should apply environment nonce', async ({ build }) => {
+test('should apply environment nonce', async ({ build }) => {
   const rsbuild = await build({
     config: {
       environments: {

--- a/e2e/cases/security/sri-algotithm-multiple/index.test.ts
+++ b/e2e/cases/security/sri-algotithm-multiple/index.test.ts
@@ -1,22 +1,22 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest(
-  'generate integrity using multiple algorithms',
-  async ({ page, buildPreview }) => {
-    const rsbuild = await buildPreview();
+test('generate integrity using multiple algorithms', async ({
+  page,
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview();
 
-    const files = rsbuild.getDistFiles();
-    const html = getFileContent(files, 'index.html');
+  const files = rsbuild.getDistFiles();
+  const html = getFileContent(files, 'index.html');
 
-    expect(html).toMatch(
-      /<script defer src="\/static\/js\/index\.\w{8}\.js" integrity="sha512-[A-Za-z0-9+/=]+ sha256-[A-Za-z0-9+/=]+ sha384-[A-Za-z0-9+/=]+"/,
-    );
+  expect(html).toMatch(
+    /<script defer src="\/static\/js\/index\.\w{8}\.js" integrity="sha512-[A-Za-z0-9+/=]+ sha256-[A-Za-z0-9+/=]+ sha384-[A-Za-z0-9+/=]+"/,
+  );
 
-    expect(html).toMatch(
-      /link href="\/static\/css\/index\.\w{8}\.css" rel="stylesheet" integrity="sha512-[A-Za-z0-9+/=]+ sha256-[A-Za-z0-9+/=]+ sha384-[A-Za-z0-9+/=]+"/,
-    );
+  expect(html).toMatch(
+    /link href="\/static\/css\/index\.\w{8}\.css" rel="stylesheet" integrity="sha512-[A-Za-z0-9+/=]+ sha256-[A-Za-z0-9+/=]+ sha384-[A-Za-z0-9+/=]+"/,
+  );
 
-    const testEl = page.locator('#root');
-    await expect(testEl).toHaveText('Hello Rsbuild!');
-  },
-);
+  const testEl = page.locator('#root');
+  await expect(testEl).toHaveText('Hello Rsbuild!');
+});

--- a/e2e/cases/security/sri-algotithm/index.test.ts
+++ b/e2e/cases/security/sri-algotithm/index.test.ts
@@ -1,22 +1,22 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest(
-  'generate integrity using sha512 algorithm',
-  async ({ page, buildPreview }) => {
-    const rsbuild = await buildPreview();
+test('generate integrity using sha512 algorithm', async ({
+  page,
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview();
 
-    const files = rsbuild.getDistFiles();
-    const html = getFileContent(files, 'index.html');
+  const files = rsbuild.getDistFiles();
+  const html = getFileContent(files, 'index.html');
 
-    expect(html).toMatch(
-      /<script defer src="\/static\/js\/index\.\w{8}\.js" integrity="sha512-[A-Za-z0-9+/=]+"/,
-    );
+  expect(html).toMatch(
+    /<script defer src="\/static\/js\/index\.\w{8}\.js" integrity="sha512-[A-Za-z0-9+/=]+"/,
+  );
 
-    expect(html).toMatch(
-      /link href="\/static\/css\/index\.\w{8}\.css" rel="stylesheet" integrity="sha512-[A-Za-z0-9+/=]+"/,
-    );
+  expect(html).toMatch(
+    /link href="\/static\/css\/index\.\w{8}\.css" rel="stylesheet" integrity="sha512-[A-Za-z0-9+/=]+"/,
+  );
 
-    const testEl = page.locator('#root');
-    await expect(testEl).toHaveText('Hello Rsbuild!');
-  },
-);
+  const testEl = page.locator('#root');
+  await expect(testEl).toHaveText('Hello Rsbuild!');
+});

--- a/e2e/cases/security/sri-async-chunks/index.test.ts
+++ b/e2e/cases/security/sri-async-chunks/index.test.ts
@@ -1,17 +1,17 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'generate integrity for async script tags in build',
-  async ({ page, buildPreview }) => {
-    const rsbuild = await buildPreview();
+test('generate integrity for async script tags in build', async ({
+  page,
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview();
 
-    const content = await rsbuild.getIndexBundle();
+  const content = await rsbuild.getIndexBundle();
 
-    expect(
-      content.includes('sriHashes={') && content.includes('"sha384-'),
-    ).toBe(true);
+  expect(content.includes('sriHashes={') && content.includes('"sha384-')).toBe(
+    true,
+  );
 
-    const testEl = page.locator('#root');
-    await expect(testEl).toHaveText('foo');
-  },
-);
+  const testEl = page.locator('#root');
+  await expect(testEl).toHaveText('foo');
+});

--- a/e2e/cases/security/sri-basic/index.test.ts
+++ b/e2e/cases/security/sri-basic/index.test.ts
@@ -1,25 +1,25 @@
-import { expect, getFileContent, rspackTest, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest(
-  'should generate integrity attributes for script and style tags in build',
-  async ({ page, buildPreview }) => {
-    const rsbuild = await buildPreview();
+test('should generate integrity attributes for script and style tags in build', async ({
+  page,
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview();
 
-    const files = rsbuild.getDistFiles();
-    const html = getFileContent(files, 'index.html');
+  const files = rsbuild.getDistFiles();
+  const html = getFileContent(files, 'index.html');
 
-    expect(html).toMatch(
-      /<script defer src="\/static\/js\/index\.\w{8}\.js" integrity="sha384-[A-Za-z0-9+/=]+"/,
-    );
+  expect(html).toMatch(
+    /<script defer src="\/static\/js\/index\.\w{8}\.js" integrity="sha384-[A-Za-z0-9+/=]+"/,
+  );
 
-    expect(html).toMatch(
-      /link href="\/static\/css\/index\.\w{8}\.css" rel="stylesheet" integrity="sha384-[A-Za-z0-9+/=]+"/,
-    );
+  expect(html).toMatch(
+    /link href="\/static\/css\/index\.\w{8}\.css" rel="stylesheet" integrity="sha384-[A-Za-z0-9+/=]+"/,
+  );
 
-    const testEl = page.locator('#root');
-    await expect(testEl).toHaveText('Hello Rsbuild!');
-  },
-);
+  const testEl = page.locator('#root');
+  await expect(testEl).toHaveText('Hello Rsbuild!');
+});
 
 test('should not generate integrity attributes for script and style tags in dev', async ({
   page,

--- a/e2e/cases/security/sri-enable-dev/index.test.ts
+++ b/e2e/cases/security/sri-enable-dev/index.test.ts
@@ -1,21 +1,21 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'generate integrity for script and style tags in dev build',
-  async ({ page, dev }) => {
-    const rsbuild = await dev();
+test('generate integrity for script and style tags in dev build', async ({
+  page,
+  dev,
+}) => {
+  const rsbuild = await dev();
 
-    const testEl = page.locator('#root');
-    await expect(testEl).toHaveText('Hello Rsbuild!');
+  const testEl = page.locator('#root');
+  await expect(testEl).toHaveText('Hello Rsbuild!');
 
-    expect(
-      await page.evaluate(
-        'document.querySelector("script")?.getAttribute("integrity")',
-      ),
-    ).toMatch(/sha384-[A-Za-z0-9+/=]+/);
+  expect(
+    await page.evaluate(
+      'document.querySelector("script")?.getAttribute("integrity")',
+    ),
+  ).toMatch(/sha384-[A-Za-z0-9+/=]+/);
 
-    await rsbuild.expectLog(
-      'SubResourceIntegrityPlugin may interfere with hot reloading',
-    );
-  },
-);
+  await rsbuild.expectLog(
+    'SubResourceIntegrityPlugin may interfere with hot reloading',
+  );
+});

--- a/e2e/cases/security/sri-preload/index.test.ts
+++ b/e2e/cases/security/sri-preload/index.test.ts
@@ -1,18 +1,18 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest(
-  'generate integrity for preload tags in build',
-  async ({ page, buildPreview }) => {
-    const rsbuild = await buildPreview();
+test('generate integrity for preload tags in build', async ({
+  page,
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview();
 
-    const files = rsbuild.getDistFiles();
-    const html = getFileContent(files, 'index.html');
+  const files = rsbuild.getDistFiles();
+  const html = getFileContent(files, 'index.html');
 
-    expect(html).toMatch(
-      /<link href="\/static\/js\/async\/foo\.\w{8}\.js" rel="preload" as="script" integrity="sha384-[A-Za-z0-9+/=]+"/,
-    );
+  expect(html).toMatch(
+    /<link href="\/static\/js\/async\/foo\.\w{8}\.js" rel="preload" as="script" integrity="sha384-[A-Za-z0-9+/=]+"/,
+  );
 
-    const testEl = page.locator('#root');
-    await expect(testEl).toHaveText('Hello Rsbuild!');
-  },
-);
+  const testEl = page.locator('#root');
+  await expect(testEl).toHaveText('Hello Rsbuild!');
+});

--- a/e2e/cases/server/base-url-env-var/index.test.ts
+++ b/e2e/cases/server/base-url-env-var/index.test.ts
@@ -1,45 +1,45 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should define BASE_URL env var correctly in dev',
-  async ({ page, dev }) => {
-    await dev({
-      config: {
-        html: {
-          template: './src/index.html',
-        },
-        server: {
-          base: '/base',
-        },
+test('should define BASE_URL env var correctly in dev', async ({
+  page,
+  dev,
+}) => {
+  await dev({
+    config: {
+      html: {
+        template: './src/index.html',
       },
-    });
-
-    // should define `process.env.BASE_URL` correctly
-    await expect(page.locator('#public-base-path-process')).toHaveText('/base');
-
-    // should define `import.meta.env.BASE_URL` correctly
-    await expect(page.locator('#public-base-path-meta')).toHaveText('/base');
-  },
-);
-
-rspackTest(
-  'should define BASE_URL env var correctly in build',
-  async ({ page, buildPreview }) => {
-    await buildPreview({
-      config: {
-        html: {
-          template: './src/index.html',
-        },
-        server: {
-          base: '/base',
-        },
+      server: {
+        base: '/base',
       },
-    });
+    },
+  });
 
-    // should define `process.env.BASE_URL` correctly
-    await expect(page.locator('#public-base-path-process')).toHaveText('/base');
+  // should define `process.env.BASE_URL` correctly
+  await expect(page.locator('#public-base-path-process')).toHaveText('/base');
 
-    // should define `import.meta.env.BASE_URL` correctly
-    await expect(page.locator('#public-base-path-meta')).toHaveText('/base');
-  },
-);
+  // should define `import.meta.env.BASE_URL` correctly
+  await expect(page.locator('#public-base-path-meta')).toHaveText('/base');
+});
+
+test('should define BASE_URL env var correctly in build', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview({
+    config: {
+      html: {
+        template: './src/index.html',
+      },
+      server: {
+        base: '/base',
+      },
+    },
+  });
+
+  // should define `process.env.BASE_URL` correctly
+  await expect(page.locator('#public-base-path-process')).toHaveText('/base');
+
+  // should define `import.meta.env.BASE_URL` correctly
+  await expect(page.locator('#public-base-path-meta')).toHaveText('/base');
+});

--- a/e2e/cases/server/cors/index.test.ts
+++ b/e2e/cases/server/cors/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, rspackTest, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import { defaultAllowedOrigins } from '@rsbuild/core';
 
 test('should expose `defaultAllowedOrigins`', async () => {
@@ -37,7 +37,7 @@ test('should include CORS headers for preview server if `cors` is `true`', async
   expect(response.headers()['access-control-allow-origin']).toEqual('*');
 });
 
-rspackTest('should include CORS headers for MF', async ({ request, dev }) => {
+test('should include CORS headers for MF', async ({ request, dev }) => {
   const rsbuild = await dev({
     config: {
       moduleFederation: {

--- a/e2e/cases/server/custom-server/index.test.ts
+++ b/e2e/cases/server/custom-server/index.test.ts
@@ -1,10 +1,10 @@
-import { expect, gotoPage, rspackTest } from '@e2e/helper';
+import { expect, gotoPage, test } from '@e2e/helper';
 // @ts-expect-error
 import { startDevServerPure } from './scripts/pureServer.js';
 // @ts-expect-error
 import { startDevServer } from './scripts/server.js';
 
-rspackTest('should support a custom dev server', async ({ page }) => {
+test('should support a custom dev server', async ({ page }) => {
   const { config, close } = await startDevServer(import.meta.dirname);
 
   await gotoPage(page, config);
@@ -21,26 +21,25 @@ rspackTest('should support a custom dev server', async ({ page }) => {
   await close();
 });
 
-rspackTest(
-  'should support a custom dev server without compilation',
-  async ({ page }) => {
-    const { config, close } = await startDevServerPure(import.meta.dirname);
-    const indexRes = await gotoPage(page, config);
+test('should support a custom dev server without compilation', async ({
+  page,
+}) => {
+  const { config, close } = await startDevServerPure(import.meta.dirname);
+  const indexRes = await gotoPage(page, config);
 
-    expect(indexRes?.status()).toBe(404);
+  expect(indexRes?.status()).toBe(404);
 
-    const url1 = new URL(`http://localhost:${config.port}/bbb`);
+  const url1 = new URL(`http://localhost:${config.port}/bbb`);
 
-    const res = await page.goto(url1.href);
+  const res = await page.goto(url1.href);
 
-    expect(await res?.text()).toBe('Hello polka!');
+  expect(await res?.text()).toBe('Hello polka!');
 
-    const url2 = new URL(`http://localhost:${config.port}/test`);
+  const url2 = new URL(`http://localhost:${config.port}/test`);
 
-    const res2 = await page.goto(url2.href);
+  const res2 = await page.goto(url2.href);
 
-    expect(await res2?.text()).toBe('Hello polka!');
+  expect(await res2?.text()).toBe('Hello polka!');
 
-    await close();
-  },
-);
+  await close();
+});

--- a/e2e/cases/server/history-api-fallback-rewrites/index.test.ts
+++ b/e2e/cases/server/history-api-fallback-rewrites/index.test.ts
@@ -1,18 +1,18 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should apply `historyApiFallback.rewrites` correctly',
-  async ({ page, devOnly }) => {
-    const rsbuild = await devOnly();
+test('should apply `historyApiFallback.rewrites` correctly', async ({
+  page,
+  devOnly,
+}) => {
+  const rsbuild = await devOnly();
 
-    await page.goto(`http://localhost:${rsbuild.port}`);
-    expect(await page.locator('#root').innerHTML()).toEqual('index');
+  await page.goto(`http://localhost:${rsbuild.port}`);
+  expect(await page.locator('#root').innerHTML()).toEqual('index');
 
-    // `/baz` should be rewritten to `/foo`
-    await page.goto(`http://localhost:${rsbuild.port}/baz`);
-    expect(await page.locator('#root').innerHTML()).toEqual('foo');
+  // `/baz` should be rewritten to `/foo`
+  await page.goto(`http://localhost:${rsbuild.port}/baz`);
+  expect(await page.locator('#root').innerHTML()).toEqual('foo');
 
-    await page.goto(`http://localhost:${rsbuild.port}/bar`);
-    expect(await page.locator('#root').innerHTML()).toEqual('bar');
-  },
-);
+  await page.goto(`http://localhost:${rsbuild.port}/bar`);
+  expect(await page.locator('#root').innerHTML()).toEqual('bar');
+});

--- a/e2e/cases/server/history-api-fallback/index.test.ts
+++ b/e2e/cases/server/history-api-fallback/index.test.ts
@@ -1,35 +1,35 @@
-import { expect, rspackTest, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 
-rspackTest(
-  'should provide history api fallback for dev server correctly',
-  async ({ page, devOnly }) => {
-    const rsbuild = await devOnly({
-      config: {
-        plugins: [pluginReact()],
-        source: {
-          entry: {
-            main: './src/index.jsx',
-          },
-        },
-        server: {
-          historyApiFallback: {
-            index: '/main.html',
-          },
+test('should provide history api fallback for dev server correctly', async ({
+  page,
+  devOnly,
+}) => {
+  const rsbuild = await devOnly({
+    config: {
+      plugins: [pluginReact()],
+      source: {
+        entry: {
+          main: './src/index.jsx',
         },
       },
-    });
+      server: {
+        historyApiFallback: {
+          index: '/main.html',
+        },
+      },
+    },
+  });
 
-    await page.goto(`http://localhost:${rsbuild.port}`);
-    expect(await page.innerHTML('body')).toContain('<div>home<div>');
+  await page.goto(`http://localhost:${rsbuild.port}`);
+  expect(await page.innerHTML('body')).toContain('<div>home<div>');
 
-    await page.goto(`http://localhost:${rsbuild.port}/a`);
-    expect(await page.innerHTML('body')).toContain('<div>A</div>');
+  await page.goto(`http://localhost:${rsbuild.port}/a`);
+  expect(await page.innerHTML('body')).toContain('<div>A</div>');
 
-    await page.goto(`http://localhost:${rsbuild.port}/b`);
-    expect(await page.innerHTML('body')).toContain('<div>B</div>');
-  },
-);
+  await page.goto(`http://localhost:${rsbuild.port}/b`);
+  expect(await page.innerHTML('body')).toContain('<div>B</div>');
+});
 
 test('should provide history api fallback for preview server correctly', async ({
   page,

--- a/e2e/cases/server/reload-html/index.test.ts
+++ b/e2e/cases/server/reload-html/index.test.ts
@@ -1,24 +1,26 @@
 import { join } from 'node:path';
-import { expect, rspackTest, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should reload page when HTML template changed',
-  async ({ page, dev, editFile, copySrcDir }) => {
-    // Failed to run this case on Windows
-    if (process.platform === 'win32') {
-      test.skip();
-    }
+test('should reload page when HTML template changed', async ({
+  page,
+  dev,
+  editFile,
+  copySrcDir,
+}) => {
+  // Failed to run this case on Windows
+  if (process.platform === 'win32') {
+    test.skip();
+  }
 
-    const tempSrc = await copySrcDir();
+  const tempSrc = await copySrcDir();
 
-    await dev();
+  await dev();
 
-    await expect(page).toHaveTitle('Foo');
+  await expect(page).toHaveTitle('Foo');
 
-    await editFile(join(tempSrc, 'index.html'), (code) =>
-      code.replace('Foo', 'Bar'),
-    );
-    // expect page title to be 'Bar' after HTML template changed
-    await expect(page).toHaveTitle('Bar');
-  },
-);
+  await editFile(join(tempSrc, 'index.html'), (code) =>
+    code.replace('Foo', 'Bar'),
+  );
+  // expect page title to be 'Bar' after HTML template changed
+  await expect(page).toHaveTitle('Bar');
+});

--- a/e2e/cases/server/ssr-type-module/index.test.ts
+++ b/e2e/cases/server/ssr-type-module/index.test.ts
@@ -1,14 +1,11 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'support SSR load esm with type module',
-  async ({ page, devOnly }) => {
-    const rsbuild = await devOnly();
+test('support SSR load esm with type module', async ({ page, devOnly }) => {
+  const rsbuild = await devOnly();
 
-    const url1 = new URL(`http://localhost:${rsbuild.port}`);
+  const url1 = new URL(`http://localhost:${rsbuild.port}`);
 
-    const res = await page.goto(url1.href);
+  const res = await page.goto(url1.href);
 
-    expect(await res?.text()).toMatch(/Rsbuild with React/);
-  },
-);
+  expect(await res?.text()).toMatch(/Rsbuild with React/);
+});

--- a/e2e/cases/server/ssr/index.test.ts
+++ b/e2e/cases/server/ssr/index.test.ts
@@ -1,6 +1,6 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest('support SSR', async ({ page, devOnly }) => {
+test('support SSR', async ({ page, devOnly }) => {
   const rsbuild = await devOnly();
 
   const url = new URL(`http://localhost:${rsbuild.port}`);
@@ -15,7 +15,7 @@ rspackTest('support SSR', async ({ page, devOnly }) => {
   expect(rsbuild.logs.filter((log) => log.includes('load SSR')).length).toBe(1);
 });
 
-rspackTest('support SSR with external', async ({ page, devOnly }) => {
+test('support SSR with external', async ({ page, devOnly }) => {
   const rsbuild = await devOnly({
     config: {
       output: {
@@ -39,7 +39,7 @@ rspackTest('support SSR with external', async ({ page, devOnly }) => {
   expect(rsbuild.logs.filter((log) => log.includes('load SSR')).length).toBe(1);
 });
 
-rspackTest('support SSR with esm target', async ({ page, devOnly }) => {
+test('support SSR with esm target', async ({ page, devOnly }) => {
   process.env.TEST_ESM_LIBRARY = '1';
 
   const rsbuild = await devOnly();
@@ -53,33 +53,30 @@ rspackTest('support SSR with esm target', async ({ page, devOnly }) => {
   delete process.env.TEST_ESM_LIBRARY;
 });
 
-rspackTest(
-  'support SSR with esm target & external',
-  async ({ page, devOnly }) => {
-    process.env.TEST_ESM_LIBRARY = '1';
+test('support SSR with esm target & external', async ({ page, devOnly }) => {
+  process.env.TEST_ESM_LIBRARY = '1';
 
-    const rsbuild = await devOnly({
-      config: {
-        output: {
-          externals: {
-            react: 'react',
-            'react-dom': 'react-dom',
-          },
+  const rsbuild = await devOnly({
+    config: {
+      output: {
+        externals: {
+          react: 'react',
+          'react-dom': 'react-dom',
         },
       },
-    });
+    },
+  });
 
-    const url1 = new URL(`http://localhost:${rsbuild.port}`);
+  const url1 = new URL(`http://localhost:${rsbuild.port}`);
 
-    const res = await page.goto(url1.href);
+  const res = await page.goto(url1.href);
 
-    expect(await res?.text()).toMatch(/Rsbuild with React/);
+  expect(await res?.text()).toMatch(/Rsbuild with React/);
 
-    delete process.env.TEST_ESM_LIBRARY;
-  },
-);
+  delete process.env.TEST_ESM_LIBRARY;
+});
 
-rspackTest('support SSR with split chunk', async ({ page, devOnly }) => {
+test('support SSR with split chunk', async ({ page, devOnly }) => {
   process.env.TEST_SPLIT_CHUNK = '1';
 
   const rsbuild = await devOnly();

--- a/e2e/cases/server/viewing-served-files/index.test.ts
+++ b/e2e/cases/server/viewing-served-files/index.test.ts
@@ -1,125 +1,125 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should show assets on /rsbuild-dev-server path',
-  async ({ page, dev }) => {
-    const rsbuild = await dev();
+test('should show assets on /rsbuild-dev-server path', async ({
+  page,
+  dev,
+}) => {
+  const rsbuild = await dev();
 
-    await page.goto(`http://localhost:${rsbuild.port}/rsbuild-dev-server`);
+  await page.goto(`http://localhost:${rsbuild.port}/rsbuild-dev-server`);
 
-    await page.waitForSelector('h1', { state: 'attached' });
-    await page.waitForSelector('ul', { state: 'attached' });
+  await page.waitForSelector('h1', { state: 'attached' });
+  await page.waitForSelector('ul', { state: 'attached' });
 
-    const titles = await page.$$eval('h1', (nodes) =>
-      nodes.map((n) => n.textContent),
-    );
-    expect(titles.includes('Assets Report')).toBe(true);
+  const titles = await page.$$eval('h1', (nodes) =>
+    nodes.map((n) => n.textContent),
+  );
+  expect(titles.includes('Assets Report')).toBe(true);
 
-    // check all href are valid
-    const hrefList = await page.$$eval('ul li a', (nodes) =>
-      nodes.map((node) => node?.textContent),
-    );
-    for (const href of hrefList) {
-      const status = await page.evaluate(async (url) => {
-        const response = await fetch(url as string);
-        return response.status;
-      }, href);
+  // check all href are valid
+  const hrefList = await page.$$eval('ul li a', (nodes) =>
+    nodes.map((node) => node?.textContent),
+  );
+  for (const href of hrefList) {
+    const status = await page.evaluate(async (url) => {
+      const response = await fetch(url as string);
+      return response.status;
+    }, href);
 
-      expect(status).toBeGreaterThanOrEqual(200);
-    }
-  },
-);
+    expect(status).toBeGreaterThanOrEqual(200);
+  }
+});
 
-rspackTest(
-  'should show assets on /rsbuild-dev-server path with server.base and assetPrefix',
-  async ({ page, dev }) => {
-    const rsbuild = await dev({
-      config: {
-        dev: {
-          assetPrefix: '/testing/assets/',
-        },
-        server: {
-          base: '/testing',
-        },
+test('should show assets on /rsbuild-dev-server path with server.base and assetPrefix', async ({
+  page,
+  dev,
+}) => {
+  const rsbuild = await dev({
+    config: {
+      dev: {
+        assetPrefix: '/testing/assets/',
       },
-    });
+      server: {
+        base: '/testing',
+      },
+    },
+  });
 
-    await page.goto(
-      `http://localhost:${rsbuild.port}/testing/rsbuild-dev-server`,
-    );
-    await page.waitForSelector('h1', { state: 'attached' });
-    await page.waitForSelector('ul', { state: 'attached' });
-    const titles = await page.$$eval('h1', (nodes) =>
-      nodes.map((n) => n.textContent),
-    );
-    expect(titles.includes('Assets Report')).toBe(true);
+  await page.goto(
+    `http://localhost:${rsbuild.port}/testing/rsbuild-dev-server`,
+  );
+  await page.waitForSelector('h1', { state: 'attached' });
+  await page.waitForSelector('ul', { state: 'attached' });
+  const titles = await page.$$eval('h1', (nodes) =>
+    nodes.map((n) => n.textContent),
+  );
+  expect(titles.includes('Assets Report')).toBe(true);
 
-    // check all href are valid
-    const hrefList = await page.$$eval('ul li a', (nodes) =>
-      nodes.map((node) => node?.textContent),
-    );
-    for (const href of hrefList) {
-      const status = await page.evaluate(async (url) => {
-        const response = await fetch(url as string);
-        return response.status;
-      }, href);
+  // check all href are valid
+  const hrefList = await page.$$eval('ul li a', (nodes) =>
+    nodes.map((node) => node?.textContent),
+  );
+  for (const href of hrefList) {
+    const status = await page.evaluate(async (url) => {
+      const response = await fetch(url as string);
+      return response.status;
+    }, href);
 
-      expect(status).toBeGreaterThanOrEqual(200);
-    }
-  },
-);
+    expect(status).toBeGreaterThanOrEqual(200);
+  }
+});
 
-rspackTest(
-  'should show assets on /rsbuild-dev-server path with environments',
-  async ({ page, dev }) => {
-    const entry1 = './src/index.tsx';
-    const entry2 = './src2/index.tsx';
+test('should show assets on /rsbuild-dev-server path with environments', async ({
+  page,
+  dev,
+}) => {
+  const entry1 = './src/index.tsx';
+  const entry2 = './src2/index.tsx';
 
-    const rsbuild = await dev({
-      config: {
-        environments: {
-          test1: {
-            source: {
-              entry: {
-                index: entry1,
-              },
-            },
-          },
-          test2: {
-            source: {
-              entry: {
-                index: entry2,
-              },
+  const rsbuild = await dev({
+    config: {
+      environments: {
+        test1: {
+          source: {
+            entry: {
+              index: entry1,
             },
           },
         },
+        test2: {
+          source: {
+            entry: {
+              index: entry2,
+            },
+          },
+        },
       },
-    });
+    },
+  });
 
-    await page.goto(`http://localhost:${rsbuild.port}/rsbuild-dev-server`);
-    await page.waitForSelector('h1', { state: 'attached' });
-    await page.waitForSelector('ul', { state: 'attached' });
-    const titles = await page.$$eval('h1', (nodes) =>
-      nodes.map((n) => n.textContent),
-    );
-    const subTitles = await page.$$eval('h2', (nodes) =>
-      nodes.map((n) => n.textContent),
-    );
-    expect(titles.includes('Assets Report')).toBe(true);
-    expect(subTitles.includes('Environment: test1')).toBe(true);
-    expect(subTitles.includes('Environment: test2')).toBe(true);
+  await page.goto(`http://localhost:${rsbuild.port}/rsbuild-dev-server`);
+  await page.waitForSelector('h1', { state: 'attached' });
+  await page.waitForSelector('ul', { state: 'attached' });
+  const titles = await page.$$eval('h1', (nodes) =>
+    nodes.map((n) => n.textContent),
+  );
+  const subTitles = await page.$$eval('h2', (nodes) =>
+    nodes.map((n) => n.textContent),
+  );
+  expect(titles.includes('Assets Report')).toBe(true);
+  expect(subTitles.includes('Environment: test1')).toBe(true);
+  expect(subTitles.includes('Environment: test2')).toBe(true);
 
-    // check all href are valid
-    const hrefList = await page.$$eval('ul li a', (nodes) =>
-      nodes.map((node) => node?.textContent),
-    );
-    for (const href of hrefList) {
-      const status = await page.evaluate(async (url) => {
-        const response = await fetch(url as string);
-        return response.status;
-      }, href);
+  // check all href are valid
+  const hrefList = await page.$$eval('ul li a', (nodes) =>
+    nodes.map((node) => node?.textContent),
+  );
+  for (const href of hrefList) {
+    const status = await page.evaluate(async (url) => {
+      const response = await fetch(url as string);
+      return response.status;
+    }, href);
 
-      expect(status).toBeGreaterThanOrEqual(200);
-    }
-  },
-);
+    expect(status).toBeGreaterThanOrEqual(200);
+  }
+});

--- a/e2e/cases/server/watch-files/index.test.ts
+++ b/e2e/cases/server/watch-files/index.test.ts
@@ -1,58 +1,52 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { rspackTest } from '@e2e/helper';
+import { test } from '@e2e/helper';
 
-rspackTest(
-  'should work with string and path to file',
-  async ({ dev, page }) => {
-    const file = path.join(import.meta.dirname, '/assets/example.txt');
-    await dev({
-      config: {
-        dev: {
-          watchFiles: {
-            paths: file,
-          },
+test('should work with string and path to file', async ({ dev, page }) => {
+  const file = path.join(import.meta.dirname, '/assets/example.txt');
+  await dev({
+    config: {
+      dev: {
+        watchFiles: {
+          paths: file,
         },
       },
-    });
+    },
+  });
 
-    await fs.promises.writeFile(file, 'test');
-    // check the page is reloaded
-    await new Promise((resolve) => {
-      page.waitForURL(page.url()).then(resolve);
-    });
+  await fs.promises.writeFile(file, 'test');
+  // check the page is reloaded
+  await new Promise((resolve) => {
+    page.waitForURL(page.url()).then(resolve);
+  });
 
-    // reset file
-    fs.truncateSync(file);
-  },
-);
+  // reset file
+  fs.truncateSync(file);
+});
 
-rspackTest(
-  'should work with string and path to directory',
-  async ({ dev, page }) => {
-    const file = path.join(import.meta.dirname, '/assets/example.txt');
-    await dev({
-      config: {
-        dev: {
-          watchFiles: {
-            paths: path.join(import.meta.dirname, '/assets'),
-          },
+test('should work with string and path to directory', async ({ dev, page }) => {
+  const file = path.join(import.meta.dirname, '/assets/example.txt');
+  await dev({
+    config: {
+      dev: {
+        watchFiles: {
+          paths: path.join(import.meta.dirname, '/assets'),
         },
       },
-    });
+    },
+  });
 
-    await fs.promises.writeFile(file, 'test');
+  await fs.promises.writeFile(file, 'test');
 
-    await new Promise((resolve) => {
-      page.waitForURL(page.url()).then(resolve);
-    });
+  await new Promise((resolve) => {
+    page.waitForURL(page.url()).then(resolve);
+  });
 
-    // reset file
-    fs.truncateSync(file);
-  },
-);
+  // reset file
+  fs.truncateSync(file);
+});
 
-rspackTest('should work with string array directory', async ({ dev, page }) => {
+test('should work with string array directory', async ({ dev, page }) => {
   const file = path.join(import.meta.dirname, '/assets/example.txt');
   const other = path.join(import.meta.dirname, '/other/other.txt');
   await dev({
@@ -85,7 +79,7 @@ rspackTest('should work with string array directory', async ({ dev, page }) => {
   fs.truncateSync(other);
 });
 
-rspackTest('should work with string and glob', async ({ dev, page }) => {
+test('should work with string and glob', async ({ dev, page }) => {
   const file = path.join(import.meta.dirname, '/assets/example.txt');
   const watchDir = path.join(import.meta.dirname, '/assets');
   await dev({
@@ -108,7 +102,7 @@ rspackTest('should work with string and glob', async ({ dev, page }) => {
   fs.truncateSync(file);
 });
 
-rspackTest('should work with options', async ({ dev, page }) => {
+test('should work with options', async ({ dev, page }) => {
   const file = path.join(import.meta.dirname, '/assets/example.txt');
   await dev({
     config: {

--- a/e2e/cases/source-map/basic/index.test.ts
+++ b/e2e/cases/source-map/basic/index.test.ts
@@ -5,7 +5,7 @@ import {
   expect,
   getFileContent,
   mapSourceMapPositions,
-  rspackTest,
+  test,
 } from '@e2e/helper';
 import type { Rspack } from '@rsbuild/core';
 
@@ -78,81 +78,77 @@ const productionDevtools: Rspack.Configuration['devtool'][] = [
 ];
 
 for (const devtool of productionDevtools) {
-  rspackTest(
-    `should generate correct "${devtool}" source map in build`,
-    async ({ build }) => {
-      await testSourceMapType(devtool, build);
-    },
-  );
+  test(`should generate correct "${devtool}" source map in build`, async ({
+    build,
+  }) => {
+    await testSourceMapType(devtool, build);
+  });
 }
 
-rspackTest(
-  'should not generate source map by default in build',
-  async ({ build }) => {
-    const rsbuild = await build();
+test('should not generate source map by default in build', async ({
+  build,
+}) => {
+  const rsbuild = await build();
 
-    const files = rsbuild.getDistFiles({ sourceMaps: true });
+  const files = rsbuild.getDistFiles({ sourceMaps: true });
 
-    const jsMapPaths = Object.keys(files).filter((files) =>
-      files.endsWith('.js.map'),
-    );
-    const cssMapFiles = Object.keys(files).filter((files) =>
-      files.endsWith('.css.map'),
-    );
-    expect(jsMapPaths.length).toEqual(0);
-    expect(cssMapFiles.length).toEqual(0);
-  },
-);
+  const jsMapPaths = Object.keys(files).filter((files) =>
+    files.endsWith('.js.map'),
+  );
+  const cssMapFiles = Object.keys(files).filter((files) =>
+    files.endsWith('.css.map'),
+  );
+  expect(jsMapPaths.length).toEqual(0);
+  expect(cssMapFiles.length).toEqual(0);
+});
 
-rspackTest(
-  'should generate source map if `output.sourceMap` is true',
-  async ({ build }) => {
-    const rsbuild = await build({
-      config: {
-        output: {
-          sourceMap: true,
-        },
+test('should generate source map if `output.sourceMap` is true', async ({
+  build,
+}) => {
+  const rsbuild = await build({
+    config: {
+      output: {
+        sourceMap: true,
       },
-    });
+    },
+  });
 
-    const files = rsbuild.getDistFiles({ sourceMaps: true });
+  const files = rsbuild.getDistFiles({ sourceMaps: true });
 
-    const jsMapPaths = Object.keys(files).filter((files) =>
-      files.endsWith('.js.map'),
-    );
-    const cssMapFiles = Object.keys(files).filter((files) =>
-      files.endsWith('.css.map'),
-    );
-    expect(jsMapPaths.length).toBeGreaterThan(0);
-    expect(cssMapFiles.length).toBeGreaterThan(0);
-  },
-);
+  const jsMapPaths = Object.keys(files).filter((files) =>
+    files.endsWith('.js.map'),
+  );
+  const cssMapFiles = Object.keys(files).filter((files) =>
+    files.endsWith('.css.map'),
+  );
+  expect(jsMapPaths.length).toBeGreaterThan(0);
+  expect(cssMapFiles.length).toBeGreaterThan(0);
+});
 
-rspackTest(
-  'should not generate source map if `output.sourceMap` is false',
-  async ({ build }) => {
-    const rsbuild = await build({
-      config: {
-        output: {
-          sourceMap: false,
-        },
+test('should not generate source map if `output.sourceMap` is false', async ({
+  build,
+}) => {
+  const rsbuild = await build({
+    config: {
+      output: {
+        sourceMap: false,
       },
-    });
+    },
+  });
 
-    const files = rsbuild.getDistFiles({ sourceMaps: true });
+  const files = rsbuild.getDistFiles({ sourceMaps: true });
 
-    const jsMapPaths = Object.keys(files).filter((files) =>
-      files.endsWith('.js.map'),
-    );
-    const cssMapFiles = Object.keys(files).filter((files) =>
-      files.endsWith('.css.map'),
-    );
-    expect(jsMapPaths.length).toEqual(0);
-    expect(cssMapFiles.length).toEqual(0);
-  },
-);
+  const jsMapPaths = Object.keys(files).filter((files) =>
+    files.endsWith('.js.map'),
+  );
+  const cssMapFiles = Object.keys(files).filter((files) =>
+    files.endsWith('.css.map'),
+  );
+  expect(jsMapPaths.length).toEqual(0);
+  expect(cssMapFiles.length).toEqual(0);
+});
 
-rspackTest('should generate source map correctly in dev', async ({ dev }) => {
+test('should generate source map correctly in dev', async ({ dev }) => {
   const rsbuild = await dev();
   const files = rsbuild.getDistFiles({ sourceMaps: true });
 
@@ -168,29 +164,26 @@ rspackTest('should generate source map correctly in dev', async ({ dev }) => {
   expect(jsMap.mappings).not.toBeUndefined();
 });
 
-rspackTest(
-  'should generate source maps only for CSS files',
-  async ({ build }) => {
-    const rsbuild = await build({
-      config: {
-        output: {
-          sourceMap: {
-            js: false,
-            css: true,
-          },
+test('should generate source maps only for CSS files', async ({ build }) => {
+  const rsbuild = await build({
+    config: {
+      output: {
+        sourceMap: {
+          js: false,
+          css: true,
         },
       },
-    });
+    },
+  });
 
-    const files = rsbuild.getDistFiles({ sourceMaps: true });
+  const files = rsbuild.getDistFiles({ sourceMaps: true });
 
-    const jsMapPaths = Object.keys(files).filter((files) =>
-      files.endsWith('.js.map'),
-    );
-    const cssMapFiles = Object.keys(files).filter((files) =>
-      files.endsWith('.css.map'),
-    );
-    expect(jsMapPaths.length).toEqual(0);
-    expect(cssMapFiles.length).toBeGreaterThan(0);
-  },
-);
+  const jsMapPaths = Object.keys(files).filter((files) =>
+    files.endsWith('.js.map'),
+  );
+  const cssMapFiles = Object.keys(files).filter((files) =>
+    files.endsWith('.css.map'),
+  );
+  expect(jsMapPaths.length).toEqual(0);
+  expect(cssMapFiles.length).toBeGreaterThan(0);
+});

--- a/e2e/cases/source-map/multi-environments/index.test.ts
+++ b/e2e/cases/source-map/multi-environments/index.test.ts
@@ -1,41 +1,39 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { expect, findFile, rspackTest } from '@e2e/helper';
+import { expect, findFile, test } from '@e2e/helper';
 
-rspackTest(
-  'should generate source map for multiple environments',
-  async ({ build }) => {
-    const rsbuild = await build();
-    const files = rsbuild.getDistFiles({ sourceMaps: true });
+test('should generate source map for multiple environments', async ({
+  build,
+}) => {
+  const rsbuild = await build();
+  const files = rsbuild.getDistFiles({ sourceMaps: true });
 
-    const web1JsMapPath = findFile(
-      files,
-      (path) =>
-        path.includes('static/js/index.js.map') && !path.includes('web2'),
-    );
-    const web2JsMapPath = findFile(files, 'web2/static/js/index.js.map');
-    const sourceContent = readFileSync(
-      join(import.meta.dirname, './src/index.js'),
-      'utf-8',
-    );
+  const web1JsMapPath = findFile(
+    files,
+    (path) => path.includes('static/js/index.js.map') && !path.includes('web2'),
+  );
+  const web2JsMapPath = findFile(files, 'web2/static/js/index.js.map');
+  const sourceContent = readFileSync(
+    join(import.meta.dirname, './src/index.js'),
+    'utf-8',
+  );
 
-    expect(JSON.parse(files[web1JsMapPath])).toEqual({
-      version: 3,
-      file: 'static/js/index.js',
-      sources: ['../../../src/index.js'],
-      sourcesContent: [sourceContent],
-      names: ['console'],
-      // cspell:disable-next-line
-      mappings: 'AAAAA,QAAQ,GAAG,CAAC',
-    });
-    expect(JSON.parse(files[web2JsMapPath])).toEqual({
-      version: 3,
-      file: 'static/js/index.js',
-      sources: ['../../../../../src/index.js'],
-      sourcesContent: [sourceContent],
-      names: ['console'],
-      // cspell:disable-next-line
-      mappings: 'AAAAA,QAAQ,GAAG,CAAC',
-    });
-  },
-);
+  expect(JSON.parse(files[web1JsMapPath])).toEqual({
+    version: 3,
+    file: 'static/js/index.js',
+    sources: ['../../../src/index.js'],
+    sourcesContent: [sourceContent],
+    names: ['console'],
+    // cspell:disable-next-line
+    mappings: 'AAAAA,QAAQ,GAAG,CAAC',
+  });
+  expect(JSON.parse(files[web2JsMapPath])).toEqual({
+    version: 3,
+    file: 'static/js/index.js',
+    sources: ['../../../../../src/index.js'],
+    sourcesContent: [sourceContent],
+    names: ['console'],
+    // cspell:disable-next-line
+    mappings: 'AAAAA,QAAQ,GAAG,CAAC',
+  });
+});

--- a/e2e/cases/swc/jsc-target/index.test.ts
+++ b/e2e/cases/swc/jsc-target/index.test.ts
@@ -1,16 +1,13 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest(
-  'should configure jsc.target correctly in dev',
-  async ({ devOnly }) => {
-    const rsbuild = await devOnly();
-    const files = rsbuild.getDistFiles();
-    const content = getFileContent(files, 'index.js');
-    expect(content).not.toContain('...a');
-  },
-);
+test('should configure jsc.target correctly in dev', async ({ devOnly }) => {
+  const rsbuild = await devOnly();
+  const files = rsbuild.getDistFiles();
+  const content = getFileContent(files, 'index.js');
+  expect(content).not.toContain('...a');
+});
 
-rspackTest('should configure jsc.target correctly in build', async ({ build }) => {
+test('should configure jsc.target correctly in build', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
   const content = getFileContent(files, 'index.js');

--- a/e2e/cases/swc/swc-plugin/index.test.ts
+++ b/e2e/cases/swc/swc-plugin/index.test.ts
@@ -1,29 +1,29 @@
-import { expect, gotoPage, rspackTest } from '@e2e/helper';
+import { expect, gotoPage, test } from '@e2e/helper';
 
-rspackTest(
-  'should run SWC Wasm plugin correctly in dev',
-  async ({ page, devOnly }) => {
-    const rsbuild = await devOnly();
+test('should run SWC Wasm plugin correctly in dev', async ({
+  page,
+  devOnly,
+}) => {
+  const rsbuild = await devOnly();
 
-    const msgPromise = page.waitForEvent('console');
-    await gotoPage(page, rsbuild);
+  const msgPromise = page.waitForEvent('console');
+  await gotoPage(page, rsbuild);
 
-    const msg = await msgPromise;
-    expect(await msg.args()[0].jsonValue()).toEqual('this is error');
-  },
-);
+  const msg = await msgPromise;
+  expect(await msg.args()[0].jsonValue()).toEqual('this is error');
+});
 
-rspackTest(
-  'should run SWC Wasm plugin correctly in build',
-  async ({ page, build }) => {
-    const rsbuild = await build({
-      runServer: true,
-    });
+test('should run SWC Wasm plugin correctly in build', async ({
+  page,
+  build,
+}) => {
+  const rsbuild = await build({
+    runServer: true,
+  });
 
-    const msgPromise = page.waitForEvent('console');
-    await gotoPage(page, rsbuild);
+  const msgPromise = page.waitForEvent('console');
+  await gotoPage(page, rsbuild);
 
-    const msg = await msgPromise;
-    expect(await msg.args()[0].jsonValue()).toEqual('this is error');
-  },
-);
+  const msg = await msgPromise;
+  expect(await msg.args()[0].jsonValue()).toEqual('this is error');
+});

--- a/e2e/cases/syntax-es/decorator-2022-03/index.test.ts
+++ b/e2e/cases/syntax-es/decorator-2022-03/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, rspackTest, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import { pluginBabel } from '@rsbuild/plugin-babel';
 
 test('should run stage 3 decorators correctly', async ({
@@ -12,20 +12,20 @@ test('should run stage 3 decorators correctly', async ({
   expect(await page.evaluate('window.field')).toBe('message');
 });
 
-rspackTest(
-  'should run stage 3 decorators correctly with babel-plugin',
-  async ({ page, buildPreview }) => {
-    await buildPreview({
-      config: {
-        plugins: [pluginBabel()],
-      },
-    });
+test('should run stage 3 decorators correctly with babel-plugin', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview({
+    config: {
+      plugins: [pluginBabel()],
+    },
+  });
 
-    expect(await page.evaluate('window.message')).toBe('hello');
-    expect(await page.evaluate('window.method')).toBe('targetMethod');
-    expect(await page.evaluate('window.field')).toBe('message');
-  },
-);
+  expect(await page.evaluate('window.message')).toBe('hello');
+  expect(await page.evaluate('window.method')).toBe('targetMethod');
+  expect(await page.evaluate('window.field')).toBe('message');
+});
 
 test.fail(
   'stage 3 decorators do not support decoratorBeforeExport',

--- a/e2e/cases/syntax-es/decorator-config/index.test.ts
+++ b/e2e/cases/syntax-es/decorator-config/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, rspackTest, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import { pluginBabel } from '@rsbuild/plugin-babel';
 
 test('should use legacy decorators by default', async ({
@@ -31,37 +31,37 @@ test('should allow to use stage 3 decorators', async ({
   expect(await page.evaluate('window.ccc')).toBe('hello world');
 });
 
-rspackTest(
-  'should use legacy decorators with babel-plugin',
-  async ({ page, buildPreview }) => {
-    await buildPreview({
-      config: {
-        plugins: [pluginBabel()],
-      },
-    });
+test('should use legacy decorators with babel-plugin', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview({
+    config: {
+      plugins: [pluginBabel()],
+    },
+  });
 
-    expect(await page.evaluate('window.aaa')).toBe('hello');
-    expect(await page.evaluate('window.bbb')).toBe('world');
-    expect(await page.evaluate('window.ccc')).toBe('hello world');
-  },
-);
+  expect(await page.evaluate('window.aaa')).toBe('hello');
+  expect(await page.evaluate('window.bbb')).toBe('world');
+  expect(await page.evaluate('window.ccc')).toBe('hello world');
+});
 
-rspackTest(
-  'should allow to use stage 3 decorators with babel-plugin',
-  async ({ page, buildPreview }) => {
-    await buildPreview({
-      config: {
-        plugins: [pluginBabel()],
-        source: {
-          decorators: {
-            version: '2022-03',
-          },
+test('should allow to use stage 3 decorators with babel-plugin', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview({
+    config: {
+      plugins: [pluginBabel()],
+      source: {
+        decorators: {
+          version: '2022-03',
         },
       },
-    });
+    },
+  });
 
-    expect(await page.evaluate('window.aaa')).toBe('hello');
-    expect(await page.evaluate('window.bbb')).toBe('world');
-    expect(await page.evaluate('window.ccc')).toBe('hello world');
-  },
-);
+  expect(await page.evaluate('window.aaa')).toBe('hello');
+  expect(await page.evaluate('window.bbb')).toBe('world');
+  expect(await page.evaluate('window.ccc')).toBe('hello world');
+});

--- a/e2e/cases/syntax-es/import-attributes/index.test.ts
+++ b/e2e/cases/syntax-es/import-attributes/index.test.ts
@@ -1,6 +1,6 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest('should support import attributes syntax', async ({ build }) => {
+test('should support import attributes syntax', async ({ build }) => {
   const rsbuild = await build();
   const indexJs = await rsbuild.getIndexBundle();
   expect(indexJs).toContain('with import attributes');

--- a/e2e/cases/syntax-es/using-declaration/index.test.ts
+++ b/e2e/cases/syntax-es/using-declaration/index.test.ts
@@ -1,19 +1,19 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should allow to use the `using` declaration for explicit resource management in development',
-  async ({ page, dev }) => {
-    await dev();
+test('should allow to use the `using` declaration for explicit resource management in development', async ({
+  page,
+  dev,
+}) => {
+  await dev();
 
-    expect(await page.evaluate('window.disposeCounter')).toEqual(4);
-  },
-);
+  expect(await page.evaluate('window.disposeCounter')).toEqual(4);
+});
 
-rspackTest(
-  'should allow to use the `using` declaration for explicit resource management in production',
-  async ({ page, buildPreview }) => {
-    await buildPreview();
+test('should allow to use the `using` declaration for explicit resource management in production', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview();
 
-    expect(await page.evaluate('window.disposeCounter')).toEqual(4);
-  },
-);
+  expect(await page.evaluate('window.disposeCounter')).toEqual(4);
+});

--- a/e2e/cases/syntax-ts/const-enum/index.test.ts
+++ b/e2e/cases/syntax-ts/const-enum/index.test.ts
@@ -1,26 +1,26 @@
-import { expect, rspackTest, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should inline the enum values in build',
-  async ({ page, buildPreview }) => {
-    const result = await buildPreview();
+test('should inline the enum values in build', async ({
+  page,
+  buildPreview,
+}) => {
+  const result = await buildPreview();
 
-    await page.waitForFunction(() => window.testDog);
-    expect(await page.evaluate(() => window.testFish)).toBe('fish,FISH');
-    expect(await page.evaluate(() => window.testCat)).toBe('cat,CAT');
-    expect(await page.evaluate(() => window.testDog)).toBe('dog,DOG');
-    expect(await page.evaluate(() => window.testNumbers)).toBe(
-      '0,1,10,1.1,1.0,-1,-1.1',
-    );
-    expect(await page.evaluate(() => window.testNamespace)).toBe('0,1,0,1');
+  await page.waitForFunction(() => window.testDog);
+  expect(await page.evaluate(() => window.testFish)).toBe('fish,FISH');
+  expect(await page.evaluate(() => window.testCat)).toBe('cat,CAT');
+  expect(await page.evaluate(() => window.testDog)).toBe('dog,DOG');
+  expect(await page.evaluate(() => window.testNumbers)).toBe(
+    '0,1,10,1.1,1.0,-1,-1.1',
+  );
+  expect(await page.evaluate(() => window.testNamespace)).toBe('0,1,0,1');
 
-    const indexJs = await result.getIndexBundle();
-    expect(indexJs).toContain('window.testFish="fish,FISH"');
-    expect(indexJs).toContain('window.testCat="cat,CAT"');
-    expect(indexJs).toContain('window.testNumbers="0,1,10,1.1,1.0,-1,-1.1"');
-    expect(indexJs).toContain('window.testNamespace="0,1,0,1"');
-  },
-);
+  const indexJs = await result.getIndexBundle();
+  expect(indexJs).toContain('window.testFish="fish,FISH"');
+  expect(indexJs).toContain('window.testCat="cat,CAT"');
+  expect(indexJs).toContain('window.testNumbers="0,1,10,1.1,1.0,-1,-1.1"');
+  expect(indexJs).toContain('window.testNamespace="0,1,0,1"');
+});
 
 test('should import the enum values as expected in dev', async ({
   page,

--- a/e2e/cases/syntax-ts/type-re-exports/index.test.ts
+++ b/e2e/cases/syntax-ts/type-re-exports/index.test.ts
@@ -1,11 +1,10 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-rspackTest(
-  'should allow to re-export type without the type modifier',
-  async ({ buildPreview }) => {
-    const rsbuild = await buildPreview({
-      catchBuildError: true,
-    });
-    expect(rsbuild.buildError).toBeFalsy();
-  },
-);
+test('should allow to re-export type without the type modifier', async ({
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview({
+    catchBuildError: true,
+  });
+  expect(rsbuild.buildError).toBeFalsy();
+});

--- a/e2e/cases/tailwindcss/hmr/index.test.ts
+++ b/e2e/cases/tailwindcss/hmr/index.test.ts
@@ -1,13 +1,13 @@
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
 const getContent = (
   classNames: string,
 ) => `document.querySelector('#root').className = '${classNames}';
 `;
 
-rspackTest('should support tailwindcss HMR', async ({ page, dev }) => {
+test('should support tailwindcss HMR', async ({ page, dev }) => {
   const tempFile = join(import.meta.dirname, 'src/test-temp-file.js');
 
   writeFileSync(tempFile, getContent('text-black'));

--- a/e2e/cases/tailwindcss/vendor-prefix/index.test.ts
+++ b/e2e/cases/tailwindcss/vendor-prefix/index.test.ts
@@ -1,14 +1,13 @@
-import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
-rspackTest(
-  'should generate tailwindcss utilities with vendor prefixes correctly',
-  async ({ build }) => {
-    const rsbuild = await build();
-    const files = rsbuild.getDistFiles();
-    const indexCss = getFileContent(files, 'index.css');
+test('should generate tailwindcss utilities with vendor prefixes correctly', async ({
+  build,
+}) => {
+  const rsbuild = await build();
+  const files = rsbuild.getDistFiles();
+  const indexCss = getFileContent(files, 'index.css');
 
-    expect(indexCss).toContain('-webkit-user-select: none;');
-    expect(indexCss).toContain('-ms-user-select: none;');
-    expect(indexCss).toContain('user-select: none;');
-  },
-);
+  expect(indexCss).toContain('-webkit-user-select: none;');
+  expect(indexCss).toContain('-ms-user-select: none;');
+  expect(indexCss).toContain('user-select: none;');
+});

--- a/e2e/cases/wasm/wasm-filename-hash-disabled/index.test.ts
+++ b/e2e/cases/wasm/wasm-filename-hash-disabled/index.test.ts
@@ -1,13 +1,12 @@
-import { expect, findFile, rspackTest } from '@e2e/helper';
+import { expect, findFile, test } from '@e2e/helper';
 
-rspackTest(
-  'should not allow to disable filename hash of Wasm files',
-  async ({ buildPreview }) => {
-    const rsbuild = await buildPreview();
-    const files = rsbuild.getDistFiles();
+test('should not allow to disable filename hash of Wasm files', async ({
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview();
+  const files = rsbuild.getDistFiles();
 
-    const wasmFile = findFile(files, 'module.wasm');
+  const wasmFile = findFile(files, 'module.wasm');
 
-    expect(/[a-f0-9]{8}\.module\.wasm/.test(wasmFile)).toBeTruthy();
-  },
-);
+  expect(/[a-f0-9]{8}\.module\.wasm/.test(wasmFile)).toBeTruthy();
+});

--- a/e2e/cases/wasm/wasm-filename-hash/index.test.ts
+++ b/e2e/cases/wasm/wasm-filename-hash/index.test.ts
@@ -1,13 +1,12 @@
-import { expect, findFile, rspackTest } from '@e2e/helper';
+import { expect, findFile, test } from '@e2e/helper';
 
-rspackTest(
-  'should allow to custom the filename hash of Wasm files',
-  async ({ buildPreview }) => {
-    const rsbuild = await buildPreview();
-    const files = rsbuild.getDistFiles();
+test('should allow to custom the filename hash of Wasm files', async ({
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview();
+  const files = rsbuild.getDistFiles();
 
-    const wasmFile = findFile(files, 'module.wasm');
+  const wasmFile = findFile(files, 'module.wasm');
 
-    expect(/[a-f0-9]{16}\.module\.wasm/.test(wasmFile)).toBeTruthy();
-  },
-);
+  expect(/[a-f0-9]{16}\.module\.wasm/.test(wasmFile)).toBeTruthy();
+});

--- a/e2e/cases/wasm/wasm-filename/index.test.ts
+++ b/e2e/cases/wasm/wasm-filename/index.test.ts
@@ -1,13 +1,12 @@
-import { expect, findFile, rspackTest } from '@e2e/helper';
+import { expect, findFile, test } from '@e2e/helper';
 
-rspackTest(
-  'should allow to custom the filename of Wasm files',
-  async ({ buildPreview }) => {
-    const rsbuild = await buildPreview();
-    const files = rsbuild.getDistFiles();
+test('should allow to custom the filename of Wasm files', async ({
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview();
+  const files = rsbuild.getDistFiles();
 
-    const wasmFile = findFile(files, 'factorial.wasm');
+  const wasmFile = findFile(files, 'factorial.wasm');
 
-    expect(wasmFile).toBeTruthy();
-  },
-);
+  expect(wasmFile).toBeTruthy();
+});

--- a/e2e/helper/fixture.ts
+++ b/e2e/helper/fixture.ts
@@ -311,22 +311,3 @@ export const test = base.extend<RsbuildFixture>({
 });
 
 export { expect };
-
-export const rspackTest = ((): typeof test => {
-  if (process.env.PROVIDE_TYPE !== 'webpack') {
-    return test;
-  }
-
-  const testSkip = test.skip;
-  // @ts-expect-error
-  testSkip.describe = test.describe.skip;
-  // @ts-expect-error
-  testSkip.fail = test.describe.skip;
-  // @ts-expect-error
-  testSkip.only = test.only;
-  // @ts-expect-error
-  return testSkip as typeof test.skip & {
-    describe: typeof test.describe.skip;
-    only: typeof test.only;
-  };
-})();

--- a/e2e/helper/jsApi.ts
+++ b/e2e/helper/jsApi.ts
@@ -1,42 +1,16 @@
 import assert from 'node:assert';
 import { join } from 'node:path';
 import { stripVTControlCharacters as stripAnsi } from 'node:util';
-import type {
-  CreateRsbuildOptions,
-  BuildResult as RsbuildBuildResult,
-  RsbuildConfig,
-  RsbuildInstance,
+import {
+  type CreateRsbuildOptions,
+  createRsbuild,
+  type BuildResult as RsbuildBuildResult,
+  type RsbuildConfig,
+  type RsbuildInstance,
 } from '@rsbuild/core';
-import { pluginSwc } from '@rsbuild/plugin-webpack-swc';
 import type { Page } from 'playwright';
 import type { LogHelper } from './logs.ts';
 import { getRandomPort, gotoPage, noop, toPosixPath } from './utils.ts';
-
-const createRsbuild = async (
-  rsbuildOptions: CreateRsbuildOptions & { config?: RsbuildConfig },
-) => {
-  const { createRsbuild } = await import('@rsbuild/core');
-
-  if (process.env.PROVIDE_TYPE === 'rspack') {
-    const rsbuild = await createRsbuild(rsbuildOptions);
-
-    return rsbuild;
-  }
-
-  const { webpackProvider } = await import('@rsbuild/webpack');
-
-  rsbuildOptions.config ||= {};
-  rsbuildOptions.config.provider = webpackProvider;
-
-  const rsbuild = await createRsbuild(rsbuildOptions);
-
-  const swc = pluginSwc();
-  if (!rsbuild.isPluginExists(swc.name)) {
-    rsbuild.addPlugins([swc]);
-  }
-
-  return rsbuild;
-};
 
 const updateConfigForTest = async (
   originalConfig: RsbuildConfig,

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -40,8 +40,6 @@
     "@rsbuild/plugin-type-check": "^1.3.2",
     "@rsbuild/plugin-vue": "workspace:*",
     "@rsbuild/plugin-vue-jsx": "^1.1.1",
-    "@rsbuild/plugin-webpack-swc": "^1.1.2",
-    "@rsbuild/webpack": "workspace:*",
     "@rsdoctor/rspack-plugin": "1.4.0",
     "@scripts/test-helper": "workspace:*",
     "@tailwindcss/postcss": "^4.1.18",

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,6 +1,5 @@
 import { defineConfig } from '@playwright/test';
 
-process.env.PROVIDE_TYPE ||= 'rspack';
 // https://playwright.dev/docs/service-workers-experimental
 process.env.PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS = '1';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,10 +109,10 @@ importers:
         version: link:helper
       '@module-federation/enhanced':
         specifier: 0.22.0
-        version: 0.22.0(@rspack/core@1.7.0(@swc/helpers@0.5.17))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(webpack@5.104.1)
+        version: 0.22.0(@rspack/core@1.7.0(@swc/helpers@0.5.18))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(webpack@5.104.1)
       '@module-federation/rsbuild-plugin':
         specifier: 0.22.0
-        version: 0.22.0(@rsbuild/core@packages+core)(@rspack/core@1.7.0(@swc/helpers@0.5.17))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(webpack@5.104.1)
+        version: 0.22.0(@rsbuild/core@packages+core)(@rspack/core@1.7.0(@swc/helpers@0.5.18))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(webpack@5.104.1)
       '@playwright/test':
         specifier: 1.57.0
         version: 1.57.0
@@ -154,22 +154,16 @@ importers:
         version: link:../packages/plugin-svgr
       '@rsbuild/plugin-type-check':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@packages+core)(@rspack/core@1.7.0(@swc/helpers@0.5.17))(typescript@5.9.3)
+        version: 1.3.2(@rsbuild/core@packages+core)(@rspack/core@1.7.0(@swc/helpers@0.5.18))(typescript@5.9.3)
       '@rsbuild/plugin-vue':
         specifier: workspace:*
         version: link:../packages/plugin-vue
       '@rsbuild/plugin-vue-jsx':
         specifier: ^1.1.1
         version: 1.1.1(@babel/core@7.28.5)(@rsbuild/core@packages+core)
-      '@rsbuild/plugin-webpack-swc':
-        specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@packages+core)
-      '@rsbuild/webpack':
-        specifier: workspace:*
-        version: link:../packages/webpack
       '@rsdoctor/rspack-plugin':
         specifier: 1.4.0
-        version: 1.4.0(@rsbuild/core@packages+core)(@rspack/core@1.7.0(@swc/helpers@0.5.17))(webpack@5.104.1)
+        version: 1.4.0(@rsbuild/core@packages+core)(@rspack/core@1.7.0(@swc/helpers@0.5.18))(webpack@5.104.1)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../scripts/test-helper
@@ -1720,63 +1714,6 @@ packages:
       '@types/react': '>=16'
       react: '>=16'
 
-  '@modern-js/swc-plugins-darwin-arm64@0.6.11':
-    resolution: {integrity: sha512-UMH0bo20vcD10//F7KaINLfuHawQBVcWCCyJvkYOiBt7e1tUjeybKu+y6eNq1USyFVElEMul8ytnYdwAS9sY+w==}
-    engines: {node: '>=14.12'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@modern-js/swc-plugins-darwin-x64@0.6.11':
-    resolution: {integrity: sha512-qLcXAnM/IGcZX7B0MvxSdZjvgGofhOtHaEdj8CFkt75CzriBMu7lrGsRP4+paXbFAgM4vp7ZV7julaFrrDCoZw==}
-    engines: {node: '>=14.12'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@modern-js/swc-plugins-linux-arm64-gnu@0.6.11':
-    resolution: {integrity: sha512-3WcTpQqJp7RM/i8lLe+GjOCx17ljKdPbxlIY4LkJe+SQXATd3YducTtNqsEAdBA8Au907rI1ImuhN0kxvR97jQ==}
-    engines: {node: '>=14.12'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@modern-js/swc-plugins-linux-arm64-musl@0.6.11':
-    resolution: {integrity: sha512-RFE3xJWbABM8ZzPMVqlr3qovgnwamgpGjGN15rJ4tVqieO2FORQ14xSQE1ROBun6kIADUD+TxnepTlGb7EJg0w==}
-    engines: {node: '>=14.12'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@modern-js/swc-plugins-linux-x64-gnu@0.6.11':
-    resolution: {integrity: sha512-vSDF5aznEtnS0kHFm7UXHHaFzEZEyTV+CTQOVEp84hU5+HW1fMR+MFmbeCJnqXpB+R8Kg93SL4KWePGzm2ZNWw==}
-    engines: {node: '>=14.12'}
-    cpu: [x64]
-    os: [linux]
-
-  '@modern-js/swc-plugins-linux-x64-musl@0.6.11':
-    resolution: {integrity: sha512-jfwQeuSmHbgvw9fjFRi5ZkLWejF8WZkYew0MGHqkSyLYZU+p7RgGo+tSpT4CK+b6p9qzh8LxoFpYjx6YycCY/w==}
-    engines: {node: '>=14.12'}
-    cpu: [x64]
-    os: [linux]
-
-  '@modern-js/swc-plugins-win32-arm64-msvc@0.6.11':
-    resolution: {integrity: sha512-MWbuMTdGZ81Xce+OmnM3xsKKQIHmp9Eq0FlueRIPQdSLCO6IogIjALsMum4Vd1tRnEosKXj0xcuD4IsAWgtW6w==}
-    engines: {node: '>=14.12'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@modern-js/swc-plugins-win32-x64-msvc@0.6.11':
-    resolution: {integrity: sha512-UH4BeAjfs7Z6sZQOaFjgOB9h99qAPRtRFbmkQ+77FDlwNdjii0xPJvdNPCxAJITnqHjHSqrbz9rFDSrWnI9eKg==}
-    engines: {node: '>=14.12'}
-    cpu: [x64]
-    os: [win32]
-
-  '@modern-js/swc-plugins@0.6.11':
-    resolution: {integrity: sha512-bXwjeFa5mg1hD6zzSHzw94FMNFb9SV458g76zWYfXRw7wMjp97NYl6n3dOTOixdngC0JqZctSbP4mJwSZ0p3Gw==}
-    engines: {node: '>=14.17.6'}
-    peerDependencies:
-      '@swc/helpers': '>=0.5.3'
-    peerDependenciesMeta:
-      '@swc/helpers':
-        optional: true
-
   '@module-federation/bridge-react-webpack-plugin@0.22.0':
     resolution: {integrity: sha512-OzMBBbUhOMbDVX/wkVDxaOshgyUdxv+kRQDtxl1/ipV5GXTjs1tpS4NHtDwiJi0qKeG0AvnvGCrPu7bjMOcAVw==}
 
@@ -2253,12 +2190,6 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  '@rsbuild/plugin-webpack-swc@1.1.2':
-    resolution: {integrity: sha512-frvZXLTqyRpDWrN5S4KJelrxDkCCreJmDNLMdncgl9+KXHsMF423WT0F5VXrAG5chumk6/NAUNkK0198ntIzcQ==}
-    deprecated: No longer maintained. Use Rspack instead.
-    peerDependencies:
-      '@rsbuild/core': 1.x
-
   '@rsdoctor/client@1.4.0':
     resolution: {integrity: sha512-kq4GUk0tfLl0l5FDeD/hin0ZHgoL16IM7PKBmjkkgZcACjxKwIQjOLFP8V7RmUxS0nfyS6nbNiZsSIaQV4vVhg==}
 
@@ -2719,9 +2650,6 @@ packages:
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
-
-  '@swc/helpers@0.5.17':
-    resolution: {integrity: sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==}
 
   '@swc/helpers@0.5.18':
     resolution: {integrity: sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==}
@@ -3599,9 +3527,6 @@ packages:
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       webpack: ^5.1.0
-
-  core-js@3.44.0:
-    resolution: {integrity: sha512-aFCtd4l6GvAXwVEh3XbbVqJGHDJt0OZRa+5ePGx3LLwi12WfexqQxcsohb2wgsa/92xtl19Hd66G/L+TaAxDMw==}
 
   core-js@3.47.0:
     resolution: {integrity: sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg==}
@@ -7205,42 +7130,6 @@ snapshots:
       '@types/react': 19.2.7
       react: 19.2.3
 
-  '@modern-js/swc-plugins-darwin-arm64@0.6.11':
-    optional: true
-
-  '@modern-js/swc-plugins-darwin-x64@0.6.11':
-    optional: true
-
-  '@modern-js/swc-plugins-linux-arm64-gnu@0.6.11':
-    optional: true
-
-  '@modern-js/swc-plugins-linux-arm64-musl@0.6.11':
-    optional: true
-
-  '@modern-js/swc-plugins-linux-x64-gnu@0.6.11':
-    optional: true
-
-  '@modern-js/swc-plugins-linux-x64-musl@0.6.11':
-    optional: true
-
-  '@modern-js/swc-plugins-win32-arm64-msvc@0.6.11':
-    optional: true
-
-  '@modern-js/swc-plugins-win32-x64-msvc@0.6.11':
-    optional: true
-
-  '@modern-js/swc-plugins@0.6.11(@swc/helpers@0.5.17)':
-    optionalDependencies:
-      '@modern-js/swc-plugins-darwin-arm64': 0.6.11
-      '@modern-js/swc-plugins-darwin-x64': 0.6.11
-      '@modern-js/swc-plugins-linux-arm64-gnu': 0.6.11
-      '@modern-js/swc-plugins-linux-arm64-musl': 0.6.11
-      '@modern-js/swc-plugins-linux-x64-gnu': 0.6.11
-      '@modern-js/swc-plugins-linux-x64-musl': 0.6.11
-      '@modern-js/swc-plugins-win32-arm64-msvc': 0.6.11
-      '@modern-js/swc-plugins-win32-x64-msvc': 0.6.11
-      '@swc/helpers': 0.5.17
-
   '@module-federation/bridge-react-webpack-plugin@0.22.0':
     dependencies:
       '@module-federation/sdk': 0.22.0
@@ -7292,34 +7181,6 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - debug
-      - supports-color
-      - utf-8-validate
-
-  '@module-federation/enhanced@0.22.0(@rspack/core@1.7.0(@swc/helpers@0.5.17))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(webpack@5.104.1)':
-    dependencies:
-      '@module-federation/bridge-react-webpack-plugin': 0.22.0
-      '@module-federation/cli': 0.22.0(typescript@5.9.3)
-      '@module-federation/data-prefetch': 0.22.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@module-federation/dts-plugin': 0.22.0(typescript@5.9.3)
-      '@module-federation/error-codes': 0.22.0
-      '@module-federation/inject-external-runtime-core-plugin': 0.22.0(@module-federation/runtime-tools@0.22.0)
-      '@module-federation/managers': 0.22.0
-      '@module-federation/manifest': 0.22.0(typescript@5.9.3)
-      '@module-federation/rspack': 0.22.0(@rspack/core@1.7.0(@swc/helpers@0.5.17))(typescript@5.9.3)
-      '@module-federation/runtime-tools': 0.22.0
-      '@module-federation/sdk': 0.22.0
-      btoa: 1.2.1
-      schema-utils: 4.3.3
-      upath: 2.0.1
-    optionalDependencies:
-      typescript: 5.9.3
-      webpack: 5.104.1
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - bufferutil
-      - debug
-      - react
-      - react-dom
       - supports-color
       - utf-8-validate
 
@@ -7380,27 +7241,6 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.26(@rspack/core@1.7.0(@swc/helpers@0.5.17))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(webpack@5.104.1)':
-    dependencies:
-      '@module-federation/enhanced': 0.22.0(@rspack/core@1.7.0(@swc/helpers@0.5.17))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(webpack@5.104.1)
-      '@module-federation/runtime': 0.22.0
-      '@module-federation/sdk': 0.22.0
-      btoa: 1.2.1
-      encoding: 0.1.13
-      node-fetch: 2.7.0(encoding@0.1.13)
-      webpack: 5.104.1
-    optionalDependencies:
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - bufferutil
-      - debug
-      - supports-color
-      - typescript
-      - utf-8-validate
-      - vue-tsc
-
   '@module-federation/node@2.7.26(@rspack/core@1.7.0(@swc/helpers@0.5.18))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(webpack@5.104.1)':
     dependencies:
       '@module-federation/enhanced': 0.22.0(@rspack/core@1.7.0(@swc/helpers@0.5.18))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(webpack@5.104.1)
@@ -7422,27 +7262,6 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@0.22.0(@rsbuild/core@packages+core)(@rspack/core@1.7.0(@swc/helpers@0.5.17))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(webpack@5.104.1)':
-    dependencies:
-      '@module-federation/enhanced': 0.22.0(@rspack/core@1.7.0(@swc/helpers@0.5.17))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(webpack@5.104.1)
-      '@module-federation/node': 2.7.26(@rspack/core@1.7.0(@swc/helpers@0.5.17))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(webpack@5.104.1)
-      '@module-federation/sdk': 0.22.0
-      fs-extra: 11.3.0
-    optionalDependencies:
-      '@rsbuild/core': link:packages/core
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - bufferutil
-      - debug
-      - next
-      - react
-      - react-dom
-      - supports-color
-      - typescript
-      - utf-8-validate
-      - vue-tsc
-      - webpack
-
   '@module-federation/rsbuild-plugin@0.22.0(@rsbuild/core@packages+core)(@rspack/core@1.7.0(@swc/helpers@0.5.18))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(webpack@5.104.1)':
     dependencies:
       '@module-federation/enhanced': 0.22.0(@rspack/core@1.7.0(@swc/helpers@0.5.18))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(webpack@5.104.1)
@@ -7463,25 +7282,6 @@ snapshots:
       - utf-8-validate
       - vue-tsc
       - webpack
-
-  '@module-federation/rspack@0.22.0(@rspack/core@1.7.0(@swc/helpers@0.5.17))(typescript@5.9.3)':
-    dependencies:
-      '@module-federation/bridge-react-webpack-plugin': 0.22.0
-      '@module-federation/dts-plugin': 0.22.0(typescript@5.9.3)
-      '@module-federation/inject-external-runtime-core-plugin': 0.22.0(@module-federation/runtime-tools@0.22.0)
-      '@module-federation/managers': 0.22.0
-      '@module-federation/manifest': 0.22.0(typescript@5.9.3)
-      '@module-federation/runtime-tools': 0.22.0
-      '@module-federation/sdk': 0.22.0
-      '@rspack/core': 1.7.0(@swc/helpers@0.5.17)
-      btoa: 1.2.1
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
 
   '@module-federation/rspack@0.22.0(@rspack/core@1.7.0(@swc/helpers@0.5.18))(typescript@5.9.3)':
     dependencies:
@@ -7829,12 +7629,12 @@ snapshots:
       reduce-configs: 1.1.1
       sass-embedded: 1.97.1
 
-  '@rsbuild/plugin-type-check@1.3.2(@rsbuild/core@packages+core)(@rspack/core@1.7.0(@swc/helpers@0.5.17))(typescript@5.9.3)':
+  '@rsbuild/plugin-type-check@1.3.2(@rsbuild/core@packages+core)(@rspack/core@1.7.0(@swc/helpers@0.5.18))(typescript@5.9.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.1
-      ts-checker-rspack-plugin: 1.2.1(@rspack/core@1.7.0(@swc/helpers@0.5.17))(typescript@5.9.3)
+      ts-checker-rspack-plugin: 1.2.1(@rspack/core@1.7.0(@swc/helpers@0.5.18))(typescript@5.9.3)
     optionalDependencies:
       '@rsbuild/core': link:packages/core
     transitivePeerDependencies:
@@ -7852,26 +7652,15 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@rsbuild/plugin-webpack-swc@1.1.2(@rsbuild/core@packages+core)':
-    dependencies:
-      '@modern-js/swc-plugins': 0.6.11(@swc/helpers@0.5.17)
-      '@rsbuild/core': link:packages/core
-      '@swc/helpers': 0.5.17
-      core-js: 3.44.0
-      deepmerge: 4.3.1
-      lodash: 4.17.21
-      picocolors: 1.1.1
-      semver: 7.7.3
-
   '@rsdoctor/client@1.4.0': {}
 
-  '@rsdoctor/core@1.4.0(@rsbuild/core@packages+core)(@rspack/core@1.7.0(@swc/helpers@0.5.17))(webpack@5.104.1)':
+  '@rsdoctor/core@1.4.0(@rsbuild/core@packages+core)(@rspack/core@1.7.0(@swc/helpers@0.5.18))(webpack@5.104.1)':
     dependencies:
       '@rsbuild/plugin-check-syntax': 1.5.0(@rsbuild/core@packages+core)
-      '@rsdoctor/graph': 1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.17))(webpack@5.104.1)
-      '@rsdoctor/sdk': 1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.17))(webpack@5.104.1)
-      '@rsdoctor/types': 1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.17))(webpack@5.104.1)
-      '@rsdoctor/utils': 1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.17))(webpack@5.104.1)
+      '@rsdoctor/graph': 1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.18))(webpack@5.104.1)
+      '@rsdoctor/sdk': 1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.18))(webpack@5.104.1)
+      '@rsdoctor/types': 1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.18))(webpack@5.104.1)
+      '@rsdoctor/utils': 1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.18))(webpack@5.104.1)
       browserslist-load-config: 1.0.1
       enhanced-resolve: 5.12.0
       es-toolkit: 1.41.0
@@ -7887,10 +7676,10 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/graph@1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.17))(webpack@5.104.1)':
+  '@rsdoctor/graph@1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.18))(webpack@5.104.1)':
     dependencies:
-      '@rsdoctor/types': 1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.17))(webpack@5.104.1)
-      '@rsdoctor/utils': 1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.17))(webpack@5.104.1)
+      '@rsdoctor/types': 1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.18))(webpack@5.104.1)
+      '@rsdoctor/utils': 1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.18))(webpack@5.104.1)
       es-toolkit: 1.41.0
       path-browserify: 1.0.1
       source-map: 0.7.6
@@ -7898,15 +7687,15 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rsdoctor/rspack-plugin@1.4.0(@rsbuild/core@packages+core)(@rspack/core@1.7.0(@swc/helpers@0.5.17))(webpack@5.104.1)':
+  '@rsdoctor/rspack-plugin@1.4.0(@rsbuild/core@packages+core)(@rspack/core@1.7.0(@swc/helpers@0.5.18))(webpack@5.104.1)':
     dependencies:
-      '@rsdoctor/core': 1.4.0(@rsbuild/core@packages+core)(@rspack/core@1.7.0(@swc/helpers@0.5.17))(webpack@5.104.1)
-      '@rsdoctor/graph': 1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.17))(webpack@5.104.1)
-      '@rsdoctor/sdk': 1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.17))(webpack@5.104.1)
-      '@rsdoctor/types': 1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.17))(webpack@5.104.1)
-      '@rsdoctor/utils': 1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.17))(webpack@5.104.1)
+      '@rsdoctor/core': 1.4.0(@rsbuild/core@packages+core)(@rspack/core@1.7.0(@swc/helpers@0.5.18))(webpack@5.104.1)
+      '@rsdoctor/graph': 1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.18))(webpack@5.104.1)
+      '@rsdoctor/sdk': 1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.18))(webpack@5.104.1)
+      '@rsdoctor/types': 1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.18))(webpack@5.104.1)
+      '@rsdoctor/utils': 1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.18))(webpack@5.104.1)
     optionalDependencies:
-      '@rspack/core': 1.7.0(@swc/helpers@0.5.17)
+      '@rspack/core': 1.7.0(@swc/helpers@0.5.18)
     transitivePeerDependencies:
       - '@rsbuild/core'
       - bufferutil
@@ -7914,12 +7703,12 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/sdk@1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.17))(webpack@5.104.1)':
+  '@rsdoctor/sdk@1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.18))(webpack@5.104.1)':
     dependencies:
       '@rsdoctor/client': 1.4.0
-      '@rsdoctor/graph': 1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.17))(webpack@5.104.1)
-      '@rsdoctor/types': 1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.17))(webpack@5.104.1)
-      '@rsdoctor/utils': 1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.17))(webpack@5.104.1)
+      '@rsdoctor/graph': 1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.18))(webpack@5.104.1)
+      '@rsdoctor/types': 1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.18))(webpack@5.104.1)
+      '@rsdoctor/utils': 1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.18))(webpack@5.104.1)
       safer-buffer: 2.1.2
       socket.io: 4.8.1
       tapable: 2.2.3
@@ -7930,20 +7719,20 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/types@1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.17))(webpack@5.104.1)':
+  '@rsdoctor/types@1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.18))(webpack@5.104.1)':
     dependencies:
       '@types/connect': 3.4.38
       '@types/estree': 1.0.5
       '@types/tapable': 2.2.7
       source-map: 0.7.6
     optionalDependencies:
-      '@rspack/core': 1.7.0(@swc/helpers@0.5.17)
+      '@rspack/core': 1.7.0(@swc/helpers@0.5.18)
       webpack: 5.104.1
 
-  '@rsdoctor/utils@1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.17))(webpack@5.104.1)':
+  '@rsdoctor/utils@1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.18))(webpack@5.104.1)':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@rsdoctor/types': 1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.17))(webpack@5.104.1)
+      '@rsdoctor/types': 1.4.0(@rspack/core@1.7.0(@swc/helpers@0.5.18))(webpack@5.104.1)
       '@types/estree': 1.0.5
       acorn: 8.15.0
       acorn-import-attributes: 1.9.5(acorn@8.15.0)
@@ -8094,14 +7883,6 @@ snapshots:
       '@rspack/lite-tapable': 1.1.0
     optionalDependencies:
       '@swc/helpers': 0.5.18
-
-  '@rspack/core@1.7.0(@swc/helpers@0.5.17)':
-    dependencies:
-      '@module-federation/runtime-tools': 0.22.0
-      '@rspack/binding': 1.7.0
-      '@rspack/lite-tapable': 1.1.0
-    optionalDependencies:
-      '@swc/helpers': 0.5.17
 
   '@rspack/core@1.7.0(@swc/helpers@0.5.18)':
     dependencies:
@@ -8423,10 +8204,6 @@ snapshots:
       - typescript
 
   '@swc/counter@0.1.3': {}
-
-  '@swc/helpers@0.5.17':
-    dependencies:
-      tslib: 2.8.1
 
   '@swc/helpers@0.5.18':
     dependencies:
@@ -9389,8 +9166,6 @@ snapshots:
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       webpack: 5.104.1
-
-  core-js@3.44.0: {}
 
   core-js@3.47.0: {}
 
@@ -12366,7 +12141,7 @@ snapshots:
     dependencies:
       matchit: 1.1.0
 
-  ts-checker-rspack-plugin@1.2.1(@rspack/core@1.7.0(@swc/helpers@0.5.17))(typescript@5.9.3):
+  ts-checker-rspack-plugin@1.2.1(@rspack/core@1.7.0(@swc/helpers@0.5.18))(typescript@5.9.3):
     dependencies:
       '@babel/code-frame': 7.27.1
       '@rspack/lite-tapable': 1.1.0
@@ -12377,7 +12152,7 @@ snapshots:
       picocolors: 1.1.1
       typescript: 5.9.3
     optionalDependencies:
-      '@rspack/core': 1.7.0(@swc/helpers@0.5.17)
+      '@rspack/core': 1.7.0(@swc/helpers@0.5.18)
 
   tsconfig-paths-webpack-plugin@4.2.0:
     dependencies:


### PR DESCRIPTION
## Summary

Remove webpack-related e2e helpers, as Rsbuild v2 does not support switching to webpack.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
