### PR TITLE
refactor(core): `context.bundlerType` no longer includes `webpack`

### DIFF
--- a/packages/core/src/createContext.ts
+++ b/packages/core/src/createContext.ts
@@ -195,15 +195,13 @@ export async function createContext(
       ? options.environment
       : undefined;
 
-  const bundlerType = userConfig.provider ? 'webpack' : 'rspack';
-
   return {
     version: RSBUILD_VERSION,
     rootPath,
     distPath: '',
     cachePath,
     callerName: options.callerName,
-    bundlerType,
+    bundlerType: 'rspack',
     environments: {},
     environmentList: [],
     publicPathnames: [],

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -46,22 +46,20 @@ export const pluginBasic = (): RsbuildPlugin => ({
             .use(bundler.HotModuleReplacementPlugin);
         }
 
-        if (api.context.bundlerType === 'rspack') {
-          chain.module.parser.merge({
-            javascript: {
-              typeReexportsPresence: 'tolerant',
-            },
-          });
+        chain.module.parser.merge({
+          javascript: {
+            typeReexportsPresence: 'tolerant',
+          },
+        });
 
-          chain.experiments({
-            ...chain.get('experiments'),
-            rspackFuture: {
-              bundlerInfo: {
-                force: false,
-              },
+        chain.experiments({
+          ...chain.get('experiments'),
+          rspackFuture: {
+            bundlerInfo: {
+              force: false,
             },
-          });
-        }
+          },
+        });
       },
     );
   },

--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -357,10 +357,7 @@ export const pluginCss = (): RsbuildPlugin => ({
         });
 
         // `builtin:lightningcss-loader` is not supported when using webpack
-        if (
-          api.context.bundlerType === 'rspack' &&
-          config.tools.lightningcssLoader !== false
-        ) {
+        if (config.tools.lightningcssLoader !== false) {
           if (emitCss) {
             importLoaders.normal++;
           }

--- a/packages/core/src/plugins/lazyCompilation.ts
+++ b/packages/core/src/plugins/lazyCompilation.ts
@@ -8,7 +8,7 @@ export const pluginLazyCompilation = (): RsbuildPlugin => ({
 
   setup(api) {
     api.modifyBundlerChain((chain, { environment, target }) => {
-      if (target !== 'web' || api.context.bundlerType === 'webpack') {
+      if (target !== 'web') {
         return;
       }
 

--- a/packages/core/src/plugins/minimize.ts
+++ b/packages/core/src/plugins/minimize.ts
@@ -87,8 +87,6 @@ export const pluginMinimize = (): RsbuildPlugin => ({
   name: 'rsbuild:minimize',
 
   setup(api) {
-    const isRspack = api.context.bundlerType === 'rspack';
-
     api.modifyBundlerChain((chain, { environment, CHAIN_ID, rspack }) => {
       const { config } = environment;
       const { minifyJs, minifyCss, jsOptions, cssOptions } =
@@ -96,7 +94,7 @@ export const pluginMinimize = (): RsbuildPlugin => ({
 
       chain.optimization.minimize(minifyJs || minifyCss);
 
-      if (minifyJs && isRspack) {
+      if (minifyJs) {
         chain.optimization
           .minimizer(CHAIN_ID.MINIMIZER.JS)
           .use(rspack.SwcJsMinimizerRspackPlugin, [
@@ -105,7 +103,7 @@ export const pluginMinimize = (): RsbuildPlugin => ({
           .end();
       }
 
-      if (minifyCss && isRspack) {
+      if (minifyCss) {
         const loaderOptions = getLightningCSSLoaderOptions(
           config,
           environment.browserslist,

--- a/packages/core/src/plugins/moduleFederation.ts
+++ b/packages/core/src/plugins/moduleFederation.ts
@@ -6,11 +6,6 @@ export function pluginModuleFederation(): RsbuildPlugin {
     name: 'rsbuild:module-federation',
 
     setup(api) {
-      // Rspack only
-      if (api.context.bundlerType === 'webpack') {
-        return;
-      }
-
       api.modifyRsbuildConfig((config) => {
         const { moduleFederation } = config;
 

--- a/packages/core/src/plugins/output.ts
+++ b/packages/core/src/plugins/output.ts
@@ -130,7 +130,7 @@ export const pluginOutput = (): RsbuildPlugin => ({
           });
         }
 
-        if (config.output.copy && api.context.bundlerType === 'rspack') {
+        if (config.output.copy) {
           const { copy } = config.output;
           const options = Array.isArray(copy) ? { patterns: copy } : copy;
 

--- a/packages/core/src/plugins/progress.ts
+++ b/packages/core/src/plugins/progress.ts
@@ -4,11 +4,6 @@ export const pluginProgress = (): RsbuildPlugin => ({
   name: 'rsbuild:progress',
 
   setup(api) {
-    // This plugin uses Rspack builtin progress plugin and is not suitable for webpack
-    if (api.context.bundlerType === 'webpack') {
-      return;
-    }
-
     api.modifyBundlerChain((chain, { CHAIN_ID, environment, rspack }) => {
       const { config } = environment;
       const options = config.dev.progressBar;

--- a/packages/core/src/plugins/resolve.ts
+++ b/packages/core/src/plugins/resolve.ts
@@ -170,12 +170,7 @@ export const pluginResolve = (): RsbuildPlugin => ({
         const aliasStrategy =
           config.source.aliasStrategy ?? config.resolve.aliasStrategy;
 
-        if (
-          tsconfigPath &&
-          // Only Rspack has the tsConfig option
-          api.context.bundlerType === 'rspack' &&
-          aliasStrategy === 'prefer-tsconfig'
-        ) {
+        if (tsconfigPath && aliasStrategy === 'prefer-tsconfig') {
           chain.resolve.tsConfig({
             configFile: tsconfigPath,
             // read `paths` in referenced tsconfig files

--- a/packages/core/src/plugins/rsdoctor.ts
+++ b/packages/core/src/plugins/rsdoctor.ts
@@ -28,10 +28,7 @@ export const pluginRsdoctor = (): RsbuildPlugin => ({
       }
 
       // Add Rsdoctor plugin to start analysis.
-      const isRspack = api.context.bundlerType === 'rspack';
-      const pluginName = isRspack
-        ? 'RsdoctorRspackPlugin'
-        : 'RsdoctorWebpackPlugin';
+      const pluginName = 'RsdoctorRspackPlugin';
 
       const isRsdoctorPlugin = (plugin: MaybeRsdoctorPlugin) =>
         plugin?.isRsdoctorPlugin === true ||
@@ -48,9 +45,7 @@ export const pluginRsdoctor = (): RsbuildPlugin => ({
         }
       }
 
-      const packageName = isRspack
-        ? '@rsdoctor/rspack-plugin'
-        : '@rsdoctor/webpack-plugin';
+      const packageName = '@rsdoctor/rspack-plugin';
       let packagePath: string;
 
       try {

--- a/packages/core/src/plugins/rspackProfile.ts
+++ b/packages/core/src/plugins/rspackProfile.ts
@@ -82,10 +82,6 @@ export const pluginRspackProfile = (): RsbuildPlugin => ({
   name: 'rsbuild:rspack-profile',
 
   setup(api) {
-    if (api.context.bundlerType === 'webpack') {
-      return;
-    }
-
     const { RSPACK_PROFILE } = process.env;
     if (!RSPACK_PROFILE) {
       return;

--- a/packages/core/src/plugins/sourceMap.ts
+++ b/packages/core/src/plugins/sourceMap.ts
@@ -42,11 +42,7 @@ export const pluginSourceMap = (): RsbuildPlugin => ({
       const devtool = getDevtool(config);
       chain.devtool(devtool);
 
-      if (
-        (isDev && target === 'web') ||
-        // webpack does not support [relative-resource-path]
-        api.context.bundlerType === 'webpack'
-      ) {
+      if (isDev && target === 'web') {
         // Use POSIX-style absolute paths in source maps during development
         // This ensures VS Code and browser debuggers can correctly resolve breakpoints
         chain.output.devtoolModuleFilenameTemplate(

--- a/packages/core/src/plugins/splitChunks.ts
+++ b/packages/core/src/plugins/splitChunks.ts
@@ -254,13 +254,6 @@ export const pluginSplitChunks = (): RsbuildPlugin => ({
           cacheGroups: {},
         };
 
-        if (api.context.bundlerType === 'webpack') {
-          // When chunk size >= 50000 bytes, split it into separate chunk
-          // @ts-expect-error Rspack does not support enforceSizeThreshold yet
-          // https://github.com/web-infra-dev/rspack/issues/3565
-          defaultConfig.enforceSizeThreshold = 50000;
-        }
-
         const { chunkSplit } = config.performance;
         let forceSplittingGroups = {};
 

--- a/packages/core/src/plugins/sri.ts
+++ b/packages/core/src/plugins/sri.ts
@@ -8,10 +8,6 @@ export const pluginSri = (): RsbuildPlugin => ({
 
   setup(api) {
     api.modifyBundlerChain((chain, { environment, CHAIN_ID, rspack }) => {
-      if (api.context.bundlerType === 'webpack') {
-        return;
-      }
-
       const { config, htmlPaths } = environment;
 
       if (Object.keys(htmlPaths).length === 0) {

--- a/packages/core/src/plugins/swc.ts
+++ b/packages/core/src/plugins/swc.ts
@@ -148,11 +148,6 @@ export const pluginSwc = (): RsbuildPlugin => ({
           rsbuildTarget: target,
         });
 
-        // Rspack builtin SWC is not suitable for webpack
-        if (api.context.bundlerType === 'webpack') {
-          return;
-        }
-
         const swcConfig = getDefaultSwcConfig({
           browserslist,
           cacheRoot,

--- a/packages/core/src/plugins/wasm.ts
+++ b/packages/core/src/plugins/wasm.ts
@@ -11,10 +11,7 @@ export const pluginWasm = (): RsbuildPlugin => ({
       const distPath = config.output.distPath.wasm;
       const filename = posix.join(
         distPath,
-        // webpack does not support contenthash for Wasm files
-        api.context.bundlerType === 'webpack'
-          ? '[hash].module.wasm'
-          : getFilename(config, 'wasm', isProd),
+        getFilename(config, 'wasm', isProd),
       );
 
       chain.experiments({

--- a/packages/core/src/server/devMiddlewares.ts
+++ b/packages/core/src/server/devMiddlewares.ts
@@ -122,11 +122,7 @@ const applyDefaultMiddlewares = ({
   }
 
   // enable lazy compilation
-  if (
-    context.action === 'dev' &&
-    context.bundlerType === 'rspack' &&
-    buildManager
-  ) {
+  if (context.action === 'dev' && buildManager) {
     const { compiler } = buildManager;
 
     // We check the compiler options to determine whether lazy compilation is enabled.

--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -339,8 +339,6 @@ export class SocketServer {
         const { browserLogs, client } = config.dev;
         if (
           payload.type === 'client-error' &&
-          // Do not report browser error when using webpack
-          context.bundlerType === 'rspack' &&
           // Do not report browser error when build failed
           !context.buildState.hasErrors &&
           browserLogs

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -5,7 +5,7 @@ import type { EnvironmentContext } from './hooks';
 import type { RsbuildPluginAPI } from './plugin';
 import type { RsbuildStats } from './rsbuild';
 
-export type BundlerType = 'rspack' | 'webpack';
+export type BundlerType = 'rspack';
 
 export type ActionType = 'dev' | 'build' | 'preview';
 
@@ -53,7 +53,8 @@ export type RsbuildContext = {
    */
   action?: ActionType;
   /**
-   * The bundler type, can be `rspack` or `webpack`.
+   * The bundler type, currently only `rspack` is supported.
+   * @deprecated Do not use this field, it will be removed in future versions.
    */
   bundlerType: BundlerType;
   /**

--- a/packages/core/tests/builder.test.ts
+++ b/packages/core/tests/builder.test.ts
@@ -14,8 +14,6 @@ describe('should use Rspack as the default bundler', () => {
       },
     });
 
-    expect(rsbuild.context.bundlerType).toBe('rspack');
-
     const bundlerConfigs = await rsbuild.initConfigs();
 
     expect(bundlerConfigs[0]).toMatchSnapshot();

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -162,18 +162,6 @@ if (rsbuild.context.action === 'dev') {
 }
 ```
 
-### context.bundlerType
-
-The bundler type for the current build.
-
-- **Type:**
-
-```ts
-type bundlerType = 'rspack' | 'webpack';
-```
-
-> Rsbuild internally supports switching to webpack for comparative testing, so this field is provided for differentiation. Usually, you do not need to use this field.
-
 ## rsbuild.build
 
 Runs a production build, generating optimized production bundles and writing them to the output directory.

--- a/website/docs/en/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/en/guide/upgrade/v1-to-v2.mdx
@@ -12,3 +12,4 @@ The specific changes are as follows:
 
 - The `@rsbuild/webpack` package is no longer provided.
 - The `@rsbuild/plugin-webpack-swc` package is no longer provided.
+- The type of `context.bundlerType` no longer includes `webpack`.

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -162,18 +162,6 @@ if (rsbuild.context.action === 'dev') {
 }
 ```
 
-### context.bundlerType
-
-当前执行构建的构建工具类型。
-
-- **类型：**
-
-```ts
-type bundlerType = 'rspack' | 'webpack';
-```
-
-> Rsbuild 内部支持切换到 webpack 进行对照测试，因此提供了该字段进行区分，通常你不需要使用此字段。
-
 ## rsbuild.environments
 
 ### target

--- a/website/docs/zh/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/zh/guide/upgrade/v1-to-v2.mdx
@@ -12,3 +12,4 @@ Rsbuild 2.0 不再支持使用 webpack 作为打包工具。在 Rsbuild 1.x 版�
 
 - 不再提供 `@rsbuild/webpack` 包。
 - 不再提供 `@rsbuild/plugin-webpack-swc` 包。
+- `context.bundlerType` 的类型中不再包含 `webpack`。


### PR DESCRIPTION
## Summary

- Removed all conditional logic and code branches related to webpack from core plugins, middleware, and server logic.
* Changed the `context.bundlerType` type and related documentation to only allow `'rspack'`, marking the field as deprecated.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/6896

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
