### PR TITLE
refactor: replace webpack references with rspack

### DIFF
--- a/packages/core/src/helpers/compiler.ts
+++ b/packages/core/src/helpers/compiler.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_ASSET_PREFIX } from '../constants';
+import { rspack } from '../rspack';
 import type { Rspack } from '../types';
 
 export const isMultiCompiler = (
@@ -39,7 +40,5 @@ export const addCompilationError = (
   compilation: Rspack.Compilation,
   message: string,
 ): void => {
-  compilation.errors.push(
-    new compilation.compiler.webpack.WebpackError(message),
-  );
+  compilation.errors.push(new rspack.WebpackError(message));
 };

--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -8,6 +8,7 @@ import { removeLeadingSlash } from './helpers/url';
 import type { TransformLoaderOptions } from './loader/transformLoader';
 import { logger } from './logger';
 import { isEnvironmentMatch } from './pluginManager';
+import { rspack } from './rspack';
 import type {
   GetRsbuildConfig,
   InternalContext,
@@ -41,11 +42,8 @@ export function getHTMLPathByEntry(
   return removeLeadingSlash(posix.join(prefix, filename));
 }
 
-const mapProcessAssetsStage = (
-  compiler: Compiler,
-  stage: ProcessAssetsStage,
-) => {
-  const { Compilation } = compiler.webpack;
+const mapProcessAssetsStage = (stage: ProcessAssetsStage) => {
+  const { Compilation } = rspack;
   switch (stage) {
     case 'additional':
       return Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL;
@@ -198,7 +196,7 @@ export function initPluginAPI({
             childCompiler.__rsbuildTransformer = transformer;
           });
 
-          const { sources } = compiler.webpack;
+          const { sources } = rspack;
 
           for (const {
             descriptor,
@@ -224,7 +222,7 @@ export function initPluginAPI({
             compilation.hooks.processAssets.tapPromise(
               {
                 name: pluginName,
-                stage: mapProcessAssetsStage(compiler, descriptor.stage),
+                stage: mapProcessAssetsStage(descriptor.stage),
               },
               async (assets) =>
                 handler({

--- a/packages/core/src/plugins/nonce.ts
+++ b/packages/core/src/plugins/nonce.ts
@@ -1,5 +1,6 @@
 import { createVirtualModule } from '../helpers';
 import { applyToCompiler } from '../helpers/compiler';
+import { rspack } from '../rspack';
 import type { RsbuildPlugin } from '../types';
 
 export const pluginNonce = (): RsbuildPlugin => ({
@@ -32,7 +33,7 @@ export const pluginNonce = (): RsbuildPlugin => ({
         const injectCode = createVirtualModule(
           `__webpack_nonce__ = "${nonce}";`,
         );
-        new compiler.webpack.EntryPlugin(compiler.context, injectCode, {
+        new rspack.EntryPlugin(compiler.context, injectCode, {
           name: undefined,
         }).apply(compiler);
       });

--- a/packages/core/src/rspack-plugins/RsbuildHtmlPlugin.ts
+++ b/packages/core/src/rspack-plugins/RsbuildHtmlPlugin.ts
@@ -5,6 +5,7 @@ import { addCompilationError } from '../helpers/compiler';
 import { readFileAsync } from '../helpers/fs';
 import { ensureAssetPrefix, isURL } from '../helpers/url';
 import { logger } from '../logger';
+import { rspack } from '../rspack';
 import type {
   EnvironmentContext,
   HtmlBasicTag,
@@ -302,7 +303,7 @@ export class RsbuildHtmlPlugin {
         return null;
       }
 
-      const source = new compiler.webpack.sources.RawSource(fileContent, false);
+      const source = new rspack.sources.RawSource(fileContent, false);
       const outputFilename = path.posix.join(faviconDistPath, name);
       compilation.emitAsset(outputFilename, source);
 

--- a/packages/core/src/server/assets-middleware/index.ts
+++ b/packages/core/src/server/assets-middleware/index.ts
@@ -14,6 +14,7 @@ import { createVirtualModule, pick } from '../../helpers';
 import { applyToCompiler, isMultiCompiler } from '../../helpers/compiler';
 import { toPosixPath } from '../../helpers/path';
 import { logger } from '../../logger';
+import { rspack } from '../../rspack';
 import type {
   InternalContext,
   NormalizedConfig,
@@ -188,11 +189,9 @@ init(
 )
 `;
 
-  new compiler.webpack.EntryPlugin(
-    compiler.context,
-    createVirtualModule(hmrEntry),
-    { name: undefined },
-  ).apply(compiler);
+  new rspack.EntryPlugin(compiler.context, createVirtualModule(hmrEntry), {
+    name: undefined,
+  }).apply(compiler);
 }
 
 /**


### PR DESCRIPTION
## Summary

Refactors several core files to consistently use the `rspack` import for accessing Rspack-specific classes and utilities, instead of relying on `compiler.webpack`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
