### PR TITLE
refactor!: remove `compiler` parameter from `rsbuild.build()`

### DIFF
--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -10,34 +10,23 @@ export const RSPACK_BUILD_ERROR = 'Rspack build failed.';
 
 export const build = async (
   initOptions: InitConfigsOptions,
-  { watch, compiler: customCompiler }: BuildOptions = {},
+  { watch }: BuildOptions = {},
 ): Promise<ReturnType<Build>> => {
   const { context } = initOptions;
-
-  let compiler: Rspack.Compiler | Rspack.MultiCompiler;
-  let bundlerConfigs: Rspack.Configuration[] | undefined;
-
-  if (customCompiler) {
-    compiler = customCompiler;
-    bundlerConfigs = customCompiler.options as Rspack.Configuration[];
-  } else {
-    const result = await createCompiler(initOptions);
-    compiler = result.compiler;
-    bundlerConfigs = result.rspackConfigs;
-  }
+  const { compiler, rspackConfigs } = await createCompiler(initOptions);
 
   registerBuildHook({
     context,
-    bundlerConfigs,
+    rspackConfigs,
     compiler,
     isWatch: Boolean(watch),
     MultiStatsCtor: rspack.MultiStats,
   });
 
   if (watch) {
-    const watchOptions: WatchOptions[] = bundlerConfigs
-      ? bundlerConfigs.map((options) => options.watchOptions || {})
-      : [];
+    const watchOptions: WatchOptions[] = rspackConfigs.map(
+      (options) => options.watchOptions || {},
+    );
 
     compiler.watch(
       watchOptions.length > 1 ? watchOptions : watchOptions[0] || {},

--- a/packages/core/src/hooks.ts
+++ b/packages/core/src/hooks.ts
@@ -354,10 +354,10 @@ export const registerBuildHook = ({
   context,
   isWatch,
   compiler,
-  bundlerConfigs,
+  rspackConfigs,
   MultiStatsCtor,
 }: {
-  bundlerConfigs: Rspack.Configuration[];
+  rspackConfigs: Rspack.Configuration[];
   context: InternalContext;
   compiler: Rspack.Compiler | Rspack.MultiCompiler;
   isWatch: boolean;
@@ -369,7 +369,7 @@ export const registerBuildHook = ({
 
   const beforeCompile = async () =>
     context.hooks.onBeforeBuild.callBatch({
-      bundlerConfigs,
+      bundlerConfigs: rspackConfigs,
       environments: context.environments,
       isWatch,
       isFirstCompile,
@@ -381,7 +381,7 @@ export const registerBuildHook = ({
       environment: environment.name,
       args: [
         {
-          bundlerConfig: bundlerConfigs[buildIndex],
+          bundlerConfig: rspackConfigs[buildIndex],
           environment,
           isWatch,
           isFirstCompile,

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -52,11 +52,6 @@ export type BuildOptions = {
    * @default false
    */
   watch?: boolean;
-  /**
-   * Using a custom Rspack Compiler object.
-   * @deprecated This is no longer supported and will be removed in a future version.
-   */
-  compiler?: Compiler | MultiCompiler;
 };
 
 export type Build = (options?: BuildOptions) => Promise<BuildResult>;

--- a/website/docs/en/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/en/guide/upgrade/v1-to-v2.mdx
@@ -4,7 +4,9 @@ This document lists all breaking changes from Rsbuild 1.x to 2.0. Use it as a mi
 
 > This guide is a work in progress. Content will be added incrementally as Rsbuild 2.0 beta evolves.
 
-## Remove `source.alias`
+## Configuration
+
+### Remove `source.alias`
 
 The deprecated `source.alias` option has been removed. Use [resolve.alias](/config/resolve/alias) instead.
 
@@ -19,7 +21,7 @@ export default {
 };
 ```
 
-## Remove `source.aliasStrategy`
+### Remove `source.aliasStrategy`
 
 The deprecated `source.aliasStrategy` option has been removed. Use [resolve.aliasStrategy](/config/resolve/alias-strategy) instead.
 
@@ -32,7 +34,7 @@ export default {
 };
 ```
 
-## Remove `performance.bundleAnalyze`
+### Remove `performance.bundleAnalyze`
 
 The deprecated `performance.bundleAnalyze` option has been removed.
 
@@ -56,14 +58,7 @@ export default {
 };
 ```
 
-## Remove HTML template parameters
-
-The deprecated template parameters have been removed from `html.templateParameters`
-
-- `webpackConfig`: use `rspackConfig` instead.
-- `htmlWebpackPlugin`: use `htmlPlugin` instead.
-
-## Remove `performance.profile`
+### Remove `performance.profile`
 
 The `performance.profile` option has been removed. If you relied on it to emit a stats JSON file, use [stats.toJson()](/api/javascript-api/instance#stats-object) in a custom plugin instead:
 
@@ -83,6 +78,17 @@ const statsJsonPlugin = {
   },
 };
 ```
+
+### Remove HTML template parameters
+
+The deprecated template parameters have been removed from `html.templateParameters`
+
+- `webpackConfig`: use `rspackConfig` instead.
+- `htmlWebpackPlugin`: use `htmlPlugin` instead.
+
+## JavaScript API
+
+- Removed the deprecated `compiler` parameter from `rsbuild.build()`.
 
 ## Dropping webpack support
 

--- a/website/docs/zh/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/zh/guide/upgrade/v1-to-v2.mdx
@@ -4,7 +4,9 @@
 
 > 本指南仍在持续完善中。随着 Rsbuild 2.0 Beta 的推进，相关内容将逐步补充。
 
-## 移除 `source.alias`
+## 配置
+
+### 移除 `source.alias`
 
 废弃的 `source.alias` 选项已被移除，使用 [resolve.alias](/config/resolve/alias) 进行替代。
 
@@ -19,7 +21,7 @@ export default {
 };
 ```
 
-## 移除 `source.aliasStrategy`
+### 移除 `source.aliasStrategy`
 
 废弃的 `source.aliasStrategy` 选项已被移除，使用 [resolve.aliasStrategy](/config/resolve/alias-strategy) 进行替代。
 
@@ -32,7 +34,7 @@ export default {
 };
 ```
 
-## 移除 `performance.bundleAnalyze`
+### 移除 `performance.bundleAnalyze`
 
 废弃的 `performance.bundleAnalyze` 选项已被移除。
 
@@ -56,14 +58,7 @@ export default {
 };
 ```
 
-## 移除 HTML 模板参数
-
-`html.templateParameters` 中废弃的默认参数已被移除：
-
-- `webpackConfig`：使用 `rspackConfig` 代替。
-- `htmlWebpackPlugin`：使用 `htmlPlugin` 代替。
-
-## 移除 `performance.profile`
+### 移除 `performance.profile`
 
 `performance.profile` 选项已被移除。如果你依赖它来输出 stats JSON 文件，可以在自定义插件中调用 [stats.toJson()](/api/javascript-api/instance#stats-object) 代替：
 
@@ -83,6 +78,17 @@ const statsJsonPlugin = {
   },
 };
 ```
+
+### 移除 HTML 模板参数
+
+`html.templateParameters` 中废弃的默认参数已被移除：
+
+- `webpackConfig`：使用 `rspackConfig` 代替。
+- `htmlWebpackPlugin`：使用 `htmlPlugin` 代替。
+
+## JavaScript API
+
+- 移除 `rsbuild.build()` 中废弃的 `compiler` 参数
 
 ## 移除 webpack 支持
 


### PR DESCRIPTION
## Summary

Removes the deprecated `compiler` parameter from the `rsbuild.build()` JavaScript API and updates related code and documentation. It also reorganizes and clarifies the breaking changes documentation for Rsbuild 2.0, grouping configuration changes and improving readability.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
