### PR TITLE
refactor!: remove `compiler` parameter from `rsbuild.startDevServer()`

### DIFF
--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -133,11 +133,7 @@ export async function createDevServer<
   options: Options,
   createCompiler: CreateCompiler,
   config: NormalizedConfig,
-  {
-    compiler: customCompiler,
-    getPortSilently,
-    runCompile = true,
-  }: CreateDevServerOptions = {},
+  { getPortSilently, runCompile = true }: CreateDevServerOptions = {},
 ): Promise<RsbuildDevServer> {
   logger.debug('create dev server');
 
@@ -188,7 +184,7 @@ export async function createDevServer<
   });
 
   const startCompile: () => Promise<BuildManager> = async () => {
-    const compiler = customCompiler || (await createCompiler());
+    const compiler = await createCompiler();
 
     if (!compiler) {
       throw new Error(

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -14,11 +14,6 @@ import type { Falsy } from './utils';
 
 export type StartDevServerOptions = {
   /**
-   * Using a custom Rspack Compiler object.
-   * @deprecated This is no longer supported and will be removed in a future version.
-   */
-  compiler?: Compiler | MultiCompiler;
-  /**
    * Whether to get port silently and not print any logs.
    * @default false
    */

--- a/website/docs/en/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/en/guide/upgrade/v1-to-v2.mdx
@@ -89,6 +89,7 @@ The deprecated template parameters have been removed from `html.templateParamete
 ## JavaScript API
 
 - Removed the deprecated `compiler` parameter from `rsbuild.build()`.
+- Removed the deprecated `compiler` parameter from `rsbuild.startDevServer()`.
 
 ## Dropping webpack support
 

--- a/website/docs/zh/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/zh/guide/upgrade/v1-to-v2.mdx
@@ -89,6 +89,7 @@ const statsJsonPlugin = {
 ## JavaScript API
 
 - 移除 `rsbuild.build()` 中废弃的 `compiler` 参数
+- 移除 `rsbuild.startDevServer()` 中废弃的 `compiler` 参数
 
 ## 移除 webpack 支持
 


### PR DESCRIPTION
## Summary

Removed support for the deprecated `compiler` parameter from the `createDevServer` API. 

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
