### PR TITLE
refactor: replace URL parsing helper with native URL.canParse

### DIFF
--- a/packages/core/src/helpers/url.ts
+++ b/packages/core/src/helpers/url.ts
@@ -18,16 +18,6 @@ export const urlJoin = (base: string, path: string) => {
   return `${urlProtocol}://${posix.join(baseUrl, path)}`;
 };
 
-// Can be replaced with URL.canParse when we drop support for Node.js 18
-export const canParse = (url: string): boolean => {
-  try {
-    new URL(url);
-    return true;
-  } catch {
-    return false;
-  }
-};
-
 export const ensureAssetPrefix = (
   url: string,
   assetPrefix: Rspack.PublicPath = DEFAULT_ASSET_PREFIX,
@@ -42,7 +32,7 @@ export const ensureAssetPrefix = (
   // If str is an complete URL, just return it.
   // Only absolute url with hostname & protocol can be parsed into URL instance.
   // e.g. str is https://example.com/foo.js
-  if (canParse(url)) {
+  if (URL.canParse(url)) {
     return url;
   }
 

--- a/packages/core/src/server/open.ts
+++ b/packages/core/src/server/open.ts
@@ -1,6 +1,6 @@
+import { URL } from 'node:url';
 import { STATIC_PATH } from '../constants';
 import { castArray, color } from '../helpers';
-import { canParse } from '../helpers/url';
 import { logger } from '../logger';
 import type { NormalizedConfig, Routes } from '../types';
 import { getHostInUrl } from './helper';
@@ -138,7 +138,7 @@ export const replacePortPlaceholder = (url: string, port: number): string =>
   url.replace(/<port>/g, String(port));
 
 export function resolveUrl(str: string, base: string): string {
-  if (canParse(str)) {
+  if (URL.canParse(str)) {
     return str;
   }
 


### PR DESCRIPTION
## Summary

Removed the custom `canParse` function and replaced its usage with the native `URL.canParse` method, as Node.js versions older than 20 are no longer supported.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/6914
- https://nodejs.org/api/url.html#urlcanparseinput-base

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
