### PR TITLE
feat!: do not minify Node bundles

### DIFF
--- a/e2e/cases/plugin-vue/sfc-css-modules-ssr/index.test.ts
+++ b/e2e/cases/plugin-vue/sfc-css-modules-ssr/index.test.ts
@@ -18,6 +18,6 @@ test('should build Vue SFC with CSS Modules correctly in build for node target',
 
   const files = rsbuild.getDistFiles();
   const indexJs = getFileContent(files, 'index.js');
-  expect(indexJs).toMatch(/"red-\w{6}"/);
-  expect(indexJs).toMatch(/"blue-\w{6}"/);
+  expect(indexJs).toMatch(/`red-\w{6}`/);
+  expect(indexJs).toMatch(/`blue-\w{6}`/);
 });

--- a/e2e/cases/polyfill/dirname-filename-node/index.test.ts
+++ b/e2e/cases/polyfill/dirname-filename-node/index.test.ts
@@ -5,8 +5,8 @@ test('should not polyfill dirname and filename in node target when output.module
 }) => {
   const rsbuild = await build();
   const content = await rsbuild.getIndexBundle();
-  expect(content).toContain(`"__dirname",__dirname`);
-  expect(content).toContain(`"__filename",__filename`);
-  expect(content).toContain(`"import.meta.dirname",import.meta.dirname`);
-  expect(content).toContain(`"import.meta.filename",import.meta.filename`);
+  expect(content).toContain(`'__dirname', __dirname`);
+  expect(content).toContain(`'__filename', __filename`);
+  expect(content).toContain(`'import.meta.dirname', import.meta.dirname`);
+  expect(content).toContain(`'import.meta.filename', import.meta.filename`);
 });

--- a/packages/core/src/defaultConfig.ts
+++ b/packages/core/src/defaultConfig.ts
@@ -181,7 +181,6 @@ const getDefaultOutputConfig = (): NormalizedOutputConfig => ({
   },
   legalComments: 'linked',
   injectStyles: false,
-  minify: true,
   module: false,
   manifest: false,
   sourceMap: {

--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -362,17 +362,18 @@ export const pluginCss = (): RsbuildPlugin => ({
           }
           importLoaders.inline++;
 
-          const { minifyCss } = parseMinifyOptions(config);
-
-          // Use the same browserslist as web bundles to ensure consistent CSS output
-          // Prevent mismatched prefixes or features between SSR and client hydration
+          let minifyCss = parseMinifyOptions(config).minifyCss;
           let { browserslist } = environment;
+
+          // Use the same browserslist and minification as web bundles to ensure consistent
+          // CSS output. Prevent mismatched prefixes or features between SSR and client hydration.
           if (target === 'node') {
             const webEnvironment = Object.values(environments).find(
               (env) => env.config.output.target === 'web',
             );
-            if (webEnvironment?.browserslist) {
+            if (webEnvironment) {
               browserslist = webEnvironment.browserslist;
+              minifyCss = parseMinifyOptions(webEnvironment.config).minifyCss;
             }
           }
 

--- a/packages/core/src/plugins/minimize.ts
+++ b/packages/core/src/plugins/minimize.ts
@@ -65,7 +65,10 @@ export const parseMinifyOptions = (
   cssOptions?: LightningCssMinimizerRspackPluginOptions;
 } => {
   const isProd = config.mode === 'production';
-  const { minify } = config.output;
+
+  // For `web` and `web-worker` targets, minify is true by default in production mode
+  // For `node` target, minify is false by default
+  const { minify = config.output.target !== 'node' } = config.output;
 
   if (typeof minify === 'boolean') {
     const shouldMinify = minify && isProd;

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1370,7 +1370,6 @@ export interface NormalizedOutputConfig extends OutputConfig {
   dataUriLimit: number | NormalizedDataUriLimit;
   manifest: ManifestConfig;
   module: boolean;
-  minify: Minify;
   inlineScripts: InlineChunkConfig;
   inlineStyles: InlineChunkConfig;
   injectStyles: boolean;

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -77,7 +77,6 @@ exports[`environment config > should normalize environment config correctly 1`] 
     "inlineStyles": false,
     "legalComments": "linked",
     "manifest": false,
-    "minify": true,
     "module": false,
     "polyfill": "off",
     "sourceMap": {
@@ -235,7 +234,6 @@ exports[`environment config > should normalize environment config correctly 2`] 
     "inlineStyles": false,
     "legalComments": "linked",
     "manifest": false,
-    "minify": true,
     "module": false,
     "polyfill": "off",
     "sourceMap": {
@@ -397,7 +395,6 @@ exports[`environment config > should print environment config when inspect confi
       "inlineStyles": false,
       "legalComments": "linked",
       "manifest": false,
-      "minify": true,
       "module": false,
       "polyfill": "off",
       "sourceMap": {
@@ -555,7 +552,6 @@ exports[`environment config > should print environment config when inspect confi
       "inlineStyles": false,
       "legalComments": "linked",
       "manifest": false,
-      "minify": true,
       "module": false,
       "polyfill": "off",
       "sourceMap": {
@@ -733,7 +729,6 @@ exports[`environment config > should support modify environment config by api.mo
       "inlineStyles": false,
       "legalComments": "linked",
       "manifest": false,
-      "minify": true,
       "module": false,
       "polyfill": "off",
       "sourceMap": {
@@ -891,7 +886,6 @@ exports[`environment config > should support modify environment config by api.mo
       "inlineStyles": false,
       "legalComments": "linked",
       "manifest": false,
-      "minify": true,
       "module": false,
       "polyfill": "off",
       "sourceMap": {
@@ -1050,7 +1044,6 @@ exports[`environment config > should support modify environment config by api.mo
       "inlineStyles": false,
       "legalComments": "linked",
       "manifest": false,
-      "minify": true,
       "module": false,
       "polyfill": "off",
       "sourceMap": {
@@ -1212,7 +1205,6 @@ exports[`environment config > should support modify single environment config by
       "inlineStyles": false,
       "legalComments": "linked",
       "manifest": false,
-      "minify": true,
       "module": false,
       "polyfill": "off",
       "sourceMap": {
@@ -1370,7 +1362,6 @@ exports[`environment config > should support modify single environment config by
       "inlineStyles": false,
       "legalComments": "linked",
       "manifest": false,
-      "minify": true,
       "module": false,
       "polyfill": "off",
       "sourceMap": {


### PR DESCRIPTION
## Summary

For Node targets, production builds no longer enable minification by default.

Server bundles prioritize debuggability, clear stack traces, and stable runtime behavior over bundle size. Minification remains available as an explicit opt-in via `output.minify: true`

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
