### PR TITLE
docs: update minification defaults for Node target

### DIFF
--- a/website/docs/en/config/output/minify.mdx
+++ b/website/docs/en/config/output/minify.mdx
@@ -13,17 +13,34 @@ type Minify =
     };
 ```
 
-- **Default:** `true`
+- **Default:**
+  - `true` when [output.target](/config/output/target) is `web` or `web-worker`.
+  - `false` when [output.target](/config/output/target) is `node`.
 
-Controls code minification in production mode and configures minimizer options.
+Controls whether code minification is enabled in production builds, and provides configuration options for the minimizers.
 
-JavaScript and CSS code are automatically minified in production mode to improve page performance. To disable minification entirely, set `minify` to `false`. Control specific minification behavior using the detailed `minify` options:
+By default, production builds for the `web` and `web-worker` targets automatically minify JavaScript and CSS to improve runtime performance. For the `node` target, minification is not enabled by default in production builds unless explicitly opted in.
+
+To disable minification entirely, set `minify` to `false`. You can also fine-tune the behavior and scope of minification through the detailed `minify` configuration options.
 
 :::tip
 Rsbuild uses [SWC](/guide/configuration/swc) to minify JavaScript code and [Lightning CSS](/guide/styling/css-usage#lightning-css) to minify CSS code by default.
 :::
 
 ## Example
+
+### Enable minification
+
+Enable code minification for the `node` target:
+
+```ts title="rsbuild.config.ts"
+export default {
+  output: {
+    target: 'node',
+    minify: true,
+  },
+};
+```
 
 ### Disable minification
 
@@ -212,3 +229,9 @@ export default {
 :::tip
 When using a custom JS minifier, the `minify.jsOptions` option will no longer take effect.
 :::
+
+## Version history
+
+| Version | Changes                               |
+| ------- | ------------------------------------- |
+| v2.0.0  | Defaults to `false` for `node` target |

--- a/website/docs/en/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/en/guide/upgrade/v1-to-v2.mdx
@@ -24,7 +24,7 @@ In Node.js 20 and later, the runtime natively supports loading ESM modules via [
 
 The deprecated `source.alias` option has been removed. Use [resolve.alias](/config/resolve/alias) instead.
 
-```diff
+```diff title="rsbuild.config.ts"
 export default {
 - source: {
 + resolve: {
@@ -39,7 +39,7 @@ export default {
 
 The deprecated `source.aliasStrategy` option has been removed. Use [resolve.aliasStrategy](/config/resolve/alias-strategy) instead.
 
-```diff
+```diff title="rsbuild.config.ts"
 export default {
 - source: {
 + resolve: {
@@ -56,7 +56,7 @@ In earlier versions, Rsbuild bundled `webpack-bundle-analyzer` by default. Rsdoc
 
 Use [Rsdoctor](/guide/debug/rsdoctor) to analyze bundle size, or register [webpack-bundle-analyzer](https://www.npmjs.com/package/webpack-bundle-analyzer) yourself via [tools.rspack](/config/tools/rspack):
 
-```ts
+```ts title="rsbuild.config.ts"
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 
 export default {
@@ -76,7 +76,7 @@ export default {
 
 The `performance.profile` option has been removed. If you relied on it to emit a stats JSON file, use [stats.toJson()](/api/javascript-api/instance#stats-object) in a custom plugin instead:
 
-```ts
+```ts title="rsbuild.config.ts"
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -91,6 +91,10 @@ const statsJsonPlugin = {
     });
   },
 };
+
+export default {
+  plugins: [statsJsonPlugin],
+};
 ```
 
 ### Remove HTML template parameters
@@ -99,6 +103,21 @@ The deprecated template parameters have been removed from `html.templateParamete
 
 - `webpackConfig`: use `rspackConfig` instead.
 - `htmlWebpackPlugin`: use `htmlPlugin` instead.
+
+### Node minification
+
+For Node targets, production builds no longer enable minification by default.
+
+Server bundles now prioritize debuggability, clear stack traces, and stable runtime behavior over bundle size. If you still want minified output, opt in with [output.minify](/config/output/minify):
+
+```ts title="rsbuild.config.ts"
+export default {
+  output: {
+    target: 'node',
+    minify: true,
+  },
+};
+```
 
 ## JavaScript API
 

--- a/website/docs/zh/config/output/minify.mdx
+++ b/website/docs/zh/config/output/minify.mdx
@@ -13,17 +13,34 @@ type Minify =
     };
 ```
 
-- **默认值：** `true`
+- **默认值：**
+  - 当 [output.target](/config/output/target) 为 `web` 或 `web-worker` 时为 `true`。
+  - 当 [output.target](/config/output/target) 为 `node` 时为 `false`。
 
-用于设置是否在生产模式下开启代码压缩，以及配置压缩工具的选项。
+用于设置是否在生产模式下开启代码压缩，以及提供选项来配置压缩工具。
 
-默认情况下，JS 和 CSS 代码会在生产模式构建时被自动压缩，从而提升页面性能。如果你不希望执行代码压缩，可以将 `minify` 设置为 `false` 关闭对所有代码的压缩。或者可以通过 `minify` 选项的详细配置来控制代码压缩的行为。
+默认情况下，生产模式下的 `web` 和 `web-worker` 构建产物会自动压缩 JavaScript 和 CSS，以提升页面性能。`node` 目标在生产构建时默认不启用压缩，除非你显式开启。
+
+如果需要关闭压缩，可以将 `minify` 设置为 `false`；也可以通过 `minify` 选项的细粒度配置，控制代码压缩的行为和范围。
 
 :::tip
 Rsbuild 默认使用 [SWC](/guide/configuration/swc) 压缩 JS 代码，使用 [Lightning CSS](/guide/styling/css-usage#lightning-css) 压缩 CSS 代码。
 :::
 
 ## 示例
+
+### 启用压缩
+
+为 `node` 目标开启代码压缩：
+
+```ts title="rsbuild.config.ts"
+export default {
+  output: {
+    target: 'node',
+    minify: true,
+  },
+};
+```
 
 ### 禁用压缩
 
@@ -212,3 +229,9 @@ export default {
 :::tip
 在使用自定义的 JS 压缩器时，`minify.jsOptions` 选项将不再生效。
 :::
+
+## 版本历史
+
+| 版本   | 变更内容                        |
+| ------ | ------------------------------- |
+| v2.0.0 | `node` 产物的默认值改为 `false` |

--- a/website/docs/zh/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/zh/guide/upgrade/v1-to-v2.mdx
@@ -24,7 +24,7 @@ Rsbuild 2.0 最低支持版本为 Node.js 20.19+ 或 22.12+。
 
 废弃的 `source.alias` 选项已被移除，使用 [resolve.alias](/config/resolve/alias) 进行替代。
 
-```diff
+```diff title="rsbuild.config.ts"
 export default {
 - source: {
 + resolve: {
@@ -39,7 +39,7 @@ export default {
 
 废弃的 `source.aliasStrategy` 选项已被移除，使用 [resolve.aliasStrategy](/config/resolve/alias-strategy) 进行替代。
 
-```diff
+```diff title="rsbuild.config.ts"
 export default {
 - source: {
 + resolve: {
@@ -56,7 +56,7 @@ export default {
 
 推荐使用 [Rsdoctor](/guide/debug/rsdoctor) 分析产物体积，或通过 [tools.rspack](/config/tools/rspack) 自行注册 [webpack-bundle-analyzer](https://www.npmjs.com/package/webpack-bundle-analyzer)：
 
-```ts
+```ts title="rsbuild.config.ts"
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 
 export default {
@@ -76,7 +76,7 @@ export default {
 
 `performance.profile` 选项已被移除。如果你依赖它来输出 stats JSON 文件，可以在自定义插件中调用 [stats.toJson()](/api/javascript-api/instance#stats-object) 代替：
 
-```ts
+```ts title="rsbuild.config.ts"
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -91,6 +91,10 @@ const statsJsonPlugin = {
     });
   },
 };
+
+export default {
+  plugins: [statsJsonPlugin],
+};
 ```
 
 ### 移除 HTML 模板参数
@@ -99,6 +103,21 @@ const statsJsonPlugin = {
 
 - `webpackConfig`：使用 `rspackConfig` 代替。
 - `htmlWebpackPlugin`：使用 `htmlPlugin` 代替。
+
+### Node 压缩
+
+在 Node 目标下，生产环境构建默认不再开启压缩。
+
+服务端产物会优先保证可调试性、清晰的堆栈信息与稳定的运行时行为，而非体积。如果你仍需要压缩产物，可以显式开启 [output.minify](/config/output/minify):
+
+```ts title="rsbuild.config.ts"
+export default {
+  output: {
+    target: 'node',
+    minify: true,
+  },
+};
+```
 
 ## JavaScript API
 


### PR DESCRIPTION
## Summary

- Clarified that `output.minify` defaults to `true` for `web`/`web-worker` targets and `false` for `node` targets
- Added explicit upgrade notes in upgrade guides explaining the new default for Node minification, with code samples for opting in.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
