### PR TITLE
fix(fileSize): remove extra newline for multi environment builds

### DIFF
--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -584,7 +584,7 @@ export const pluginFileSize = (context: InternalContext): RsbuildPlugin => ({
       });
 
       if (logs) {
-        logger.log(logs.join('\n'));
+        logger.log(logs.join(''));
       }
 
       // Save current sizes for next build comparison (only if diff is enabled)


### PR DESCRIPTION
## Summary

Remove extra newline from file size logs for multi environment builds.

### Before

<img width="500" height="374" alt="Screenshot 2026-01-07 at 19 10 25" src="https://github.com/user-attachments/assets/f4c76615-e52c-4976-b4a1-a1386e15037e" />

### After

<img width="500" height="350" alt="Screenshot 2026-01-07 at 19 09 54" src="https://github.com/user-attachments/assets/c7740a24-9a8c-418c-ab0b-082e8b06e8d6" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
