### PR TITLE
refactor: simplify inspectConfig functions

### DIFF
--- a/packages/core/src/inspectConfig.ts
+++ b/packages/core/src/inspectConfig.ts
@@ -157,7 +157,6 @@ export async function inspectConfig({
     inspectOptions.verbose,
   );
 
-  const environmentConfigs: Record<string, NormalizedEnvironmentConfig> = {};
   const stringifiedEnvironmentConfigs: ConfigItem[] = [];
 
   for (const [name, config] of Object.entries(environments)) {
@@ -172,7 +171,6 @@ export async function inspectConfig({
       name,
       content: stringifyConfig(normalizedEnvConfig, inspectOptions.verbose),
     });
-    environmentConfigs[name] = normalizedEnvConfig;
   }
 
   const outputPath = getInspectOutputPath(context, inspectOptions);


### PR DESCRIPTION
## Summary

Refactors the configuration inspection and output logic:

- Removed the `getRsbuildInspectConfig` function and moved its logic into the main `inspectConfig` function, resulting in more straightforward and maintainable code.
- Refactored the logic for emitting config files into a new `emitConfigFiles` function

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
