### PR TITLE
fix(create-rsbuild): remove unused fields from Rstest templates

### DIFF
--- a/packages/create-rsbuild/template-rstest/react-js/package.json
+++ b/packages/create-rsbuild/template-rstest/react-js/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "rsbuild-rstest-react-js",
-  "private": true,
-  "version": "1.0.0",
   "scripts": {
     "test": "rstest",
     "test:watch": "rstest --watch"

--- a/packages/create-rsbuild/template-rstest/react-ts/package.json
+++ b/packages/create-rsbuild/template-rstest/react-ts/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "rsbuild-rstest-react-ts",
-  "private": true,
-  "version": "1.0.0",
   "scripts": {
     "test": "rstest",
     "test:watch": "rstest --watch"

--- a/packages/create-rsbuild/template-rstest/vanilla-js/package.json
+++ b/packages/create-rsbuild/template-rstest/vanilla-js/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "rsbuild-rstest-vanilla-js",
-  "private": true,
-  "version": "1.0.0",
   "scripts": {
     "test": "rstest",
     "test:watch": "rstest --watch"

--- a/packages/create-rsbuild/template-rstest/vanilla-ts/package.json
+++ b/packages/create-rsbuild/template-rstest/vanilla-ts/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "rsbuild-rstest-vanilla-ts",
-  "private": true,
-  "version": "1.0.0",
   "scripts": {
     "test": "rstest",
     "test:watch": "rstest --watch"

--- a/packages/create-rsbuild/template-rstest/vue-js/package.json
+++ b/packages/create-rsbuild/template-rstest/vue-js/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "rsbuild-rstest-vue-js",
-  "private": true,
-  "version": "1.0.0",
   "scripts": {
     "test": "rstest",
     "test:watch": "rstest --watch"

--- a/packages/create-rsbuild/template-rstest/vue-ts/package.json
+++ b/packages/create-rsbuild/template-rstest/vue-ts/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "rsbuild-rstest-vue-ts",
-  "private": true,
-  "version": "1.0.0",
   "scripts": {
     "test": "rstest",
     "test:watch": "rstest --watch"


### PR DESCRIPTION
## Summary

Removes the unused fields (`name`, `private`, and `version`) from the `package.json` files in all Rstest templates.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
