### PR TITLE
feat(create-rsbuild): add Tailwind CSS support

### DIFF
--- a/e2e/cases/create-rsbuild/tools.test.ts
+++ b/e2e/cases/create-rsbuild/tools.test.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { expect, rspackTest } from '@e2e/helper';
 import { createAndValidate } from './helper';
@@ -32,6 +32,50 @@ rspackTest('should create project with prettier as expected', async () => {
   expect(existsSync(join(dir, '.prettierrc'))).toBeTruthy();
   await clean();
 });
+
+rspackTest('should create project with tailwindcss as expected', async () => {
+  const { dir, pkgJson, clean } = await createAndValidate(
+    import.meta.dirname,
+    'vanilla',
+    {
+      name: 'test-temp-tailwindcss',
+      tools: ['tailwindcss'],
+      clean: false,
+    },
+  );
+  expect(pkgJson.devDependencies.tailwindcss).toBeTruthy();
+  expect(pkgJson.devDependencies['@tailwindcss/postcss']).toBeTruthy();
+  expect(existsSync(join(dir, 'postcss.config.mjs'))).toBeTruthy();
+
+  const cssFile = join(dir, 'src/index.css');
+  expect(existsSync(cssFile)).toBeTruthy();
+  const cssContent = readFileSync(cssFile, 'utf-8');
+  expect(cssContent.includes("@import 'tailwindcss';")).toBeTruthy();
+  await clean();
+});
+
+rspackTest(
+  'should create React project with tailwindcss as expected',
+  async () => {
+    const { dir, pkgJson, clean } = await createAndValidate(
+      import.meta.dirname,
+      'react',
+      {
+        name: 'test-temp-tailwindcss',
+        tools: ['tailwindcss'],
+        clean: false,
+      },
+    );
+    expect(pkgJson.devDependencies.tailwindcss).toBeTruthy();
+    expect(pkgJson.devDependencies['@tailwindcss/postcss']).toBeTruthy();
+    expect(existsSync(join(dir, 'postcss.config.mjs'))).toBeTruthy();
+    const cssFile = join(dir, 'src/App.css');
+    expect(existsSync(cssFile)).toBeTruthy();
+    const cssContent = readFileSync(cssFile, 'utf-8');
+    expect(cssContent.includes("@import 'tailwindcss';")).toBeTruthy();
+    await clean();
+  },
+);
 
 rspackTest(
   'should create project with ESLint and prettier as expected',

--- a/packages/create-rsbuild/src/index.ts
+++ b/packages/create-rsbuild/src/index.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
@@ -132,6 +133,32 @@ create({
           isMergePackageJson: true,
         });
         addAgentsMdSearchDirs(toolFolder);
+      },
+    },
+    {
+      value: 'tailwindcss',
+      label: 'Tailwind CSS - styling',
+      action: async ({ distFolder }) => {
+        const from = path.join(__dirname, '..', 'template-tailwindcss');
+        copyFolder({
+          from: from,
+          to: distFolder,
+          isMergePackageJson: true,
+        });
+
+        // Insert tailwindcss import to main CSS file
+        const mainCssFile = ['index.css', 'App.css'];
+        for (const cssFile of mainCssFile) {
+          const filePath = path.join(distFolder, 'src', cssFile);
+          if (fs.existsSync(filePath)) {
+            const content = await fs.promises.readFile(filePath, 'utf-8');
+            await fs.promises.writeFile(
+              filePath,
+              `@import 'tailwindcss';\n\n${content}`,
+            );
+            break;
+          }
+        }
       },
     },
     {

--- a/packages/create-rsbuild/template-tailwindcss/package.json
+++ b/packages/create-rsbuild/template-tailwindcss/package.json
@@ -1,0 +1,6 @@
+{
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.18",
+    "tailwindcss": "^4.1.18"
+  }
+}

--- a/packages/create-rsbuild/template-tailwindcss/postcss.config.mjs
+++ b/packages/create-rsbuild/template-tailwindcss/postcss.config.mjs
@@ -1,0 +1,5 @@
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+};

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -71,15 +71,16 @@ When creating an application, you can choose from the following templates provid
 
 ### Optional tools
 
-`create-rsbuild` can help you set up commonly used tools, including [Biome](https://github.com/biomejs/biome), [ESLint](https://github.com/eslint/eslint), [Prettier](https://github.com/prettier/prettier), and [Storybook](https://storybook.js.org/). Use the arrow keys to navigate and the space bar to select. Press Enter without selecting anything to skip these tools.
+`create-rsbuild` can help you set up commonly used tools, including [Rstest](https://rstest.rs), [Biome](https://github.com/biomejs/biome), [ESLint](https://github.com/eslint/eslint), [Prettier](https://github.com/prettier/prettier), [Tailwind CSS](https://tailwindcss.com) and [Storybook](https://storybook.js.org/). Use the arrow keys to navigate and the space bar to select. Press Enter without selecting anything to skip these tools.
 
 ```
 ◆  Select additional tools (Use <space> to select, <enter> to continue)
-│  ◻ Add Biome for code linting and formatting
-│  ◻ Add ESLint for code linting
-│  ◻ Add Prettier for code formatting
-│  ◻ Add Storybook for component development
-│  ◻ Add Rstest for unit testing
+│  ◻ Rstest - testing
+│  ◻ Biome - linting & formatting
+│  ◻ ESLint - linting
+│  ◻ Prettier - formatting
+│  ◻ Tailwind CSS - styling
+│  ◻ Storybook - component development
 └
 ```
 
@@ -127,7 +128,7 @@ Options:
   -h, --help            display help for command
   -d, --dir <dir>       create project in specified directory
   -t, --template <tpl>  specify the template to use
-  --tools <tool>        select additional tools (biome, eslint, prettier, storybook, rstest)
+  --tools <tool>        add additional tools, comma separated
   --override            override files in target directory
   --packageName <name>  specify the package name
 
@@ -135,6 +136,9 @@ Templates:
 
   react-js, react-ts, vue3-js, vue3-ts, vue2-js, vue2-ts, svelte-js, svelte-ts,
   solid-js, solid-ts, vanilla-js, vanilla-ts
+
+Optional tools:
+  rstest, biome, eslint, prettier, tailwindcss, storybook
 ```
 
 ## Migrate from existing projects

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -71,15 +71,16 @@ import { PackageManagerTabs } from '@theme';
 
 ### 可选工具
 
-`create-rsbuild` 能够帮助你设置一些常用的工具，包括 [Biome](https://github.com/biomejs/biome)、[ESLint](https://github.com/eslint/eslint)、[prettier](https://github.com/prettier/prettier) 和 [Storybook](https://storybook.js.org/)，你可以使用上下箭头和空格进行选择。如果你不需要这些工具，可以直接按回车跳过。
+`create-rsbuild` 能够帮助你设置一些常用的工具，包括 [Rstest](https://rstest.rs)、[Biome](https://github.com/biomejs/biome)、[ESLint](https://github.com/eslint/eslint)、[prettier](https://github.com/prettier/prettier)、[Tailwind CSS](https://tailwindcss.com) 和 [Storybook](https://storybook.js.org/)，你可以使用上下箭头和空格进行选择。如果你不需要这些工具，可以直接按回车跳过。
 
 ```
 ◆  Select additional tools (Use <space> to select, <enter> to continue)
-│  ◻ Add Biome for code linting and formatting
-│  ◻ Add ESLint for code linting
-│  ◻ Add Prettier for code formatting
-│  ◻ Add Storybook for component development
-│  ◻ Add Rstest for unit testing
+│  ◻ Rstest - testing
+│  ◻ Biome - linting & formatting
+│  ◻ ESLint - linting
+│  ◻ Prettier - formatting
+│  ◻ Tailwind CSS - styling
+│  ◻ Storybook - component development
 └
 ```
 
@@ -127,7 +128,7 @@ Options:
   -h, --help            display help for command
   -d, --dir <dir>       create project in specified directory
   -t, --template <tpl>  specify the template to use
-  --tools <tool>        select additional tools (biome, eslint, prettier, storybook, rstest)
+  --tools <tool>        add additional tools, comma separated
   --override            override files in target directory
   --packageName <name>  specify the package name
 
@@ -135,6 +136,9 @@ Templates:
 
   react-js, react-ts, vue3-js, vue3-ts, vue2-js, vue2-ts, svelte-js, svelte-ts,
   solid-js, solid-ts, vanilla-js, vanilla-ts
+
+Optional tools:
+  rstest, biome, eslint, prettier, tailwindcss, storybook
 ```
 
 ## 从现有项目迁移


### PR DESCRIPTION
## Summary

- Added Tailwind CSS support to `create-rsbuild`
-  Updated quick start guides to include Tailwind CSS in the list of optional tools

<img width="800" height="366" alt="image" src="https://github.com/user-attachments/assets/f8e0ec2f-ce91-4ad7-bd0f-c13080515f5a" />

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
