### PR TITLE
refactor: migrate pre-bundled sirv to dynamic imports

### DIFF
--- a/packages/core/prebundle.config.ts
+++ b/packages/core/prebundle.config.ts
@@ -23,7 +23,6 @@ export default {
   dependencies: [
     'ws',
     'html-rspack-plugin',
-    'mrmime',
     'chokidar',
     'webpack-merge',
     {
@@ -45,13 +44,6 @@ export default {
       ignoreDts: true,
       externals: {
         picocolors: '../picocolors/index.js',
-      },
-    },
-    {
-      name: 'sirv',
-      ignoreDts: true,
-      externals: {
-        mrmime: '../mrmime/index.js',
       },
     },
     {

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -81,7 +81,7 @@ export default defineConfig({
   },
   lib: [
     {
-      id: 'esm_index',
+      id: 'node',
       format: 'esm',
       syntax: 'es2023',
       plugins: [pluginFixDtsTypes],
@@ -123,7 +123,7 @@ export default defineConfig({
       },
     },
     {
-      id: 'esm_client',
+      id: 'client',
       format: 'esm',
       syntax: 'es2017',
       source: {

--- a/packages/core/src/helpers/vendors.ts
+++ b/packages/core/src/helpers/vendors.ts
@@ -5,8 +5,6 @@ const require = createRequire(import.meta.url);
 
 type CompiledPackages = {
   ws: typeof import('../../compiled/ws').default;
-  sirv: typeof import('../../compiled/sirv');
-  mrmime: typeof import('../../compiled/mrmime');
   chokidar: typeof import('../../compiled/chokidar').default;
   picocolors: typeof import('../../compiled/picocolors').default;
   'webpack-merge': typeof import('../../compiled/webpack-merge');

--- a/packages/core/src/plugins/appIcon.ts
+++ b/packages/core/src/plugins/appIcon.ts
@@ -6,7 +6,6 @@ import {
 } from '../helpers/compiler';
 import { fileExistsByCompilation, readFileAsync } from '../helpers/fs';
 import { ensureAssetPrefix, isURL } from '../helpers/url';
-import { requireCompiledPackage } from '../helpers/vendors';
 import type { AppIconItem, HtmlBasicTag, RsbuildPlugin } from '../types';
 
 type IconExtra = {
@@ -90,7 +89,7 @@ export const pluginAppIcon = (): RsbuildPlugin => ({
           return;
         }
 
-        const { lookup } = requireCompiledPackage('mrmime');
+        const { lookup } = await import('mrmime');
 
         const distDir = config.output.distPath.image;
         const manifestFile = appIcon.filename ?? 'manifest.webmanifest';

--- a/packages/core/src/server/assets-middleware/middleware.ts
+++ b/packages/core/src/server/assets-middleware/middleware.ts
@@ -2,7 +2,6 @@ import type { Stats as FSStats, ReadStream } from 'node:fs';
 import type { ServerResponse } from 'node:http';
 import onFinished from 'on-finished';
 import type { Range, Result as RangeResult, Ranges } from 'range-parser';
-import { requireCompiledPackage } from '../../helpers/vendors';
 import { logger } from '../../logger';
 import type { InternalContext, RequestHandler, Rspack } from '../../types';
 import { HttpCode } from '../helper';
@@ -35,8 +34,8 @@ function createReadStreamOrReadFileSync(
   return { bufferOrStream, byteLength };
 }
 
-function getContentType(str: string): false | string {
-  const { lookup } = requireCompiledPackage('mrmime');
+async function getContentType(str: string): Promise<false | string> {
+  const { lookup } = await import('mrmime');
   let mime = lookup(str);
   if (!mime) {
     return false;
@@ -339,7 +338,7 @@ export function createMiddleware(
       let offset = 0;
 
       if (!res.getHeader('Content-Type')) {
-        const contentType = getContentType(filename);
+        const contentType = await getContentType(filename);
         if (contentType) {
           res.setHeader('Content-Type', contentType);
         }

--- a/packages/core/src/server/devMiddlewares.ts
+++ b/packages/core/src/server/devMiddlewares.ts
@@ -187,15 +187,19 @@ const applyDefaultMiddlewares = async ({
     );
   }
 
-  for (const { name } of server.publicDir) {
-    const sirv = requireCompiledPackage('sirv');
-    const sirvMiddleware = sirv(name, {
-      etag: true,
-      dev: true,
-    });
-    middlewares.push(function publicDirMiddleware(req, res, next) {
-      sirvMiddleware(req, res, next);
-    });
+  if (server.publicDir.length) {
+    const { default: sirv } = await import(
+      /* webpackChunkName: "sirv" */ 'sirv'
+    );
+    for (const { name } of server.publicDir) {
+      const sirvMiddleware = sirv(name, {
+        etag: true,
+        dev: true,
+      });
+      middlewares.push(function publicDirMiddleware(req, res, next) {
+        sirvMiddleware(req, res, next);
+      });
+    }
   }
 
   // Execute callbacks returned by the `onBeforeStartDevServer` hook.

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -1,7 +1,6 @@
 import type { Server } from 'node:http';
 import type { Http2SecureServer } from 'node:http2';
 import { getPathnameFromUrl } from '../helpers/path';
-import { requireCompiledPackage } from '../helpers/vendors';
 import { isVerbose, logger } from '../logger';
 import type {
   Connect,
@@ -120,7 +119,7 @@ export class RsbuildProdServer {
       this.middlewares.use(getBaseUrlMiddleware({ base }));
     }
 
-    this.applyStaticAssetMiddleware();
+    await this.applyStaticAssetMiddleware();
 
     if (historyApiFallback) {
       this.middlewares.use(
@@ -130,7 +129,7 @@ export class RsbuildProdServer {
       );
 
       // ensure fallback request can be handled by sirv
-      this.applyStaticAssetMiddleware();
+      await this.applyStaticAssetMiddleware();
     }
 
     this.middlewares.use(faviconFallbackMiddleware);
@@ -138,13 +137,15 @@ export class RsbuildProdServer {
     this.middlewares.use(notFoundMiddleware);
   }
 
-  private applyStaticAssetMiddleware() {
+  private async applyStaticAssetMiddleware() {
     const {
       output: { path, assetPrefixes },
       serverConfig: { htmlFallback },
     } = this.options;
 
-    const sirv = requireCompiledPackage('sirv');
+    const { default: sirv } = await import(
+      /* webpackChunkName: "sirv" */ 'sirv'
+    );
 
     const assetsMiddleware = sirv(path, {
       etag: true,


### PR DESCRIPTION
## Summary

Replaced all uses of `requireCompiledPackage('sirv')` and `requireCompiledPackage('mrmime')` with dynamic `import()` calls.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/6925

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
