### PR TITLE
feat(server): print hint when host is not set

### DIFF
--- a/e2e/cases/server/print-urls/index.test.ts
+++ b/e2e/cases/server/print-urls/index.test.ts
@@ -17,6 +17,7 @@ test('should print server urls correctly by default', async ({
   expect(await page.evaluate(() => window.test)).toBe(1);
 
   await rsbuild.expectLog(`➜  Local:    ${url}`);
+  await rsbuild.expectLog('➜  Network:  use --host to expose');
   rsbuild.expectNoLog(NETWORK_LOG_REGEX);
 
   expect(rsbuild.logs.find((log) => log.includes('/./'))).toBeFalsy();

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -231,6 +231,7 @@ export async function createDevServer<
       protocol,
       printUrls: config.server.printUrls,
       trailingLineBreak: !cliShortcutsEnabled,
+      originalConfig: context.originalConfig,
     });
 
   const openPage = async () => {

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -14,6 +14,7 @@ import type {
   OutputStructure,
   PrintUrls,
   Routes,
+  RsbuildConfig,
   RsbuildEntry,
 } from '../types';
 
@@ -184,6 +185,7 @@ export function printServerURLs({
   protocol,
   printUrls,
   trailingLineBreak = true,
+  originalConfig,
 }: {
   urls: { url: string; label: string }[];
   port: number;
@@ -191,6 +193,7 @@ export function printServerURLs({
   protocol: string;
   printUrls?: PrintUrls;
   trailingLineBreak?: boolean;
+  originalConfig?: Readonly<RsbuildConfig>;
 }): string | null {
   if (printUrls === false) {
     return null;
@@ -234,6 +237,10 @@ export function printServerURLs({
   }
 
   let message = getURLMessages(urls, routes);
+
+  if (originalConfig && originalConfig.server?.host === undefined) {
+    message += `  ➜  ${color.dim('Network:')}  ${color.dim('use')} ${color.bold('--host')} ${color.dim('to expose')}\n`;
+  }
 
   if (!trailingLineBreak && message.endsWith('\n')) {
     message = message.slice(0, -1);

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -258,6 +258,7 @@ export async function startProdServer(
             protocol,
             printUrls: serverConfig.printUrls,
             trailingLineBreak: !cliShortcutsEnabled,
+            originalConfig: context.originalConfig,
           });
 
         const openPage = async () => {


### PR DESCRIPTION
## Summary

Append a message about using `--host` to expose the server on the network when no `host` is set in the configuration:

```
  ➜  Local:    http://localhost:3000/
  ➜  Network:  use --host to expose
  ➜  press h + enter to show shortcuts
```

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/6940

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
