### PR TITLE
docs: add server host changes to v2 guide

### DIFF
--- a/website/docs/en/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/en/guide/upgrade/v1-to-v2.mdx
@@ -20,6 +20,28 @@ In Node.js 20 and later, the runtime natively supports loading ESM modules via [
 
 ## Configuration
 
+### Default server host
+
+The default value of [server.host](/config/server/host) has changed from `'0.0.0.0'` to `'localhost'`.
+
+This change prevents the dev server from being exposed to the local network by default, ensuring "secure by default" behavior.
+
+If you need to access the server from other devices on the same network (e.g., for mobile testing), you can manually set the host to `'0.0.0.0'`:
+
+```ts title="rsbuild.config.ts"
+export default {
+  server: {
+    host: '0.0.0.0',
+  },
+};
+```
+
+Alternatively, you can use the `--host` CLI flag to enable network access on demand:
+
+```bash
+rsbuild dev --host
+```
+
 ### Remove `source.alias`
 
 The deprecated `source.alias` option has been removed. Use [resolve.alias](/config/resolve/alias) instead.

--- a/website/docs/zh/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/zh/guide/upgrade/v1-to-v2.mdx
@@ -20,6 +20,28 @@ Rsbuild 2.0 最低支持版本为 Node.js 20.19+ 或 22.12+。
 
 ## 配置
 
+### 默认 host 变更
+
+[server.host](/config/server/host) 的默认值从 `'0.0.0.0'` 变更为 `'localhost'`。
+
+这防止了开发服务器默认暴露在局域网中，从而确保了"默认安全"。
+
+如果你需要从同一局域网内的其他设备访问服务器（例如进行移动端测试），可以将 host 手动设置为 `'0.0.0.0'`：
+
+```ts title="rsbuild.config.ts"
+export default {
+  server: {
+    host: '0.0.0.0',
+  },
+};
+```
+
+你也可以使用 CLI 的 `--host` 选项来开启网络访问：
+
+```bash
+rsbuild dev --host
+```
+
 ### 移除 `source.alias`
 
 废弃的 `source.alias` 选项已被移除，使用 [resolve.alias](/config/resolve/alias) 进行替代。


### PR DESCRIPTION
## Summary

Updated the upgrade guide to document that the default value of `server.host` has changed from `'0.0.0.0'` to `'localhost'`, including examples for overriding this behavior and using the CLI flag for network access.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/6940

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
