### PR TITLE
feat!: output ESM by default for node target

### DIFF
--- a/e2e/cases/css/inline-query-node-target/rsbuild.config.ts
+++ b/e2e/cases/css/inline-query-node-target/rsbuild.config.ts
@@ -9,7 +9,6 @@ export default defineConfig({
     node: {
       output: {
         target: 'node',
-        module: true,
         distPath:
           process.env.NODE_ENV === 'production' ? 'dist-build' : 'dist-dev',
       },

--- a/e2e/cases/node-addons/cjs/rsbuild.config.ts
+++ b/e2e/cases/node-addons/cjs/rsbuild.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
     filename: {
       js: '[name].cjs',
     },
-    minify: false,
+    module: false,
   },
 });

--- a/e2e/cases/node-addons/esm/rsbuild.config.ts
+++ b/e2e/cases/node-addons/esm/rsbuild.config.ts
@@ -3,6 +3,5 @@ import { defineConfig } from '@rsbuild/core';
 export default defineConfig({
   output: {
     target: 'node',
-    module: true,
   },
 });

--- a/e2e/cases/polyfill/dirname-filename-node/rsbuild.config.ts
+++ b/e2e/cases/polyfill/dirname-filename-node/rsbuild.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from '@rsbuild/core';
 
 export default defineConfig({
   output: {
-    module: true,
     target: 'node',
     filenameHash: false,
   },

--- a/e2e/cases/server/ssr-type-module/rsbuild.config.ts
+++ b/e2e/cases/server/ssr-type-module/rsbuild.config.ts
@@ -53,7 +53,6 @@ export default defineConfig({
     },
     node: {
       output: {
-        module: true,
         target: 'node',
       },
       source: {

--- a/examples/node/rsbuild.config.ts
+++ b/examples/node/rsbuild.config.ts
@@ -3,7 +3,5 @@ import { defineConfig } from '@rsbuild/core';
 export default defineConfig({
   output: {
     target: 'node',
-    module: true,
-    minify: false,
   },
 });

--- a/packages/core/src/initConfigs.ts
+++ b/packages/core/src/initConfigs.ts
@@ -132,6 +132,11 @@ const initEnvironmentConfigs = (
       config.output.distPath.js = isServer ? '' : JS_DIST_DIR;
     }
 
+    // For node target, default to ESM output
+    if (config.output.module === undefined) {
+      config.output.module = isServer;
+    }
+
     return config;
   };
 

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1286,10 +1286,8 @@ export interface OutputConfig {
    */
   manifest?: ManifestConfig;
   /**
-   * Whether to output JavaScript files in ES modules format. This feature is currently
-   * experimental and only available when `output.target` is `'node'`.
-   * @experimental
-   * @default false
+   * Whether to output JavaScript files in ES modules format.
+   * @default true when `output.target` is `node`, otherwise `false`
    */
   module?: boolean;
   /**
@@ -1369,7 +1367,6 @@ export interface NormalizedOutputConfig extends OutputConfig {
   assetPrefix: string;
   dataUriLimit: number | NormalizedDataUriLimit;
   manifest: ManifestConfig;
-  module: boolean;
   inlineScripts: InlineChunkConfig;
   inlineStyles: InlineChunkConfig;
   injectStyles: boolean;

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -1061,6 +1061,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   "devtool": "cheap-module-source-map",
   "experiments": {
     "asyncWebAssembly": true,
+    "outputModule": true,
     "rspackFuture": {
       "bundlerInfo": {
         "force": false,
@@ -1416,6 +1417,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     ],
   },
   "name": "node",
+  "node": {
+    "__dirname": false,
+    "__filename": false,
+  },
   "optimization": {
     "minimize": false,
     "splitChunks": false,
@@ -1423,14 +1428,18 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   "output": {
     "assetModuleFilename": "static/assets/[name].[contenthash:8][ext]",
     "chunkFilename": "[name].js",
+    "chunkFormat": "module",
+    "chunkLoading": "import",
     "devtoolModuleFilenameTemplate": "[relative-resource-path]",
     "filename": "[name].js",
     "library": {
-      "type": "commonjs2",
+      "type": "module",
     },
+    "module": true,
     "path": "<ROOT>/packages/core/tests/dist",
     "publicPath": "/",
     "webassemblyModuleFilename": "static/wasm/[contenthash:8].module.wasm",
+    "workerChunkLoading": "import",
   },
   "performance": {
     "hints": false,

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -234,7 +234,7 @@ exports[`environment config > should normalize environment config correctly 2`] 
     "inlineStyles": false,
     "legalComments": "linked",
     "manifest": false,
-    "module": false,
+    "module": true,
     "polyfill": "off",
     "sourceMap": {
       "css": false,
@@ -1903,6 +1903,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
     "devtool": "eval",
     "experiments": {
       "asyncWebAssembly": true,
+      "outputModule": true,
       "rspackFuture": {
         "bundlerInfo": {
           "force": false,
@@ -2261,6 +2262,10 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
       ],
     },
     "name": "node",
+    "node": {
+      "__dirname": false,
+      "__filename": false,
+    },
     "optimization": {
       "minimize": false,
       "splitChunks": false,
@@ -2268,14 +2273,18 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
     "output": {
       "assetModuleFilename": "static/assets/[name].[contenthash:8][ext]",
       "chunkFilename": "[name].js",
+      "chunkFormat": "module",
+      "chunkLoading": "import",
       "devtoolModuleFilenameTemplate": "[relative-resource-path]",
       "filename": "bundle.js",
       "library": {
-        "type": "commonjs2",
+        "type": "module",
       },
+      "module": true,
       "path": "<ROOT>/dist",
       "publicPath": "/",
       "webassemblyModuleFilename": "static/wasm/[contenthash:8].module.wasm",
+      "workerChunkLoading": "import",
     },
     "performance": {
       "hints": false,


### PR DESCRIPTION
## Summary

Changes the default value of `output.module` to `true` when the target is `'node'`.

To preserve the v1 behavior (outputting CommonJS bundles), set `output.module` to `false`:

```ts
// rsbuild.config.ts
export default {
  output: {
    module: false,
    target: 'node',
  },
};
```

## Related Links

https://github.com/web-infra-dev/rsbuild/discussions/5275#discussioncomment-15465815

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
