### PR TITLE
docs: update default value and descriptions for `output.module`

### DIFF
--- a/website/docs/en/config/output/module.mdx
+++ b/website/docs/en/config/output/module.mdx
@@ -1,13 +1,13 @@
 # output.module
 
 - **Type:** `boolean`
-- **Default:** `false`
+- **Default:** `true` when `output.target` is `node`, otherwise `false`
 
 Whether to output JavaScript files in ES modules format.
 
 :::tip
 
-- This feature is currently experimental and only available when [output.target](/config/output/target) is `'web'` or `'node'`.
+- This option is only available when [output.target](/config/output/target) is `'web'` or `'node'`.
 - If you need to build JavaScript libraries in ESM format, we recommend using [Rslib](https://rslib.rs), which is an out-of-the-box library development tool built on top of Rsbuild.
 
 :::
@@ -32,20 +32,20 @@ When `output.module` is enabled, Rsbuild automatically adds `type="module"` to t
 
 ## Node.js applications
 
-When building Node.js applications, Rsbuild outputs CommonJS format by default. You can set `output.module` to `true` to output ES modules format:
+When building Node.js applications, Rsbuild outputs ES modules format by default. You can set `output.module` to `false` to output CommonJS format instead:
 
 ```ts title="rsbuild.config.ts"
 export default {
   output: {
     target: 'node',
-    module: true,
+    module: false,
   },
 };
 ```
 
 ### Running ESM bundles
 
-To properly run ESM bundles in Node.js, you can choose either of the following approaches:
+Choose either of the following approaches to run ESM bundles in Node.js:
 
 1. Set the `type` field in package.json to `'module'`:
 
@@ -69,7 +69,8 @@ export default {
 
 ## Version history
 
-| Version | Changes                     |
-| ------- | --------------------------- |
-| v1.5.0  | Added this option           |
-| v1.6.0  | Support for `target: 'web'` |
+| Version | Changes                             |
+| ------- | ----------------------------------- |
+| v1.5.0  | Added this option                   |
+| v1.6.0  | Support for `target: 'web'`         |
+| v2.0.0  | Default to ESM for `target: 'node'` |

--- a/website/docs/zh/config/output/module.mdx
+++ b/website/docs/zh/config/output/module.mdx
@@ -1,13 +1,13 @@
 # output.module
 
 - **类型：** `boolean`
-- **默认值：** `false`
+- **默认值：** 当 `output.target` 为 `node` 时为 `true`，否则为 `false`
 
 是否以 ES 模块格式输出 JavaScript 文件。
 
 :::tip
 
-- 此功能目前为实验性功能，仅在 [output.target](/config/output/target) 为 `'web'` 或 `'node'` 时可用。
+- 该选项仅在 [output.target](/config/output/target) 为 `'web'` 或 `'node'` 时可用。
 - 如果你需要构建 ESM 格式的 JavaScript 库，推荐使用 [Rslib](https://rslib.rs)，它是一个开箱即用的库开发工具，基于 Rsbuild 实现。
 
 :::
@@ -32,20 +32,20 @@ export default {
 
 ## Node.js 应用
 
-在构建 Node.js 应用时，Rsbuild 默认输出 CommonJS 格式的产物，你可以将 `output.module` 设置为 `true` 来输出 ES modules 格式：
+在构建 Node.js 应用时，Rsbuild 默认输出 ES modules 格式的产物，你可以将 `output.module` 设置为 `false` 来输出 CommonJS 格式：
 
 ```ts title="rsbuild.config.ts"
 export default {
   output: {
     target: 'node',
-    module: true,
+    module: false,
   },
 };
 ```
 
 ### 运行 ESM 产物
 
-为了在 Node.js 中正确运行 ESM 产物，你可以选择以下任一方式：
+选择以下任一方式在 Node.js 中正确运行 ESM 产物：
 
 1. 将 package.json 的 `type` 字段设置为 `'module'`：
 
@@ -69,7 +69,8 @@ export default {
 
 ## 版本历史
 
-| 版本   | 变更内容                      |
-| ------ | ----------------------------- |
-| v1.5.0 | 新增该选项                    |
-| v1.6.0 | 支持在 `target: 'web'` 时使用 |
+| 版本   | 变更内容                        |
+| ------ | ------------------------------- |
+| v1.5.0 | 新增该选项                      |
+| v1.6.0 | 支持在 `target: 'web'` 时使用   |
+| v2.0.0 | `target: 'node'` 时默认输出 ESM |


### PR DESCRIPTION
## Summary

Updated the default value of `output.module` in documentation.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/6950

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
