### PR TITLE
docs: add Node target output defaults in v2 upgrade guide

### DIFF
--- a/website/docs/en/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/en/guide/upgrade/v1-to-v2.mdx
@@ -146,21 +146,6 @@ The deprecated template parameters have been removed from `html.templateParamete
 - `webpackConfig`: use `rspackConfig` instead.
 - `htmlWebpackPlugin`: use `htmlPlugin` instead.
 
-### Node minification
-
-For Node targets, production builds no longer enable minification by default.
-
-Server bundles now prioritize debuggability, clear stack traces, and stable runtime behavior over bundle size. If you still want minified output, opt in with [output.minify](/config/output/minify):
-
-```ts title="rsbuild.config.ts"
-export default {
-  output: {
-    target: 'node',
-    minify: true,
-  },
-};
-```
-
 ## JavaScript API
 
 - Removed the deprecated `compiler` parameter from `rsbuild.build()`.

--- a/website/docs/zh/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/zh/guide/upgrade/v1-to-v2.mdx
@@ -146,21 +146,6 @@ export default {
 - `webpackConfig`：使用 `rspackConfig` 代替。
 - `htmlWebpackPlugin`：使用 `htmlPlugin` 代替。
 
-### Node 压缩
-
-在 Node 目标下，生产环境构建默认不再开启压缩。
-
-服务端产物会优先保证可调试性、清晰的堆栈信息与稳定的运行时行为，而非体积。如果你仍需要压缩产物，可以显式开启 [output.minify](/config/output/minify):
-
-```ts title="rsbuild.config.ts"
-export default {
-  output: {
-    target: 'node',
-    minify: true,
-  },
-};
-```
-
 ## JavaScript API
 
 - 移除 `rsbuild.build()` 中废弃的 `compiler` 参数


### PR DESCRIPTION
## Summary

Explaining that Rsbuild 2.0 now defaults to ESM output and disables minification for Node targets.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/6950

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
