### PR TITLE
feat!: remove deprecated 'content-changed' socket type

### DIFF
--- a/packages/core/src/client/hmr.ts
+++ b/packages/core/src/client/hmr.ts
@@ -232,7 +232,6 @@ export function init(
         break;
       // Triggered when static files changed
       case 'static-changed':
-      case 'content-changed':
         reloadPage();
         break;
       case 'warnings':

--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -28,7 +28,7 @@ function isEqualSet(a: Set<string>, b: Set<string>): boolean {
 const CHECK_SOCKETS_INTERVAL = 30000;
 
 export type ServerMessageStaticChanged = {
-  type: 'static-changed' | 'content-changed';
+  type: 'static-changed';
 };
 
 export type ServerMessageHash = {

--- a/website/docs/en/api/javascript-api/dev-server-api.mdx
+++ b/website/docs/en/api/javascript-api/dev-server-api.mdx
@@ -277,5 +277,3 @@ if (someCondition) {
   rsbuildServer.sockWrite('static-changed');
 }
 ```
-
-> Sending `content-changed` and `static-changed` have the same effect. Since `content-changed` has been deprecated, please use `static-changed` instead.

--- a/website/docs/en/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/en/guide/upgrade/v1-to-v2.mdx
@@ -150,6 +150,7 @@ The deprecated template parameters have been removed from `html.templateParamete
 
 - Removed the deprecated `compiler` parameter from `rsbuild.build()`.
 - Removed the deprecated `compiler` parameter from `rsbuild.startDevServer()`.
+- Removed the deprecated [content-changed](/api/javascript-api/dev-server-api#sockwrite) message type from `sockWrite`, use `static-changed` instead.
 
 ## Dropping webpack support
 

--- a/website/docs/zh/api/javascript-api/dev-server-api.mdx
+++ b/website/docs/zh/api/javascript-api/dev-server-api.mdx
@@ -273,5 +273,3 @@ if (someCondition) {
   rsbuildServer.sockWrite('static-changed');
 }
 ```
-
-> 发送 `content-changed` 与 `static-changed` 具有相同的效果。由于 `content-changed` 已经被弃用，请优先使用 `static-changed`。

--- a/website/docs/zh/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/zh/guide/upgrade/v1-to-v2.mdx
@@ -150,6 +150,7 @@ export default {
 
 - 移除 `rsbuild.build()` 中废弃的 `compiler` 参数
 - 移除 `rsbuild.startDevServer()` 中废弃的 `compiler` 参数
+- 移除 [sockWrite](/api/javascript-api/dev-server-api#sockwrite) 中废弃的 `content-changed` 消息类型，使用 `static-changed` 代替
 
 ## 移除 webpack 支持
 


### PR DESCRIPTION
## Summary

Removes support for the deprecated `content-changed` message type from the dev server's socket communication, consolidating on the `static-changed` message type instead.

## Related Links

- https://github.com/webpack/webpack-dev-server/blob/92bf644784741e8ea5adaa4a1dc26f4d462f223d/migration-v5.md?plain=1#L296-L308

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
