### PR TITLE
feat(plugin-vue): bump rspack-vue-loader to support hot update

### DIFF
--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -28,7 +28,7 @@
     "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {
-    "rspack-vue-loader": "^17.4.4",
+    "rspack-vue-loader": "^17.4.5",
     "webpack": "^5.104.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1002,8 +1002,8 @@ importers:
   packages/plugin-vue:
     dependencies:
       rspack-vue-loader:
-        specifier: ^17.4.4
-        version: 17.4.4(vue@3.5.26(typescript@5.9.3))(webpack@5.104.1)
+        specifier: ^17.4.5
+        version: 17.4.5(vue@3.5.26(typescript@5.9.3))(webpack@5.104.1)
       webpack:
         specifier: ^5.104.1
         version: 5.104.1
@@ -5368,12 +5368,12 @@ packages:
       '@rspack/core':
         optional: true
 
-  rspack-vue-loader@17.4.4:
-    resolution: {integrity: sha512-T4rkTZWg9hC7DZapTaJcIphser4ogsTffH/rwnX0pwMpNKjv1XKLBPa5Icd/xNPOh1NiKVxoxcT+gb8NQliukA==}
+  rspack-vue-loader@17.4.5:
+    resolution: {integrity: sha512-i88hGa4mySkwiP7HqRICIAhomcMdkNCZ5tQGcxkcUWmDfC2QfeQegFBEKY4RdbuxJ3p1Ocj/Ul6Sh4yl6L7mDg==}
     peerDependencies:
       '@vue/compiler-sfc': '*'
       vue: '*'
-      webpack: ^4.1.0 || ^5.0.0-0
+      webpack: ^5.0.0
     peerDependenciesMeta:
       '@vue/compiler-sfc':
         optional: true
@@ -11059,7 +11059,7 @@ snapshots:
     optionalDependencies:
       '@rspack/core': 1.7.1(@swc/helpers@0.5.18)
 
-  rspack-vue-loader@17.4.4(vue@3.5.26(typescript@5.9.3))(webpack@5.104.1):
+  rspack-vue-loader@17.4.5(vue@3.5.26(typescript@5.9.3))(webpack@5.104.1):
     dependencies:
       chalk: 4.1.2
       watchpack: 2.5.0


### PR DESCRIPTION
## Summary

use rspack-vue-loader v17.4.5 to support vue hot update

![img_v3_02ts_fed02d36-52da-479e-a60f-ed6379cbc54g](https://github.com/user-attachments/assets/7797d8f5-3754-4249-835f-ed945c9d589c)


## Related Links

https://github.com/rstackjs/rspack-vue-loader/pull/11

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
