### PR TITLE
docs: remove export formats section from JS API docs

### DIFF
--- a/website/docs/en/api/start/index.mdx
+++ b/website/docs/en/api/start/index.mdx
@@ -54,17 +54,3 @@ await rsbuild.build();
 > For more information about Rsbuild instance methods, see the [Rsbuild Instance](/api/javascript-api/instance) documentation.
 
 These three steps cover the basic usage of Rsbuild. Next, you can customize the build process with Rsbuild plugins and configurations.
-
-## Export formats
-
-Rsbuild supports both ES Modules and CommonJS formats:
-
-```js title="index.mjs"
-import { createRsbuild } from '@rsbuild/core';
-```
-
-```js title="index.cjs"
-const { createRsbuild } = require('@rsbuild/core');
-```
-
-> We recommend using ES modules, which align better with community standards.

--- a/website/docs/zh/api/start/index.mdx
+++ b/website/docs/zh/api/start/index.mdx
@@ -54,17 +54,3 @@ await rsbuild.build();
 > 关于 Rsbuild 实例方法的更多介绍，请阅读 [Rsbuild Instance](/api/javascript-api/instance) 章节。
 
 通过以上三个步骤，你已经了解了 Rsbuild 基本的使用方法。接下来你可以通过 Rsbuild 插件和 Rsbuild 配置来对构建流程进行定制。
-
-## 导出格式
-
-Rsbuild 提供 ES modules 和 CommonJS 两种格式的导出：
-
-```js title="index.mjs"
-import { createRsbuild } from '@rsbuild/core';
-```
-
-```js title="index.cjs"
-const { createRsbuild } = require('@rsbuild/core');
-```
-
-> 推荐使用更符合社区规范的 ES modules 格式。


### PR DESCRIPTION
## Summary

Remove export formats section from JS API docs as `@rsbuild/core` v2 is a pure ESM package.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
