### PR TITLE
perf!: make `core-js` an optional peer dependency

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,6 +9,7 @@
     "type-check": "tsc"
   },
   "dependencies": {
+    "core-js": "^3.47.0",
     "lodash": "^4.17.21",
     "moment": "^2.30.1",
     "preact": "^10.28.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,8 +45,15 @@
     "@rspack/core": "~1.7.2",
     "@rspack/lite-tapable": "~1.1.0",
     "@swc/helpers": "^0.5.18",
-    "core-js": "~3.47.0",
     "jiti": "^2.6.1"
+  },
+  "peerDependencies": {
+    "core-js": ">= 3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "core-js": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@jridgewell/remapping": "^2.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,9 @@ importers:
 
   e2e:
     dependencies:
+      core-js:
+        specifier: ^3.47.0
+        version: 3.47.0
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -508,7 +511,7 @@ importers:
         specifier: ^0.5.18
         version: 0.5.18
       core-js:
-        specifier: ~3.47.0
+        specifier: '>= 3.0.0'
         version: 3.47.0
       jiti:
         specifier: ^2.6.1


### PR DESCRIPTION
## Summary

Change `core-js` from a direct dependency of `@rsbuild/core` to an optional peer dependency.

When users enable `output.polyfill`, they need to install `core-js` themselves:

```bash
npm i core-js
```

Rsbuild will load `core-js` from the user project. If it is missing, Rsbuild will show a clear error.

## Related Links

- https://github.com/web-infra-dev/rsbuild/discussions/5275#discussioncomment-14877968

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
