### PR TITLE
docs: update upgrade guide to reflect core-js changes

### DIFF
--- a/website/docs/en/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/en/guide/upgrade/v1-to-v2.mdx
@@ -1,3 +1,5 @@
+import { PackageManagerTabs } from '@theme';
+
 # Upgrading from v1 to v2
 
 This document lists all breaking changes from Rsbuild 1.x to 2.0. Use it as a migration reference.
@@ -17,6 +19,14 @@ Rsbuild 2.0 requires Node.js 20.19+ or 22.12+.
 In Node.js 20 and later, the runtime natively supports loading ESM modules via [require(esm)](https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require). As a result, for most projects that use Rsbuild through its JavaScript API, this change should have no practical impact and does not require any code modifications.
 
 > This does not affect Rsbuild's ability to build CommonJS output. All related build behavior and configuration options remain unchanged.
+
+## Polyfill dependency change
+
+[core-js](https://www.npmjs.com/package/core-js) has been changed from a default dependency of `@rsbuild/core` to an optional peer dependency to reduce installation size.
+
+If you enabled [output.polyfill](/config/output/polyfill), install `core-js` v3 in your project:
+
+<PackageManagerTabs command="add core-js" />
 
 ## Configuration
 

--- a/website/docs/zh/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/zh/guide/upgrade/v1-to-v2.mdx
@@ -1,3 +1,5 @@
+import { PackageManagerTabs } from '@theme';
+
 # 从 v1 升级到 v2
 
 当前文档列出了从 Rsbuild 1.x 到 2.0 的所有不兼容更新，你可以参考此文档来迁移。
@@ -17,6 +19,14 @@ Rsbuild 2.0 最低支持版本为 Node.js 20.19+ 或 22.12+。
 在 Node.js 20 及以上版本中，运行时已原生支持通过 [require(esm)](https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require) 加载 ESM 模块。因此，对大多数仍通过 JavaScript API 使用 Rsbuild 的项目来说，这一变更通常不会带来实际影响，也无需额外修改现有代码。
 
 > 这一变更不影响 Rsbuild 构建 CommonJS 产物的能力，相关的构建行为和配置方式也保持不变。
+
+## Polyfill 依赖变更
+
+[core-js](https://www.npmjs.com/package/core-js) 从 `@rsbuild/core` 的默认依赖变更为可选的 peer 依赖，以减小安装体积。
+
+如果你启用了 [output.polyfill](/config/output/polyfill)，请在项目中安装 `core-js` v3：
+
+<PackageManagerTabs command="add core-js" />
 
 ## 配置
 


### PR DESCRIPTION
## Summary

Updates v2 upgrade guides to clarify that `core-js` is no longer a default dependency, but an optional peer dependency, and provide instructions for users who need to install it.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/6960

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
