### PR TITLE
feat!: raise default Node target to 20

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -45,7 +45,7 @@ export const DEFAULT_WEB_BROWSERSLIST: string[] = [
 export const DEFAULT_BROWSERSLIST: Record<string, string[]> = {
   web: DEFAULT_WEB_BROWSERSLIST,
   'web-worker': DEFAULT_WEB_BROWSERSLIST,
-  node: ['node >= 16'],
+  node: ['node >= 20'],
 };
 
 // RegExp

--- a/packages/core/tests/__snapshots__/css.test.ts.snap
+++ b/packages/core/tests/__snapshots__/css.test.ts.snap
@@ -170,7 +170,7 @@ exports[`plugin-css injectStyles > should apply ignoreCssLoader when injectStyle
             "options": {
               "errorRecovery": true,
               "targets": [
-                "node >= 16",
+                "node >= 20",
               ],
             },
           },

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -1146,7 +1146,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "options": {
               "errorRecovery": true,
               "targets": [
-                "node >= 16",
+                "node >= 20",
               ],
             },
           },
@@ -1182,7 +1182,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
               },
               "env": {
                 "targets": [
-                  "node >= 16",
+                  "node >= 20",
                 ],
               },
               "isModule": "unknown",
@@ -1234,7 +1234,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
               },
               "env": {
                 "targets": [
-                  "node >= 16",
+                  "node >= 20",
                 ],
               },
               "isModule": "unknown",

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -2027,7 +2027,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
                 },
                 "env": {
                   "targets": [
-                    "node >= 16",
+                    "node >= 20",
                   ],
                 },
                 "isModule": "unknown",
@@ -2079,7 +2079,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
                 },
                 "env": {
                   "targets": [
-                    "node >= 16",
+                    "node >= 20",
                   ],
                 },
                 "isModule": "unknown",

--- a/packages/core/tests/__snapshots__/swc.test.ts.snap
+++ b/packages/core/tests/__snapshots__/swc.test.ts.snap
@@ -618,7 +618,7 @@ exports[`plugin-swc > should apply environment config correctly 2`] = `
           },
           "env": {
             "targets": [
-              "node >= 16",
+              "node >= 20",
             ],
           },
           "isModule": "unknown",
@@ -677,7 +677,7 @@ exports[`plugin-swc > should apply environment config correctly 2`] = `
           },
           "env": {
             "targets": [
-              "node >= 16",
+              "node >= 20",
             ],
           },
           "isModule": "unknown",
@@ -1031,7 +1031,7 @@ exports[`plugin-swc > should disable preset_env in target other than web 1`] = `
                 },
                 "env": {
                   "targets": [
-                    "node >= 16",
+                    "node >= 20",
                   ],
                 },
                 "isModule": "unknown",
@@ -1083,7 +1083,7 @@ exports[`plugin-swc > should disable preset_env in target other than web 1`] = `
                 },
                 "env": {
                   "targets": [
-                    "node >= 16",
+                    "node >= 20",
                   ],
                 },
                 "isModule": "unknown",
@@ -1720,7 +1720,7 @@ exports[`plugin-swc > should has correct core-js 2`] = `
                 },
                 "env": {
                   "targets": [
-                    "node >= 16",
+                    "node >= 20",
                   ],
                 },
                 "isModule": "unknown",
@@ -1772,7 +1772,7 @@ exports[`plugin-swc > should has correct core-js 2`] = `
                 },
                 "env": {
                   "targets": [
-                    "node >= 16",
+                    "node >= 20",
                   ],
                 },
                 "isModule": "unknown",

--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -208,7 +208,7 @@ exports[`plugins/babel > should apply environment config correctly 2`] = `
         },
         "env": {
           "targets": [
-            "node >= 16",
+            "node >= 20",
           ],
         },
         "isModule": "unknown",

--- a/website/docs/en/config/output/target.mdx
+++ b/website/docs/en/config/output/target.mdx
@@ -69,7 +69,7 @@ When `target` is set to `'node'`, Rsbuild will:
 - No HTML files will be generated, and HTML-related logic will not be executed, since HTML is not required in the Node.js environment.
 - The default code split strategy will be disabled, but dynamic import can still work.
 - Disable HMR.
-- Set the default value of Browserslist to `['node >= 16']`.
+- Set the default value of Browserslist to `['node >= 20']`.
 - Set the default value of [output.emitCss](/config/output/emit-css) to `false`. This means CSS code will not be extracted to separate files, but CSS Modules id information will be included in the bundle.
 
 ### Node addons

--- a/website/docs/en/guide/advanced/browserslist.mdx
+++ b/website/docs/en/guide/advanced/browserslist.mdx
@@ -53,10 +53,10 @@ With this browser range, the build output will be compatible with browsers that 
 
 ### Node target
 
-If `output.target` is `node`, Rsbuild will default to outputting bundles that run on Node.js 16.0 or later.
+If `output.target` is `node`, Rsbuild will default to outputting bundles that run on Node.js 20.0 or later.
 
 ```yaml title=".browserslistrc"
-node >= 16
+node >= 20
 ```
 
 ### Web Workers target

--- a/website/docs/zh/config/output/target.mdx
+++ b/website/docs/zh/config/output/target.mdx
@@ -69,7 +69,7 @@ export default {
 - 不会生成 HTML 文件，与 HTML 相关的逻辑也不会执行，因为 Node.js 环境不需要 HTML。
 - 不会开启默认的拆包策略，但 dynamic import 依然可以生效。
 - 不会开启热更新相关的能力。
-- 将 Browserslist 的默认值设置为 `['node >= 16']`。
+- 将 Browserslist 的默认值设置为 `['node >= 20']`。
 - 将 [output.emitCss](/config/output/emit-css) 的默认值设置为 `false`。这意味着 CSS 代码不会被抽取为单独的文件，但产物中会包含 CSS Modules 的 id 信息。
 
 ### Node addons

--- a/website/docs/zh/guide/advanced/browserslist.mdx
+++ b/website/docs/zh/guide/advanced/browserslist.mdx
@@ -53,10 +53,10 @@ safari >= 14
 
 ### Node 产物
 
-当 `output.target` 为 `node` 时，Rsbuild 默认输出运行在 Node.js 16.0 及以上版本的产物。
+当 `output.target` 为 `node` 时，Rsbuild 默认输出运行在 Node.js 20.0 及以上版本的产物。
 
 ```yaml title=".browserslistrc"
-node >= 16
+node >= 20
 ```
 
 ### Web Workers 产物


### PR DESCRIPTION
## Summary

Align the default Node target with the current supported runtime baseline (Node 20) to reduce unnecessary transpilation in modern environments.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
