### PR TITLE
docs: update server logs examples

### DIFF
--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -334,8 +334,8 @@ try {
 Once the dev server starts successfully, these logs appear:
 
 ```
-  ➜ Local:    http://localhost:3000
-  ➜ Network:  http://192.168.0.1:3000
+  ➜  Local:    http://localhost:3000
+  ➜  Network:  use --host to expose
 ```
 
 `startDevServer` returns these parameters:

--- a/website/docs/en/api/start/index.mdx
+++ b/website/docs/en/api/start/index.mdx
@@ -41,8 +41,8 @@ await rsbuild.startDevServer();
 Once the dev server starts successfully, these logs will appear:
 
 ```
-  ➜ Local:    http://localhost:3000
-  ➜ Network:  http://192.168.0.1:3000
+  ➜  Local:    http://localhost:3000
+  ➜  Network:  use --host to expose
 ```
 
 For production deployment, use the [rsbuild.build](/api/javascript-api/instance#rsbuildbuild) method to build production outputs:

--- a/website/docs/en/config/server/https.mdx
+++ b/website/docs/en/config/server/https.mdx
@@ -16,15 +16,15 @@ Configure HTTPS options to enable HTTPS server. When enabled, HTTP server will b
 HTTP:
 
 ```
-  ➜ Local: http://localhost:3000/
-  ➜ Network: http://192.168.0.1:3000/
+  ➜  Local:    http://localhost:3000
+  ➜  Network:  use --host to expose
 ```
 
 HTTPS:
 
 ```
-  ➜ Local: https://localhost:3000/
-  ➜ Network: https://192.168.0.1:3000/
+  ➜  Local:    https://localhost:3000
+  ➜  Network:  use --host to expose
 ```
 
 :::tip

--- a/website/docs/en/config/server/print-urls.mdx
+++ b/website/docs/en/config/server/print-urls.mdx
@@ -25,8 +25,8 @@ Controls whether and how server URLs are printed when the server starts.
 By default, when you start the dev server or preview server, Rsbuild will print the following logs:
 
 ```
-  ➜ Local:    http://localhost:3000
-  ➜ Network:  http://192.168.0.1:3000
+  ➜  Local:    http://localhost:3000
+  ➜  Network:  use --host to expose
 ```
 
 ## Custom logging
@@ -50,8 +50,8 @@ export default {
 Output:
 
 ```
-  ➜ Local:    http://localhost:3000/base/
-  ➜ Network:  http://192.168.0.1:3000/base/
+  ➜  Local:    http://localhost:3000/base/
+  ➜  Network:  use --host to expose
 ```
 
 You may also return an array containing both strings and objects. Each object may include an optional `label` that overrides the default `Local:` or `Network:` label; if omitted, the default label is used:
@@ -69,9 +69,9 @@ export default {
 Output:
 
 ```
-  ➜ Local:    http://localhost:3000/
-  ➜ Network:  http://192.168.0.1:3000/
-  ➜ Custom:   https://example.com/
+  ➜  Local:    http://localhost:3000/
+  ➜  Custom:   https://example.com/
+  ➜  Network:  use --host to expose
 ```
 
 ### Fully customizable
@@ -144,7 +144,7 @@ export default {
 Output:
 
 ```
-  ➜ Local:    http://localhost:3000
+  ➜  Local:    http://localhost:3000
 ```
 
 ## Version history

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -357,8 +357,8 @@ try {
 成功启动 dev server 后，可以看到以下日志信息：
 
 ```
-  ➜ Local:    http://localhost:3000
-  ➜ Network:  http://192.168.0.1:3000
+  ➜  Local:    http://localhost:3000
+  ➜  Network:  use --host to expose
 ```
 
 `startDevServer` 会返回以下参数：

--- a/website/docs/zh/api/start/index.mdx
+++ b/website/docs/zh/api/start/index.mdx
@@ -41,8 +41,8 @@ await rsbuild.startDevServer();
 成功启动 dev server 后，可以看到以下日志信息：
 
 ```
-  ➜ Local:    http://localhost:3000
-  ➜ Network:  http://192.168.0.1:3000
+  ➜  Local:    http://localhost:3000
+  ➜  Network:  use --host to expose
 ```
 
 在生产环境部署场景，建议使用 [rsbuild.build](/api/javascript-api/instance#rsbuildbuild) 方法，调用后会构建出生产模式产物。

--- a/website/docs/zh/config/server/https.mdx
+++ b/website/docs/zh/config/server/https.mdx
@@ -16,15 +16,15 @@ type Https = ServerOptions | SecureServerSessionOptions;
 开启前：
 
 ```
-  ➜ Local:    http://localhost:3000/
-  ➜ Network:  http://192.168.0.1:3000/
+  ➜  Local:    http://localhost:3000
+  ➜  Network:  use --host to expose
 ```
 
 开启后：
 
 ```
-  ➜ Local:    https://localhost:3000/
-  ➜ Network:  https://192.168.0.1:3000/
+  ➜  Local:    https://localhost:3000
+  ➜  Network:  use --host to expose
 ```
 
 :::tip

--- a/website/docs/zh/config/server/print-urls.mdx
+++ b/website/docs/zh/config/server/print-urls.mdx
@@ -25,8 +25,8 @@ type PrintUrls =
 默认情况下，当你启动 dev server 或 preview server 后，Rsbuild 会输出以下日志信息：
 
 ```
-  ➜ Local:    http://localhost:3000
-  ➜ Network:  http://192.168.0.1:3000
+  ➜  Local:    http://localhost:3000
+  ➜  Network:  use --host to expose
 ```
 
 ## 自定义日志
@@ -50,8 +50,8 @@ export default {
 输出为：
 
 ```
-  ➜ Local:    http://localhost:3000/base/
-  ➜ Network:  http://192.168.0.1:3000/base/
+  ➜  Local:    http://localhost:3000/base/
+  ➜  Network:  use --host to expose
 ```
 
 你还可以返回一个同时包含字符串和对象的数组。
@@ -70,9 +70,9 @@ export default {
 输出为：
 
 ```
-  ➜ Local:    http://localhost:3000/
-  ➜ Network:  http://192.168.0.1:3000/
-  ➜ Custom:   https://example.com/
+  ➜  Local:    http://localhost:3000/
+  ➜  Custom:   https://example.com/
+  ➜  Network:  use --host to expose
 ```
 
 ### 完全自定义
@@ -145,7 +145,7 @@ export default {
 输出：
 
 ```
-  ➜ Local:    http://localhost:3000
+  ➜  Local:    http://localhost:3000
 ```
 
 ## 版本历史


### PR DESCRIPTION
## Summary

Updated all dev server startup log examples in docs to show "`Network:  use --host to expose`" instead of a specific IP address. 

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
