### PR TITLE
fix(create-rsbuild): update @rsbuild/core dependency to v2.0.0-0

### DIFF
--- a/packages/create-rsbuild/template-lit-js/package.json
+++ b/packages/create-rsbuild/template-lit-js/package.json
@@ -12,6 +12,6 @@
     "lit": "^3.3.2"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.7.2"
+    "@rsbuild/core": "^2.0.0-0"
   }
 }

--- a/packages/create-rsbuild/template-lit-ts/package.json
+++ b/packages/create-rsbuild/template-lit-ts/package.json
@@ -12,7 +12,7 @@
     "lit": "^3.3.2"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.7.2",
+    "@rsbuild/core": "^2.0.0-0",
     "typescript": "^5.9.3"
   }
 }

--- a/packages/create-rsbuild/template-preact-js/package.json
+++ b/packages/create-rsbuild/template-preact-js/package.json
@@ -12,7 +12,7 @@
     "preact": "^10.28.2"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.7.2",
+    "@rsbuild/core": "^2.0.0-0",
     "@rsbuild/plugin-preact": "^1.7.0"
   }
 }

--- a/packages/create-rsbuild/template-preact-ts/package.json
+++ b/packages/create-rsbuild/template-preact-ts/package.json
@@ -12,7 +12,7 @@
     "preact": "^10.28.2"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.7.2",
+    "@rsbuild/core": "^2.0.0-0",
     "@rsbuild/plugin-preact": "^1.7.0",
     "typescript": "^5.9.3"
   }

--- a/packages/create-rsbuild/template-react-js/package.json
+++ b/packages/create-rsbuild/template-react-js/package.json
@@ -13,7 +13,7 @@
     "react-dom": "^19.2.3"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.7.2",
+    "@rsbuild/core": "^2.0.0-0",
     "@rsbuild/plugin-react": "^1.4.2"
   }
 }

--- a/packages/create-rsbuild/template-react-ts/package.json
+++ b/packages/create-rsbuild/template-react-ts/package.json
@@ -13,7 +13,7 @@
     "react-dom": "^19.2.3"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.7.2",
+    "@rsbuild/core": "^2.0.0-0",
     "@rsbuild/plugin-react": "^1.4.2",
     "@types/react": "^19.2.8",
     "@types/react-dom": "^19.2.3",

--- a/packages/create-rsbuild/template-react18-js/package.json
+++ b/packages/create-rsbuild/template-react18-js/package.json
@@ -13,7 +13,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.7.2",
+    "@rsbuild/core": "^2.0.0-0",
     "@rsbuild/plugin-react": "^1.4.2"
   }
 }

--- a/packages/create-rsbuild/template-react18-ts/package.json
+++ b/packages/create-rsbuild/template-react18-ts/package.json
@@ -13,7 +13,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.7.2",
+    "@rsbuild/core": "^2.0.0-0",
     "@rsbuild/plugin-react": "^1.4.2",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",

--- a/packages/create-rsbuild/template-solid-js/package.json
+++ b/packages/create-rsbuild/template-solid-js/package.json
@@ -12,7 +12,7 @@
     "solid-js": "^1.9.10"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.7.2",
+    "@rsbuild/core": "^2.0.0-0",
     "@rsbuild/plugin-babel": "^1.0.6",
     "@rsbuild/plugin-solid": "^1.0.6"
   }

--- a/packages/create-rsbuild/template-solid-ts/package.json
+++ b/packages/create-rsbuild/template-solid-ts/package.json
@@ -12,7 +12,7 @@
     "solid-js": "^1.9.10"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.7.2",
+    "@rsbuild/core": "^2.0.0-0",
     "@rsbuild/plugin-babel": "^1.0.6",
     "@rsbuild/plugin-solid": "^1.0.6",
     "typescript": "^5.9.3"

--- a/packages/create-rsbuild/template-svelte-js/package.json
+++ b/packages/create-rsbuild/template-svelte-js/package.json
@@ -12,7 +12,7 @@
     "svelte": "^5.46.1"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.7.2",
+    "@rsbuild/core": "^2.0.0-0",
     "@rsbuild/plugin-svelte": "^1.0.11"
   }
 }

--- a/packages/create-rsbuild/template-svelte-ts/package.json
+++ b/packages/create-rsbuild/template-svelte-ts/package.json
@@ -13,7 +13,7 @@
     "svelte": "^5.46.1"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.7.2",
+    "@rsbuild/core": "^2.0.0-0",
     "@rsbuild/plugin-svelte": "^1.0.11",
     "svelte-check": "^4.3.5",
     "typescript": "^5.9.3"

--- a/packages/create-rsbuild/template-vanilla-js/package.json
+++ b/packages/create-rsbuild/template-vanilla-js/package.json
@@ -9,6 +9,6 @@
     "preview": "rsbuild preview"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.7.2"
+    "@rsbuild/core": "^2.0.0-0"
   }
 }

--- a/packages/create-rsbuild/template-vanilla-ts/package.json
+++ b/packages/create-rsbuild/template-vanilla-ts/package.json
@@ -9,7 +9,7 @@
     "preview": "rsbuild preview"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.7.2",
+    "@rsbuild/core": "^2.0.0-0",
     "typescript": "^5.9.3"
   }
 }

--- a/packages/create-rsbuild/template-vue2-js/package.json
+++ b/packages/create-rsbuild/template-vue2-js/package.json
@@ -12,7 +12,7 @@
     "vue": "^2.7.16"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.7.2",
+    "@rsbuild/core": "^2.0.0-0",
     "@rsbuild/plugin-vue2": "^1.0.5"
   }
 }

--- a/packages/create-rsbuild/template-vue2-ts/package.json
+++ b/packages/create-rsbuild/template-vue2-ts/package.json
@@ -12,7 +12,7 @@
     "vue": "^2.7.16"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.7.2",
+    "@rsbuild/core": "^2.0.0-0",
     "@rsbuild/plugin-vue2": "^1.0.5",
     "typescript": "^5.9.3"
   }

--- a/packages/create-rsbuild/template-vue3-js/package.json
+++ b/packages/create-rsbuild/template-vue3-js/package.json
@@ -12,7 +12,7 @@
     "vue": "^3.5.26"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.7.2",
+    "@rsbuild/core": "^2.0.0-0",
     "@rsbuild/plugin-vue": "^1.2.2"
   }
 }

--- a/packages/create-rsbuild/template-vue3-ts/package.json
+++ b/packages/create-rsbuild/template-vue3-ts/package.json
@@ -12,7 +12,7 @@
     "vue": "^3.5.26"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.7.2",
+    "@rsbuild/core": "^2.0.0-0",
     "@rsbuild/plugin-vue": "^1.2.2",
     "typescript": "^5.9.3"
   }


### PR DESCRIPTION
## Summary

Updates the `@rsbuild/core` version from `^1.7.2` to`^2.0.0-0` across all templates in the `create-rsbuild`.

## Related Links

- https://github.com/web-infra-dev/rsbuild/releases/tag/v2.0.0-alpha.0

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
