### PR TITLE
fix: update transformImport typing

### DIFF
--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -245,13 +245,7 @@ export const pluginHtml = (context: InternalContext): RsbuildPlugin => ({
 
         const finalOptions = await Promise.all(
           entryNames.map(async (entryName) => {
-            // EntryDescription type is different between webpack and Rspack
-            const entryValue = entries[entryName].values() as (
-              | string
-              | string[]
-              | EntryDescription
-            )[];
-
+            const entryValue = entries[entryName].values();
             const chunks = getChunks(entryName, entryValue);
             const inject = getInject(entryName, config);
             const filename = htmlPaths[entryName];

--- a/packages/core/src/plugins/splitChunks.ts
+++ b/packages/core/src/plugins/splitChunks.ts
@@ -22,11 +22,11 @@ interface SplitChunksContext {
    */
   forceSplittingGroups: CacheGroups;
   /**
-   * Default split config in webpack
+   * Default split config in Rspack
    */
   defaultConfig: Exclude<SplitChunks, false>;
   /**
-   * User webpack `splitChunks` config
+   * User Rspack `splitChunks` config
    */
   override: Exclude<SplitChunks, false>;
   /**

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -294,14 +294,14 @@ export interface SourceConfig {
 export type TransformImport = {
   libraryName: string;
   libraryDirectory?: string;
+  customName?: string;
+  customStyleName?: string;
   style?: string | boolean;
   styleLibraryDirectory?: string;
   camelToDashComponentName?: boolean;
   transformToDefaultImport?: boolean;
-  // Use a loose type to compat webpack
-  customName?: any;
-  // Use a loose type to compat webpack
-  customStyleName?: any;
+  ignoreEsComponent?: string[];
+  ignoreStyleComponent?: string[];
 };
 
 type TransformImportFn = (

--- a/scripts/test-helper/src/index.ts
+++ b/scripts/test-helper/src/index.ts
@@ -83,7 +83,7 @@ export async function createStubRsbuild({
     return configs[index];
   };
 
-  /** Match rspack/webpack plugin by constructor name. */
+  /** Match Rspack plugin by constructor name. */
   const matchBundlerPlugin = async (pluginName: string, index?: number) => {
     const config = await unwrapConfig(index);
 

--- a/website/docs/en/config/source/transform-import.mdx
+++ b/website/docs/en/config/source/transform-import.mdx
@@ -7,12 +7,14 @@ type TransformImport =
   | Array<{
       libraryName: string;
       libraryDirectory?: string;
+      customName?: string;
+      customStyleName?: string;
       style?: string | boolean;
       styleLibraryDirectory?: string;
       camelToDashComponentName?: boolean;
       transformToDefaultImport?: boolean;
-      customName?: string;
-      customStyleName?: string;
+      ignoreEsComponent?: string[];
+      ignoreStyleComponent?: string[];
     }>
   | Function;
 ```

--- a/website/docs/zh/config/source/transform-import.mdx
+++ b/website/docs/zh/config/source/transform-import.mdx
@@ -7,12 +7,14 @@ type TransformImport =
   | Array<{
       libraryName: string;
       libraryDirectory?: string;
+      customName?: string;
+      customStyleName?: string;
       style?: string | boolean;
       styleLibraryDirectory?: string;
       camelToDashComponentName?: boolean;
       transformToDefaultImport?: boolean;
-      customName?: string;
-      customStyleName?: string;
+      ignoreEsComponent?: string[];
+      ignoreStyleComponent?: string[];
     }>
   | Function;
 ```


### PR DESCRIPTION
## Summary

Updated the `TransformImport` type to use stricter types for `customName` and `customStyleName`, and added new options `ignoreEsComponent` and `ignoreStyleComponent`

## Related Links

- https://rspack.rs/guide/features/builtin-swc-loader#rspackexperimentsimport

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
