### PR TITLE
fix: correct 'drafts' in lightningcss minimize plugin

### DIFF
--- a/packages/core/src/plugins/minimize.ts
+++ b/packages/core/src/plugins/minimize.ts
@@ -117,7 +117,7 @@ export const pluginMinimize = (): RsbuildPlugin => ({
               ? environment.browserslist
               : loaderOptions.targets,
             ...pick(loaderOptions, [
-              'draft',
+              'drafts',
               'include',
               'exclude',
               'nonStandard',


### PR DESCRIPTION
## Summary

Corrects the property name from `draft` to `drafts` when picking lightningcss options from `loaderOptions`.

## Related Links

- https://github.com/web-infra-dev/rspack/pull/12740

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
