### PR TITLE
docs: add `performance.removeMomentLocale` to upgrade guide

### DIFF
--- a/website/docs/en/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/en/guide/upgrade/v1-to-v2.mdx
@@ -165,6 +165,14 @@ export default {
 };
 ```
 
+### Remove `performance.removeMomentLocale`
+
+The `performance.removeMomentLocale` option has been removed.
+
+This option existed to drop Moment.js locale data from the bundle, but Rspack v2 does not include Moment locales by default, so the option is no longer necessary.
+
+> For background, see [web-infra-dev/rsbuild#6991](https://github.com/web-infra-dev/rsbuild/pull/6991).
+
 ### Remove `performance.profile`
 
 The `performance.profile` option has been removed. If you relied on it to emit a stats JSON file, use [stats.toJson()](/api/javascript-api/instance#stats-object) in a custom plugin instead:

--- a/website/docs/zh/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/zh/guide/upgrade/v1-to-v2.mdx
@@ -165,6 +165,14 @@ export default {
 };
 ```
 
+### 移除 `performance.removeMomentLocale`
+
+`performance.removeMomentLocale` 选项已被移除。
+
+该选项原本用于从产物中移除 Moment.js 的语言包。但在 Rspack v2 中，Moment 的 locales 默认不会被打包，因此该选项已不再需要。
+
+> 背景信息可参考 [web-infra-dev/rsbuild#6991](https://github.com/web-infra-dev/rsbuild/pull/6991)。
+
 ### 移除 `performance.profile`
 
 `performance.profile` 选项已被移除。如果你依赖它来输出 stats JSON 文件，可以在自定义插件中调用 [stats.toJson()](/api/javascript-api/instance#stats-object) 代替：


### PR DESCRIPTION
## Summary

Added a section in upgrade guide, explaining the removal of the `performance.removeMomentLocale` option and the reason for its deprecation.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/6991

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
