### PR TITLE
docs: add Rspack v2 dependency information to upgrade guide

### DIFF
--- a/website/docs/en/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/en/guide/upgrade/v1-to-v2.mdx
@@ -6,6 +6,12 @@ This document lists all breaking changes from Rsbuild 1.x to 2.0. Use it as a mi
 
 > This guide is a work in progress. Content will be added incrementally as Rsbuild 2.0 beta evolves.
 
+## Upgrade to Rspack v2
+
+Rsbuild v2 now depends on [@rspack/core](https://www.npmjs.com/package/@rspack/core) v2.
+
+See the [Rspack v2 Upgrade Guide](https://github.com/web-infra-dev/rspack/discussions/9270) for all breaking changes.
+
 ## Default browserslist updated
 
 In Rsbuild 2.0, the default browserslist have been updated to better reflect the modern web platform baseline.

--- a/website/docs/zh/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/zh/guide/upgrade/v1-to-v2.mdx
@@ -6,6 +6,12 @@ import { PackageManagerTabs } from '@theme';
 
 > 本指南仍在持续完善中。随着 Rsbuild 2.0 Beta 的推进，相关内容将逐步补充。
 
+## 升级 Rspack v2
+
+Rsbuild v2 现在依赖 [@rspack/core](https://www.npmjs.com/package/@rspack/core) v2。
+
+参考 [Rspack v2 升级指南](https://github.com/web-infra-dev/rspack/discussions/9270) 了解所有不兼容更新。
+
 ## 默认 browserslist 更新
 
 在 Rsbuild 2.0 中，默认的 browserslist 已进行更新，以更好地反映现代 Web 平台的基线水平。


### PR DESCRIPTION
## Summary

Added a section to note that Rsbuild v2 now relies on `@rspack/core` v2 and included a link to the Rspack v2 upgrade guide for breaking changes.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
