### PR TITLE
test(e2e): enable skipped tests for Preact

### DIFF
--- a/e2e/cases/plugin-preact/basic/index.test.ts
+++ b/e2e/cases/plugin-preact/basic/index.test.ts
@@ -1,10 +1,6 @@
 import { expect, test } from '@e2e/helper';
 
-// TODO: Fix this test
-test.skip('should render basic Preact component in dev', async ({
-  page,
-  dev,
-}) => {
+test('should render basic Preact component in dev', async ({ page, dev }) => {
   await dev();
 
   const button = page.locator('#button');

--- a/e2e/cases/plugin-preact/prefresh-context/index.test.ts
+++ b/e2e/cases/plugin-preact/prefresh-context/index.test.ts
@@ -2,8 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { expect, test } from '@e2e/helper';
 
-// TODO: Fix this test
-test.skip('HMR should work properly with `createContext`', async ({
+test('HMR should work properly with `createContext`', async ({
   page,
   dev,
   editFile,

--- a/e2e/cases/plugin-preact/prefresh/index.test.ts
+++ b/e2e/cases/plugin-preact/prefresh/index.test.ts
@@ -2,8 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { expect, test } from '@e2e/helper';
 
-// TODO: Fix this test
-test.skip('HMR should work properly', async ({ page, dev, editFile }) => {
+test('HMR should work properly', async ({ page, dev, editFile }) => {
   // Prefresh does not work as expected on Windows
   if (process.platform === 'win32') {
     test.skip();

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@prefresh/core": "^1.5.9",
     "@prefresh/utils": "^1.2.1",
-    "@rspack/plugin-preact-refresh": "^1.1.4",
+    "@rspack/plugin-preact-refresh": "^1.1.5",
     "@swc/plugin-prefresh": "^12.3.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -779,8 +779,8 @@ importers:
         specifier: ^1.2.1
         version: 1.2.1
       '@rspack/plugin-preact-refresh':
-        specifier: ^1.1.4
-        version: 1.1.4(@prefresh/core@1.5.9(preact@10.28.2))(@prefresh/utils@1.2.1)
+        specifier: ^1.1.5
+        version: 1.1.5(@prefresh/core@1.5.9(preact@10.28.2))(@prefresh/utils@1.2.1)
       '@swc/plugin-prefresh':
         specifier: ^12.3.0
         version: 12.3.0
@@ -2452,8 +2452,8 @@ packages:
   '@rspack/lite-tapable@1.1.0':
     resolution: {integrity: sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==}
 
-  '@rspack/plugin-preact-refresh@1.1.4':
-    resolution: {integrity: sha512-M197BNmvxD7h0hwccmAyc3H6QCeOFPLUExoC9jgEpZI4+dLnbrJyGEEuGss2svUIT6T5d92S71K0o8xSyjuFPQ==}
+  '@rspack/plugin-preact-refresh@1.1.5':
+    resolution: {integrity: sha512-1oXF8ovAF+XoMcZ1qjeJ+l28qXAnKmVulV8Q5/Q1bXDkfMBmvC10O94wpxojcIY/kdMrHIFTfWbUhm0qBcYeGA==}
     peerDependencies:
       '@prefresh/core': ^1.5.0
       '@prefresh/utils': ^1.2.0
@@ -7845,7 +7845,7 @@ snapshots:
 
   '@rspack/lite-tapable@1.1.0': {}
 
-  '@rspack/plugin-preact-refresh@1.1.4(@prefresh/core@1.5.9(preact@10.28.2))(@prefresh/utils@1.2.1)':
+  '@rspack/plugin-preact-refresh@1.1.5(@prefresh/core@1.5.9(preact@10.28.2))(@prefresh/utils@1.2.1)':
     dependencies:
       '@prefresh/core': 1.5.9(preact@10.28.2)
       '@prefresh/utils': 1.2.1


### PR DESCRIPTION
## Summary

- Re-enabled the E2E test for Preact
- Updated `@rspack/plugin-preact-refresh` from version `1.1.4` to `1.1.5`

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
