### PR TITLE
chore: update renovate configuration to include Rstest group

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,6 +30,11 @@
       matchPackageNames: ['/rspress/'],
     },
     {
+      groupName: 'Rstest',
+      groupSlug: 'rstest',
+      matchPackageNames: ['/rstest/'],
+    },
+    {
       groupName: 'Rslib',
       groupSlug: 'rslib',
       matchPackageNames: ['/rslib/'],
@@ -38,11 +43,6 @@
       groupName: 'Sass',
       groupSlug: 'sass',
       matchPackageNames: ['/sass/'],
-    },
-    {
-      groupName: 'ESLint',
-      groupSlug: 'eslint',
-      matchPackageNames: ['/eslint/'],
     },
     {
       groupName: 'Module Federation',


### PR DESCRIPTION
## Summary

* Added a new Renovate group named to match packages with names containing `/rstest/`.
* Removed the Renovate group for `'ESLint'`

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
