### PR TITLE
test: simplify assertions in SSR tests

### DIFF
--- a/e2e/cases/server/custom-server/index.test.ts
+++ b/e2e/cases/server/custom-server/index.test.ts
@@ -14,9 +14,8 @@ test('should support a custom dev server', async ({ page }) => {
 
   const url1 = new URL(`http://localhost:${config.port}/bbb`);
 
-  const res = await page.goto(url1.href);
-
-  expect(await res?.text()).toBe('Hello polka!');
+  await page.goto(url1.href);
+  await expect(page.locator('body')).toContainText('Hello polka!');
 
   await close();
 });
@@ -31,9 +30,8 @@ test('should support a custom dev server without compilation', async ({
 
   const url1 = new URL(`http://localhost:${config.port}/bbb`);
 
-  const res = await page.goto(url1.href);
-
-  expect(await res?.text()).toBe('Hello polka!');
+  await page.goto(url1.href);
+  await expect(page.locator('body')).toContainText('Hello polka!');
 
   const url2 = new URL(`http://localhost:${config.port}/test`);
 

--- a/e2e/cases/server/ssr/index.test.ts
+++ b/e2e/cases/server/ssr/index.test.ts
@@ -5,9 +5,8 @@ test('support SSR', async ({ page, devOnly }) => {
 
   const url = new URL(`http://localhost:${rsbuild.port}`);
 
-  const res = await page.goto(url.href);
-
-  expect(await res?.text()).toMatch(/Rsbuild with React/);
+  await page.goto(url.href);
+  await expect(page.locator('body')).toContainText('Rsbuild with React');
 
   await page.goto(url.href);
 
@@ -29,9 +28,8 @@ test('support SSR with external', async ({ page, devOnly }) => {
 
   const url = new URL(`http://localhost:${rsbuild.port}`);
 
-  const res = await page.goto(url.href);
-
-  expect(await res?.text()).toMatch(/Rsbuild with React/);
+  await page.goto(url.href);
+  await expect(page.locator('body')).toContainText('Rsbuild with React');
 
   await page.goto(url.href);
 
@@ -46,9 +44,8 @@ test('support SSR with esm target', async ({ page, devOnly }) => {
 
   const url1 = new URL(`http://localhost:${rsbuild.port}`);
 
-  const res = await page.goto(url1.href);
-
-  expect(await res?.text()).toMatch(/Rsbuild with React/);
+  await page.goto(url1.href);
+  await expect(page.locator('body')).toContainText('Rsbuild with React');
 
   delete process.env.TEST_ESM_LIBRARY;
 });
@@ -69,9 +66,8 @@ test('support SSR with esm target & external', async ({ page, devOnly }) => {
 
   const url1 = new URL(`http://localhost:${rsbuild.port}`);
 
-  const res = await page.goto(url1.href);
-
-  expect(await res?.text()).toMatch(/Rsbuild with React/);
+  await page.goto(url1.href);
+  await expect(page.locator('body')).toContainText('Rsbuild with React');
 
   delete process.env.TEST_ESM_LIBRARY;
 });
@@ -80,12 +76,10 @@ test('support SSR with split chunk', async ({ page, devOnly }) => {
   process.env.TEST_SPLIT_CHUNK = '1';
 
   const rsbuild = await devOnly();
-
   const url1 = new URL(`http://localhost:${rsbuild.port}`);
 
-  const res = await page.goto(url1.href);
-
-  expect(await res?.text()).toMatch(/Rsbuild with React/);
+  await page.goto(url1.href);
+  await expect(page.locator('body')).toContainText('Rsbuild with React');
 
   delete process.env.TEST_SPLIT_CHUNK;
 });


### PR DESCRIPTION
## Summary

* Updated SSR-related tests to use `page.locator('body')` with `toContainText` for verifying the presence of "Rsbuild with React" instead of checking the response text directly.

## Related Links

- the same as https://github.com/web-infra-dev/rsbuild/pull/7011

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
