### PR TITLE
feat(deps): update @rspack/core to 2.0.0-alpha.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,7 @@
     "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {
-    "@rspack/core": "2.0.0-canary.20260120",
+    "@rspack/core": "2.0.0-alpha.0",
     "@rspack/lite-tapable": "~1.1.0",
     "@swc/helpers": "^0.5.18",
     "jiti": "^2.6.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -502,8 +502,8 @@ importers:
   packages/core:
     dependencies:
       '@rspack/core':
-        specifier: 2.0.0-canary.20260120
-        version: 2.0.0-canary.20260120(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18)
+        specifier: 2.0.0-alpha.0
+        version: 2.0.0-alpha.0(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18)
       '@rspack/lite-tapable':
         specifier: ~1.1.0
         version: 1.1.0
@@ -561,7 +561,7 @@ importers:
         version: 2.8.5
       css-loader:
         specifier: 7.1.2
-        version: 7.1.2(patch_hash=f108465818eeda8955fecc4aa57dbfd6219c34a7a876fc224f229836292996a6)(@rspack/core@2.0.0-canary.20260120(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18))(webpack@5.104.1)
+        version: 7.1.2(patch_hash=f108465818eeda8955fecc4aa57dbfd6219c34a7a876fc224f229836292996a6)(@rspack/core@2.0.0-alpha.0(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18))(webpack@5.104.1)
       deepmerge:
         specifier: ^4.3.1
         version: 4.3.1
@@ -570,7 +570,7 @@ importers:
         version: 12.0.3
       html-rspack-plugin:
         specifier: 6.1.4
-        version: 6.1.4(@rspack/core@2.0.0-canary.20260120(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18))
+        version: 6.1.4(@rspack/core@2.0.0-alpha.0(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18))
       http-proxy-middleware:
         specifier: ^2.0.9
         version: 2.0.9
@@ -600,7 +600,7 @@ importers:
         version: 6.0.1(jiti@2.6.1)(postcss@8.5.6)(yaml@2.8.2)
       postcss-loader:
         specifier: 8.2.0
-        version: 8.2.0(patch_hash=7434af0286aadb1ef0e2daed0d97ebc69f717990e106d650e6e515683e89988a)(@rspack/core@2.0.0-canary.20260120(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18))(postcss@8.5.6)(typescript@5.9.3)(webpack@5.104.1)
+        version: 8.2.0(patch_hash=7434af0286aadb1ef0e2daed0d97ebc69f717990e106d650e6e515683e89988a)(@rspack/core@2.0.0-alpha.0(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18))(postcss@8.5.6)(typescript@5.9.3)(webpack@5.104.1)
       prebundle:
         specifier: 1.6.0
         version: 1.6.0(typescript@5.9.3)
@@ -615,10 +615,10 @@ importers:
         version: 1.3.2
       rspack-chain:
         specifier: ^2.0.0-alpha.0
-        version: 2.0.0-alpha.0(@rspack/core@2.0.0-canary.20260120(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18))
+        version: 2.0.0-alpha.0(@rspack/core@2.0.0-alpha.0(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18))
       rspack-manifest-plugin:
         specifier: 5.2.1
-        version: 5.2.1(@rspack/core@2.0.0-canary.20260120(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18))
+        version: 5.2.1(@rspack/core@2.0.0-alpha.0(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18))
       sirv:
         specifier: ^3.0.2
         version: 3.0.2
@@ -2267,13 +2267,13 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-arm64@2.0.0-canary-20260116':
-    resolution: {integrity: sha512-q52OGw7CsMfP6Qg84mKKDejqHO320A8/7qJaOtfHuZWyfx7PrIgOLQquTNbS9Vrk/ygwUavWVIk77rLfDgqYAg==}
+  '@rspack/binding-darwin-arm64@2.0.0-alpha.0':
+    resolution: {integrity: sha512-t1Mx0ddUsJoBu1UE7vImUzTgYUM+8aAsRPhyI5+I6KrsX1EhNuAmnUI0l3dyuR96g/xu5zbYTX/xHrTOzXnt+A==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-arm64@2.0.0-canary.20260120':
-    resolution: {integrity: sha512-X2F5jgQaCYwzIAYtiLMnI0C0NqKZ6KTRDkTk4JbAcp11CtmVblV/Rjmc88J/LGONCuRizJ3w0nAb7kin6GJqJg==}
+  '@rspack/binding-darwin-arm64@2.0.0-canary-20260116':
+    resolution: {integrity: sha512-q52OGw7CsMfP6Qg84mKKDejqHO320A8/7qJaOtfHuZWyfx7PrIgOLQquTNbS9Vrk/ygwUavWVIk77rLfDgqYAg==}
     cpu: [arm64]
     os: [darwin]
 
@@ -2287,13 +2287,13 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@2.0.0-canary-20260116':
-    resolution: {integrity: sha512-gfCDTX8yTLkNKxcKqbOZwVkzolDFNHoFZd45ofIZVVVyNtdoZ8w2+aS8AzdW8e5zRWuddszmqUx/URa3Z1pLxw==}
+  '@rspack/binding-darwin-x64@2.0.0-alpha.0':
+    resolution: {integrity: sha512-iCpiYrwaf+tfKNcHzy3mbxITfC8ng2IndJLhKZRXfHX6Ez4kx3X9oICmmI3SalP1tBFDJC9hCcxgOx0SrSVDvg==}
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@2.0.0-canary.20260120':
-    resolution: {integrity: sha512-3uKTDyGsQdVSeYD4h0eAe83yMdwXbUiiRMHkztG83O67GyRvy0zfbrL81Q3Dzw28PwqUNuCoRLs6Jh8OpSa1Qg==}
+  '@rspack/binding-darwin-x64@2.0.0-canary-20260116':
+    resolution: {integrity: sha512-gfCDTX8yTLkNKxcKqbOZwVkzolDFNHoFZd45ofIZVVVyNtdoZ8w2+aS8AzdW8e5zRWuddszmqUx/URa3Z1pLxw==}
     cpu: [x64]
     os: [darwin]
 
@@ -2307,13 +2307,13 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-gnu@2.0.0-canary-20260116':
-    resolution: {integrity: sha512-y/eOk37cFjFpENvl3mVwrMW2L18/hLPmAfrvHIYq/wv+uwVHJ07LcKle6FwnGJXnPsO8ZXtsu6P1SAnfuKXtPQ==}
+  '@rspack/binding-linux-arm64-gnu@2.0.0-alpha.0':
+    resolution: {integrity: sha512-xFqvqU7e+S8SPAQ+CXzP0YJIQcKHVFt5WLnXR7rnlxW0iikCJfkxFgPpmuSEeIPrV/Wzj4tPJHKp2qhfr1FMoQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-gnu@2.0.0-canary.20260120':
-    resolution: {integrity: sha512-8ubyIJXbNulld06mwcmLsuKcfpGcOdBRCskXVgvM7oD4zxtIuAQhtP7G8NUllLSYi2Tx6R4p6gxtLFoNlO/uYg==}
+  '@rspack/binding-linux-arm64-gnu@2.0.0-canary-20260116':
+    resolution: {integrity: sha512-y/eOk37cFjFpENvl3mVwrMW2L18/hLPmAfrvHIYq/wv+uwVHJ07LcKle6FwnGJXnPsO8ZXtsu6P1SAnfuKXtPQ==}
     cpu: [arm64]
     os: [linux]
 
@@ -2327,13 +2327,13 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-musl@2.0.0-canary-20260116':
-    resolution: {integrity: sha512-HUip7i2zIRqX/STjFfaf2a02ZbWX8BQcCs8Yv1cFZ76OMjwpte2mtw+6TbZxoCUACNENt+w592pbpinTCo45uA==}
+  '@rspack/binding-linux-arm64-musl@2.0.0-alpha.0':
+    resolution: {integrity: sha512-7ur+eWufMelM5CXebK+o6dg/JBErXd6cGwZaJlLyHSUbsdpNFrtenH38ipNRBKAd/O4YqktMkcqOEYSskmxn3w==}
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-musl@2.0.0-canary.20260120':
-    resolution: {integrity: sha512-jA86zCDh9VyNTGMGqxV4M0PmflkcZRAPKfp+As5BV6Nh4rwvSujtPqmVDlU6anH7Axoj7f/Jq553vhZ6GgLKjw==}
+  '@rspack/binding-linux-arm64-musl@2.0.0-canary-20260116':
+    resolution: {integrity: sha512-HUip7i2zIRqX/STjFfaf2a02ZbWX8BQcCs8Yv1cFZ76OMjwpte2mtw+6TbZxoCUACNENt+w592pbpinTCo45uA==}
     cpu: [arm64]
     os: [linux]
 
@@ -2347,13 +2347,13 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-gnu@2.0.0-canary-20260116':
-    resolution: {integrity: sha512-v+udhhMGSvkbioYWCQK6fHTc3K4Pkl2y34LPDxK6r1PCAPWcktyZXTIrvH3j9HyU1Ntv8pZHXNYtB19fZ4faFA==}
+  '@rspack/binding-linux-x64-gnu@2.0.0-alpha.0':
+    resolution: {integrity: sha512-IqME4JyDBTJo3VtZuFhhkwWUzyGjk7NESq8gRS+7tjZFIfPpTC8wLmerRIAoOSI8ou9V2lJ/jMB3bBXUyZcSjA==}
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-gnu@2.0.0-canary.20260120':
-    resolution: {integrity: sha512-y4WstUStLwCSDVWr+6AugzVx7oUhqyB442GS5L2W+trc1w5AkepRsxzOt+lvGY9LeDQzOqxRCc/UD3HcdLSgAw==}
+  '@rspack/binding-linux-x64-gnu@2.0.0-canary-20260116':
+    resolution: {integrity: sha512-v+udhhMGSvkbioYWCQK6fHTc3K4Pkl2y34LPDxK6r1PCAPWcktyZXTIrvH3j9HyU1Ntv8pZHXNYtB19fZ4faFA==}
     cpu: [x64]
     os: [linux]
 
@@ -2367,13 +2367,13 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-musl@2.0.0-canary-20260116':
-    resolution: {integrity: sha512-Q0MRTEXUG7bUtcA2rn1n3lz3OmEgrjJMGRBT4LLa0mOD4LFBznY3NRxcaADoi5BNplpeMr+54Q83iGsoAB6UGw==}
+  '@rspack/binding-linux-x64-musl@2.0.0-alpha.0':
+    resolution: {integrity: sha512-EMnOI0NM8iqau9cLEL8N8SIX72/jOtePaqZp6E6P/Ai20mN4w2qz//+9RTXfxneDu3qict+Htba0ZmbXEfANGQ==}
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-musl@2.0.0-canary.20260120':
-    resolution: {integrity: sha512-b9A8Qj0IrHJA6NOu5SPKScSnkiKLX3Xte8SYyvDa6qFHqJlF8MgNPI8WeypmLDG2ZU+RHuWwYweJ+oxxrbwF1g==}
+  '@rspack/binding-linux-x64-musl@2.0.0-canary-20260116':
+    resolution: {integrity: sha512-Q0MRTEXUG7bUtcA2rn1n3lz3OmEgrjJMGRBT4LLa0mOD4LFBznY3NRxcaADoi5BNplpeMr+54Q83iGsoAB6UGw==}
     cpu: [x64]
     os: [linux]
 
@@ -2385,12 +2385,12 @@ packages:
     resolution: {integrity: sha512-TU/aLBpm9CTR/RTLF27WlvBKGyju6gpiNTRd3XRbX2JfY3UBNUQN/Ev+gQMVeOj55y9Fruzou42/w9ncTKA0Dw==}
     cpu: [wasm32]
 
-  '@rspack/binding-wasm32-wasi@2.0.0-canary-20260116':
-    resolution: {integrity: sha512-2pKO4rKfD2FcwlAV9l/odOv3z3dQyOhvoDonwx4/CvAPWp9WTijqljwxEqyf49DLdQmVNlJwYONGvnRfYs6DHA==}
+  '@rspack/binding-wasm32-wasi@2.0.0-alpha.0':
+    resolution: {integrity: sha512-x3obe2ptcoS4/M07HOpE2PZ0o+A47dv99x1vta4guUmVLo9lnHPZZuMp3296uBGnqecZrJdgAkTPQEC/JyxQXQ==}
     cpu: [wasm32]
 
-  '@rspack/binding-wasm32-wasi@2.0.0-canary.20260120':
-    resolution: {integrity: sha512-mEE4Erxidto/ZzVvkrgptUdv9En13I2Lq6sYSNPCce8Ixp+C/8I5LdhU66brOn8HEZA8gqUEbdxiUfm/bLNKkQ==}
+  '@rspack/binding-wasm32-wasi@2.0.0-canary-20260116':
+    resolution: {integrity: sha512-2pKO4rKfD2FcwlAV9l/odOv3z3dQyOhvoDonwx4/CvAPWp9WTijqljwxEqyf49DLdQmVNlJwYONGvnRfYs6DHA==}
     cpu: [wasm32]
 
   '@rspack/binding-win32-arm64-msvc@1.7.0':
@@ -2403,13 +2403,13 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-arm64-msvc@2.0.0-canary-20260116':
-    resolution: {integrity: sha512-e4UJO3TbhkG+xR97tt87n1vDwOCdUXQy6XZVAtjocKdZaYB3ir5hQxErlMbtfgLntjcvrrbT6TWXlfVOq1sRBQ==}
+  '@rspack/binding-win32-arm64-msvc@2.0.0-alpha.0':
+    resolution: {integrity: sha512-j7AkQ903q0aGzvHJGi+ZOwEwmlrS1YYpTuRXw2V7sxwsSPbMIweRp2mOSZ9hezzxrwglcdu/+5/oxKToyXvcSQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-arm64-msvc@2.0.0-canary.20260120':
-    resolution: {integrity: sha512-1tPdUkKNp9Qnc7GnMpfp8OfUfCB92W+gH8cR5cYHuYhWsCHzCDXAtEwFWhoDpU30ughCtJJqFf49idw6Onko+Q==}
+  '@rspack/binding-win32-arm64-msvc@2.0.0-canary-20260116':
+    resolution: {integrity: sha512-e4UJO3TbhkG+xR97tt87n1vDwOCdUXQy6XZVAtjocKdZaYB3ir5hQxErlMbtfgLntjcvrrbT6TWXlfVOq1sRBQ==}
     cpu: [arm64]
     os: [win32]
 
@@ -2423,13 +2423,13 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@2.0.0-canary-20260116':
-    resolution: {integrity: sha512-JezTHy8DyFNfjMQCW80aEjd29iVL6a6YNTVz+pXqXx77kHIaLYZStMUyWFsH7awtV2Oi2iXC5Y6DgjyBQB0SzQ==}
+  '@rspack/binding-win32-ia32-msvc@2.0.0-alpha.0':
+    resolution: {integrity: sha512-ZkSYAeQmhuP1kTccezXLiP4Si1vrBdpL3Ar6HfqiYTfxjhv7OuZSzLseFGFRePtyEUULpcXlHmj219ObCu0D2Q==}
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@2.0.0-canary.20260120':
-    resolution: {integrity: sha512-5pifP0LMAfdjsXDt1C2EBgDY7eC+eZbJqlYi6bVKVUP8H0p7ymTigaMcCwtueUAcjB9DcBEuOFEs556uOiXSmQ==}
+  '@rspack/binding-win32-ia32-msvc@2.0.0-canary-20260116':
+    resolution: {integrity: sha512-JezTHy8DyFNfjMQCW80aEjd29iVL6a6YNTVz+pXqXx77kHIaLYZStMUyWFsH7awtV2Oi2iXC5Y6DgjyBQB0SzQ==}
     cpu: [ia32]
     os: [win32]
 
@@ -2443,13 +2443,13 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@2.0.0-canary-20260116':
-    resolution: {integrity: sha512-O6MC9DGgTTV2EQjzeShbpNLUKuSQGzZQ3oxEqnpVxB+ZBdkC5r2uCYij4L0puQTiRXBulJ7GyvXnkkVGdmOlHA==}
+  '@rspack/binding-win32-x64-msvc@2.0.0-alpha.0':
+    resolution: {integrity: sha512-dKSYMsK/kDUz/DDCElRs//7nNSgBzXEIYT0whbBVcvTjdSz38kgKu5meYY5u/NnmHiXGquz0exOo1M8Ij2ag0w==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@2.0.0-canary.20260120':
-    resolution: {integrity: sha512-Y9s1TVPc7QXMAM6fSnCD19thvs8FBrr9YjfFwCXpunpafL8G//4uHKX3e+blHnufQ4b6m9mVuAaVLZoOEt5cUw==}
+  '@rspack/binding-win32-x64-msvc@2.0.0-canary-20260116':
+    resolution: {integrity: sha512-O6MC9DGgTTV2EQjzeShbpNLUKuSQGzZQ3oxEqnpVxB+ZBdkC5r2uCYij4L0puQTiRXBulJ7GyvXnkkVGdmOlHA==}
     cpu: [x64]
     os: [win32]
 
@@ -2459,11 +2459,11 @@ packages:
   '@rspack/binding@1.7.2':
     resolution: {integrity: sha512-bVssRQ39TgGA2RxKEbhUBKYRHln9sbBi0motHmqSU53aMnIkiLXjcj7tZC5dK7Okl2SrHM5KCYK9eG4UodDfdA==}
 
+  '@rspack/binding@2.0.0-alpha.0':
+    resolution: {integrity: sha512-E8agK5QlLYcRGSE+p+2gjad3uFcZsFsvhfSJMxhTLIfWt0fIvnq4d6suS3Hk8WArFDQgzM7WPgFlFGF4pXddlg==}
+
   '@rspack/binding@2.0.0-canary-20260116':
     resolution: {integrity: sha512-WyfaDI9IBJeRvfkTL6YupcA9pRXdrCEQx8B981BgzelshoaFkbMHopky/fH1pD4030tHNYLMfgxZ8E42cj91GQ==}
-
-  '@rspack/binding@2.0.0-canary.20260120':
-    resolution: {integrity: sha512-ThlYyPI15EEqfwXYbnvlIgp+5GBF8Ert0zMgKrkwqRLSvhR3t1mM5rUVSTrtWSlPAkB7eJQcCNjMXGKgKuDkMA==}
 
   '@rspack/core@1.7.0':
     resolution: {integrity: sha512-uDxPQsPh/+2DnOISuKnUiXZ9M0y2G1BOsI0IesxPJGp42ME2QW7axbJfUqD3bwp4bi3RN2zqh56NgxU/XETQvA==}
@@ -2483,8 +2483,8 @@ packages:
       '@swc/helpers':
         optional: true
 
-  '@rspack/core@2.0.0-canary-20260116':
-    resolution: {integrity: sha512-S4gknWkOscsGvCp2vv4TKpgdKrczB1cD66xULQtpoXZPdTEnZUPdTN9VGuxrZSy6JNyC/9tu6bZCVektYEuTCQ==}
+  '@rspack/core@2.0.0-alpha.0':
+    resolution: {integrity: sha512-9v5ICuuxJccRM+65QjokBJ04BZeqRNpE0/sUvJs/rdcQGpAnZm1ApQayBd3l2YJHA2Z5gHiybr3HcxGkmExw8g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': '>=0.22.0'
@@ -2495,8 +2495,8 @@ packages:
       '@swc/helpers':
         optional: true
 
-  '@rspack/core@2.0.0-canary.20260120':
-    resolution: {integrity: sha512-KNcPDTo2bZuGTcjQBB+gnqHk/95UMvGAIDsAnakQy3gzXhHGHozVDLTOUBlAYSaMO/wzpzA3s8aR3ptWupntFg==}
+  '@rspack/core@2.0.0-canary-20260116':
+    resolution: {integrity: sha512-S4gknWkOscsGvCp2vv4TKpgdKrczB1cD66xULQtpoXZPdTEnZUPdTN9VGuxrZSy6JNyC/9tu6bZCVektYEuTCQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': '>=0.22.0'
@@ -7744,10 +7744,10 @@ snapshots:
   '@rspack/binding-darwin-arm64@1.7.2':
     optional: true
 
-  '@rspack/binding-darwin-arm64@2.0.0-canary-20260116':
+  '@rspack/binding-darwin-arm64@2.0.0-alpha.0':
     optional: true
 
-  '@rspack/binding-darwin-arm64@2.0.0-canary.20260120':
+  '@rspack/binding-darwin-arm64@2.0.0-canary-20260116':
     optional: true
 
   '@rspack/binding-darwin-x64@1.7.0':
@@ -7756,10 +7756,10 @@ snapshots:
   '@rspack/binding-darwin-x64@1.7.2':
     optional: true
 
-  '@rspack/binding-darwin-x64@2.0.0-canary-20260116':
+  '@rspack/binding-darwin-x64@2.0.0-alpha.0':
     optional: true
 
-  '@rspack/binding-darwin-x64@2.0.0-canary.20260120':
+  '@rspack/binding-darwin-x64@2.0.0-canary-20260116':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@1.7.0':
@@ -7768,10 +7768,10 @@ snapshots:
   '@rspack/binding-linux-arm64-gnu@1.7.2':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@2.0.0-canary-20260116':
+  '@rspack/binding-linux-arm64-gnu@2.0.0-alpha.0':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@2.0.0-canary.20260120':
+  '@rspack/binding-linux-arm64-gnu@2.0.0-canary-20260116':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@1.7.0':
@@ -7780,10 +7780,10 @@ snapshots:
   '@rspack/binding-linux-arm64-musl@1.7.2':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@2.0.0-canary-20260116':
+  '@rspack/binding-linux-arm64-musl@2.0.0-alpha.0':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@2.0.0-canary.20260120':
+  '@rspack/binding-linux-arm64-musl@2.0.0-canary-20260116':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@1.7.0':
@@ -7792,10 +7792,10 @@ snapshots:
   '@rspack/binding-linux-x64-gnu@1.7.2':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@2.0.0-canary-20260116':
+  '@rspack/binding-linux-x64-gnu@2.0.0-alpha.0':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@2.0.0-canary.20260120':
+  '@rspack/binding-linux-x64-gnu@2.0.0-canary-20260116':
     optional: true
 
   '@rspack/binding-linux-x64-musl@1.7.0':
@@ -7804,10 +7804,10 @@ snapshots:
   '@rspack/binding-linux-x64-musl@1.7.2':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@2.0.0-canary-20260116':
+  '@rspack/binding-linux-x64-musl@2.0.0-alpha.0':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@2.0.0-canary.20260120':
+  '@rspack/binding-linux-x64-musl@2.0.0-canary-20260116':
     optional: true
 
   '@rspack/binding-wasm32-wasi@1.7.0':
@@ -7820,12 +7820,12 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.0.7
     optional: true
 
-  '@rspack/binding-wasm32-wasi@2.0.0-canary-20260116':
+  '@rspack/binding-wasm32-wasi@2.0.0-alpha.0':
     dependencies:
       '@napi-rs/wasm-runtime': 1.0.7
     optional: true
 
-  '@rspack/binding-wasm32-wasi@2.0.0-canary.20260120':
+  '@rspack/binding-wasm32-wasi@2.0.0-canary-20260116':
     dependencies:
       '@napi-rs/wasm-runtime': 1.0.7
     optional: true
@@ -7836,10 +7836,10 @@ snapshots:
   '@rspack/binding-win32-arm64-msvc@1.7.2':
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@2.0.0-canary-20260116':
+  '@rspack/binding-win32-arm64-msvc@2.0.0-alpha.0':
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@2.0.0-canary.20260120':
+  '@rspack/binding-win32-arm64-msvc@2.0.0-canary-20260116':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@1.7.0':
@@ -7848,10 +7848,10 @@ snapshots:
   '@rspack/binding-win32-ia32-msvc@1.7.2':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@2.0.0-canary-20260116':
+  '@rspack/binding-win32-ia32-msvc@2.0.0-alpha.0':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@2.0.0-canary.20260120':
+  '@rspack/binding-win32-ia32-msvc@2.0.0-canary-20260116':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@1.7.0':
@@ -7860,10 +7860,10 @@ snapshots:
   '@rspack/binding-win32-x64-msvc@1.7.2':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@2.0.0-canary-20260116':
+  '@rspack/binding-win32-x64-msvc@2.0.0-alpha.0':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@2.0.0-canary.20260120':
+  '@rspack/binding-win32-x64-msvc@2.0.0-canary-20260116':
     optional: true
 
   '@rspack/binding@1.7.0':
@@ -7892,6 +7892,19 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 1.7.2
       '@rspack/binding-win32-x64-msvc': 1.7.2
 
+  '@rspack/binding@2.0.0-alpha.0':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 2.0.0-alpha.0
+      '@rspack/binding-darwin-x64': 2.0.0-alpha.0
+      '@rspack/binding-linux-arm64-gnu': 2.0.0-alpha.0
+      '@rspack/binding-linux-arm64-musl': 2.0.0-alpha.0
+      '@rspack/binding-linux-x64-gnu': 2.0.0-alpha.0
+      '@rspack/binding-linux-x64-musl': 2.0.0-alpha.0
+      '@rspack/binding-wasm32-wasi': 2.0.0-alpha.0
+      '@rspack/binding-win32-arm64-msvc': 2.0.0-alpha.0
+      '@rspack/binding-win32-ia32-msvc': 2.0.0-alpha.0
+      '@rspack/binding-win32-x64-msvc': 2.0.0-alpha.0
+
   '@rspack/binding@2.0.0-canary-20260116':
     optionalDependencies:
       '@rspack/binding-darwin-arm64': 2.0.0-canary-20260116
@@ -7904,19 +7917,6 @@ snapshots:
       '@rspack/binding-win32-arm64-msvc': 2.0.0-canary-20260116
       '@rspack/binding-win32-ia32-msvc': 2.0.0-canary-20260116
       '@rspack/binding-win32-x64-msvc': 2.0.0-canary-20260116
-
-  '@rspack/binding@2.0.0-canary.20260120':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 2.0.0-canary.20260120
-      '@rspack/binding-darwin-x64': 2.0.0-canary.20260120
-      '@rspack/binding-linux-arm64-gnu': 2.0.0-canary.20260120
-      '@rspack/binding-linux-arm64-musl': 2.0.0-canary.20260120
-      '@rspack/binding-linux-x64-gnu': 2.0.0-canary.20260120
-      '@rspack/binding-linux-x64-musl': 2.0.0-canary.20260120
-      '@rspack/binding-wasm32-wasi': 2.0.0-canary.20260120
-      '@rspack/binding-win32-arm64-msvc': 2.0.0-canary.20260120
-      '@rspack/binding-win32-ia32-msvc': 2.0.0-canary.20260120
-      '@rspack/binding-win32-x64-msvc': 2.0.0-canary.20260120
 
   '@rspack/core@1.7.0(@swc/helpers@0.5.18)':
     dependencies:
@@ -7934,17 +7934,17 @@ snapshots:
     optionalDependencies:
       '@swc/helpers': 0.5.18
 
-  '@rspack/core@2.0.0-canary-20260116(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18)':
+  '@rspack/core@2.0.0-alpha.0(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18)':
     dependencies:
-      '@rspack/binding': 2.0.0-canary-20260116
+      '@rspack/binding': 2.0.0-alpha.0
       '@rspack/lite-tapable': 1.1.0
     optionalDependencies:
       '@module-federation/runtime-tools': 0.22.1
       '@swc/helpers': 0.5.18
 
-  '@rspack/core@2.0.0-canary.20260120(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18)':
+  '@rspack/core@2.0.0-canary-20260116(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18)':
     dependencies:
-      '@rspack/binding': 2.0.0-canary.20260120
+      '@rspack/binding': 2.0.0-canary-20260116
       '@rspack/lite-tapable': 1.1.0
     optionalDependencies:
       '@module-federation/runtime-tools': 0.22.1
@@ -9170,7 +9170,7 @@ snapshots:
 
   cspell-ban-words@0.0.4: {}
 
-  css-loader@7.1.2(patch_hash=f108465818eeda8955fecc4aa57dbfd6219c34a7a876fc224f229836292996a6)(@rspack/core@2.0.0-canary.20260120(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18))(webpack@5.104.1):
+  css-loader@7.1.2(patch_hash=f108465818eeda8955fecc4aa57dbfd6219c34a7a876fc224f229836292996a6)(@rspack/core@2.0.0-alpha.0(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18))(webpack@5.104.1):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -9181,7 +9181,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.3
     optionalDependencies:
-      '@rspack/core': 2.0.0-canary.20260120(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18)
+      '@rspack/core': 2.0.0-alpha.0(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18)
       webpack: 5.104.1
 
   css-select@5.2.2:
@@ -9877,11 +9877,11 @@ snapshots:
       relateurl: 0.2.7
       terser: 5.44.1
 
-  html-rspack-plugin@6.1.4(@rspack/core@2.0.0-canary.20260120(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18)):
+  html-rspack-plugin@6.1.4(@rspack/core@2.0.0-alpha.0(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18)):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
     optionalDependencies:
-      '@rspack/core': 2.0.0-canary.20260120(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18)
+      '@rspack/core': 2.0.0-alpha.0(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18)
 
   html-to-text@9.0.5:
     dependencies:
@@ -11082,14 +11082,14 @@ snapshots:
       postcss: 8.5.6
       yaml: 2.8.2
 
-  postcss-loader@8.2.0(patch_hash=7434af0286aadb1ef0e2daed0d97ebc69f717990e106d650e6e515683e89988a)(@rspack/core@2.0.0-canary.20260120(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18))(postcss@8.5.6)(typescript@5.9.3)(webpack@5.104.1):
+  postcss-loader@8.2.0(patch_hash=7434af0286aadb1ef0e2daed0d97ebc69f717990e106d650e6e515683e89988a)(@rspack/core@2.0.0-alpha.0(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18))(postcss@8.5.6)(typescript@5.9.3)(webpack@5.104.1):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.9.3)
       jiti: 2.6.1
       postcss: 8.5.6
       semver: 7.7.3
     optionalDependencies:
-      '@rspack/core': 2.0.0-canary.20260120(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18)
+      '@rspack/core': 2.0.0-alpha.0(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18)
       webpack: 5.104.1
     transitivePeerDependencies:
       - typescript
@@ -11426,18 +11426,18 @@ snapshots:
 
   rslog@1.3.2: {}
 
-  rspack-chain@2.0.0-alpha.0(@rspack/core@2.0.0-canary.20260120(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18)):
+  rspack-chain@2.0.0-alpha.0(@rspack/core@2.0.0-alpha.0(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18)):
     dependencies:
       deepmerge: 4.3.1
       javascript-stringify: 2.1.0
     optionalDependencies:
-      '@rspack/core': 2.0.0-canary.20260120(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18)
+      '@rspack/core': 2.0.0-alpha.0(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18)
 
-  rspack-manifest-plugin@5.2.1(@rspack/core@2.0.0-canary.20260120(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18)):
+  rspack-manifest-plugin@5.2.1(@rspack/core@2.0.0-alpha.0(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18)):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
     optionalDependencies:
-      '@rspack/core': 2.0.0-canary.20260120(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18)
+      '@rspack/core': 2.0.0-alpha.0(@module-federation/runtime-tools@0.22.1)(@swc/helpers@0.5.18)
 
   rspack-vue-loader@17.4.5(vue@3.5.26(typescript@5.9.3))(webpack@5.104.1):
     dependencies:


### PR DESCRIPTION
## Summary

Update dependency `@rspack/core` to 2.0.0-alpha.0.

## Related Links

- https://github.com/web-infra-dev/rspack/releases/tag/v2.0.0-alpha.0

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
