### PR TITLE
test: reset logger level after each test

### DIFF
--- a/e2e/cases/hmr/log-level/index.test.ts
+++ b/e2e/cases/hmr/log-level/index.test.ts
@@ -1,9 +1,14 @@
 import { join } from 'node:path';
 import { expect, HMR_CONNECTED_LOG, test } from '@e2e/helper';
-import { logger } from '@rsbuild/core';
+import { type LogLevel, logger } from '@rsbuild/core';
 
+let originalLevel: LogLevel;
+
+test.beforeEach(() => {
+  originalLevel = logger.level as LogLevel;
+});
 test.afterEach(() => {
-  logger.level = 'info'; // reset logger level after each test
+  logger.level = originalLevel;
 });
 
 test('should respect dev.client.logLevel when set to warn', async ({


### PR DESCRIPTION
## Summary

Adds an `afterEach` hook to reset `logger.level` to `'info'` after each test, ensuring logger state does not leak between tests.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
