### PR TITLE
chore: simplify prebundle config

### DIFF
--- a/packages/core/prebundle.config.ts
+++ b/packages/core/prebundle.config.ts
@@ -37,13 +37,6 @@ export default {
       name: 'rspack-chain',
       copyDts: true,
       dtsOnly: true,
-      // rspack-chain provides ESM types
-      afterBundle(task) {
-        const pkgJsonPath = join(task.distPath, 'package.json');
-        const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
-        pkgJson.type = 'module';
-        fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson));
-      },
     },
     {
       name: 'http-proxy-middleware',


### PR DESCRIPTION
## Summary

Removing the `afterBundle` hook for the `rspack-chain` package.

## Related Links

- https://github.com/rstackjs/prebundle/commit/2f09a0e1577148f8884b6170995780539ebb8e0b

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
