### PR TITLE
test: streamline custom message tests

### DIFF
--- a/e2e/cases/javascript-api/server-custom-message/index.test.ts
+++ b/e2e/cases/javascript-api/server-custom-message/index.test.ts
@@ -1,70 +1,54 @@
-import fs from 'node:fs/promises';
 import path from 'node:path';
-import { expectPoll, gotoPage, test } from '@e2e/helper';
-import { createRsbuild } from '@rsbuild/core';
+import { expectPoll, test } from '@e2e/helper';
 
 test('should trigger the client HMR handler when dev server sends a custom message via `sockWrite`', async ({
   page,
+  dev,
 }) => {
-  const rsbuild = await createRsbuild({
-    cwd: import.meta.dirname,
-  });
+  const { server } = await dev();
+  const before = await page.evaluate<number>('window.__count');
 
-  const server = await rsbuild.createDevServer();
+  server?.sockWrite('custom', { event: 'count' });
 
-  await server.listen();
-
-  try {
-    await gotoPage(page, server);
-
-    const before = await page.evaluate<number>('window.__count');
-
-    server.sockWrite('custom', { event: 'count' });
-
-    await expectPoll(() => page.evaluate<number>('window.__count')).toBe(
-      before + 1,
-    );
-  } finally {
-    await server.close();
-  }
+  await expectPoll(() => page.evaluate<number>('window.__count')).toBe(
+    before + 1,
+  );
 });
 
 test('should dispose old HMR event callbacks after page reload', async ({
   page,
+  dev,
+  editFile,
+  copySrcDir,
 }) => {
-  const rsbuild = await createRsbuild({
-    cwd: import.meta.dirname,
+  const srcDir = await copySrcDir();
+  const indexPath = path.join(srcDir, 'index.js');
+  const { server } = await dev({
+    config: {
+      source: {
+        entry: {
+          index: indexPath,
+        },
+      },
+    },
   });
 
-  const server = await rsbuild.createDevServer();
-  await server.listen();
+  // 1) Trigger once and assert callback executed.
+  const afterFirst = await page.evaluate<number>('window.__count');
+  server?.sockWrite('custom', { event: 'count' });
+  await expectPoll(() => page.evaluate<number>('window.__count')).toBe(
+    afterFirst + 1,
+  );
 
-  const indexPath = path.join(import.meta.dirname, 'src/index.js');
-  const originalSource = await fs.readFile(indexPath, 'utf-8');
+  // 2) Modify the source file to trigger an HMR update.
+  await editFile(indexPath, (content) => content.replace('hello', 'hi'));
 
-  try {
-    await gotoPage(page, server);
-
-    // 1) Trigger once and assert callback executed.
-    const afterFirst = await page.evaluate<number>('window.__count');
-    server.sockWrite('custom', { event: 'count' });
-    await expectPoll(() => page.evaluate<number>('window.__count')).toBe(
-      afterFirst + 1,
-    );
-
-    // 2) Modify the source file to trigger an HMR update.
-    await fs.writeFile(indexPath, originalSource.replace('hello', 'hi'));
-
-    // 3) Trigger again. If old callback leaked, we'd observe multiple runs.
-    await expectPoll(() => page.evaluate<number>('window.__count')).toBe(
-      afterFirst + 1,
-    );
-    server.sockWrite('custom', { event: 'count' });
-    await expectPoll(() => page.evaluate<number>('window.__count')).toBe(
-      afterFirst + 2,
-    );
-  } finally {
-    await fs.writeFile(indexPath, originalSource);
-    await server.close();
-  }
+  // 3) Trigger again. If old callback leaked, we'd observe multiple runs.
+  await expectPoll(() => page.evaluate<number>('window.__count')).toBe(
+    afterFirst + 1,
+  );
+  server?.sockWrite('custom', { event: 'count' });
+  await expectPoll(() => page.evaluate<number>('window.__count')).toBe(
+    afterFirst + 2,
+  );
 });

--- a/e2e/helper/jsApi.ts
+++ b/e2e/helper/jsApi.ts
@@ -6,6 +6,7 @@ import {
   createRsbuild,
   type BuildResult as RsbuildBuildResult,
   type RsbuildConfig,
+  type RsbuildDevServer,
   type RsbuildInstance,
 } from '@rsbuild/core';
 import type { Page } from 'playwright';
@@ -128,6 +129,11 @@ export async function dev({
       })
     : Promise.resolve();
 
+  let server: RsbuildDevServer | undefined;
+  rsbuild.onBeforeStartDevServer((context) => {
+    server = context.server;
+  });
+
   const result = await rsbuild.startDevServer();
 
   await wait;
@@ -142,6 +148,7 @@ export async function dev({
     ...result,
     ...logHelper!,
     distPath,
+    server,
     instance: rsbuild,
     getDistFiles: ({ sourceMaps }: { sourceMaps?: boolean } = {}) =>
       sourceMaps ? getOutputFiles() : filterSourceMaps(getOutputFiles()),


### PR DESCRIPTION
## Summary

- The `dev` test helper now returns the running dev server instance
- Updated custom message test cases to use the new `dev` helper, resulting in less repetitive setup and teardown code

## Related

- https://github.com/web-infra-dev/rsbuild/pull/7003

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
