### PR TITLE
docs: add guide to reflect CSS rule structure changes

### DIFF
--- a/website/docs/en/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/en/guide/upgrade/v1-to-v2.mdx
@@ -243,7 +243,7 @@ The built-in JS rule is now split into two `oneOf` branches:
 - `CHAIN_ID.ONE_OF.JS_MAIN`: for SWC transforms
 - `CHAIN_ID.ONE_OF.JS_RAW`: for `?raw` imports
 
-If you previously added loaders on `CHAIN_ID.RULE.JS`, move them to the corresponding `oneOf` branch:
+If you previously added loaders on `CHAIN_ID.RULE.JS`, move them to the `JS_MAIN` branch:
 
 ```diff title="rsbuild.config.ts"
 export default {
@@ -260,3 +260,31 @@ export default {
   },
 };
 ```
+
+### CSS rule
+
+The built-in CSS rule is split into three `oneOf` branches:
+
+- `CHAIN_ID.ONE_OF.CSS_MAIN`: normal CSS transforms
+- `CHAIN_ID.ONE_OF.CSS_RAW`: for `?raw` imports
+- `CHAIN_ID.ONE_OF.CSS_INLINE`: for `?inline` imports
+
+If you previously added loaders on `CHAIN_ID.RULE.CSS`, move them to the `CSS_MAIN` branch:
+
+```diff title="rsbuild.config.ts"
+export default {
+  tools: {
+    bundlerChain(chain, { CHAIN_ID }) {
+      const cssRule = chain.module.rule(CHAIN_ID.RULE.CSS);
+
+-     cssRule.use('my-css-loader').loader('my-css-loader');
++     cssRule
++       .oneOf(CHAIN_ID.ONE_OF.CSS_MAIN)
++       .use('my-css-loader')
++       .loader('my-css-loader');
+    },
+  },
+};
+```
+
+The built-in rules in the Less/Sass/Stylus plugins have the same `oneOf` change, so update customizations to use the corresponding `ONE_OF` branches there as well.

--- a/website/docs/zh/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/zh/guide/upgrade/v1-to-v2.mdx
@@ -243,7 +243,7 @@ Rsbuild 内置的 JS 和 CSS 转换规则现在使用了 [oneOf](https://rspack.
 - `CHAIN_ID.ONE_OF.JS_MAIN`：用于 SWC 转换
 - `CHAIN_ID.ONE_OF.JS_RAW`：用于处理 `?raw` 导入
 
-如果你之前在 `CHAIN_ID.RULE.JS` 上添加 loader，现在需要改为在对应的 `oneOf` 上配置：
+如果你之前在 `CHAIN_ID.RULE.JS` 上添加 loader，需要迁移到 `JS_MAIN` 分支：
 
 ```diff title="rsbuild.config.ts"
 export default {
@@ -260,3 +260,31 @@ export default {
   },
 };
 ```
+
+### CSS 规则
+
+内置 CSS 规则拆分为三个 `oneOf` 分支：
+
+- `CHAIN_ID.ONE_OF.CSS_MAIN`：常规 CSS 转换
+- `CHAIN_ID.ONE_OF.CSS_RAW`：用于处理 `?raw` 导入
+- `CHAIN_ID.ONE_OF.CSS_INLINE`：用于处理 `?inline` 导入
+
+如果你之前在 `CHAIN_ID.RULE.CSS` 上添加 loader，需要迁移到 `CSS_MAIN` 分支：
+
+```diff title="rsbuild.config.ts"
+export default {
+  tools: {
+    bundlerChain(chain, { CHAIN_ID }) {
+      const cssRule = chain.module.rule(CHAIN_ID.RULE.CSS);
+
+-     cssRule.use('my-css-loader').loader('my-css-loader');
++     cssRule
++       .oneOf(CHAIN_ID.ONE_OF.CSS_MAIN)
++       .use('my-css-loader')
++       .loader('my-css-loader');
+    },
+  },
+};
+```
+
+Less / Sass / Stylus 插件的内置规则也已采用相同的 `oneOf` 结构，修改规则时请使用对应的 `ONE_OF` 分支。


### PR DESCRIPTION
## Summary

 Added a new section explaining that the built-in CSS rule is now split into three `oneOf` branches: `CSS_MAIN`, `CSS_RAW`, and `CSS_INLINE`, with instructions to move custom loaders to the `CSS_MAIN` branch.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/7037

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
