### PR TITLE
test: remove compatibility tests for Rsbuild < 1.3.0

### DIFF
--- a/packages/plugin-less/tests/index.test.ts
+++ b/packages/plugin-less/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { createRsbuild, type RsbuildPluginAPI } from '@rsbuild/core';
+import { createRsbuild } from '@rsbuild/core';
 import { matchRules } from '@scripts/test-helper';
 import { pluginLess } from '../src';
 
@@ -110,33 +110,5 @@ describe('plugin-less', () => {
     const bundlerConfigs = await rsbuild.initConfigs();
     expect(matchRules(bundlerConfigs[0], 'a.less').length).toBe(1);
     expect(matchRules(bundlerConfigs[0], 'b.less').length).toBe(2);
-  });
-
-  it('should be compatible with Rsbuild < 1.3.0', async () => {
-    const rsbuild = await createRsbuild({
-      config: {
-        plugins: [
-          {
-            name: 'rsbuild-plugin-test',
-            post: ['rsbuild:css'],
-            setup(api: RsbuildPluginAPI) {
-              // Mock the behavior of Rsbuild < 1.3.0
-              api.modifyBundlerChain((chain, { CHAIN_ID }) => {
-                chain.module.rules.delete(CHAIN_ID.RULE.CSS_INLINE);
-                // @ts-expect-error
-                delete CHAIN_ID.RULE.CSS_INLINE;
-              });
-            },
-          },
-          pluginLess(),
-        ],
-      },
-    });
-
-    await rsbuild.initConfigs();
-
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(matchRules(bundlerConfigs[0], 'a.less').length).toBe(1);
-    expect(matchRules(bundlerConfigs[0], 'a.less?inline').length).toBe(0);
   });
 });

--- a/packages/plugin-sass/tests/index.test.ts
+++ b/packages/plugin-sass/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { createRsbuild, type RsbuildPluginAPI } from '@rsbuild/core';
+import { createRsbuild } from '@rsbuild/core';
 import { matchRules } from '@scripts/test-helper';
 import { pluginSass } from '../src';
 
@@ -79,33 +79,5 @@ describe('plugin-sass', () => {
     const bundlerConfigs = await rsbuild.initConfigs();
     expect(matchRules(bundlerConfigs[0], 'a.scss').length).toBe(1);
     expect(matchRules(bundlerConfigs[0], 'b.scss').length).toBe(2);
-  });
-
-  it('should be compatible with Rsbuild < 1.3.0', async () => {
-    const rsbuild = await createRsbuild({
-      config: {
-        plugins: [
-          {
-            name: 'rsbuild-plugin-test',
-            post: ['rsbuild:css'],
-            setup(api: RsbuildPluginAPI) {
-              // Mock the behavior of Rsbuild < 1.3.0
-              api.modifyBundlerChain((chain, { CHAIN_ID }) => {
-                chain.module.rules.delete(CHAIN_ID.RULE.CSS_INLINE);
-                // @ts-expect-error
-                delete CHAIN_ID.RULE.CSS_INLINE;
-              });
-            },
-          },
-          pluginSass(),
-        ],
-      },
-    });
-
-    await rsbuild.initConfigs();
-
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(matchRules(bundlerConfigs[0], 'a.scss').length).toBe(1);
-    expect(matchRules(bundlerConfigs[0], 'a.scss?inline').length).toBe(0);
   });
 });

--- a/packages/plugin-stylus/tests/index.test.ts
+++ b/packages/plugin-stylus/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { createRsbuild, type RsbuildPluginAPI } from '@rsbuild/core';
+import { createRsbuild } from '@rsbuild/core';
 import { matchRules } from '@scripts/test-helper';
 import { pluginStylus } from '../src';
 
@@ -28,32 +28,5 @@ describe('plugin-stylus', () => {
     });
     const bundlerConfigs = await rsbuild.initConfigs();
     expect(matchRules(bundlerConfigs[0], 'a.styl')).toMatchSnapshot();
-  });
-
-  it('should be compatible with Rsbuild < 1.3.0', async () => {
-    const rsbuild = await createRsbuild({
-      config: {
-        plugins: [
-          {
-            name: 'rsbuild-plugin-test',
-            post: ['rsbuild:css'],
-            setup(api: RsbuildPluginAPI) {
-              api.modifyBundlerChain((chain, { CHAIN_ID }) => {
-                chain.module.rules.delete(CHAIN_ID.RULE.CSS_INLINE);
-                // @ts-expect-error
-                delete CHAIN_ID.RULE.CSS_INLINE;
-              });
-            },
-          },
-          pluginStylus(),
-        ],
-      },
-    });
-
-    await rsbuild.initConfigs();
-
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(matchRules(bundlerConfigs[0], 'a.styl').length).toBe(1);
-    expect(matchRules(bundlerConfigs[0], 'a.styl?inline').length).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Simplifies the test setup for the Less, Sass, and Stylus plugins by removing compatibility tests for Rsbuild versions older than 1.3.0.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
