### PR TITLE
docs: update bundlerChain examples to use oneOf

### DIFF
--- a/website/docs/en/guide/configuration/rspack.mdx
+++ b/website/docs/en/guide/configuration/rspack.mdx
@@ -200,6 +200,7 @@ export default {
     bundlerChain: (chain, { CHAIN_ID }) => {
       chain.module
         .rule(CHAIN_ID.RULE.JS)
+        .oneOf(CHAIN_ID.ONE_OF.JS_MAIN)
         .use(CHAIN_ID.USE.SWC)
         .tap((options) => {
           console.log(options);
@@ -216,7 +217,10 @@ export default {
 export default {
   tools: {
     bundlerChain: (chain, { CHAIN_ID }) => {
-      chain.module.rule(CHAIN_ID.RULE.JS).uses.delete(CHAIN_ID.USE.SWC);
+      chain.module
+        .rule(CHAIN_ID.RULE.JS)
+        .oneOf(CHAIN_ID.ONE_OF.JS_MAIN)
+        .uses.delete(CHAIN_ID.USE.SWC);
     },
   },
 };
@@ -230,6 +234,7 @@ export default {
     bundlerChain: (chain, { CHAIN_ID }) => {
       chain.module
         .rule(CHAIN_ID.RULE.JS)
+        .oneOf(CHAIN_ID.ONE_OF.JS_MAIN)
         .use('my-loader')
         .after(CHAIN_ID.USE.SWC)
         // The package name or module path of the loader
@@ -252,6 +257,7 @@ export default {
     bundlerChain: (chain, { CHAIN_ID }) => {
       chain.module
         .rule(CHAIN_ID.RULE.JS)
+        .oneOf(CHAIN_ID.ONE_OF.JS_MAIN)
         // Loader ID, not actually meaningful, just for locating
         .use('my-loader')
         .before(CHAIN_ID.USE.SWC)

--- a/website/docs/zh/guide/configuration/rspack.mdx
+++ b/website/docs/zh/guide/configuration/rspack.mdx
@@ -202,6 +202,7 @@ export default {
     bundlerChain: (chain, { CHAIN_ID }) => {
       chain.module
         .rule(CHAIN_ID.RULE.JS)
+        .oneOf(CHAIN_ID.ONE_OF.JS_MAIN)
         .use(CHAIN_ID.USE.SWC)
         .tap((options) => {
           console.log(options);
@@ -218,7 +219,10 @@ export default {
 export default {
   tools: {
     bundlerChain: (chain, { CHAIN_ID }) => {
-      chain.module.rule(CHAIN_ID.RULE.JS).uses.delete(CHAIN_ID.USE.SWC);
+      chain.module
+        .rule(CHAIN_ID.RULE.JS)
+        .oneOf(CHAIN_ID.ONE_OF.JS_MAIN)
+        .uses.delete(CHAIN_ID.USE.SWC);
     },
   },
 };
@@ -232,6 +236,7 @@ export default {
     bundlerChain: (chain, { CHAIN_ID }) => {
       chain.module
         .rule(CHAIN_ID.RULE.JS)
+        .oneOf(CHAIN_ID.ONE_OF.JS_MAIN)
         .use('my-loader')
         .after(CHAIN_ID.USE.SWC)
         // loader 的包名或模块路径
@@ -254,6 +259,7 @@ export default {
     bundlerChain: (chain, { CHAIN_ID }) => {
       chain.module
         .rule(CHAIN_ID.RULE.JS)
+        .oneOf(CHAIN_ID.ONE_OF.JS_MAIN)
         // loader id，没有实际意义，仅用于定位
         .use('my-loader')
         .before(CHAIN_ID.USE.SWC)


### PR DESCRIPTION
## Summary

Updated examples to include `oneOf` when modifying loaders in the JS rule.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/7032

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
