### PR TITLE
docs: update chain IDs for bundlerChain

### DIFF
--- a/website/docs/en/config/tools/bundler-chain.mdx
+++ b/website/docs/en/config/tools/bundler-chain.mdx
@@ -231,26 +231,39 @@ For example, the `RULE.STYLUS` rule exists only when the Stylus plugin is regist
 | `RULE.JS`     | Rule for `js` and `ts`                                                    |
 | `RULE.SVG`    | Rule for `svg`                                                            |
 | `RULE.CSS`    | Rule for `css`                                                            |
-| `RULE.LESS`   | Rule for `less`                                                           |
-| `RULE.SASS`   | Rule for `sass`                                                           |
-| `RULE.YAML`   | Rule for `yaml`                                                           |
 | `RULE.WASM`   | Rule for `WASM`                                                           |
 | `RULE.FONT`   | Rule for `font`                                                           |
 | `RULE.IMAGE`  | Rule for `image`                                                          |
 | `RULE.MEDIA`  | Rule for `media`                                                          |
 | `RULE.VUE`    | Rule for `vue` (requires [Vue plugin](/plugins/list/plugin-vue))          |
+| `RULE.LESS`   | Rule for `less` (requires [Less plugin](/plugins/list/plugin-less))       |
+| `RULE.SASS`   | Rule for `sass` (requires [Sass plugin](/plugins/list/plugin-sass))       |
 | `RULE.SVELTE` | Rule for `svelte` (requires [Svelte plugin](/plugins/list/plugin-svelte)) |
 | `RULE.STYLUS` | Rule for `stylus` (requires [Stylus plugin](/plugins/list/plugin-stylus)) |
 
 ### CHAIN_ID.ONE_OF
 
-`ONE_OF.[ID]` can match a certain type of rule in the rule array.
+`ONE_OF.[ID]` points to a specific branch inside a rule's `oneOf` list, such as the main branch or `?raw`/`?inline` branches. It is not a top-level rule; it lives under `RULE.JS`, `RULE.CSS`, and similar rules.
 
-| ID                  | Description                                                        |
-| ------------------- | ------------------------------------------------------------------ |
-| `ONE_OF.SVG_URL`    | Rules for SVG, output as a separate file                           |
-| `ONE_OF.SVG_INLINE` | Rules for SVG, inlined into bundles as data URIs                   |
-| `ONE_OF.SVG_ASSETS` | Rules for SVG, automatic choice between data URI and separate file |
+| ID                     | Description                                             |
+| ---------------------- | ------------------------------------------------------- |
+| `ONE_OF.JS_MAIN`       | Main JS branch under `RULE.JS` (SWC transforms)         |
+| `ONE_OF.JS_RAW`        | `?raw` branch under `RULE.JS`                           |
+| `ONE_OF.CSS_MAIN`      | Main CSS branch under `RULE.CSS`                        |
+| `ONE_OF.CSS_RAW`       | `?raw` branch under `RULE.CSS`                          |
+| `ONE_OF.CSS_INLINE`    | `?inline` branch under `RULE.CSS`                       |
+| `ONE_OF.LESS_MAIN`     | Main Less branch under `RULE.LESS`                      |
+| `ONE_OF.LESS_RAW`      | `?raw` branch under `RULE.LESS`                         |
+| `ONE_OF.LESS_INLINE`   | `?inline` branch under `RULE.LESS`                      |
+| `ONE_OF.SASS_MAIN`     | Main Sass branch under `RULE.SASS`                      |
+| `ONE_OF.SASS_RAW`      | `?raw` branch under `RULE.SASS`                         |
+| `ONE_OF.SASS_INLINE`   | `?inline` branch under `RULE.SASS`                      |
+| `ONE_OF.STYLUS_MAIN`   | Main Stylus branch under `RULE.STYLUS`                  |
+| `ONE_OF.STYLUS_RAW`    | `?raw` branch under `RULE.STYLUS`                       |
+| `ONE_OF.STYLUS_INLINE` | `?inline` branch under `RULE.STYLUS`                    |
+| `ONE_OF.SVG_URL`       | SVG branch for emitting a separate file                 |
+| `ONE_OF.SVG_INLINE`    | SVG branch for inlining as data URI                     |
+| `ONE_OF.SVG_ASSETS`    | SVG branch for auto selection between data URI and file |
 
 ### CHAIN_ID.USE
 

--- a/website/docs/zh/config/tools/bundler-chain.mdx
+++ b/website/docs/zh/config/tools/bundler-chain.mdx
@@ -231,25 +231,39 @@ Rsbuild 中预先定义了一些常用的 Chain ID，你可以通过这些 ID �
 | `RULE.JS`     | 处理 `js` 和 `ts` 的规则                                                |
 | `RULE.SVG`    | 处理 `svg` 的规则                                                       |
 | `RULE.CSS`    | 处理 `css` 的规则                                                       |
-| `RULE.LESS`   | 处理 `less` 的规则                                                      |
-| `RULE.SASS`   | 处理 `sass` 的规则                                                      |
 | `RULE.WASM`   | 处理 `wasm` 的规则                                                      |
 | `RULE.FONT`   | 处理 `font` 的规则                                                      |
 | `RULE.IMAGE`  | 处理 `image` 的规则                                                     |
 | `RULE.MEDIA`  | 处理 `media` 的规则                                                     |
 | `RULE.VUE`    | 处理 `vue` 的规则（依赖 [Vue 插件](/plugins/list/plugin-vue)）          |
+| `RULE.LESS`   | 处理 `less` 的规则（依赖 [Less 插件](/plugins/list/plugin-less)）       |
+| `RULE.SASS`   | 处理 `sass` 的规则（依赖 [Sass 插件](/plugins/list/plugin-sass)）       |
 | `RULE.SVELTE` | 处理 `svelte` 的规则（依赖 [Svelte 插件](/plugins/list/plugin-svelte)） |
 | `RULE.STYLUS` | 处理 `stylus` 的规则（依赖 [Stylus 插件](/plugins/list/plugin-stylus)） |
 
 ### CHAIN_ID.ONE_OF
 
-通过 `ONE_OF.[ID]` 可以匹配到规则数组中的某一类规则。
+`ONE_OF.[ID]` 用于定位规则内部 `oneOf` 的具体分支，比如主分支或 `?raw`/`?inline` 分支；它不是顶层规则，而是挂在 `RULE.JS`、`RULE.CSS` 等规则下面。
 
-| ID                  | 描述                                                |
-| ------------------- | --------------------------------------------------- |
-| `ONE_OF.SVG_URL`    | 处理 SVG 的规则，输出为单独文件                     |
-| `ONE_OF.SVG_INLINE` | 处理 SVG 的规则，作为 data URI 内联到 bundle 中     |
-| `ONE_OF.SVG_ASSETS` | 处理 SVG 的规则，在 data URI 和单独文件之间自动选择 |
+| ID                     | 描述                                         |
+| ---------------------- | -------------------------------------------- |
+| `ONE_OF.JS_MAIN`       | `RULE.JS` 下的主分支（SWC 转换）             |
+| `ONE_OF.JS_RAW`        | `RULE.JS` 下的 `?raw` 分支                   |
+| `ONE_OF.CSS_MAIN`      | `RULE.CSS` 下的主分支                        |
+| `ONE_OF.CSS_RAW`       | `RULE.CSS` 下的 `?raw` 分支                  |
+| `ONE_OF.CSS_INLINE`    | `RULE.CSS` 下的 `?inline` 分支               |
+| `ONE_OF.LESS_MAIN`     | `RULE.LESS` 下的主分支                       |
+| `ONE_OF.LESS_RAW`      | `RULE.LESS` 下的 `?raw` 分支                 |
+| `ONE_OF.LESS_INLINE`   | `RULE.LESS` 下的 `?inline` 分支              |
+| `ONE_OF.SASS_MAIN`     | `RULE.SASS` 下的主分支                       |
+| `ONE_OF.SASS_RAW`      | `RULE.SASS` 下的 `?raw` 分支                 |
+| `ONE_OF.SASS_INLINE`   | `RULE.SASS` 下的 `?inline` 分支              |
+| `ONE_OF.STYLUS_MAIN`   | `RULE.STYLUS` 下的主分支                     |
+| `ONE_OF.STYLUS_RAW`    | `RULE.STYLUS` 下的 `?raw` 分支               |
+| `ONE_OF.STYLUS_INLINE` | `RULE.STYLUS` 下的 `?inline` 分支            |
+| `ONE_OF.SVG_URL`       | SVG 输出为独立文件的分支                     |
+| `ONE_OF.SVG_INLINE`    | SVG 内联为 data URI 的分支                   |
+| `ONE_OF.SVG_ASSETS`    | SVG 在 data URI 与独立文件之间自动选择的分支 |
 
 ### CHAIN_ID.USE
 


### PR DESCRIPTION
## Summary

Expanded and reorganized the list of `ONE_OF` chain IDs to include branches for JS, CSS, Less, Sass, Stylus, and SVG, and explained that these are not top-level rules but branches under specific rule types.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/7037

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
