### PR TITLE
docs: add links for Rsbuild 2.x documentation

### DIFF
--- a/website/docs/en/_nav.json
+++ b/website/docs/en/_nav.json
@@ -33,11 +33,11 @@
       },
       {
         "text": "Rsbuild 0.x Docs",
-        "link": "http://v0.rsbuild.rs/"
+        "link": "https://v0.rsbuild.rs/"
       },
       {
         "text": "Rsbuild 2.x Docs",
-        "link": "http://v2.rsbuild.rs/"
+        "link": "https://v2.rsbuild.rs/"
       }
     ]
   }

--- a/website/docs/zh/_nav.json
+++ b/website/docs/zh/_nav.json
@@ -33,11 +33,11 @@
       },
       {
         "text": "Rsbuild 0.x 文档",
-        "link": "http://v0.rsbuild.rs/zh/"
+        "link": "https://v0.rsbuild.rs/zh/"
       },
       {
         "text": "Rsbuild 2.x 文档",
-        "link": "http://v2.rsbuild.rs/zh/"
+        "link": "https://v2.rsbuild.rs/zh/"
       }
     ]
   }


### PR DESCRIPTION
## Summary

Added a new entry for "Rsbuild 2.x Doc" with a link to `http://v2.rsbuild.rs/`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
