### PR TITLE
docs: update installation instructions for plugins

### DIFF
--- a/website/docs/en/plugins/list/plugin-babel.mdx
+++ b/website/docs/en/plugins/list/plugin-babel.mdx
@@ -10,11 +10,15 @@ Rsbuild uses SWC transpilation by default. When existing functions cannot meet t
 
 ### Install plugin
 
-You can install the plugin using the following command:
-
 import { PackageManagerTabs } from '@theme';
 
-<PackageManagerTabs command="add @rsbuild/plugin-babel -D" />
+- When using `@rsbuild/core` v1:
+
+<PackageManagerTabs command="add @rsbuild/plugin-babel@1 -D" />
+
+- When using `@rsbuild/core` v2:
+
+<PackageManagerTabs command="add @rsbuild/plugin-babel@alpha -D" />
 
 ### Register plugin
 

--- a/website/docs/en/plugins/list/plugin-less.mdx
+++ b/website/docs/en/plugins/list/plugin-less.mdx
@@ -10,18 +10,15 @@ Use [Less](https://lesscss.org/) as the CSS preprocessor, implemented based on [
 
 ### Install plugin
 
-You can install the plugin using the following command:
-
 import { PackageManagerTabs } from '@theme';
 
-<PackageManagerTabs command="add @rsbuild/plugin-less -D" />
+- When using `@rsbuild/core` v1:
 
-:::tip
+<PackageManagerTabs command="add @rsbuild/plugin-less@1 -D" />
 
-- The Less plugin only supports @rsbuild/core versions >= 0.7.0.
-- If the @rsbuild/core version is lower than 0.7.0, it has built-in support for the Less plugin, you do not need to install it.
+- When using `@rsbuild/core` v2:
 
-:::
+<PackageManagerTabs command="add @rsbuild/plugin-less@alpha -D" />
 
 ### Register plugin
 

--- a/website/docs/en/plugins/list/plugin-preact.mdx
+++ b/website/docs/en/plugins/list/plugin-preact.mdx
@@ -10,11 +10,15 @@ The Preact plugin provides support for Preact, integrating features such as JSX 
 
 ### Install plugin
 
-You can install the plugin using the following command:
-
 import { PackageManagerTabs } from '@theme';
 
-<PackageManagerTabs command="add @rsbuild/plugin-preact -D" />
+- When using `@rsbuild/core` v1:
+
+<PackageManagerTabs command="add @rsbuild/plugin-preact@1 -D" />
+
+- When using `@rsbuild/core` v2:
+
+<PackageManagerTabs command="add @rsbuild/plugin-preact@alpha -D" />
 
 ### Register plugin
 

--- a/website/docs/en/plugins/list/plugin-react.mdx
+++ b/website/docs/en/plugins/list/plugin-react.mdx
@@ -14,7 +14,13 @@ Install the plugin using this command:
 
 import { PackageManagerTabs } from '@theme';
 
-<PackageManagerTabs command="add @rsbuild/plugin-react -D" />
+- When using `@rsbuild/core` v1:
+
+<PackageManagerTabs command="add @rsbuild/plugin-react@1 -D" />
+
+- When using `@rsbuild/core` v2:
+
+<PackageManagerTabs command="add @rsbuild/plugin-react@alpha -D" />
 
 ### Register plugin
 

--- a/website/docs/en/plugins/list/plugin-sass.mdx
+++ b/website/docs/en/plugins/list/plugin-sass.mdx
@@ -14,14 +14,13 @@ Install the plugin using this command:
 
 import { PackageManagerTabs } from '@theme';
 
-<PackageManagerTabs command="add @rsbuild/plugin-sass -D" />
+- When using `@rsbuild/core` v1:
 
-:::tip
+<PackageManagerTabs command="add @rsbuild/plugin-sass@1 -D" />
 
-- The Sass plugin only supports @rsbuild/core versions >= 0.7.0.
-- If the @rsbuild/core version is lower than 0.7.0, it has built-in support for the Sass plugin; you don't need to install it.
+- When using `@rsbuild/core` v2:
 
-:::
+<PackageManagerTabs command="add @rsbuild/plugin-sass@alpha -D" />
 
 ### Register plugin
 

--- a/website/docs/en/plugins/list/plugin-solid.mdx
+++ b/website/docs/en/plugins/list/plugin-solid.mdx
@@ -14,11 +14,15 @@ The Solid plugin relies on Babel transpilation and requires an additional [Babel
 
 ### Install plugin
 
-You can install the plugin using the following command:
-
 import { PackageManagerTabs } from '@theme';
 
-<PackageManagerTabs command="add @rsbuild/plugin-babel @rsbuild/plugin-solid -D" />
+- When using `@rsbuild/core` v1:
+
+<PackageManagerTabs command="add @rsbuild/plugin-babel@1 @rsbuild/plugin-solid@1 -D" />
+
+- When using `@rsbuild/core` v2:
+
+<PackageManagerTabs command="add @rsbuild/plugin-babel@alpha @rsbuild/plugin-solid@alpha -D" />
 
 ### Register plugin
 

--- a/website/docs/en/plugins/list/plugin-stylus.mdx
+++ b/website/docs/en/plugins/list/plugin-stylus.mdx
@@ -10,11 +10,15 @@ import { SourceCode } from '@theme';
 
 ### Install plugin
 
-You can install the plugin using the following command:
-
 import { PackageManagerTabs } from '@theme';
 
-<PackageManagerTabs command="add @rsbuild/plugin-stylus -D" />
+- When using `@rsbuild/core` v1:
+
+<PackageManagerTabs command="add @rsbuild/plugin-stylus@1 -D" />
+
+- When using `@rsbuild/core` v2:
+
+<PackageManagerTabs command="add @rsbuild/plugin-stylus@alpha -D" />
 
 ### Register plugin
 

--- a/website/docs/en/plugins/list/plugin-svelte.mdx
+++ b/website/docs/en/plugins/list/plugin-svelte.mdx
@@ -10,11 +10,15 @@ The Svelte plugin provides support for Svelte components (`.svelte` files). The 
 
 ### Install plugin
 
-You can install the plugin using the following command:
-
 import { PackageManagerTabs } from '@theme';
 
-<PackageManagerTabs command="add @rsbuild/plugin-svelte -D" />
+- When using `@rsbuild/core` v1:
+
+<PackageManagerTabs command="add @rsbuild/plugin-svelte@1 -D" />
+
+- When using `@rsbuild/core` v2:
+
+<PackageManagerTabs command="add @rsbuild/plugin-svelte@alpha -D" />
 
 ### Register plugin
 

--- a/website/docs/en/plugins/list/plugin-svgr.mdx
+++ b/website/docs/en/plugins/list/plugin-svgr.mdx
@@ -12,11 +12,15 @@ With the SVGR plugin, Rsbuild supports transforming SVG to React components via 
 
 ### Install plugin
 
-You can install the plugin using the following command:
-
 import { PackageManagerTabs } from '@theme';
 
-<PackageManagerTabs command="add @rsbuild/plugin-svgr -D" />
+- When using `@rsbuild/core` v1:
+
+<PackageManagerTabs command="add @rsbuild/plugin-svgr@1 -D" />
+
+- When using `@rsbuild/core` v2:
+
+<PackageManagerTabs command="add @rsbuild/plugin-svgr@alpha -D" />
 
 ### Register plugin
 

--- a/website/docs/en/plugins/list/plugin-vue.mdx
+++ b/website/docs/en/plugins/list/plugin-vue.mdx
@@ -18,7 +18,13 @@ Install the plugin with this command:
 
 import { PackageManagerTabs } from '@theme';
 
-<PackageManagerTabs command="add @rsbuild/plugin-vue -D" />
+- When using `@rsbuild/core` v1:
+
+<PackageManagerTabs command="add @rsbuild/plugin-vue@1 -D" />
+
+- When using `@rsbuild/core` v2:
+
+<PackageManagerTabs command="add @rsbuild/plugin-vue@alpha -D" />
 
 ### Register plugin
 

--- a/website/docs/zh/plugins/list/plugin-babel.mdx
+++ b/website/docs/zh/plugins/list/plugin-babel.mdx
@@ -10,11 +10,15 @@ Rsbuild 默认使用 SWC 编译，当内置的功能无法满足诉求、需要�
 
 ### 安装插件
 
-你可以通过如下的命令安装插件:
-
 import { PackageManagerTabs } from '@theme';
 
-<PackageManagerTabs command="add @rsbuild/plugin-babel -D" />
+- 使用 `@rsbuild/core` v1 时：
+
+<PackageManagerTabs command="add @rsbuild/plugin-babel@1 -D" />
+
+- 使用 `@rsbuild/core` v2 时：
+
+<PackageManagerTabs command="add @rsbuild/plugin-babel@alpha -D" />
 
 ### 注册插件
 

--- a/website/docs/zh/plugins/list/plugin-less.mdx
+++ b/website/docs/zh/plugins/list/plugin-less.mdx
@@ -10,18 +10,15 @@ import { SourceCode } from '@theme';
 
 ### 安装插件
 
-你可以通过如下的命令安装插件:
-
 import { PackageManagerTabs } from '@theme';
 
-<PackageManagerTabs command="add @rsbuild/plugin-less -D" />
+- 使用 `@rsbuild/core` v1 时：
 
-:::tip
+<PackageManagerTabs command="add @rsbuild/plugin-less@1 -D" />
 
-- Less 插件仅支持 @rsbuild/core >= 0.7.0 版本。
-- 当 @rsbuild/core 版本小于 0.7.0 时，内置支持 Less 插件，你不需要安装该插件。
+- 使用 `@rsbuild/core` v2 时：
 
-:::
+<PackageManagerTabs command="add @rsbuild/plugin-less@alpha -D" />
 
 ### 注册插件
 

--- a/website/docs/zh/plugins/list/plugin-preact.mdx
+++ b/website/docs/zh/plugins/list/plugin-preact.mdx
@@ -10,11 +10,15 @@ Preact 插件提供了对 Preact 的支持，插件内部集成了 JSX 编译、
 
 ### 安装插件
 
-你可以通过如下的命令安装插件:
-
 import { PackageManagerTabs } from '@theme';
 
-<PackageManagerTabs command="add @rsbuild/plugin-preact -D" />
+- 使用 `@rsbuild/core` v1 时：
+
+<PackageManagerTabs command="add @rsbuild/plugin-preact@1 -D" />
+
+- 使用 `@rsbuild/core` v2 时：
+
+<PackageManagerTabs command="add @rsbuild/plugin-preact@alpha -D" />
 
 ### 注册插件
 

--- a/website/docs/zh/plugins/list/plugin-react.mdx
+++ b/website/docs/zh/plugins/list/plugin-react.mdx
@@ -10,11 +10,15 @@ React 插件提供了对 React 的支持，插件内部集成了 JSX 编译、Re
 
 ### 安装插件
 
-你可以通过如下的命令安装插件:
-
 import { PackageManagerTabs } from '@theme';
 
-<PackageManagerTabs command="add @rsbuild/plugin-react -D" />
+- 使用 `@rsbuild/core` v1 时：
+
+<PackageManagerTabs command="add @rsbuild/plugin-react@1 -D" />
+
+- 使用 `@rsbuild/core` v2 时：
+
+<PackageManagerTabs command="add @rsbuild/plugin-react@alpha -D" />
 
 ### 注册插件
 

--- a/website/docs/zh/plugins/list/plugin-sass.mdx
+++ b/website/docs/zh/plugins/list/plugin-sass.mdx
@@ -10,18 +10,15 @@ import { SourceCode } from '@theme';
 
 ### 安装插件
 
-你可以通过如下的命令安装插件:
-
 import { PackageManagerTabs } from '@theme';
 
-<PackageManagerTabs command="add @rsbuild/plugin-sass -D" />
+- 使用 `@rsbuild/core` v1 时：
 
-:::tip
+<PackageManagerTabs command="add @rsbuild/plugin-sass@1 -D" />
 
-- Sass 插件仅支持 @rsbuild/core >= 0.7.0 版本。
-- 当 @rsbuild/core 版本小于 0.7.0 时，内置支持 Sass 插件，你不需要安装该插件。
+- 使用 `@rsbuild/core` v2 时：
 
-:::
+<PackageManagerTabs command="add @rsbuild/plugin-sass@alpha -D" />
 
 ### 注册插件
 

--- a/website/docs/zh/plugins/list/plugin-solid.mdx
+++ b/website/docs/zh/plugins/list/plugin-solid.mdx
@@ -10,11 +10,15 @@ Solid 插件提供了对 Solid 的支持，插件内部集成了 [babel-preset-s
 
 ### 安装插件
 
-你可以通过如下的命令安装插件:
-
 import { PackageManagerTabs } from '@theme';
 
-<PackageManagerTabs command="add @rsbuild/plugin-babel @rsbuild/plugin-solid -D" />
+- 使用 `@rsbuild/core` v1 时：
+
+<PackageManagerTabs command="add @rsbuild/plugin-babel@1 @rsbuild/plugin-solid@1 -D" />
+
+- 使用 `@rsbuild/core` v2 时：
+
+<PackageManagerTabs command="add @rsbuild/plugin-babel@alpha @rsbuild/plugin-solid@alpha -D" />
 
 ### 注册插件
 

--- a/website/docs/zh/plugins/list/plugin-stylus.mdx
+++ b/website/docs/zh/plugins/list/plugin-stylus.mdx
@@ -10,11 +10,15 @@ import { SourceCode } from '@theme';
 
 ### 安装插件
 
-你可以通过如下的命令安装插件:
-
 import { PackageManagerTabs } from '@theme';
 
-<PackageManagerTabs command="add @rsbuild/plugin-stylus -D" />
+- 使用 `@rsbuild/core` v1 时：
+
+<PackageManagerTabs command="add @rsbuild/plugin-stylus@1 -D" />
+
+- 使用 `@rsbuild/core` v2 时：
+
+<PackageManagerTabs command="add @rsbuild/plugin-stylus@alpha -D" />
 
 ### 注册插件
 

--- a/website/docs/zh/plugins/list/plugin-svelte.mdx
+++ b/website/docs/zh/plugins/list/plugin-svelte.mdx
@@ -10,11 +10,15 @@ Svelte 插件提供了对 Svelte 组件（`.svelte` 文件）的支持，插件�
 
 ### 安装插件
 
-你可以通过如下的命令安装插件:
-
 import { PackageManagerTabs } from '@theme';
 
-<PackageManagerTabs command="add @rsbuild/plugin-svelte -D" />
+- 使用 `@rsbuild/core` v1 时：
+
+<PackageManagerTabs command="add @rsbuild/plugin-svelte@1 -D" />
+
+- 使用 `@rsbuild/core` v2 时：
+
+<PackageManagerTabs command="add @rsbuild/plugin-svelte@alpha -D" />
 
 ### 注册插件
 

--- a/website/docs/zh/plugins/list/plugin-svgr.mdx
+++ b/website/docs/zh/plugins/list/plugin-svgr.mdx
@@ -12,11 +12,15 @@ import { SourceCode } from '@theme';
 
 ### 安装插件
 
-你可以通过如下的命令安装插件:
-
 import { PackageManagerTabs } from '@theme';
 
-<PackageManagerTabs command="add @rsbuild/plugin-svgr -D" />
+- 使用 `@rsbuild/core` v1 时：
+
+<PackageManagerTabs command="add @rsbuild/plugin-svgr@1 -D" />
+
+- 使用 `@rsbuild/core` v2 时：
+
+<PackageManagerTabs command="add @rsbuild/plugin-svgr@alpha -D" />
 
 ### 注册插件
 

--- a/website/docs/zh/plugins/list/plugin-vue.mdx
+++ b/website/docs/zh/plugins/list/plugin-vue.mdx
@@ -14,11 +14,15 @@ Vue 插件提供了对 Vue 3 SFC（单文件组件）的支持，插件内部集
 
 ### 安装插件
 
-你可以通过如下的命令安装插件:
-
 import { PackageManagerTabs } from '@theme';
 
-<PackageManagerTabs command="add @rsbuild/plugin-vue -D" />
+- 使用 `@rsbuild/core` v1 时：
+
+<PackageManagerTabs command="add @rsbuild/plugin-vue@1 -D" />
+
+- 使用 `@rsbuild/core` v2 时：
+
+<PackageManagerTabs command="add @rsbuild/plugin-vue@alpha -D" />
 
 ### 注册插件
 


### PR DESCRIPTION
## Summary

Updated installation instructions in all relevant plugin docs to provide separate commands for `@rsbuild/core` v1 and v2, using versioned plugin packages.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
