### PR TITLE
refactor: simplify CSS rules and identifiers

### DIFF
--- a/packages/core/src/configChain.ts
+++ b/packages/core/src/configChain.ts
@@ -66,10 +66,10 @@ export const CHAIN_ID = {
   /** Predefined rule groups */
   ONE_OF: {
     /** JS oneOf rules */
-    JS_MAIN: 'js-main',
+    JS_MAIN: 'js',
     JS_RAW: 'js-raw',
     /** CSS oneOf rules */
-    CSS_MAIN: 'css-main',
+    CSS_MAIN: 'css',
     CSS_RAW: 'css-raw',
     CSS_INLINE: 'css-inline',
     /** SVG oneOf rules */

--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -290,7 +290,6 @@ export const pluginCss = (): RsbuildPlugin => ({
         // Support for `import inlineCss from "a.css?inline"`
         const inlineRule = cssRule
           .oneOf(CHAIN_ID.ONE_OF.CSS_INLINE)
-          .type('javascript/auto')
           .resourceQuery(INLINE_QUERY_REGEX);
 
         // Support for `import rawCss from "a.css?raw"`
@@ -300,10 +299,7 @@ export const pluginCss = (): RsbuildPlugin => ({
           .resourceQuery(RAW_QUERY_REGEX);
 
         // Default CSS handling
-        const mainRule = cssRule
-          .oneOf(CHAIN_ID.ONE_OF.CSS_MAIN)
-          // specify type for `CssExtractRspackPlugin` to work properly
-          .type('javascript/auto');
+        const mainRule = cssRule.oneOf(CHAIN_ID.ONE_OF.CSS_MAIN);
 
         const emitCss = config.output.emitCss ?? target === 'web';
 

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -45,7 +45,6 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
             },
             "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
             "sideEffects": true,
-            "type": "javascript/auto",
             "use": [
               {
                 "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
@@ -79,7 +78,6 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
               "preferRelative": true,
             },
             "sideEffects": true,
-            "type": "javascript/auto",
             "use": [
               {
                 "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/cssExtractLoader.js",

--- a/packages/core/tests/__snapshots__/css.test.ts.snap
+++ b/packages/core/tests/__snapshots__/css.test.ts.snap
@@ -15,7 +15,6 @@ exports[`plugin-css > should use custom cssModules rule when using output.cssMod
             },
             "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
             "sideEffects": true,
-            "type": "javascript/auto",
             "use": [
               {
                 "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
@@ -49,7 +48,6 @@ exports[`plugin-css > should use custom cssModules rule when using output.cssMod
               "preferRelative": true,
             },
             "sideEffects": true,
-            "type": "javascript/auto",
             "use": [
               {
                 "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/cssExtractLoader.js",
@@ -117,7 +115,6 @@ exports[`plugin-css injectStyles > should apply ignoreCssLoader when injectStyle
             },
             "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
             "sideEffects": true,
-            "type": "javascript/auto",
             "use": [
               {
                 "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
@@ -148,7 +145,6 @@ exports[`plugin-css injectStyles > should apply ignoreCssLoader when injectStyle
               "preferRelative": true,
             },
             "sideEffects": true,
-            "type": "javascript/auto",
             "use": [
               {
                 "loader": "<ROOT>/packages/core/src/ignoreCssLoader.mjs",
@@ -198,7 +194,6 @@ exports[`plugin-css injectStyles > should use css-loader + style-loader when inj
             },
             "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
             "sideEffects": true,
-            "type": "javascript/auto",
             "use": [
               {
                 "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
@@ -232,7 +227,6 @@ exports[`plugin-css injectStyles > should use css-loader + style-loader when inj
               "preferRelative": true,
             },
             "sideEffects": true,
-            "type": "javascript/auto",
             "use": [
               {
                 "loader": "<ROOT>/packages/core/compiled/style-loader/index.js",
@@ -291,7 +285,6 @@ exports[`should ensure isolation of PostCSS config objects between different bui
         },
         "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
         "sideEffects": true,
-        "type": "javascript/auto",
         "use": [
           {
             "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
@@ -340,7 +333,6 @@ exports[`should ensure isolation of PostCSS config objects between different bui
           "preferRelative": true,
         },
         "sideEffects": true,
-        "type": "javascript/auto",
         "use": [
           {
             "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/cssExtractLoader.js",
@@ -407,7 +399,6 @@ exports[`should ensure isolation of PostCSS config objects between different bui
         },
         "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
         "sideEffects": true,
-        "type": "javascript/auto",
         "use": [
           {
             "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
@@ -456,7 +447,6 @@ exports[`should ensure isolation of PostCSS config objects between different bui
           "preferRelative": true,
         },
         "sideEffects": true,
-        "type": "javascript/auto",
         "use": [
           {
             "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/cssExtractLoader.js",

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -45,7 +45,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             },
             "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
             "sideEffects": true,
-            "type": "javascript/auto",
             "use": [
               {
                 "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
@@ -79,7 +78,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
               "preferRelative": true,
             },
             "sideEffects": true,
-            "type": "javascript/auto",
             "use": [
               {
                 "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/cssExtractLoader.js",
@@ -552,7 +550,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
             },
             "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
             "sideEffects": true,
-            "type": "javascript/auto",
             "use": [
               {
                 "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
@@ -587,7 +584,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
               "preferRelative": true,
             },
             "sideEffects": true,
-            "type": "javascript/auto",
             "use": [
               {
                 "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/cssExtractLoader.js",
@@ -1080,7 +1076,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             },
             "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
             "sideEffects": true,
-            "type": "javascript/auto",
             "use": [
               {
                 "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
@@ -1111,7 +1106,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
               "preferRelative": true,
             },
             "sideEffects": true,
-            "type": "javascript/auto",
             "use": [
               {
                 "loader": "<ROOT>/packages/core/dist/ignoreCssLoader.mjs",
@@ -1531,7 +1525,6 @@ exports[`tools.rspack > should match snapshot 1`] = `
             },
             "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
             "sideEffects": true,
-            "type": "javascript/auto",
             "use": [
               {
                 "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
@@ -1565,7 +1558,6 @@ exports[`tools.rspack > should match snapshot 1`] = `
               "preferRelative": true,
             },
             "sideEffects": true,
-            "type": "javascript/auto",
             "use": [
               {
                 "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/cssExtractLoader.js",

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1494,7 +1494,6 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
               },
               "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
               "sideEffects": true,
-              "type": "javascript/auto",
               "use": [
                 {
                   "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
@@ -1528,7 +1527,6 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
                 "preferRelative": true,
               },
               "sideEffects": true,
-              "type": "javascript/auto",
               "use": [
                 {
                   "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/cssExtractLoader.js",
@@ -1937,7 +1935,6 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
               },
               "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
               "sideEffects": true,
-              "type": "javascript/auto",
               "use": [
                 {
                   "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
@@ -1971,7 +1968,6 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
                 "preferRelative": true,
               },
               "sideEffects": true,
-              "type": "javascript/auto",
               "use": [
                 {
                   "loader": "<ROOT>/packages/core/src/ignoreCssLoader.mjs",

--- a/packages/plugin-less/src/index.ts
+++ b/packages/plugin-less/src/index.ts
@@ -180,10 +180,10 @@ export const pluginLess = (
   setup(api) {
     const { include = /\.less$/, parallel = false } = pluginOptions;
 
-    const CSS_MAIN = 'css-main';
+    const CSS_MAIN = 'css';
     const CSS_INLINE = 'css-inline';
     const CSS_RAW = 'css-raw';
-    const LESS_MAIN = 'less-main';
+    const LESS_MAIN = 'less';
     const LESS_INLINE = 'less-inline';
     const LESS_RAW = 'less-raw';
     const isV1 = api.context.version.startsWith('1.');
@@ -206,11 +206,10 @@ export const pluginLess = (
       const getRule = (id: string) => {
         // Compatibility for Rsbuild v1
         if (isV1) {
-          // Map `css-main` to `css` in v1
-          return chain.module.rule(id.replace('-main', ''));
+          return chain.module.rule(id);
         }
         return (
-          id.startsWith('less-')
+          id.startsWith('less')
             ? lessRule
             : chain.module.rule(CHAIN_ID.RULE.CSS)
         ).oneOf(id);
@@ -260,7 +259,7 @@ export const pluginLess = (
 
         // Copy the builtin CSS rules
         rule
-          .sideEffects(cssBranchRule.get('sideEffects'))
+          .sideEffects(true)
           .resourceQuery(cssBranchRule.get('resourceQuery'));
 
         for (const id of Object.keys(cssBranchRule.uses.entries())) {

--- a/packages/plugin-sass/src/index.ts
+++ b/packages/plugin-sass/src/index.ts
@@ -100,10 +100,10 @@ export const pluginSass = (
   setup(api) {
     const { rewriteUrls = true, include = /\.s(?:a|c)ss$/ } = pluginOptions;
 
-    const CSS_MAIN = 'css-main';
+    const CSS_MAIN = 'css';
     const CSS_INLINE = 'css-inline';
     const CSS_RAW = 'css-raw';
-    const SASS_MAIN = 'sass-main';
+    const SASS_MAIN = 'sass';
     const SASS_INLINE = 'sass-inline';
     const SASS_RAW = 'sass-raw';
     const isV1 = api.context.version.startsWith('1.');
@@ -140,11 +140,10 @@ export const pluginSass = (
       const getRule = (id: string) => {
         // Compatibility for Rsbuild v1
         if (isV1) {
-          // Map `css-main` to `css` in v1
-          return chain.module.rule(id.replace('-main', ''));
+          return chain.module.rule(id);
         }
         return (
-          id.startsWith('sass-')
+          id.startsWith('sass')
             ? sassRule
             : chain.module.rule(CHAIN_ID.RULE.CSS)
         ).oneOf(id);
@@ -200,7 +199,7 @@ export const pluginSass = (
 
         // Copy the builtin CSS rules
         rule
-          .sideEffects(cssBranchRule.get('sideEffects'))
+          .sideEffects(true)
           .resourceQuery(cssBranchRule.get('resourceQuery'));
 
         for (const id of Object.keys(cssBranchRule.uses.entries())) {

--- a/packages/plugin-stylus/src/index.ts
+++ b/packages/plugin-stylus/src/index.ts
@@ -72,10 +72,10 @@ export const pluginStylus = (options?: PluginStylusOptions): RsbuildPlugin => ({
   name: PLUGIN_STYLUS_NAME,
 
   setup(api) {
-    const CSS_MAIN = 'css-main';
+    const CSS_MAIN = 'css';
     const CSS_INLINE = 'css-inline';
     const CSS_RAW = 'css-raw';
-    const STYLUS_MAIN = 'stylus-main';
+    const STYLUS_MAIN = 'stylus';
     const STYLUS_INLINE = 'stylus-inline';
     const STYLUS_RAW = 'stylus-raw';
     const isV1 = api.context.version.startsWith('1.');
@@ -108,11 +108,10 @@ export const pluginStylus = (options?: PluginStylusOptions): RsbuildPlugin => ({
       const getRule = (id: string) => {
         // Compatibility for Rsbuild v1
         if (isV1) {
-          // Map `css-main` to `css` in v1
-          return chain.module.rule(id.replace('-main', ''));
+          return chain.module.rule(id);
         }
         return (
-          id.startsWith('stylus-')
+          id.startsWith('stylus')
             ? stylusRule
             : chain.module.rule(CHAIN_ID.RULE.CSS)
         ).oneOf(id);
@@ -143,7 +142,7 @@ export const pluginStylus = (options?: PluginStylusOptions): RsbuildPlugin => ({
       updateRules((rule, cssBranchRule) => {
         // Copy the builtin CSS rules
         rule
-          .sideEffects(cssBranchRule.get('sideEffects'))
+          .sideEffects(true)
           .resourceQuery(cssBranchRule.get('resourceQuery'));
 
         for (const id of Object.keys(cssBranchRule.uses.entries())) {


### PR DESCRIPTION
## Summary

- Removed the explicit `.type('javascript/auto')` setting from CSS rule definitions, as it is no longer necessary for correct loader behavior. See https://github.com/web-infra-dev/rspack/pull/12744.
- Standardized the rule IDs for CSS, LESS, and SASS by removing the `-main` suffix to be consistent with Rsbuild v1.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
