### PR TITLE
feat(plugin-svgr): compatible with Rsbuild v1

### DIFF
--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
+    "@rsbuild/core-v1": "npm:@rsbuild/core@^1.7.2",
     "@rslib/core": "0.19.3",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^24.10.9",

--- a/packages/plugin-svgr/src/index.ts
+++ b/packages/plugin-svgr/src/index.ts
@@ -266,13 +266,15 @@ export const pluginSvgr = (options: PluginSvgrOptions = {}): RsbuildPlugin => ({
         })
         .set('generator', generatorOptions);
 
-      // apply current JS transform rule to SVGR rules
-      const jsRule = chain.module.rules
-        .get(CHAIN_ID.RULE.JS)
-        .oneOfs.get(CHAIN_ID.ONE_OF.JS_MAIN);
+      // Compatibility for Rsbuild v1
+      const isV1 = api.context.version.startsWith('1.');
+      const jsRule = chain.module.rules.get(CHAIN_ID.RULE.JS);
+      const jsMainRule = isV1
+        ? jsRule
+        : jsRule.oneOfs.get(CHAIN_ID.ONE_OF.JS_MAIN);
 
       [CHAIN_ID.USE.SWC, CHAIN_ID.USE.BABEL].some((jsUseId) => {
-        const use = jsRule.uses.get(jsUseId);
+        const use = jsMainRule.uses.get(jsUseId);
 
         if (!use) {
           return false;
@@ -301,6 +303,7 @@ export const pluginSvgr = (options: PluginSvgrOptions = {}): RsbuildPlugin => ({
             });
           }
 
+          // apply current JS transform loader to SVGR rules
           rule
             .oneOf(oneOfId)
             .use(jsUseId)

--- a/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
@@ -103,6 +103,109 @@ exports[`svgr > configure SVGR options 1`] = `
 }
 `;
 
+exports[`svgr > configure SVGR options with Rsbuild v1 1`] = `
+{
+  "oneOf": [
+    {
+      "generator": {
+        "filename": "static/svg/[name].[contenthash:8].svg",
+      },
+      "resourceQuery": /\\^\\\\\\?url\\$/,
+      "type": "asset/resource",
+    },
+    {
+      "resourceQuery": /\\^\\\\\\?inline\\$/,
+      "type": "asset/inline",
+    },
+    {
+      "resourceQuery": /\\^\\\\\\?raw\\$/,
+      "type": "asset/source",
+    },
+    {
+      "resourceQuery": /react/,
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "builtin:swc-loader",
+          "options": {
+            "collectTypeScriptInfo": {
+              "exportedEnum": false,
+              "typeExports": true,
+            },
+            "env": {
+              "targets": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
+            },
+            "isModule": "unknown",
+            "jsc": {
+              "experimental": {
+                "cacheRoot": "<ROOT>/packages/plugin-svgr/tests/node_modules/.cache/.swc",
+                "keepImportAttributes": true,
+              },
+              "externalHelpers": true,
+              "output": {
+                "charset": "utf8",
+              },
+              "parser": {
+                "decorators": true,
+                "syntax": "typescript",
+                "tsx": true,
+              },
+              "transform": {
+                "decoratorVersion": "2022-03",
+                "legacyDecorator": false,
+                "react": {
+                  "development": true,
+                  "refresh": false,
+                  "runtime": "automatic",
+                },
+              },
+            },
+          },
+        },
+        {
+          "loader": "<ROOT>/packages/plugin-svgr/src/loader.mjs",
+          "options": {
+            "exportType": "default",
+            "svgo": true,
+            "svgoConfig": {
+              "datauri": "base64",
+              "plugins": [
+                {
+                  "name": "preset-default",
+                  "params": {
+                    "overrides": {
+                      "removeViewBox": false,
+                    },
+                  },
+                },
+                "prefixIds",
+              ],
+            },
+          },
+        },
+      ],
+    },
+    {
+      "generator": {
+        "filename": "static/svg/[name].[contenthash:8].svg",
+      },
+      "parser": {
+        "dataUrlCondition": {
+          "maxSize": 4096,
+        },
+      },
+      "type": "asset",
+    },
+  ],
+  "test": /\\\\\\.svg\\$/,
+}
+`;
+
 exports[`svgr > exportType default / mixedImport false 1`] = `
 {
   "oneOf": [
@@ -209,6 +312,179 @@ exports[`svgr > exportType default / mixedImport false 1`] = `
                 "edge >= 107",
                 "firefox >= 104",
                 "safari >= 16",
+              ],
+            },
+            "isModule": "unknown",
+            "jsc": {
+              "experimental": {
+                "cacheRoot": "<ROOT>/packages/plugin-svgr/tests/node_modules/.cache/.swc",
+                "keepImportAttributes": true,
+              },
+              "externalHelpers": true,
+              "output": {
+                "charset": "utf8",
+              },
+              "parser": {
+                "decorators": true,
+                "syntax": "typescript",
+                "tsx": true,
+              },
+              "transform": {
+                "decoratorVersion": "2022-03",
+                "legacyDecorator": false,
+                "react": {
+                  "development": true,
+                  "refresh": false,
+                  "runtime": "automatic",
+                },
+              },
+            },
+          },
+        },
+        {
+          "loader": "<ROOT>/packages/plugin-svgr/src/loader.mjs",
+          "options": {
+            "exportType": "default",
+            "svgo": true,
+            "svgoConfig": {
+              "plugins": [
+                {
+                  "name": "preset-default",
+                  "params": {
+                    "overrides": {
+                      "removeViewBox": false,
+                    },
+                  },
+                },
+                "prefixIds",
+              ],
+            },
+          },
+        },
+      ],
+    },
+    {
+      "generator": {
+        "filename": "static/svg/[name].[contenthash:8].svg",
+      },
+      "parser": {
+        "dataUrlCondition": {
+          "maxSize": 4096,
+        },
+      },
+      "type": "asset",
+    },
+  ],
+  "test": /\\\\\\.svg\\$/,
+}
+`;
+
+exports[`svgr > exportType default / mixedImport false with Rsbuild v1 1`] = `
+{
+  "oneOf": [
+    {
+      "generator": {
+        "filename": "static/svg/[name].[contenthash:8].svg",
+      },
+      "resourceQuery": /\\^\\\\\\?url\\$/,
+      "type": "asset/resource",
+    },
+    {
+      "resourceQuery": /\\^\\\\\\?inline\\$/,
+      "type": "asset/inline",
+    },
+    {
+      "resourceQuery": /\\^\\\\\\?raw\\$/,
+      "type": "asset/source",
+    },
+    {
+      "resourceQuery": /react/,
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "builtin:swc-loader",
+          "options": {
+            "collectTypeScriptInfo": {
+              "exportedEnum": false,
+              "typeExports": true,
+            },
+            "env": {
+              "targets": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
+            },
+            "isModule": "unknown",
+            "jsc": {
+              "experimental": {
+                "cacheRoot": "<ROOT>/packages/plugin-svgr/tests/node_modules/.cache/.swc",
+                "keepImportAttributes": true,
+              },
+              "externalHelpers": true,
+              "output": {
+                "charset": "utf8",
+              },
+              "parser": {
+                "decorators": true,
+                "syntax": "typescript",
+                "tsx": true,
+              },
+              "transform": {
+                "decoratorVersion": "2022-03",
+                "legacyDecorator": false,
+                "react": {
+                  "development": true,
+                  "refresh": false,
+                  "runtime": "automatic",
+                },
+              },
+            },
+          },
+        },
+        {
+          "loader": "<ROOT>/packages/plugin-svgr/src/loader.mjs",
+          "options": {
+            "exportType": "default",
+            "svgo": true,
+            "svgoConfig": {
+              "plugins": [
+                {
+                  "name": "preset-default",
+                  "params": {
+                    "overrides": {
+                      "removeViewBox": false,
+                    },
+                  },
+                },
+                "prefixIds",
+              ],
+            },
+          },
+        },
+      ],
+    },
+    {
+      "issuer": [
+        /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+        /\\\\\\.mdx\\$/,
+      ],
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "builtin:swc-loader",
+          "options": {
+            "collectTypeScriptInfo": {
+              "exportedEnum": false,
+              "typeExports": true,
+            },
+            "env": {
+              "targets": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
               ],
             },
             "isModule": "unknown",
@@ -449,6 +725,179 @@ exports[`svgr > exportType default / mixedImport true 1`] = `
 }
 `;
 
+exports[`svgr > exportType default / mixedImport true with Rsbuild v1 1`] = `
+{
+  "oneOf": [
+    {
+      "generator": {
+        "filename": "static/svg/[name].[contenthash:8].svg",
+      },
+      "resourceQuery": /\\^\\\\\\?url\\$/,
+      "type": "asset/resource",
+    },
+    {
+      "resourceQuery": /\\^\\\\\\?inline\\$/,
+      "type": "asset/inline",
+    },
+    {
+      "resourceQuery": /\\^\\\\\\?raw\\$/,
+      "type": "asset/source",
+    },
+    {
+      "resourceQuery": /react/,
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "builtin:swc-loader",
+          "options": {
+            "collectTypeScriptInfo": {
+              "exportedEnum": false,
+              "typeExports": true,
+            },
+            "env": {
+              "targets": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
+            },
+            "isModule": "unknown",
+            "jsc": {
+              "experimental": {
+                "cacheRoot": "<ROOT>/packages/plugin-svgr/tests/node_modules/.cache/.swc",
+                "keepImportAttributes": true,
+              },
+              "externalHelpers": true,
+              "output": {
+                "charset": "utf8",
+              },
+              "parser": {
+                "decorators": true,
+                "syntax": "typescript",
+                "tsx": true,
+              },
+              "transform": {
+                "decoratorVersion": "2022-03",
+                "legacyDecorator": false,
+                "react": {
+                  "development": true,
+                  "refresh": false,
+                  "runtime": "automatic",
+                },
+              },
+            },
+          },
+        },
+        {
+          "loader": "<ROOT>/packages/plugin-svgr/src/loader.mjs",
+          "options": {
+            "exportType": "default",
+            "svgo": true,
+            "svgoConfig": {
+              "plugins": [
+                {
+                  "name": "preset-default",
+                  "params": {
+                    "overrides": {
+                      "removeViewBox": false,
+                    },
+                  },
+                },
+                "prefixIds",
+              ],
+            },
+          },
+        },
+      ],
+    },
+    {
+      "issuer": [
+        /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+        /\\\\\\.mdx\\$/,
+      ],
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "builtin:swc-loader",
+          "options": {
+            "collectTypeScriptInfo": {
+              "exportedEnum": false,
+              "typeExports": true,
+            },
+            "env": {
+              "targets": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
+            },
+            "isModule": "unknown",
+            "jsc": {
+              "experimental": {
+                "cacheRoot": "<ROOT>/packages/plugin-svgr/tests/node_modules/.cache/.swc",
+                "keepImportAttributes": true,
+              },
+              "externalHelpers": true,
+              "output": {
+                "charset": "utf8",
+              },
+              "parser": {
+                "decorators": true,
+                "syntax": "typescript",
+                "tsx": true,
+              },
+              "transform": {
+                "decoratorVersion": "2022-03",
+                "legacyDecorator": false,
+                "react": {
+                  "development": true,
+                  "refresh": false,
+                  "runtime": "automatic",
+                },
+              },
+            },
+          },
+        },
+        {
+          "loader": "<ROOT>/packages/plugin-svgr/src/loader.mjs",
+          "options": {
+            "exportType": "default",
+            "svgo": true,
+            "svgoConfig": {
+              "plugins": [
+                {
+                  "name": "preset-default",
+                  "params": {
+                    "overrides": {
+                      "removeViewBox": false,
+                    },
+                  },
+                },
+                "prefixIds",
+              ],
+            },
+          },
+        },
+      ],
+    },
+    {
+      "generator": {
+        "filename": "static/svg/[name].[contenthash:8].svg",
+      },
+      "parser": {
+        "dataUrlCondition": {
+          "maxSize": 4096,
+        },
+      },
+      "type": "asset",
+    },
+  ],
+  "test": /\\\\\\.svg\\$/,
+}
+`;
+
 exports[`svgr > exportType named / mixedImport false 1`] = `
 {
   "oneOf": [
@@ -622,6 +1071,179 @@ exports[`svgr > exportType named / mixedImport false 1`] = `
 }
 `;
 
+exports[`svgr > exportType named / mixedImport false with Rsbuild v1 1`] = `
+{
+  "oneOf": [
+    {
+      "generator": {
+        "filename": "static/svg/[name].[contenthash:8].svg",
+      },
+      "resourceQuery": /\\^\\\\\\?url\\$/,
+      "type": "asset/resource",
+    },
+    {
+      "resourceQuery": /\\^\\\\\\?inline\\$/,
+      "type": "asset/inline",
+    },
+    {
+      "resourceQuery": /\\^\\\\\\?raw\\$/,
+      "type": "asset/source",
+    },
+    {
+      "resourceQuery": /react/,
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "builtin:swc-loader",
+          "options": {
+            "collectTypeScriptInfo": {
+              "exportedEnum": false,
+              "typeExports": true,
+            },
+            "env": {
+              "targets": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
+            },
+            "isModule": "unknown",
+            "jsc": {
+              "experimental": {
+                "cacheRoot": "<ROOT>/packages/plugin-svgr/tests/node_modules/.cache/.swc",
+                "keepImportAttributes": true,
+              },
+              "externalHelpers": true,
+              "output": {
+                "charset": "utf8",
+              },
+              "parser": {
+                "decorators": true,
+                "syntax": "typescript",
+                "tsx": true,
+              },
+              "transform": {
+                "decoratorVersion": "2022-03",
+                "legacyDecorator": false,
+                "react": {
+                  "development": true,
+                  "refresh": false,
+                  "runtime": "automatic",
+                },
+              },
+            },
+          },
+        },
+        {
+          "loader": "<ROOT>/packages/plugin-svgr/src/loader.mjs",
+          "options": {
+            "exportType": "default",
+            "svgo": true,
+            "svgoConfig": {
+              "plugins": [
+                {
+                  "name": "preset-default",
+                  "params": {
+                    "overrides": {
+                      "removeViewBox": false,
+                    },
+                  },
+                },
+                "prefixIds",
+              ],
+            },
+          },
+        },
+      ],
+    },
+    {
+      "issuer": [
+        /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+        /\\\\\\.mdx\\$/,
+      ],
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "builtin:swc-loader",
+          "options": {
+            "collectTypeScriptInfo": {
+              "exportedEnum": false,
+              "typeExports": true,
+            },
+            "env": {
+              "targets": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
+            },
+            "isModule": "unknown",
+            "jsc": {
+              "experimental": {
+                "cacheRoot": "<ROOT>/packages/plugin-svgr/tests/node_modules/.cache/.swc",
+                "keepImportAttributes": true,
+              },
+              "externalHelpers": true,
+              "output": {
+                "charset": "utf8",
+              },
+              "parser": {
+                "decorators": true,
+                "syntax": "typescript",
+                "tsx": true,
+              },
+              "transform": {
+                "decoratorVersion": "2022-03",
+                "legacyDecorator": false,
+                "react": {
+                  "development": true,
+                  "refresh": false,
+                  "runtime": "automatic",
+                },
+              },
+            },
+          },
+        },
+        {
+          "loader": "<ROOT>/packages/plugin-svgr/src/loader.mjs",
+          "options": {
+            "exportType": "named",
+            "svgo": true,
+            "svgoConfig": {
+              "plugins": [
+                {
+                  "name": "preset-default",
+                  "params": {
+                    "overrides": {
+                      "removeViewBox": false,
+                    },
+                  },
+                },
+                "prefixIds",
+              ],
+            },
+          },
+        },
+      ],
+    },
+    {
+      "generator": {
+        "filename": "static/svg/[name].[contenthash:8].svg",
+      },
+      "parser": {
+        "dataUrlCondition": {
+          "maxSize": 4096,
+        },
+      },
+      "type": "asset",
+    },
+  ],
+  "test": /\\\\\\.svg\\$/,
+}
+`;
+
 exports[`svgr > exportType named / mixedImport true 1`] = `
 {
   "oneOf": [
@@ -728,6 +1350,186 @@ exports[`svgr > exportType named / mixedImport true 1`] = `
                 "edge >= 107",
                 "firefox >= 104",
                 "safari >= 16",
+              ],
+            },
+            "isModule": "unknown",
+            "jsc": {
+              "experimental": {
+                "cacheRoot": "<ROOT>/packages/plugin-svgr/tests/node_modules/.cache/.swc",
+                "keepImportAttributes": true,
+              },
+              "externalHelpers": true,
+              "output": {
+                "charset": "utf8",
+              },
+              "parser": {
+                "decorators": true,
+                "syntax": "typescript",
+                "tsx": true,
+              },
+              "transform": {
+                "decoratorVersion": "2022-03",
+                "legacyDecorator": false,
+                "react": {
+                  "development": true,
+                  "refresh": false,
+                  "runtime": "automatic",
+                },
+              },
+            },
+          },
+        },
+        {
+          "loader": "<ROOT>/packages/plugin-svgr/src/loader.mjs",
+          "options": {
+            "exportType": "named",
+            "svgo": true,
+            "svgoConfig": {
+              "plugins": [
+                {
+                  "name": "preset-default",
+                  "params": {
+                    "overrides": {
+                      "removeViewBox": false,
+                    },
+                  },
+                },
+                "prefixIds",
+              ],
+            },
+          },
+        },
+        {
+          "loader": "<ROOT>/packages/plugin-svgr/compiled/url-loader/index.js",
+          "options": {
+            "limit": 4096,
+            "name": "static/svg/[name].[contenthash:8].svg",
+          },
+        },
+      ],
+    },
+    {
+      "generator": {
+        "filename": "static/svg/[name].[contenthash:8].svg",
+      },
+      "parser": {
+        "dataUrlCondition": {
+          "maxSize": 4096,
+        },
+      },
+      "type": "asset",
+    },
+  ],
+  "test": /\\\\\\.svg\\$/,
+}
+`;
+
+exports[`svgr > exportType named / mixedImport true with Rsbuild v1 1`] = `
+{
+  "oneOf": [
+    {
+      "generator": {
+        "filename": "static/svg/[name].[contenthash:8].svg",
+      },
+      "resourceQuery": /\\^\\\\\\?url\\$/,
+      "type": "asset/resource",
+    },
+    {
+      "resourceQuery": /\\^\\\\\\?inline\\$/,
+      "type": "asset/inline",
+    },
+    {
+      "resourceQuery": /\\^\\\\\\?raw\\$/,
+      "type": "asset/source",
+    },
+    {
+      "resourceQuery": /react/,
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "builtin:swc-loader",
+          "options": {
+            "collectTypeScriptInfo": {
+              "exportedEnum": false,
+              "typeExports": true,
+            },
+            "env": {
+              "targets": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
+            },
+            "isModule": "unknown",
+            "jsc": {
+              "experimental": {
+                "cacheRoot": "<ROOT>/packages/plugin-svgr/tests/node_modules/.cache/.swc",
+                "keepImportAttributes": true,
+              },
+              "externalHelpers": true,
+              "output": {
+                "charset": "utf8",
+              },
+              "parser": {
+                "decorators": true,
+                "syntax": "typescript",
+                "tsx": true,
+              },
+              "transform": {
+                "decoratorVersion": "2022-03",
+                "legacyDecorator": false,
+                "react": {
+                  "development": true,
+                  "refresh": false,
+                  "runtime": "automatic",
+                },
+              },
+            },
+          },
+        },
+        {
+          "loader": "<ROOT>/packages/plugin-svgr/src/loader.mjs",
+          "options": {
+            "exportType": "default",
+            "svgo": true,
+            "svgoConfig": {
+              "plugins": [
+                {
+                  "name": "preset-default",
+                  "params": {
+                    "overrides": {
+                      "removeViewBox": false,
+                    },
+                  },
+                },
+                "prefixIds",
+              ],
+            },
+          },
+        },
+      ],
+    },
+    {
+      "issuer": [
+        /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+        /\\\\\\.mdx\\$/,
+      ],
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "builtin:swc-loader",
+          "options": {
+            "collectTypeScriptInfo": {
+              "exportedEnum": false,
+              "typeExports": true,
+            },
+            "env": {
+              "targets": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
               ],
             },
             "isModule": "unknown",

--- a/packages/plugin-svgr/tests/index.test.ts
+++ b/packages/plugin-svgr/tests/index.test.ts
@@ -1,4 +1,5 @@
-import { createRsbuild } from '@rsbuild/core';
+import { createRsbuild, type Rspack } from '@rsbuild/core';
+import { createRsbuild as createRsbuildV1 } from '@rsbuild/core-v1';
 import { pluginReact } from '@rsbuild/plugin-react';
 import { matchRules } from '@scripts/test-helper';
 import { type PluginSvgrOptions, pluginSvgr } from '../src';
@@ -64,5 +65,20 @@ describe('svgr', () => {
 
     const config = await rsbuild.initConfigs();
     expect(matchRules(config[0], 'a.svg')[0]).toMatchSnapshot();
+  });
+
+  it.each(cases)('$name with Rsbuild v1', async (item) => {
+    const rsbuild = await createRsbuildV1({
+      cwd: import.meta.dirname,
+      config: {
+        mode: 'development',
+        plugins: [pluginSvgr(item.pluginConfig), pluginReact()],
+      },
+    });
+
+    const config = await rsbuild.initConfigs();
+    expect(
+      matchRules(config[0] as Rspack.Configuration, 'a.svg')[0],
+    ).toMatchSnapshot();
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -986,6 +986,9 @@ importers:
       '@rsbuild/core':
         specifier: workspace:*
         version: link:../core
+      '@rsbuild/core-v1':
+        specifier: npm:@rsbuild/core@^1.7.2
+        version: '@rsbuild/core@1.7.2'
       '@rslib/core':
         specifier: 0.19.3
         version: 0.19.3(@typescript/native-preview@7.0.0-dev.20260124.1)(typescript@5.9.3)


### PR DESCRIPTION
## Summary

Updated `pluginSvgr` implementation to detect Rsbuild v1 and adjust how JS transform rules are applied for SVG files, ensuring compatibility with both Rsbuild v1 and v2.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/7053

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
