### PR TITLE
feat(plugin-babel): compatible with Rsbuild v1

### DIFF
--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
+    "@rsbuild/core-v1": "npm:@rsbuild/core@^1.7.2",
     "@rslib/core": "0.19.3",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^24.10.9",

--- a/packages/plugin-babel/src/plugin.ts
+++ b/packages/plugin-babel/src/plugin.ts
@@ -161,9 +161,12 @@ export const pluginBabel = (
             .loader(babelLoader)
             .options(babelOptions);
         } else {
-          // already set source.include / exclude in plugin-swc
+          // Compatibility for Rsbuild v1
+          const isV1 = api.context.version.startsWith('1.');
           const jsRule = chain.module.rule(CHAIN_ID.RULE.JS).test(SCRIPT_REGEX);
-          const jsMainRule = jsRule.oneOfs.get(CHAIN_ID.ONE_OF.JS_MAIN);
+          const jsMainRule = isV1
+            ? jsRule
+            : jsRule.oneOfs.get(CHAIN_ID.ONE_OF.JS_MAIN);
           jsMainRule
             .use(CHAIN_ID.USE.BABEL)
             .after(CHAIN_ID.USE.SWC)

--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -95,6 +95,96 @@ exports[`plugins/babel > babel-loader should works with builtin:swc-loader 1`] =
 }
 `;
 
+exports[`plugins/babel > babel-loader should works with builtin:swc-loader for Rsbuild v1 1`] = `
+{
+  "dependency": {
+    "not": "url",
+  },
+  "exclude": [
+    "src/example",
+  ],
+  "include": [
+    {
+      "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
+    },
+    /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
+    /node_modules\\[\\\\\\\\/\\]query-string\\[\\\\\\\\/\\]/,
+  ],
+  "resourceQuery": {
+    "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+  },
+  "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+  "type": "javascript/auto",
+  "use": [
+    {
+      "loader": "builtin:swc-loader",
+      "options": {
+        "collectTypeScriptInfo": {
+          "exportedEnum": false,
+          "typeExports": true,
+        },
+        "env": {
+          "targets": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
+        },
+        "isModule": "unknown",
+        "jsc": {
+          "experimental": {
+            "cacheRoot": "<ROOT>/packages/plugin-babel/tests/node_modules/.cache/.swc",
+            "keepImportAttributes": true,
+          },
+          "externalHelpers": true,
+          "output": {
+            "charset": "utf8",
+          },
+          "parser": {
+            "decorators": true,
+            "syntax": "typescript",
+            "tsx": false,
+          },
+          "transform": {
+            "decoratorVersion": "2022-03",
+            "legacyDecorator": false,
+          },
+        },
+      },
+    },
+    {
+      "loader": "<ROOT>/packages/plugin-babel/compiled/babel-loader/index.js",
+      "options": {
+        "babelrc": false,
+        "compact": false,
+        "configFile": false,
+        "plugins": [
+          [
+            "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+            {
+              "version": "2022-03",
+            },
+          ],
+        ],
+        "presets": [
+          [
+            "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
+            {
+              "allExtensions": true,
+              "allowDeclareFields": true,
+              "allowNamespaces": true,
+              "isTSX": true,
+              "optimizeConstEnums": true,
+            },
+          ],
+        ],
+      },
+    },
+  ],
+}
+`;
+
 exports[`plugins/babel > should apply environment config correctly 1`] = `
 {
   "dependency": {

--- a/packages/plugin-babel/tests/index.test.ts
+++ b/packages/plugin-babel/tests/index.test.ts
@@ -1,4 +1,5 @@
-import { createRsbuild } from '@rsbuild/core';
+import { createRsbuild, type Rspack } from '@rsbuild/core';
+import { createRsbuild as createRsbuildV1 } from '@rsbuild/core-v1';
 import { matchRules } from '@scripts/test-helper';
 import { pluginBabel } from '../src';
 
@@ -20,6 +21,27 @@ describe('plugins/babel', () => {
 
     const config = await rsbuild.initConfigs();
     expect(matchRules(config[0], 'a.tsx')[0]).toMatchSnapshot();
+  });
+
+  it('babel-loader should works with builtin:swc-loader for Rsbuild v1', async () => {
+    const rsbuild = await createRsbuildV1({
+      cwd: import.meta.dirname,
+      config: {
+        plugins: [pluginBabel()],
+        source: {
+          include: [/node_modules[\\/]query-string[\\/]/],
+          exclude: ['src/example'],
+        },
+        performance: {
+          buildCache: false,
+        },
+      },
+    });
+
+    const config = await rsbuild.initConfigs();
+    expect(
+      matchRules(config[0] as Rspack.Configuration, 'a.tsx')[0],
+    ).toMatchSnapshot();
   });
 
   it('should apply environment config correctly', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -711,6 +711,9 @@ importers:
       '@rsbuild/core':
         specifier: workspace:*
         version: link:../core
+      '@rsbuild/core-v1':
+        specifier: npm:@rsbuild/core@^1.7.2
+        version: '@rsbuild/core@1.7.2'
       '@rslib/core':
         specifier: 0.19.3
         version: 0.19.3(@typescript/native-preview@7.0.0-dev.20260124.1)(typescript@5.9.3)


### PR DESCRIPTION
## Summary

Updated the Babel plugin to detect Rsbuild v1 and adjust how the Babel loader is applied, ensuring correct rule configuration for both v1 and v2.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/7053

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
