### PR TITLE
feat(plugin-svelte): compatible with Rsbuild v1

### DIFF
--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
+    "@rsbuild/core-v1": "npm:@rsbuild/core@^1.7.2",
     "@rslib/core": "0.19.3",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^24.10.9",

--- a/packages/plugin-svelte/src/index.ts
+++ b/packages/plugin-svelte/src/index.ts
@@ -125,9 +125,14 @@ export function pluginSvelte(options: PluginSvelteOptions = {}): RsbuildPlugin {
             },
           };
 
+          // Compatibility for Rsbuild v1
+          const isV1 = api.context.version.startsWith('1.');
           const jsRule = chain.module.rules.get(CHAIN_ID.RULE.JS);
-          const jsMainRule = jsRule.oneOfs.get(CHAIN_ID.ONE_OF.JS_MAIN);
+          const jsMainRule = isV1
+            ? jsRule
+            : jsRule.oneOfs.get(CHAIN_ID.ONE_OF.JS_MAIN);
           const swcUse = jsMainRule.uses.get(CHAIN_ID.USE.SWC);
+
           const svelteRule = chain.module
             .rule(CHAIN_ID.RULE.SVELTE)
             .test(/\.svelte$/);

--- a/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
@@ -360,6 +360,108 @@ exports[`plugin-svelte > should add svelte loader and resolve config properly 2`
 }
 `;
 
+exports[`plugin-svelte > should add svelte loader and resolve config properly for Rsbuild v1 1`] = `
+[
+  {
+    "test": /\\\\\\.svelte\\$/,
+    "use": [
+      {
+        "loader": "builtin:swc-loader",
+        "options": {
+          "collectTypeScriptInfo": {
+            "exportedEnum": false,
+            "typeExports": true,
+          },
+          "env": {
+            "targets": [
+              "chrome >= 87",
+              "edge >= 88",
+              "firefox >= 78",
+              "safari >= 14",
+            ],
+          },
+          "isModule": "unknown",
+          "jsc": {
+            "experimental": {
+              "cacheRoot": "<ROOT>/packages/plugin-svelte/tests/node_modules/.cache/.swc",
+              "keepImportAttributes": true,
+            },
+            "externalHelpers": true,
+            "output": {
+              "charset": "utf8",
+            },
+            "parser": {
+              "decorators": true,
+              "syntax": "typescript",
+              "tsx": false,
+            },
+            "transform": {
+              "decoratorVersion": "2022-03",
+              "legacyDecorator": false,
+            },
+          },
+        },
+      },
+      {
+        "loader": "<ROOT>/node_modules/<PNPM_INNER>/svelte-loader/index.js",
+        "options": {
+          "compilerOptions": {
+            "dev": false,
+          },
+          "emitCss": false,
+          "hotReload": false,
+          "preprocess": {
+            "markup": [Function],
+            "script": [Function],
+            "style": [Function],
+          },
+        },
+      },
+    ],
+  },
+]
+`;
+
+exports[`plugin-svelte > should add svelte loader and resolve config properly for Rsbuild v1 2`] = `
+{
+  "alias": {
+    "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
+  },
+  "conditionNames": [
+    "svelte",
+    "...",
+  ],
+  "extensionAlias": {
+    ".js": [
+      ".js",
+      ".ts",
+      ".tsx",
+    ],
+    ".jsx": [
+      ".jsx",
+      ".tsx",
+    ],
+  },
+  "extensions": [
+    ".ts",
+    ".tsx",
+    ".mjs",
+    ".js",
+    ".jsx",
+    ".json",
+    ".svelte",
+  ],
+  "mainFields": [
+    "svelte",
+    "...",
+  ],
+  "tsConfig": {
+    "configFile": "<ROOT>/packages/plugin-svelte/tests/tsconfig.json",
+    "references": "auto",
+  },
+}
+`;
+
 exports[`plugin-svelte > should override default svelte-loader options throw options.svelteLoaderOptions 1`] = `
 [
   {

--- a/packages/plugin-svelte/tests/index.test.ts
+++ b/packages/plugin-svelte/tests/index.test.ts
@@ -1,4 +1,5 @@
-import { createRsbuild } from '@rsbuild/core';
+import { createRsbuild, type Rspack } from '@rsbuild/core';
+import { createRsbuild as createRsbuildV1 } from '@rsbuild/core-v1';
 import { matchRules } from '@scripts/test-helper';
 import { pluginSvelte } from '../src';
 
@@ -13,6 +14,21 @@ describe('plugin-svelte', () => {
 
     const bundlerConfigs = await rsbuild.initConfigs();
     expect(matchRules(bundlerConfigs[0], 'a.svelte')).toMatchSnapshot();
+    expect(bundlerConfigs[0].resolve).toMatchSnapshot();
+  });
+
+  it('should add svelte loader and resolve config properly for Rsbuild v1', async () => {
+    const rsbuild = await createRsbuildV1({
+      cwd: __dirname,
+      config: {
+        plugins: [pluginSvelte()],
+      },
+    });
+
+    const bundlerConfigs = await rsbuild.initConfigs();
+    expect(
+      matchRules(bundlerConfigs[0] as Rspack.Configuration, 'a.svelte'),
+    ).toMatchSnapshot();
     expect(bundlerConfigs[0].resolve).toMatchSnapshot();
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -949,6 +949,9 @@ importers:
       '@rsbuild/core':
         specifier: workspace:*
         version: link:../core
+      '@rsbuild/core-v1':
+        specifier: npm:@rsbuild/core@^1.7.2
+        version: '@rsbuild/core@1.7.2'
       '@rslib/core':
         specifier: 0.19.3
         version: 0.19.3(@typescript/native-preview@7.0.0-dev.20260124.1)(typescript@5.9.3)


### PR DESCRIPTION
## Summary

Updated the Svelte plugin to detect Rsbuild v1 and adjust how it configures JS rules, ensuring compatibility with both v1 and v2.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/7053

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
