### PR TITLE
release: minor release for plugins

### DIFF
--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-babel",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "description": "Babel plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-less",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "Less plugin for Rsbuild",
   "homepage": "https://rsbuild.rs",
   "repository": {

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-sass",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Sass plugin for Rsbuild",
   "homepage": "https://rsbuild.rs",
   "repository": {

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-stylus",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Stylus plugin for Rsbuild",
   "homepage": "https://rsbuild.rs",
   "repository": {

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svelte",
-  "version": "1.0.12",
+  "version": "1.1.0",
   "description": "Svelte plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svgr",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "description": "SVGR plugin for Rsbuild",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Version bumps for plugin packages:

* Babel plugin: Updated version to `1.1.0` in `@rsbuild/plugin-babel`
* Svelte plugin: Updated version to `1.1.0` in `@rsbuild/plugin-svelte`
* Less plugin: Updated version to `1.6.0` in `@rsbuild/plugin-less`
* Sass plugin: Updated version to `1.5.0` in `@rsbuild/plugin-sass`
* Stylus plugin: Updated version to `1.3.0` in `@rsbuild/plugin-stylus`
* SVGR plugin: Updated version to `1.3.0` in `@rsbuild/plugin-svgr`

## Related

- https://github.com/web-infra-dev/rsbuild/pull/7063
- https://github.com/web-infra-dev/rsbuild/pull/7062
- https://github.com/web-infra-dev/rsbuild/pull/7061
- https://github.com/web-infra-dev/rsbuild/pull/7056
- https://github.com/web-infra-dev/rsbuild/pull/7055
- https://github.com/web-infra-dev/rsbuild/pull/7054

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
