### PR TITLE
docs: improve server options description for clarity

### DIFF
--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -2069,8 +2069,9 @@ export interface RsbuildConfig extends EnvironmentConfig {
    */
   dev?: DevConfig;
   /**
-   * Options for the Rsbuild server,
-   * will take effect during local development and preview.
+   * Options for the Rsbuild server.
+   * Mainly applies to local development and preview.
+   * Some options (e.g. `publicDir`, `base`) also affect production builds.
    */
   server?: ServerConfig;
   /**

--- a/website/docs/en/guide/configuration/rsbuild.mdx
+++ b/website/docs/en/guide/configuration/rsbuild.mdx
@@ -32,8 +32,9 @@ export default {
     // options for input source code
   },
   server: {
-    // options for the Rsbuild server,
-    // will take effect during local development and preview
+    // options for the Rsbuild server
+    // mainly for local development and preview
+    // some options (e.g. publicDir, base) also affect production builds
   },
   security: {
     // options for Web security

--- a/website/docs/zh/guide/configuration/rsbuild.mdx
+++ b/website/docs/zh/guide/configuration/rsbuild.mdx
@@ -33,7 +33,8 @@ export default {
   },
   server: {
     // 与 Rsbuild 服务器有关的选项
-    // 在本地开发和预览时都会生效
+    // 主要用于本地开发和预览
+    // 部分选项（如 publicDir、base）也会影响生产构建
   },
   security: {
     // 与 Web 安全有关的选项


### PR DESCRIPTION
## Summary

Updated the documentation to clarify that `server` options are mainly for local development and preview, but some options (such as `publicDir` and `base`) also affect production builds.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
