### PR TITLE
fix: correctly read split size config

### DIFF
--- a/packages/core/src/plugins/splitChunks.ts
+++ b/packages/core/src/plugins/splitChunks.ts
@@ -153,13 +153,14 @@ function splitByModule(ctx: Context): SplitChunks {
 }
 
 function splitBySize(ctx: Context): SplitChunks {
-  const { override, forceSplittingGroups, config, userConfig } =
-    ctx as Context & { userConfig: SplitBySize };
+  const { override, forceSplittingGroups, config } = ctx;
+  const { minSize = 0, maxSize = Number.POSITIVE_INFINITY } = config.performance
+    .chunkSplit as SplitBySize;
 
   return {
     ...getDefaultSplitChunks(config),
-    minSize: userConfig.minSize ?? 0,
-    maxSize: userConfig.maxSize ?? Number.POSITIVE_INFINITY,
+    minSize,
+    maxSize,
     ...override,
     cacheGroups: {
       ...forceSplittingGroups,


### PR DESCRIPTION
## Summary

Updated `splitBySize` to read `minSize` and `maxSize` from `config.performance.chunkSplit` instead of the removed `userConfig` property.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/7073

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
