### PR TITLE
fix(mf): remove unnecessary chunk split rules

### DIFF
--- a/packages/core/src/plugins/moduleFederation.ts
+++ b/packages/core/src/plugins/moduleFederation.ts
@@ -49,20 +49,6 @@ export function pluginModuleFederation(): RsbuildPlugin {
           return;
         }
 
-        /**
-         * Currently, splitChunks will take precedence over module federation shared modules.
-         * So we need to disable the default split chunks rules to make shared modules to work properly.
-         * @see https://github.com/module-federation/module-federation-examples/issues/3161
-         */
-        if (
-          config.performance?.chunkSplit?.strategy === 'split-by-experience'
-        ) {
-          config.performance.chunkSplit = {
-            ...config.performance.chunkSplit,
-            strategy: 'custom',
-          };
-        }
-
         // Module Federation runtime uses ES6+ syntax,
         // adding to include and let SWC transform it
         config.source.include = [

--- a/website/docs/en/config/module-federation/options.mdx
+++ b/website/docs/en/config/module-federation/options.mdx
@@ -18,7 +18,6 @@ When you set the `moduleFederation.options` option, Rsbuild will take the follow
 - Automatically register the [ModuleFederationPlugin](https://rspack.rs/plugins/webpack/module-federation-plugin) plugin, and pass the value of `options` to the plugin.
 - Set the default value of the provider's [dev.assetPrefix](/config/dev/asset-prefix) configuration to `true`. This will ensure that the static asset URL is correct for remote modules.
 - Set the default value of Rspack's [output.uniqueName](https://rspack.rs/config/output#outputuniquename) configuration to `moduleFederation.options.name`, this allows HMR to work as expected.
-- Turn off the `split-by-experience` rules in Rsbuild's [performance.chunkSplit](/config/performance/chunk-split) as it may conflict with shared modules, refer to [#3161](https://github.com/module-federation/module-federation-examples/issues/3161).
 
 ## Usage
 

--- a/website/docs/zh/config/module-federation/options.mdx
+++ b/website/docs/zh/config/module-federation/options.mdx
@@ -18,7 +18,6 @@
 - 自动注册 [ModuleFederationPlugin](https://rspack.rs/zh/plugins/webpack/module-federation-plugin) 插件，并将 `options` 的值透传给插件。
 - 将 provider 的 [dev.assetPrefix](/config/dev/asset-prefix) 配置的默认值设置为 `true`，这可以确保 remote modules 的静态资源 URL 是正确的。
 - 将 Rspack [output.uniqueName](https://rspack.rs/zh/config/output#outputuniquename) 配置的默认值设置为 `moduleFederation.options.name`，使 HMR 可以正常工作。
-- 关闭 Rsbuild [performance.chunkSplit](/config/performance/chunk-split) 中 `split-by-experience` 相关的规则，因为这可能会与 shared modules 冲突，参考 [#3161](https://github.com/module-federation/module-federation-examples/issues/3161)。
 
 ## 用法
 


### PR DESCRIPTION
## Summary

Remove unnecessary chunk split rules from the MF plugin, the related issue has been fixed.

## Related Links

The same as https://github.com/module-federation/core/pull/3215/files#diff-5ee5efd88d835533c55cc15b806482c0b87c4c979df54ce195f0c32063cf43a5L77-L82

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
