### PR TITLE
fix(plugin-react): skip chunk splitting for non-web targets

### DIFF
--- a/packages/plugin-react/src/splitChunks.ts
+++ b/packages/plugin-react/src/splitChunks.ts
@@ -29,7 +29,11 @@ export function applySplitChunksRule(
 ): void {
   api.modifyBundlerChain((chain, { environment, isProd }) => {
     const { config } = environment;
-    if (!isDefaultPreset(config) || options === false) {
+    if (
+      !isDefaultPreset(config) ||
+      config.output.target !== 'web' ||
+      options === false
+    ) {
       return;
     }
 


### PR DESCRIPTION
## Summary

Updated the condition in React plugin to skip applying the split chunks rule unless `config.output.target` is `'web'`.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/7087

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
