### PR TITLE
fix(plugin-vue): skip chunk splitting for non-web targets

### DIFF
--- a/packages/plugin-vue/src/splitChunks.ts
+++ b/packages/plugin-vue/src/splitChunks.ts
@@ -36,7 +36,8 @@ export function applySplitChunksRule(
   },
 ): void {
   api.modifyBundlerChain((chain, { environment }) => {
-    if (!isDefaultPreset(environment.config)) {
+    const { config } = environment;
+    if (!isDefaultPreset(config) || config.output.target !== 'web') {
       return;
     }
 


### PR DESCRIPTION
## Summary

Updated the condition in Vue plugin to skip applying the split chunks rule unless `config.output.target` is `'web'`.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/7087

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
