### PR TITLE
docs: update splitChunks documentation to add usage examples

### DIFF
--- a/website/docs/en/config/split-chunks.mdx
+++ b/website/docs/en/config/split-chunks.mdx
@@ -90,7 +90,7 @@ export default {
 ```
 
 :::tip
-Rsbuild first converts the preset rules into a configuration object, then deeply merges it with the `splitChunks` options you provide. The user-defined `splitChunks` configuration takes higher priority.
+Rsbuild first converts the preset rules into a configuration object, then merges it with the `splitChunks` options you provide. The user-defined `splitChunks` configuration takes higher priority.
 :::
 
 ## Disable chunk splitting

--- a/website/docs/zh/config/split-chunks.mdx
+++ b/website/docs/zh/config/split-chunks.mdx
@@ -90,7 +90,7 @@ export default {
 ```
 
 :::tip
-Rsbuild 会先将预设规则转换为配置对象，再与你配置的 `splitChunks` 选项进行深度合并，用户配置的优先级更高。
+Rsbuild 会先将预设规则转换为配置对象，再与你配置的 `splitChunks` 选项进行合并，用户配置的优先级更高。
 :::
 
 ## 关闭 chunk 拆分


### PR DESCRIPTION
## Summary

Updated the explanation of how Rsbuild's `splitChunks` builds on top of Rspack's `optimization.splitChunks`, now using clearer language and direct links to the Rspack documentation.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
