### PR TITLE
docs: remove outdated content from code splitting guide

### DIFF
--- a/website/docs/en/guide/optimization/code-splitting.mdx
+++ b/website/docs/en/guide/optimization/code-splitting.mdx
@@ -34,15 +34,15 @@ Rsbuild provides the [splitChunks](/config/split-chunks) option to configure how
 
 With `splitChunks`, you can customize chunk splitting rules. For example, you can control which modules are grouped into the same chunk and set conditions such as the minimum chunk size. This helps strike a better balance between load performance and the number of network requests.
 
-In the example below, React is split into a separate chunk named `react.js`:
+In the example below, axios is split into a separate chunk named `axios.js`:
 
 ```ts
 export default {
   splitChunks: {
     cacheGroups: {
-      react: {
-        test: /[\\/]node_modules[\\/]react[\\/]/,
-        name: 'react',
+      axios: {
+        test: /[\\/]node_modules[\\/]axios[\\/]/,
+        name: 'axios',
         chunks: 'all',
       },
     },

--- a/website/docs/zh/guide/optimization/code-splitting.mdx
+++ b/website/docs/zh/guide/optimization/code-splitting.mdx
@@ -34,15 +34,15 @@ Rsbuild 提供了 [splitChunks](/config/split-chunks) 选项来配置构建时�
 
 通过 `splitChunks`，你可以自定义 chunk 拆分规则，例如控制哪些模块被拆分到同一个 chunk 中，以及设置 chunk 的最小体积等条件，从而更好地平衡加载性能与请求数量。
 
-在下面的示例中，React 会被单独拆分到一个名为 `react.js` 的 chunk 中：
+在下面的示例中，axios 会被单独拆分到一个名为 `axios.js` 的 chunk 中：
 
 ```ts
 export default {
   splitChunks: {
     cacheGroups: {
-      react: {
-        test: /[\\/]node_modules[\\/]react[\\/]/,
-        name: 'react',
+      axios: {
+        test: /[\\/]node_modules[\\/]axios[\\/]/,
+        name: 'axios',
         chunks: 'all',
       },
     },


### PR DESCRIPTION
## Summary

Replaces the previous section on multiple chunk splitting strategies (like `split-by-experience`, `split-by-module`, etc.) with a unified explanation of the `splitChunks` configuration, which is now the recommended approach for customizing chunk splitting.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
