### PR TITLE
chore: bundle dependency @rspack/lite-tapable

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,6 @@
   },
   "dependencies": {
     "@rspack/core": "2.0.0-alpha.1",
-    "@rspack/lite-tapable": "~1.1.0",
     "@swc/helpers": "^0.5.18",
     "jiti": "^2.6.1"
   },

--- a/packages/core/prebundle.config.ts
+++ b/packages/core/prebundle.config.ts
@@ -17,7 +17,6 @@ export default {
   prettier: true,
   externals: {
     '@rspack/core': '@rspack/core',
-    '@rspack/lite-tapable': '@rspack/lite-tapable',
     typescript: 'typescript',
   },
   dependencies: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -504,9 +504,6 @@ importers:
       '@rspack/core':
         specifier: 2.0.0-alpha.1
         version: 2.0.0-alpha.1(@module-federation/runtime-tools@0.23.0)(@swc/helpers@0.5.18)
-      '@rspack/lite-tapable':
-        specifier: ~1.1.0
-        version: 1.1.0
       '@swc/helpers':
         specifier: ^0.5.18
         version: 0.5.18

--- a/website/theme/index.tsx
+++ b/website/theme/index.tsx
@@ -3,7 +3,7 @@ import { Announcement } from '@rstack-dev/doc-ui/announcement';
 import { NavIcon } from '@rstack-dev/doc-ui/nav-icon';
 import { HomeLayout } from './pages';
 import './index.scss';
-import { NoSSR, useLang, usePageData } from '@rspress/core/runtime';
+import { NoSSR, useLang, usePage } from '@rspress/core/runtime';
 import {
   Search as PluginAlgoliaSearch,
   ZH_LOCALES,
@@ -13,7 +13,7 @@ import {
 const ANNOUNCEMENT_URL = '';
 
 const Layout = () => {
-  const { page } = usePageData();
+  const { page } = usePage();
   const lang = useLang();
 
   return (


### PR DESCRIPTION
## Summary

Bundle the dependency `@rspack/lite-tapable`:

- Make `@rsbuild/core` depend on fewer packages.
- This package is small enough and fully pure, so inlining it is faster than doing a `require`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
