### PR TITLE
docs: update proxy examples for http-proxy-middleware v3

### DIFF
--- a/website/docs/en/config/server/proxy.mdx
+++ b/website/docs/en/config/server/proxy.mdx
@@ -3,15 +3,21 @@
 - **Type:**
 
 ```ts
+import type { Options } from 'http-proxy-middleware';
+
+type ProxyOptions = Options & { bypass?: ProxyBypass };
+
 type ProxyConfig =
-  | Record<string, string | ProxyOptions>
+  | ProxyOptions
   | ProxyOptions[]
-  | ProxyOptions;
+  | Record<string, string | ProxyOptions>;
 ```
 
 - **Default:** `undefined`
 
-Configure proxy rules for the dev server or preview server to proxy requests to the specified service.
+Configure proxy rules for the dev server or preview server, and forward requests to the specified service.
+
+This feature is powered by [http-proxy-middleware v3](https://github.com/chimurai/http-proxy-middleware). You can use [all options](https://github.com/chimurai/http-proxy-middleware/tree/master?tab=readme-ov-file#options) provided by `http-proxy-middleware`, plus the extra [bypass](#bypass) option from Rsbuild.
 
 ## Example
 
@@ -23,7 +29,7 @@ export default {
     proxy: {
       // http://localhost:3000/api -> http://localhost:3000/api
       // http://localhost:3000/api/foo -> http://localhost:3000/api/foo
-      '/api': 'http://localhost:3000',
+      '/api': 'http://localhost:3000/api',
     },
   },
 };
@@ -39,7 +45,7 @@ export default {
     proxy: {
       // http://localhost:3000/api -> https://nodejs.org/api
       // http://localhost:3000/api/foo -> https://nodejs.org/api/foo
-      '/api': 'https://nodejs.org',
+      '/api': 'https://nodejs.org/api',
     },
   },
 };
@@ -47,17 +53,17 @@ export default {
 
 ### Path rewrite
 
-If you do not want `/api` to be passed along, we need to rewrite the path:
+Use `pathRewrite` to rewrite request paths. For example, rewrite `/foo` to `/bar`:
 
 ```ts title="rsbuild.config.ts"
 export default {
   server: {
     proxy: {
-      // http://localhost:3000/api -> http://localhost:3000
-      // http://localhost:3000/api/foo -> http://localhost:3000/foo
-      '/api': {
+      // http://localhost:3000/foo -> http://localhost:3000/bar
+      // http://localhost:3000/foo/baz -> http://localhost:3000/bar/baz
+      '/foo': {
         target: 'http://localhost:3000',
-        pathRewrite: { '^/api': '' },
+        pathRewrite: { '^/foo': '/bar' },
       },
     },
   },
@@ -81,55 +87,57 @@ export default {
 };
 ```
 
-## Options
+### Path filter
 
-The Rsbuild server proxy uses the [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware/tree/2.x) package. Check out its documentation for more advanced usage.
+[pathFilter](https://github.com/chimurai/http-proxy-middleware/blob/master/recipes/pathFilter.md) is used to select which requests should be proxied. The `path` used for matching is the request URL pathname.
 
-The full type definition of Rsbuild server proxy is:
+For example, proxy requests under `/auth` and `/api` to the target service:
 
-```ts
-import type { Options as HttpProxyOptions } from 'http-proxy-middleware';
-
-type Filter = string | string[] | ((pathname: string, req: Request) => boolean);
-
-type ProxyOptions = HttpProxyOptions & {
-  bypass?: (
-    req: IncomingMessage,
-    res: ServerResponse,
-    proxyOptions: ProxyOptions,
-  ) => MaybePromise<string | undefined | null | boolean>;
-  context?: Filter;
+```ts title="rsbuild.config.ts"
+export default {
+  server: {
+    proxy: [
+      {
+        pathFilter: ['/auth', '/api'],
+        target: 'http://localhost:3000',
+      },
+    ],
+  },
 };
-
-type ProxyConfig =
-  | ProxyOptions
-  | ProxyOptions[]
-  | Record<string, string>
-  | Record<string, ProxyOptions>;
 ```
 
-In addition to the `http-proxy-middleware` options, Rsbuild also supports the `bypass` and `context` options.
+## Extra options
 
 ### bypass
 
-Sometimes you don't want to proxy everything. You can bypass the proxy based on the return value of a `bypass` function.
+- **Type:**
 
-In the function, you have access to the request, response, and proxy options.
+```ts
+type ProxyBypass = (
+  req: IncomingMessage,
+  res: ServerResponse,
+  proxyOptions: ProxyOptions,
+) => MaybePromise<string | undefined | null | boolean>;
+```
+
+In some cases, you may not want to proxy every request. Use the `bypass` function to skip the proxy.
+
+Inside the function, you have access to the request, response, and proxy options.
 
 - Return `null` or `undefined` to continue processing the request with proxy.
-- Return `true` to continue processing the request without proxy.
+- Return `true` to skip the proxy and continue processing the request.
 - Return `false` to produce a 404 error for the request.
-- Return a path to serve from, instead of continuing to proxy the request.
+- Return a specific path to replace the original request path.
 - Return a Promise to handle the request asynchronously.
 
-For example, for a browser request, you want to serve an HTML page, but for an API request, you want to proxy it. You could configure it like this:
+For example, you may want to serve HTML for browser requests, but keep proxying API requests:
 
 ```ts title="rsbuild.config.ts"
 export default {
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:3000',
+        target: 'http://localhost:3000/api',
         bypass(req, res, proxyOptions) {
           if (req.headers.accept.indexOf('html') !== -1) {
             console.log('Skipping proxy for browser request.');
@@ -138,23 +146,6 @@ export default {
         },
       },
     },
-  },
-};
-```
-
-### context
-
-Used to proxy multiple specified paths to the same target.
-
-```ts title="rsbuild.config.ts"
-export default {
-  server: {
-    proxy: [
-      {
-        context: ['/auth', '/api'],
-        target: 'http://localhost:3000',
-      },
-    ],
   },
 };
 ```

--- a/website/docs/zh/config/server/proxy.mdx
+++ b/website/docs/zh/config/server/proxy.mdx
@@ -3,15 +3,21 @@
 - **类型：**
 
 ```ts
+import type { Options } from 'http-proxy-middleware';
+
+type ProxyOptions = Options & { bypass?: ProxyBypass };
+
 type ProxyConfig =
-  | Record<string, string | ProxyOptions>
+  | ProxyOptions
   | ProxyOptions[]
-  | ProxyOptions;
+  | Record<string, string | ProxyOptions>;
 ```
 
 - **默认值：** `undefined`
 
-为开发服务器或预览服务器配置代理规则，将请求代理到指定的服务上。
+为开发服务器或预览服务器配置代理规则，把请求转发到指定服务。
+
+该功能基于 [http-proxy-middleware v3](https://github.com/chimurai/http-proxy-middleware) 实现。你可以使用 `http-proxy-middleware` 提供的 [全部选项](https://github.com/chimurai/http-proxy-middleware/tree/master?tab=readme-ov-file#options)，以及 Rsbuild 额外扩展的 [bypass](#bypass) 选项。
 
 ## 示例
 
@@ -23,15 +29,15 @@ export default {
     proxy: {
       // http://localhost:3000/api -> http://localhost:3000/api
       // http://localhost:3000/api/foo -> http://localhost:3000/api/foo
-      '/api': 'http://localhost:3000',
+      '/api': 'http://localhost:3000/api',
     },
   },
 };
 ```
 
-此时，`/api/users` 请求将会代理到 `http://localhost:3000/api/users`。
+此时，`/api/users` 会被代理到 `http://localhost:3000/api/users`。
 
-你也可以代理到线上域名，比如:
+你也可以代理到线上域名，例如：
 
 ```ts title="rsbuild.config.ts"
 export default {
@@ -39,7 +45,7 @@ export default {
     proxy: {
       // http://localhost:3000/api -> https://nodejs.org/api
       // http://localhost:3000/api/foo -> https://nodejs.org/api/foo
-      '/api': 'https://nodejs.org',
+      '/api': 'https://nodejs.org/api',
     },
   },
 };
@@ -47,17 +53,17 @@ export default {
 
 ### 重写路径
 
-如果你不想传递 `/api`，可以通过 `pathRewrite` 重写请求路径：
+通过 `pathRewrite` 可以重写请求路径，例如把 `/foo` 的请求改写为目标服务的 `/bar`：
 
 ```ts title="rsbuild.config.ts"
 export default {
   server: {
     proxy: {
-      // http://localhost:3000/api -> http://localhost:3000
-      // http://localhost:3000/api/foo -> http://localhost:3000/foo
-      '/api': {
+      // http://localhost:3000/foo -> http://localhost:3000/bar
+      // http://localhost:3000/foo/baz -> http://localhost:3000/bar/baz
+      '/foo': {
         target: 'http://localhost:3000',
-        pathRewrite: { '^/api': '' },
+        pathRewrite: { '^/foo': '/bar' },
       },
     },
   },
@@ -66,7 +72,7 @@ export default {
 
 ### 代理 WebSocket 请求
 
-如果你希望代理 WebSocket 请求，可以通过 `ws` 开启：
+如果需要代理 WebSocket 请求，可将 `ws` 设为 `true`：
 
 ```ts title="rsbuild.config.ts"
 export default {
@@ -81,55 +87,57 @@ export default {
 };
 ```
 
-## 选项
+### 路径过滤
 
-Rsbuild server proxy 基于 [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware/tree/2.x) 实现。你可以使用 http-proxy-middleware 的所有配置项，具体可以查看文档。
+[pathFilter](https://github.com/chimurai/http-proxy-middleware/blob/master/recipes/pathFilter.md) 用于筛选需要代理的请求。参与匹配的 `path` 为请求 URL 的 pathname。
 
-Rsbuild server proxy 完整类型定义为：
+例如，将 `/auth` 与 `/api` 的请求代理到目标服务：
 
-```ts
-import type { Options as HttpProxyOptions } from 'http-proxy-middleware';
-
-type Filter = string | string[] | ((pathname: string, req: Request) => boolean);
-
-type ProxyOptions = HttpProxyOptions & {
-  bypass?: (
-    req: IncomingMessage,
-    res: ServerResponse,
-    proxyOptions: ProxyOptions,
-  ) => MaybePromise<string | undefined | null | boolean>;
-  context?: Filter;
+```ts title="rsbuild.config.ts"
+export default {
+  server: {
+    proxy: [
+      {
+        pathFilter: ['/auth', '/api'],
+        target: 'http://localhost:3000',
+      },
+    ],
+  },
 };
-
-type ProxyConfig =
-  | ProxyOptions
-  | ProxyOptions[]
-  | Record<string, string>
-  | Record<string, ProxyOptions>;
 ```
 
-除了 `http-proxy-middleware` 的选项外，Rsbuild 还支持 `bypass` 和 `context` 两个选项。
+## 额外选项
 
 ### bypass
 
-一些情况下，你可能不想代理所有请求。可以通过 `bypass` 函数来绕过代理。
+- **类型：**
+
+```ts
+type ProxyBypass = (
+  req: IncomingMessage,
+  res: ServerResponse,
+  proxyOptions: ProxyOptions,
+) => MaybePromise<string | undefined | null | boolean>;
+```
+
+有些场景下，你可能不想代理所有请求，可以通过 `bypass` 函数来绕过代理。
 
 在函数中，你可以访问到 request、response 和 proxy 选项。
 
 - 返回 `null` 或 `undefined` 会继续用代理处理请求。
-- 返回 `true` 会跳过代理继续处理请求。
+- 返回 `true` 会跳过代理并继续处理请求。
 - 返回 `false` 会返回 404 错误。
-- 返回一个具体的服务路径，将会使用此路径替代原请求路径。
+- 返回一个具体的服务路径，会用该路径替代原请求路径。
 - 返回一个 Promise，可以异步处理请求。
 
-例如，你可能希望对浏览器请求返回 HTML 页面，而对 API 请求则进行代理转发。你可以这样配置：
+例如，你可能希望浏览器请求返回 HTML 页面，而 API 请求则继续代理转发，可以这样配置：
 
 ```ts title="rsbuild.config.ts"
 export default {
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:3000',
+        target: 'http://localhost:3000/api',
         bypass(req, res, proxyOptions) {
           if (req.headers.accept.indexOf('html') !== -1) {
             console.log('Skipping proxy for browser request.');
@@ -138,23 +146,6 @@ export default {
         },
       },
     },
-  },
-};
-```
-
-### context
-
-用于代理多个指定的路径到同一个目标。
-
-```ts title="rsbuild.config.ts"
-export default {
-  server: {
-    proxy: [
-      {
-        context: ['/auth', '/api'],
-        target: 'http://localhost:3000',
-      },
-    ],
   },
 };
 ```


### PR DESCRIPTION
## Summary

- Updated the type definition of `ProxyConfig` and `ProxyOptions` to match the latest API,
- Removed documentation for the deprecated `context` option, consolidating guidance around `pathFilter`
- Fixed proxy example targets so that the path forwarding is accurate 

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/7116

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
