### PR TITLE
docs: update GitHub links to remove tab=readme-ov-file

### DIFF
--- a/website/docs/en/community/releases/v1-0.mdx
+++ b/website/docs/en/community/releases/v1-0.mdx
@@ -68,7 +68,7 @@ After releasing Rsbuild 1.0, we also plan to collaborate with some excellent tea
 
 ## Plugin ecosystem
 
-The Rsbuild plugin ecosystem is constantly evolving. There are currently over 50 [Rsbuild plugins](https://github.com/rstackjs/awesome-rstack?tab=readme-ov-file#rsbuild-plugins) available in the community. We provide several advanced features through plugins to support the development of production-grade applications, such as [type checking](https://github.com/rstackjs/rsbuild-plugin-type-check), [compatibility checking](https://github.com/rstackjs/rsbuild-plugin-check-syntax), and [static assets retry](https://github.com/rstackjs/rsbuild-plugin-assets-retry). Thanks to Rspack's compatibility with webpack, Rsbuild also supports most webpack plugins.
+The Rsbuild plugin ecosystem is constantly evolving. There are currently over 50 [Rsbuild plugins](https://github.com/rstackjs/awesome-rstack#rsbuild-plugins) available in the community. We provide several advanced features through plugins to support the development of production-grade applications, such as [type checking](https://github.com/rstackjs/rsbuild-plugin-type-check), [compatibility checking](https://github.com/rstackjs/rsbuild-plugin-check-syntax), and [static assets retry](https://github.com/rstackjs/rsbuild-plugin-assets-retry). Thanks to Rspack's compatibility with webpack, Rsbuild also supports most webpack plugins.
 
 Compared to webpack or Rspack, the Rsbuild plugin API is more straightforward and beginner-friendly, allowing developers to easily create plugins to meet their specific needs.
 

--- a/website/docs/en/config/output/css-modules.mdx
+++ b/website/docs/en/config/output/css-modules.mdx
@@ -4,7 +4,7 @@
 
 Configure custom CSS Modules settings.
 
-The CSS Modules feature in Rsbuild is based on the `modules` option of css-loader. You can refer to [css-loader - modules](https://github.com/webpack/css-loader?tab=readme-ov-file#modules) to learn more.
+The CSS Modules feature in Rsbuild is based on the `modules` option of css-loader. You can refer to [css-loader - modules](https://github.com/webpack/css-loader#modules) to learn more.
 
 ## cssModules.auto
 

--- a/website/docs/en/config/server/open.mdx
+++ b/website/docs/en/config/server/open.mdx
@@ -116,7 +116,7 @@ npm i cross-env -D
 cross-env BROWSER=chrome npx rsbuild dev
 ```
 
-You can also refer to the [app option](https://github.com/sindresorhus/open?tab=readme-ov-file#app) documentation from `open` for additional `BROWSER` values, such as OS-specific browser names:
+You can also refer to the [app option](https://github.com/sindresorhus/open#app) documentation from `open` for additional `BROWSER` values, such as OS-specific browser names:
 
 ```bash
 # macOS

--- a/website/docs/en/config/server/proxy.mdx
+++ b/website/docs/en/config/server/proxy.mdx
@@ -17,7 +17,7 @@ type ProxyConfig =
 
 Configure proxy rules for the dev server or preview server, and forward requests to the specified service.
 
-This feature is powered by [http-proxy-middleware v3](https://github.com/chimurai/http-proxy-middleware). You can use [all options](https://github.com/chimurai/http-proxy-middleware/tree/master?tab=readme-ov-file#options) provided by `http-proxy-middleware`, plus the extra [bypass](#bypass) option from Rsbuild.
+This feature is powered by [http-proxy-middleware v3](https://github.com/chimurai/http-proxy-middleware). You can use [all options](https://github.com/chimurai/http-proxy-middleware#options) provided by `http-proxy-middleware`, plus the extra [bypass](#bypass) option from Rsbuild.
 
 ## Example
 

--- a/website/docs/en/config/source/decorators.mdx
+++ b/website/docs/en/config/source/decorators.mdx
@@ -17,7 +17,7 @@ Used to configure the decorators syntax.
 
 Specify the decorator syntax version to be used.
 
-If you want to know the differences between different decorators versions, you can refer to: [How does this proposal compare to other versions of decorators?](https://github.com/tc39/proposal-decorators?tab=readme-ov-file#how-does-this-proposal-compare-to-other-versions-of-decorators)
+If you want to know the differences between different decorators versions, you can refer to: [How does this proposal compare to other versions of decorators?](https://github.com/tc39/proposal-decorators#how-does-this-proposal-compare-to-other-versions-of-decorators)
 
 ### 2022-03
 

--- a/website/docs/en/guide/advanced/browser-compatibility.mdx
+++ b/website/docs/en/guide/advanced/browser-compatibility.mdx
@@ -238,4 +238,4 @@ It should be noted that core-js cannot provide polyfills for all JavaScript APIs
 
 The most typical example is the `Proxy` object. Since `Proxy` requires engine-level support to implement object operation interception, its behavior cannot be fully simulated through pure JavaScript code, so core-js doesn't provide a polyfill for `Proxy`.
 
-See [core-js - Missing polyfills](https://github.com/zloirock/core-js?tab=readme-ov-file#missing-polyfills) to understand which APIs core-js cannot provide polyfills for.
+See [core-js - Missing polyfills](https://github.com/zloirock/core-js#missing-polyfills) to understand which APIs core-js cannot provide polyfills for.

--- a/website/docs/en/guide/migration/vite-plugin.mdx
+++ b/website/docs/en/guide/migration/vite-plugin.mdx
@@ -7,7 +7,7 @@ This chapter introduces how to migrate a Vite plugin to Rsbuild plugin.
 Before migrating a Vite plugin, it is recommended to check if there is a corresponding plugin in the Rsbuild ecosystem. You can find the plugins through the following pages:
 
 - [Rsbuild official plugins](/plugins/list)
-- [Rsbuild community plugins](https://github.com/rstackjs/awesome-rstack?tab=readme-ov-file#rsbuild-plugins)
+- [Rsbuild community plugins](https://github.com/rstackjs/awesome-rstack#rsbuild-plugins)
 
 ## Define a plugin
 

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -67,7 +67,7 @@ When creating an application, you can choose from the following templates provid
 `create-rsbuild` provides basic templates. For more options, see:
 
 - Visit [Rspack - Ecosystem](https://rspack.rs/guide/start/quick-start#ecosystem) to learn about higher-level tools built on Rsbuild.
-- Visit [awesome-rstack - Starter](https://github.com/rstackjs/awesome-rstack?tab=readme-ov-file#starter) for community-maintained templates.
+- Visit [awesome-rstack - Starter](https://github.com/rstackjs/awesome-rstack#starter) for community-maintained templates.
 
 ### Optional tools
 

--- a/website/docs/en/plugins/list/index.mdx
+++ b/website/docs/en/plugins/list/index.mdx
@@ -80,7 +80,7 @@ You can find the source code of all official plugins in [web-infra-dev/rsbuild](
 
 ## Community plugins
 
-You can check out the Rsbuild plugins provided by the community at [awesome-rstack - Rsbuild Plugins](https://github.com/rstackjs/awesome-rstack?tab=readme-ov-file#rsbuild-plugins).
+You can check out the Rsbuild plugins provided by the community at [awesome-rstack - Rsbuild Plugins](https://github.com/rstackjs/awesome-rstack#rsbuild-plugins).
 
 You can also discover more Rsbuild plugins on npm by searching for the keyword [rsbuild-plugin](https://npmjs.com/search?q=rsbuild-plugin&ranking=popularity).
 

--- a/website/docs/en/plugins/list/plugin-sass.mdx
+++ b/website/docs/en/plugins/list/plugin-sass.mdx
@@ -141,7 +141,7 @@ Sass provides several implementations, including [sass](https://npmjs.com/packag
 
 Rsbuild uses the latest `sass-embedded` implementation by default. `sass-embedded` is a JavaScript wrapper around the native Dart Sass executable, providing a consistent API and optimal performance.
 
-To use a different Sass implementation instead of the built-in `sass-embedded` included in Rsbuild, install the preferred Sass implementation in your project and specify it using the `sass-loader`'s [implementation](https://github.com/webpack/sass-loader?tab=readme-ov-file#implementation) option.
+To use a different Sass implementation instead of the built-in `sass-embedded` included in Rsbuild, install the preferred Sass implementation in your project and specify it using the `sass-loader`'s [implementation](https://github.com/webpack/sass-loader#implementation) option.
 
 ```ts
 pluginSass({

--- a/website/docs/en/plugins/list/plugin-svelte.mdx
+++ b/website/docs/en/plugins/list/plugin-svelte.mdx
@@ -105,7 +105,7 @@ pluginSvelte({
 
 ## Notes
 
-Currently, `svelte-loader` does not support HMR for Svelte v5, see [svelte-loader - Hot Reload](https://github.com/sveltejs/svelte-loader?tab=readme-ov-file#hot-reload).
+Currently, `svelte-loader` does not support HMR for Svelte v5, see [svelte-loader - Hot Reload](https://github.com/sveltejs/svelte-loader#hot-reload).
 
 ### Alias handling in Less/Sass
 

--- a/website/docs/zh/community/releases/v1-0.mdx
+++ b/website/docs/zh/community/releases/v1-0.mdx
@@ -68,7 +68,7 @@ Rsbuild 是以 Rspack 为核心实现的，我们为 Rsbuild 设计了易于使�
 
 ## 插件生态
 
-Rsbuild 的插件生态正在不断发展，目前社区中已经有超过 50 个 [Rsbuild 插件](https://github.com/rstackjs/awesome-rstack?tab=readme-ov-file#rsbuild-plugins)。我们通过插件提供了一些高级特性，以支持生产级应用的开发，例如 [类型检查](https://github.com/rstackjs/rsbuild-plugin-type-check)、[产物语法检查](https://github.com/rstackjs/rsbuild-plugin-check-syntax)、[静态资源重试](https://github.com/rstackjs/rsbuild-plugin-assets-retry)。此外，受益于 Rspack 对 webpack 的兼容性，Rsbuild 也支持使用大部分 webpack 插件。
+Rsbuild 的插件生态正在不断发展，目前社区中已经有超过 50 个 [Rsbuild 插件](https://github.com/rstackjs/awesome-rstack#rsbuild-plugins)。我们通过插件提供了一些高级特性，以支持生产级应用的开发，例如 [类型检查](https://github.com/rstackjs/rsbuild-plugin-type-check)、[产物语法检查](https://github.com/rstackjs/rsbuild-plugin-check-syntax)、[静态资源重试](https://github.com/rstackjs/rsbuild-plugin-assets-retry)。此外，受益于 Rspack 对 webpack 的兼容性，Rsbuild 也支持使用大部分 webpack 插件。
 
 与 webpack 或 Rspack 相比，Rsbuild 的插件 API 更加简洁和容易上手，使开发者能够轻松地开发插件来满足自己的需求。
 

--- a/website/docs/zh/config/output/css-modules.mdx
+++ b/website/docs/zh/config/output/css-modules.mdx
@@ -4,7 +4,7 @@
 
 用于自定义 CSS Modules 配置。
 
-Rsbuild 的 CSS Modules 功能是基于 css-loader 的 `modules` 选项实现的，你可以参考 [css-loader - modules](https://github.com/webpack/css-loader?tab=readme-ov-file#modules) 来了解更多。
+Rsbuild 的 CSS Modules 功能是基于 css-loader 的 `modules` 选项实现的，你可以参考 [css-loader - modules](https://github.com/webpack/css-loader#modules) 来了解更多。
 
 ## cssModules.auto
 

--- a/website/docs/zh/config/server/open.mdx
+++ b/website/docs/zh/config/server/open.mdx
@@ -116,7 +116,7 @@ npm i cross-env -D
 cross-env BROWSER=chrome npx rsbuild dev
 ```
 
-你也可以参考 `open` 的 [app 选项](https://github.com/sindresorhus/open?tab=readme-ov-file#app) 来配置更多特殊的 `BROWSER` 值，例如一些操作系统特有的浏览器名称：
+你也可以参考 `open` 的 [app 选项](https://github.com/sindresorhus/open#app) 来配置更多特殊的 `BROWSER` 值，例如一些操作系统特有的浏览器名称：
 
 ```bash
 # macOS

--- a/website/docs/zh/config/server/proxy.mdx
+++ b/website/docs/zh/config/server/proxy.mdx
@@ -17,7 +17,7 @@ type ProxyConfig =
 
 为开发服务器或预览服务器配置代理规则，把请求转发到指定服务。
 
-该功能基于 [http-proxy-middleware v3](https://github.com/chimurai/http-proxy-middleware) 实现。你可以使用 `http-proxy-middleware` 提供的 [全部选项](https://github.com/chimurai/http-proxy-middleware/tree/master?tab=readme-ov-file#options)，以及 Rsbuild 额外扩展的 [bypass](#bypass) 选项。
+该功能基于 [http-proxy-middleware v3](https://github.com/chimurai/http-proxy-middleware) 实现。你可以使用 `http-proxy-middleware` 提供的 [全部选项](https://github.com/chimurai/http-proxy-middleware#options)，以及 Rsbuild 额外扩展的 [bypass](#bypass) 选项。
 
 ## 示例
 

--- a/website/docs/zh/config/source/decorators.mdx
+++ b/website/docs/zh/config/source/decorators.mdx
@@ -17,7 +17,7 @@ type Decorators = {
 
 指定需要使用的装饰器语法版本。
 
-如果你希望了解不同装饰器版本的区别，可以参考：[How does this proposal compare to other versions of decorators?](https://github.com/tc39/proposal-decorators?tab=readme-ov-file#how-does-this-proposal-compare-to-other-versions-of-decorators)
+如果你希望了解不同装饰器版本的区别，可以参考：[How does this proposal compare to other versions of decorators?](https://github.com/tc39/proposal-decorators#how-does-this-proposal-compare-to-other-versions-of-decorators)
 
 ### 2022-03
 

--- a/website/docs/zh/guide/advanced/browser-compatibility.mdx
+++ b/website/docs/zh/guide/advanced/browser-compatibility.mdx
@@ -238,4 +238,4 @@ export default {
 
 最典型的例子是 `Proxy` 对象。由于 `Proxy` 需要引擎级别的支持来实现对象操作的拦截，无法通过纯 JavaScript 代码来完全模拟其行为，因此 core-js 并不提供 `Proxy` 的 polyfill。
 
-请查看 [core-js - Missing polyfills](https://github.com/zloirock/core-js?tab=readme-ov-file#missing-polyfills) 来了解 core-js 无法提供哪些 API 的 polyfill。
+请查看 [core-js - Missing polyfills](https://github.com/zloirock/core-js#missing-polyfills) 来了解 core-js 无法提供哪些 API 的 polyfill。

--- a/website/docs/zh/guide/migration/vite-plugin.mdx
+++ b/website/docs/zh/guide/migration/vite-plugin.mdx
@@ -7,7 +7,7 @@
 在迁移一个 Vite 插件之前，建议先检查 Rsbuild 生态中是否存在对应的插件，你可以通过以下页面来查找：
 
 - [Rsbuild 官方插件](/plugins/list)
-- [Rsbuild 社区插件](https://github.com/rstackjs/awesome-rstack?tab=readme-ov-file#rsbuild-plugins)
+- [Rsbuild 社区插件](https://github.com/rstackjs/awesome-rstack#rsbuild-plugins)
 
 ## 定义一个插件
 

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -67,7 +67,7 @@ import { PackageManagerTabs } from '@theme';
 `create-rsbuild` 提供了开箱即用的基础模板，你还可以通过以下方式获取更丰富的模板：
 
 - 前往 [Rspack - 生态](https://rspack.rs/zh/guide/start/quick-start#%E7%94%9F%E6%80%81) 了解基于 Rsbuild 的各种上层工具。
-- 前往 [awesome-rstack - Starter](https://github.com/rstackjs/awesome-rstack?tab=readme-ov-file#starter) 获取更多社区维护的模板。
+- 前往 [awesome-rstack - Starter](https://github.com/rstackjs/awesome-rstack#starter) 获取更多社区维护的模板。
 
 ### 可选工具
 

--- a/website/docs/zh/plugins/list/index.mdx
+++ b/website/docs/zh/plugins/list/index.mdx
@@ -80,7 +80,7 @@
 
 ## 社区插件
 
-你可以在 [awesome-rstack - Rsbuild Plugins](https://github.com/rstackjs/awesome-rstack?tab=readme-ov-file#rsbuild-plugins) 中查看社区提供的 Rsbuild 插件。
+你可以在 [awesome-rstack - Rsbuild Plugins](https://github.com/rstackjs/awesome-rstack#rsbuild-plugins) 中查看社区提供的 Rsbuild 插件。
 
 也可以在 npm 上搜索 [rsbuild-plugin](https://npmjs.com/search?q=rsbuild-plugin&ranking=popularity) 关键词来发现更多 Rsbuild 插件。
 

--- a/website/docs/zh/plugins/list/plugin-sass.mdx
+++ b/website/docs/zh/plugins/list/plugin-sass.mdx
@@ -141,7 +141,7 @@ Sass 提供了多种实现，包括 [sass](https://npmjs.com/package/sass)、[sa
 
 Rsbuild 默认使用最新的 `sass-embedded` 实现。`sass-embedded` 是一个围绕原生 Dart Sass 可执行文件的 JavaScript wrapper，具备一致的 API 和最佳的性能。
 
-如果你需要使用其他 Sass 实现，而不是使用 Rsbuild 内置的 `sass-embedded`，可以在项目中安装需要使用的 Sass 实现，并通过 `sass-loader` 的 [implementation](https://github.com/webpack/sass-loader?tab=readme-ov-file#implementation) 选项来设置。
+如果你需要使用其他 Sass 实现，而不是使用 Rsbuild 内置的 `sass-embedded`，可以在项目中安装需要使用的 Sass 实现，并通过 `sass-loader` 的 [implementation](https://github.com/webpack/sass-loader#implementation) 选项来设置。
 
 ```ts
 pluginSass({
@@ -157,7 +157,7 @@ pluginSass({
 
 ### 选择 Sass API
 
-Rsbuild 默认使用最新的 `modern-compiler` API，如果你依赖了 Sass 的 `legacy` API，可以将 sass-loader 的 [api](https://github.com/webpack/sass-loader?tab=readme-ov-file#api) 选项设置为 `legacy`，以兼容一些废弃的 Sass 写法。
+Rsbuild 默认使用最新的 `modern-compiler` API，如果你依赖了 Sass 的 `legacy` API，可以将 sass-loader 的 [api](https://github.com/webpack/sass-loader#api) 选项设置为 `legacy`，以兼容一些废弃的 Sass 写法。
 
 ```ts
 pluginSass({

--- a/website/docs/zh/plugins/list/plugin-svelte.mdx
+++ b/website/docs/zh/plugins/list/plugin-svelte.mdx
@@ -105,7 +105,7 @@ pluginSvelte({
 
 ## 注意事项
 
-目前 `svelte-loader` 暂不支持 Svelte v5 热更新，详见 [svelte-loader - Hot Reload](https://github.com/sveltejs/svelte-loader?tab=readme-ov-file#hot-reload)。
+目前 `svelte-loader` 暂不支持 Svelte v5 热更新，详见 [svelte-loader - Hot Reload](https://github.com/sveltejs/svelte-loader#hot-reload)。
 
 ### Less/Sass 中的别名处理
 


### PR DESCRIPTION
## Summary

Removing unnecessary query parameters (such as `?tab=readme-ov-file`) from GitHub URLs.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
