### PR TITLE
docs: add version differences for proxy config

### DIFF
--- a/website/docs/en/config/server/proxy.mdx
+++ b/website/docs/en/config/server/proxy.mdx
@@ -51,6 +51,25 @@ export default {
 };
 ```
 
+### Version differences
+
+Rsbuild v1 is based on `http-proxy-middleware` v2, while Rsbuild v2 is based on `http-proxy-middleware` v3.
+
+In `http-proxy-middleware` v2, the proxied path is automatically appended to the target URL during forwarding. This behavior is no longer provided in v3, so the path must be explicitly included in the `target`.
+
+```ts title="rsbuild.config.ts"
+export default {
+  server: {
+    proxy: {
+      // http-proxy-middleware v2
+      '/api': 'http://localhost:3000',
+      // http-proxy-middleware v3
+      '/api': 'http://localhost:3000/api',
+    },
+  },
+};
+```
+
 ### Path rewrite
 
 Use `pathRewrite` to rewrite request paths. For example, rewrite `/foo` to `/bar`:

--- a/website/docs/zh/config/server/proxy.mdx
+++ b/website/docs/zh/config/server/proxy.mdx
@@ -51,6 +51,25 @@ export default {
 };
 ```
 
+### 版本差异
+
+Rsbuild v1 基于 `http-proxy-middleware` v2，而 Rsbuild v2 基于 `http-proxy-middleware` v3。
+
+`http-proxy-middleware` v2 会在转发时，会自动将代理的路径拼接到目标地址。v3 不再提供这一行为，因此需要在 `target` 中显式包含该路径。
+
+```ts title="rsbuild.config.ts"
+export default {
+  server: {
+    proxy: {
+      // http-proxy-middleware v2
+      '/api': 'http://localhost:3000',
+      // http-proxy-middleware v3
+      '/api': 'http://localhost:3000/api',
+    },
+  },
+};
+```
+
 ### 重写路径
 
 通过 `pathRewrite` 可以重写请求路径，例如把 `/foo` 的请求改写为目标服务的 `/bar`：


### PR DESCRIPTION
## Summary

Clarify differences in proxy configuration between Rsbuild v1 and v2, specifically regarding changes in the underlying `http-proxy-middleware` library.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/7116

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
