### PR TITLE
feat!: streamline proxy config typing

### DIFF
--- a/packages/core/src/server/proxy.ts
+++ b/packages/core/src/server/proxy.ts
@@ -10,39 +10,34 @@ import type {
 import { HttpCode, type UpgradeEvent } from './helper';
 
 function formatProxyOptions(proxyOptions: ProxyConfig) {
-  const ret: ProxyOptions[] = [];
+  const logPrefix = color.dim('[http-proxy-middleware]: ');
+  const defaultOptions: ProxyOptions = {
+    changeOrigin: true,
+    logger: {
+      info(msg: string) {
+        logger.debug(logPrefix + msg);
+      },
+      warn: (msg: string) => {
+        logger.warn(logPrefix + msg);
+      },
+      error: (msg: string) => {
+        logger.error(logPrefix + msg);
+      },
+    },
+  };
 
   if (Array.isArray(proxyOptions)) {
-    ret.push(...proxyOptions);
-  } else if ('target' in proxyOptions) {
-    ret.push(proxyOptions);
-  } else {
-    const logPrefix = color.dim('[http-proxy-middleware]: ');
-    const defaultOptions: ProxyOptions = {
-      changeOrigin: true,
-      logger: {
-        info(msg: string) {
-          logger.debug(logPrefix + msg);
-        },
-        warn: (msg: string) => {
-          logger.warn(logPrefix + msg);
-        },
-        error: (msg: string) => {
-          logger.error(logPrefix + msg);
-        },
-      },
-    };
-
-    for (const [pathFilter, value] of Object.entries(proxyOptions)) {
-      ret.push({
-        ...defaultOptions,
-        pathFilter,
-        ...(typeof value === 'string' ? { target: value } : value),
-      });
-    }
+    return proxyOptions.map((options) => ({
+      ...defaultOptions,
+      ...options,
+    }));
   }
 
-  return ret;
+  return Object.entries(proxyOptions).map(([pathFilter, value]) => ({
+    ...defaultOptions,
+    pathFilter,
+    ...(typeof value === 'string' ? { target: value } : value),
+  }));
 }
 
 export function createProxyMiddleware(proxyOptions: ProxyConfig): {

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -325,11 +325,12 @@ export type { ProxyFilter };
 
 export type ProxyOptions = HttpProxyOptions & {
   /**
-   * Bypass the proxy based on the return value of a function.
+   * Use the `bypass` function to skip the proxy.
+   * Inside the function, you have access to the request, response, and proxy options.
    * - Return `null` or `undefined` to continue processing the request with proxy.
-   * - Return `true` to continue processing the request without proxy.
+   * - Return `true` to skip the proxy and continue processing the request.
    * - Return `false` to produce a 404 error for the request.
-   * - Return a path to serve from, instead of continuing to proxy the request.
+   * - Return a specific path to replace the original request path.
    * - Return a Promise to handle the request asynchronously.
    */
   bypass?: ProxyBypass;
@@ -337,8 +338,7 @@ export type ProxyOptions = HttpProxyOptions & {
 
 export type ProxyConfig =
   | Record<string, string | ProxyOptions>
-  | ProxyOptions[]
-  | ProxyOptions;
+  | ProxyOptions[];
 
 export type HistoryApiFallbackContext = {
   match: RegExpMatchArray;

--- a/website/docs/en/config/server/proxy.mdx
+++ b/website/docs/en/config/server/proxy.mdx
@@ -7,10 +7,7 @@ import type { Options } from 'http-proxy-middleware';
 
 type ProxyOptions = Options & { bypass?: ProxyBypass };
 
-type ProxyConfig =
-  | ProxyOptions
-  | ProxyOptions[]
-  | Record<string, string | ProxyOptions>;
+type ProxyConfig = ProxyOptions[] | Record<string, string | ProxyOptions>;
 ```
 
 - **Default:** `undefined`
@@ -57,14 +54,14 @@ Rsbuild v1 is based on `http-proxy-middleware` v2, while Rsbuild v2 is based on 
 
 In `http-proxy-middleware` v2, the proxied path is automatically appended to the target URL during forwarding. This behavior is no longer provided in v3, so the path must be explicitly included in the `target`.
 
-```ts title="rsbuild.config.ts"
+```diff title="rsbuild.config.ts"
 export default {
   server: {
     proxy: {
-      // http-proxy-middleware v2
-      '/api': 'http://localhost:3000',
-      // http-proxy-middleware v3
-      '/api': 'http://localhost:3000/api',
+-      // http-proxy-middleware v2
+-      '/api': 'http://localhost:3000',
++      // http-proxy-middleware v3
++      '/api': 'http://localhost:3000/api',
     },
   },
 };

--- a/website/docs/zh/config/server/proxy.mdx
+++ b/website/docs/zh/config/server/proxy.mdx
@@ -7,10 +7,7 @@ import type { Options } from 'http-proxy-middleware';
 
 type ProxyOptions = Options & { bypass?: ProxyBypass };
 
-type ProxyConfig =
-  | ProxyOptions
-  | ProxyOptions[]
-  | Record<string, string | ProxyOptions>;
+type ProxyConfig = ProxyOptions[] | Record<string, string | ProxyOptions>;
 ```
 
 - **默认值：** `undefined`
@@ -55,16 +52,16 @@ export default {
 
 Rsbuild v1 基于 `http-proxy-middleware` v2，而 Rsbuild v2 基于 `http-proxy-middleware` v3。
 
-`http-proxy-middleware` v2 会在转发时，会自动将代理的路径拼接到目标地址。v3 不再提供这一行为，因此需要在 `target` 中显式包含该路径。
+`http-proxy-middleware` v2 在转发时会自动将代理的路径拼接到目标地址。v3 不再提供这一行为，因此需要在 `target` 中显式包含该路径。
 
-```ts title="rsbuild.config.ts"
+```diff title="rsbuild.config.ts"
 export default {
   server: {
     proxy: {
-      // http-proxy-middleware v2
-      '/api': 'http://localhost:3000',
-      // http-proxy-middleware v3
-      '/api': 'http://localhost:3000/api',
+-      // http-proxy-middleware v2
+-      '/api': 'http://localhost:3000',
++      // http-proxy-middleware v3
++      '/api': 'http://localhost:3000/api',
     },
   },
 };


### PR DESCRIPTION
## Summary

- Simplified the `ProxyConfig` type by removing support for a single `ProxyOptions` object; it now only accepts an array of `ProxyOptions` or a record mapping paths to targets or options.
- Applied default proxy config to `ProxyOptions[]`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
