### PR TITLE
chore(build): bundle http-proxy-middleware instead of using prebundle

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -92,6 +92,7 @@
     "sirv": "^3.0.2",
     "stacktrace-parser": "^0.1.11",
     "style-loader": "3.3.4",
+    "supports-color": "^10.2.2",
     "tinyglobby": "0.2.14",
     "typescript": "^5.9.3",
     "webpack": "^5.104.1",

--- a/packages/core/prebundle.config.ts
+++ b/packages/core/prebundle.config.ts
@@ -39,6 +39,7 @@ export default {
     },
     {
       name: 'http-proxy-middleware',
+      dtsOnly: true,
       beforeBundle(task) {
         replaceFileContent(
           join(task.depPath, 'dist/types.d.ts'),

--- a/packages/core/src/helpers/vendors.ts
+++ b/packages/core/src/helpers/vendors.ts
@@ -5,7 +5,6 @@ type CompiledPackages = {
   ws: typeof import('../../compiled/ws').default;
   'webpack-merge': typeof import('../../compiled/webpack-merge');
   'html-rspack-plugin': typeof import('../../compiled/html-rspack-plugin').default;
-  'http-proxy-middleware': typeof import('../../compiled/http-proxy-middleware');
 };
 
 export const require: NodeJS.Require = createRequire(import.meta.url);

--- a/packages/core/src/restart.ts
+++ b/packages/core/src/restart.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import type { ChokidarOptions } from '../compiled/chokidar/index.js';
+import type { ChokidarOptions } from '../compiled/chokidar';
 import { init } from './cli/init';
 import { color, isTTY } from './helpers';
 import { logger } from './logger';

--- a/packages/core/src/server/devMiddlewares.ts
+++ b/packages/core/src/server/devMiddlewares.ts
@@ -103,9 +103,8 @@ const applyDefaultMiddlewares = async ({
   // Apply proxy middleware
   // each proxy configuration creates its own middleware instance
   if (server.proxy) {
-    const { middlewares: proxyMiddlewares, upgrade } = createProxyMiddleware(
-      server.proxy,
-    );
+    const { middlewares: proxyMiddlewares, upgrade } =
+      await createProxyMiddleware(server.proxy);
     upgradeEvents.push(upgrade);
 
     for (const middleware of proxyMiddlewares) {

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -93,7 +93,7 @@ export class RsbuildProdServer {
     // Apply proxy middleware
     // each proxy configuration creates its own middleware instance
     if (proxy) {
-      const { middlewares, upgrade } = createProxyMiddleware(proxy);
+      const { middlewares, upgrade } = await createProxyMiddleware(proxy);
 
       for (const middleware of middlewares) {
         this.middlewares.use(middleware);

--- a/packages/core/src/server/proxy.ts
+++ b/packages/core/src/server/proxy.ts
@@ -1,6 +1,5 @@
-import type { RequestHandler } from '../../compiled/http-proxy-middleware/index.js';
+import type { RequestHandler } from '../../compiled/http-proxy-middleware';
 import { color } from '../helpers';
-import { requireCompiledPackage } from '../helpers/vendors';
 import { logger } from '../logger';
 import type {
   RequestHandler as Middleware,
@@ -40,18 +39,20 @@ function formatProxyOptions(proxyOptions: ProxyConfig) {
   }));
 }
 
-export function createProxyMiddleware(proxyOptions: ProxyConfig): {
+export async function createProxyMiddleware(
+  proxyOptions: ProxyConfig,
+): Promise<{
   middlewares: Middleware[];
   upgrade: UpgradeEvent;
-} {
+}> {
   // If it is not an array, it may be an object that uses the context attribute
   // or an object in the form of { source: ProxyDetail }
   const formattedOptions = formatProxyOptions(proxyOptions);
   const proxyMiddlewares: RequestHandler[] = [];
   const middlewares: Middleware[] = [];
 
-  const { createProxyMiddleware: baseMiddleware } = requireCompiledPackage(
-    'http-proxy-middleware',
+  const { createProxyMiddleware: baseMiddleware } = await import(
+    /* webpackChunkName: "http-proxy-middleware" */ 'http-proxy-middleware'
   );
 
   for (const opts of formattedOptions) {

--- a/packages/core/src/server/watchFiles.ts
+++ b/packages/core/src/server/watchFiles.ts
@@ -1,4 +1,4 @@
-import type { FSWatcher } from '../../compiled/chokidar/index.js';
+import type { FSWatcher } from '../../compiled/chokidar';
 import { castArray } from '../helpers';
 import type {
   ChokidarOptions,

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -15,11 +15,11 @@ import type {
 import type { CorsOptions } from 'cors';
 import type RspackChain from 'rspack-chain';
 import type { FileDescriptor } from 'rspack-manifest-plugin';
-import type { ChokidarOptions } from '../../compiled/chokidar/index.js';
+import type { ChokidarOptions } from '../../compiled/chokidar';
 import type {
   Options as HttpProxyOptions,
   Filter as ProxyFilter,
-} from '../../compiled/http-proxy-middleware/index.js';
+} from '../../compiled/http-proxy-middleware';
 import type { RsbuildDevServer } from '../server/devServer';
 import type {
   EnvironmentContext,

--- a/packages/core/src/types/thirdParty.ts
+++ b/packages/core/src/types/thirdParty.ts
@@ -3,7 +3,7 @@ import type {
   CssExtractRspackPluginOptions,
 } from '@rspack/core';
 import type Connect from 'connect';
-import type HtmlRspackPlugin from '../../compiled/html-rspack-plugin/index.js';
+import type HtmlRspackPlugin from '../../compiled/html-rspack-plugin';
 import type { AcceptedPlugin, ProcessOptions } from '../../compiled/postcss';
 import type { Rspack } from './rspack';
 import type { LiteralUnion } from './utils';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -552,7 +552,7 @@ importers:
         version: 5.0.0
       connect:
         specifier: 3.7.0
-        version: 3.7.0
+        version: 3.7.0(supports-color@10.2.2)
       cors:
         specifier: ^2.8.6
         version: 2.8.6
@@ -570,7 +570,7 @@ importers:
         version: 6.1.6(@rspack/core@2.0.0-alpha.1(@module-federation/runtime-tools@0.23.0)(@swc/helpers@0.5.18))
       http-proxy-middleware:
         specifier: ^3.0.5
-        version: 3.0.5
+        version: 3.0.5(supports-color@10.2.2)
       launch-editor-middleware:
         specifier: ^2.12.0
         version: 2.12.0
@@ -625,6 +625,9 @@ importers:
       style-loader:
         specifier: 3.3.4
         version: 3.3.4(webpack@5.104.1)
+      supports-color:
+        specifier: ^10.2.2
+        version: 10.2.2
       tinyglobby:
         specifier: 0.2.14
         version: 0.2.14
@@ -5865,6 +5868,10 @@ packages:
     resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
     engines: {node: '>=16'}
 
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -6420,7 +6427,7 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -6614,7 +6621,7 @@ snapshots:
       '@babel/parser': 7.28.6
       '@babel/template': 7.28.6
       '@babel/types': 7.28.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -6626,7 +6633,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -8645,7 +8652,7 @@ snapshots:
 
   axios@1.13.2:
     dependencies:
-      follow-redirects: 1.15.11(debug@4.4.3)
+      follow-redirects: 1.15.11(debug@4.4.3(supports-color@10.2.2))
       form-data: 4.0.5
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -8863,10 +8870,10 @@ snapshots:
 
   confbox@0.2.2: {}
 
-  connect@3.7.0:
+  connect@3.7.0(supports-color@10.2.2):
     dependencies:
-      debug: 2.6.9
-      finalhandler: 1.1.2
+      debug: 2.6.9(supports-color@10.2.2)
+      finalhandler: 1.1.2(supports-color@10.2.2)
       parseurl: 1.3.3
       utils-merge: 1.0.1
     transitivePeerDependencies:
@@ -8993,17 +9000,21 @@ snapshots:
 
   date-format@4.0.14: {}
 
-  debug@2.6.9:
+  debug@2.6.9(supports-color@10.2.2):
     dependencies:
       ms: 2.0.0
+    optionalDependencies:
+      supports-color: 10.2.2
 
   debug@4.3.7:
     dependencies:
       ms: 2.1.3
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@10.2.2):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 10.2.2
 
   decode-named-character-reference@1.2.0:
     dependencies:
@@ -9130,7 +9141,7 @@ snapshots:
       base64id: 2.0.0
       cookie: 0.7.2
       cors: 2.8.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       engine.io-parser: 5.2.3
       ws: 8.18.3
     transitivePeerDependencies:
@@ -9330,9 +9341,9 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@1.1.2:
+  finalhandler@1.1.2(supports-color@10.2.2):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@10.2.2)
       encodeurl: 1.0.2
       escape-html: 1.0.3
       on-finished: 2.3.0
@@ -9361,9 +9372,9 @@ snapshots:
 
   flexsearch@0.8.212: {}
 
-  follow-redirects@1.15.11(debug@4.4.3):
+  follow-redirects@1.15.11(debug@4.4.3(supports-color@10.2.2)):
     optionalDependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
 
   foreground-child@3.3.1:
     dependencies:
@@ -9696,21 +9707,21 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-proxy-middleware@3.0.5:
+  http-proxy-middleware@3.0.5(supports-color@10.2.2):
     dependencies:
       '@types/http-proxy': 1.17.17
-      debug: 4.4.3
-      http-proxy: 1.18.1(patch_hash=424b689da454f1f336d635615733f30568882789c1173f861c30f95ba8b05723)(debug@4.4.3)
+      debug: 4.4.3(supports-color@10.2.2)
+      http-proxy: 1.18.1(patch_hash=424b689da454f1f336d635615733f30568882789c1173f861c30f95ba8b05723)(debug@4.4.3(supports-color@10.2.2))
       is-glob: 4.0.3
       is-plain-object: 5.0.0
       micromatch: 4.0.8
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy@1.18.1(patch_hash=424b689da454f1f336d635615733f30568882789c1173f861c30f95ba8b05723)(debug@4.4.3):
+  http-proxy@1.18.1(patch_hash=424b689da454f1f336d635615733f30568882789c1173f861c30f95ba8b05723)(debug@4.4.3(supports-color@10.2.2)):
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11(debug@4.4.3)
+      follow-redirects: 1.15.11(debug@4.4.3(supports-color@10.2.2))
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -10056,7 +10067,7 @@ snapshots:
   log4js@6.9.1:
     dependencies:
       date-format: 4.0.14
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       flatted: 3.3.3
       rfdc: 1.4.1
       streamroller: 3.1.5
@@ -10540,7 +10551,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       decode-named-character-reference: 1.2.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -11472,7 +11483,7 @@ snapshots:
 
   socket.io-adapter@2.5.6:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
@@ -11482,7 +11493,7 @@ snapshots:
   socket.io-parser@4.2.5:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -11547,7 +11558,7 @@ snapshots:
   streamroller@3.1.5:
     dependencies:
       date-format: 4.0.14
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       fs-extra: 8.1.0
     transitivePeerDependencies:
       - supports-color
@@ -11609,7 +11620,7 @@ snapshots:
   stylus@0.64.0:
     dependencies:
       '@adobe/css-tools': 4.3.3
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       glob: 10.5.0
       sax: 1.4.4
       source-map: 0.7.6
@@ -11619,6 +11630,8 @@ snapshots:
   superjson@2.2.6:
     dependencies:
       copy-anything: 4.0.5
+
+  supports-color@10.2.2: {}
 
   supports-color@7.2.0:
     dependencies:


### PR DESCRIPTION
## Summary

Bundle `http-proxy-middleware` instead of using the `prebundle`. This reduces redundant code in the build output.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
