### PR TITLE
fix(sri): add integrity attributes with native html plugin

### DIFF
--- a/e2e/cases/security/sri-native-html-plugin/index.test.ts
+++ b/e2e/cases/security/sri-native-html-plugin/index.test.ts
@@ -1,0 +1,36 @@
+import { expect, getFileContent, test } from '@e2e/helper';
+
+test('should generate integrity attributes in build with native html plugin', async ({
+  page,
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview();
+  const files = rsbuild.getDistFiles();
+  const html = getFileContent(files, 'index.html');
+
+  expect(html).toMatch(
+    /<script crossorigin defer integrity="sha384-[A-Za-z0-9+/=]+"/,
+  );
+  expect(html).toMatch(
+    /link crossorigin href="\/static\/css\/index\.\w{8}\.css" integrity="sha384-[A-Za-z0-9+/=]+"/,
+  );
+
+  const testEl = page.locator('#root');
+  await expect(testEl).toHaveText('Hello Rsbuild!');
+});
+
+test('should generate integrity attributes in dev with native html plugin', async ({
+  page,
+  dev,
+}) => {
+  await dev();
+
+  const testEl = page.locator('#root');
+  await expect(testEl).toHaveText('Hello Rsbuild!');
+
+  expect(
+    await page.evaluate(
+      'document.querySelector("script")?.getAttribute("integrity")',
+    ),
+  ).toBeTruthy();
+});

--- a/e2e/cases/security/sri-native-html-plugin/rsbuild.config.ts
+++ b/e2e/cases/security/sri-native-html-plugin/rsbuild.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  security: {
+    sri: {
+      enable: true,
+    },
+  },
+  html: {
+    implementation: 'native',
+  },
+});

--- a/e2e/cases/security/sri-native-html-plugin/src/index.css
+++ b/e2e/cases/security/sri-native-html-plugin/src/index.css
@@ -1,0 +1,3 @@
+body {
+  color: red;
+}

--- a/e2e/cases/security/sri-native-html-plugin/src/index.js
+++ b/e2e/cases/security/sri-native-html-plugin/src/index.js
@@ -1,0 +1,3 @@
+import './index.css';
+
+document.getElementById('root').innerHTML = 'Hello Rsbuild!';

--- a/packages/core/src/plugins/sri.ts
+++ b/packages/core/src/plugins/sri.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { COMPILED_PATH } from '../constants';
 import { castArray } from '../helpers';
-import type { RsbuildPlugin, SriAlgorithm } from '../types';
+import type { RsbuildPlugin, Rspack, SriAlgorithm } from '../types';
 
 export const pluginSri = (): RsbuildPlugin => ({
   name: 'rsbuild:sri',
@@ -24,19 +24,27 @@ export const pluginSri = (): RsbuildPlugin => ({
       }
 
       const { algorithm = 'sha384' } = sri;
+      const pluginOptions: Rspack.SubresourceIntegrityPluginOptions = {
+        enabled: true,
+        hashFuncNames: castArray(algorithm) as [
+          SriAlgorithm,
+          ...SriAlgorithm[],
+        ],
+      };
+
+      if (
+        config.html.implementation === 'js' &&
+        config.tools.htmlPlugin !== false
+      ) {
+        pluginOptions.htmlPlugin = path.join(
+          COMPILED_PATH,
+          'html-rspack-plugin/index.js',
+        );
+      }
 
       chain
         .plugin(CHAIN_ID.PLUGIN.SUBRESOURCE_INTEGRITY)
-        .use(rspack.SubresourceIntegrityPlugin, [
-          {
-            enabled: true,
-            hashFuncNames: castArray(algorithm) as [
-              SriAlgorithm,
-              ...SriAlgorithm[],
-            ],
-            htmlPlugin: path.join(COMPILED_PATH, 'html-rspack-plugin/index.js'),
-          },
-        ]);
+        .use(rspack.SubresourceIntegrityPlugin, [pluginOptions]);
     });
   },
 });


### PR DESCRIPTION
## Summary

- Adds support and tests for generating SRI attributes when using the native HTML plugin
- Adds new E2E tests to verify that SRI attributes are generated correctly when using the native HTML plugin.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
