### PR TITLE
test: refactor environment variable stubbing

### DIFF
--- a/packages/core/tests/basic.test.ts
+++ b/packages/core/tests/basic.test.ts
@@ -2,8 +2,12 @@ import { createStubRsbuild } from '@scripts/test-helper';
 import { pluginBasic } from '../src/plugins/basic';
 
 describe('plugin-basic', () => {
+  afterEach(() => {
+    rs.unstubAllEnvs();
+  });
+
   it('should apply basic config correctly in development', async () => {
-    process.env.NODE_ENV = 'development';
+    rs.stubEnv('NODE_ENV', 'development');
 
     const rsbuild = await createStubRsbuild({
       plugins: [pluginBasic()],
@@ -12,12 +16,10 @@ describe('plugin-basic', () => {
     const bundlerConfigs = await rsbuild.initConfigs();
 
     expect(bundlerConfigs[0]).toMatchSnapshot();
-
-    process.env.NODE_ENV = 'test';
   });
 
   it('should apply basic config correctly in production', async () => {
-    process.env.NODE_ENV = 'production';
+    rs.stubEnv('NODE_ENV', 'production');
 
     const rsbuild = await createStubRsbuild({
       plugins: [pluginBasic()],
@@ -26,12 +28,10 @@ describe('plugin-basic', () => {
     const bundlerConfigs = await rsbuild.initConfigs();
 
     expect(bundlerConfigs[0]).toMatchSnapshot();
-
-    process.env.NODE_ENV = 'test';
   });
 
   it('should not minimizer when output.minify is false', async () => {
-    process.env.NODE_ENV = 'production';
+    rs.stubEnv('NODE_ENV', 'production');
 
     const rsbuild = await createStubRsbuild({
       plugins: [pluginBasic()],
@@ -45,7 +45,5 @@ describe('plugin-basic', () => {
     const bundlerConfigs = await rsbuild.initConfigs();
 
     expect(bundlerConfigs[0].optimization?.minimize).toBeFalsy();
-
-    process.env.NODE_ENV = 'test';
   });
 });

--- a/packages/core/tests/builder.test.ts
+++ b/packages/core/tests/builder.test.ts
@@ -1,9 +1,12 @@
 import { createRsbuild } from '../src';
 
 describe('should use Rspack as the default bundler', () => {
+  afterEach(() => {
+    rs.unstubAllEnvs();
+  });
+
   it('apply Rspack correctly', async () => {
-    const { NODE_ENV } = process.env;
-    process.env.NODE_ENV = 'development';
+    rs.stubEnv('NODE_ENV', 'development');
     const rsbuild = await createRsbuild({
       config: {
         source: {
@@ -17,8 +20,6 @@ describe('should use Rspack as the default bundler', () => {
     const bundlerConfigs = await rsbuild.initConfigs();
 
     expect(bundlerConfigs[0]).toMatchSnapshot();
-
-    process.env.NODE_ENV = NODE_ENV;
   });
 });
 

--- a/packages/core/tests/css.test.ts
+++ b/packages/core/tests/css.test.ts
@@ -36,6 +36,10 @@ describe('normalizeCssLoaderOptions', () => {
 });
 
 describe('plugin-css', () => {
+  afterEach(() => {
+    rs.unstubAllEnvs();
+  });
+
   it('should enable source map when output.sourceMap.css is true', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginCss()],
@@ -71,8 +75,7 @@ describe('plugin-css', () => {
   });
 
   it('should disable source map in production by default', async () => {
-    const { NODE_ENV } = process.env;
-    process.env.NODE_ENV = 'production';
+    rs.stubEnv('NODE_ENV', 'production');
 
     const rsbuild = await createStubRsbuild({
       plugins: [pluginCss()],
@@ -81,8 +84,6 @@ describe('plugin-css', () => {
     const bundlerConfigs = await rsbuild.initConfigs();
 
     expect(JSON.stringify(bundlerConfigs[0])).toContain('"sourceMap":false');
-
-    process.env.NODE_ENV = NODE_ENV;
   });
 
   it('should allow to custom cssModules.localIdentName', async () => {

--- a/packages/core/tests/default.test.ts
+++ b/packages/core/tests/default.test.ts
@@ -1,33 +1,30 @@
 import { createStubRsbuild } from '@scripts/test-helper';
 import type { RsbuildPlugin } from '../src';
 
+afterEach(() => {
+  rs.unstubAllEnvs();
+});
+
 describe('applyDefaultPlugins', () => {
   it('should apply default plugins correctly', async () => {
-    const { NODE_ENV } = process.env;
-    process.env.NODE_ENV = 'development';
+    rs.stubEnv('NODE_ENV', 'development');
     const rsbuild = await createStubRsbuild({});
 
     const bundlerConfigs = await rsbuild.initConfigs();
     expect(bundlerConfigs[0]).toMatchSnapshot();
-
-    process.env.NODE_ENV = NODE_ENV;
   });
 
   it('should apply default plugins correctly when prod', async () => {
-    const { NODE_ENV } = process.env;
-    process.env.NODE_ENV = 'production';
+    rs.stubEnv('NODE_ENV', 'production');
 
     const rsbuild = await createStubRsbuild({});
 
     const bundlerConfigs = await rsbuild.initConfigs();
     expect(bundlerConfigs[0]).toMatchSnapshot();
-
-    process.env.NODE_ENV = NODE_ENV;
   });
 
   it('should apply default plugins correctly when target = node', async () => {
-    const { NODE_ENV } = process.env;
-    process.env.NODE_ENV = 'test';
+    rs.stubEnv('NODE_ENV', 'test');
     const rsbuild = await createStubRsbuild({
       config: {
         mode: 'development',
@@ -40,14 +37,12 @@ describe('applyDefaultPlugins', () => {
     const bundlerConfigs = await rsbuild.initConfigs();
 
     expect(bundlerConfigs[0]).toMatchSnapshot();
-    process.env.NODE_ENV = NODE_ENV;
   });
 });
 
 describe('tools.rspack', () => {
   it('should match snapshot', async () => {
-    const { NODE_ENV } = process.env;
-    process.env.NODE_ENV = 'development';
+    rs.stubEnv('NODE_ENV', 'development');
 
     class TestPlugin {
       readonly name: string = 'TestPlugin';
@@ -80,8 +75,6 @@ describe('tools.rspack', () => {
     const bundlerConfigs = await rsbuild.initConfigs();
 
     expect(bundlerConfigs[0]).toMatchSnapshot();
-
-    process.env.NODE_ENV = NODE_ENV;
   });
 });
 

--- a/packages/core/tests/environments.test.ts
+++ b/packages/core/tests/environments.test.ts
@@ -3,8 +3,12 @@ import { matchPlugin } from '@scripts/test-helper';
 import { createRsbuild, type RsbuildPlugin } from '../src';
 
 describe('environment config', () => {
+  afterEach(() => {
+    rs.unstubAllEnvs();
+  });
+
   it('should normalize context correctly', async () => {
-    process.env.NODE_ENV = 'development';
+    rs.stubEnv('NODE_ENV', 'development');
     const cwd = process.cwd();
     const rsbuild = await createRsbuild({
       cwd,
@@ -35,7 +39,7 @@ describe('environment config', () => {
   });
 
   it('should support modify environment config by api.modifyRsbuildConfig', async () => {
-    process.env.NODE_ENV = 'development';
+    rs.stubEnv('NODE_ENV', 'development');
     const rsbuild = await createRsbuild({
       config: {
         resolve: {
@@ -98,7 +102,7 @@ describe('environment config', () => {
   });
 
   it('should support modify single environment config by api.modifyEnvironmentConfig', async () => {
-    process.env.NODE_ENV = 'development';
+    rs.stubEnv('NODE_ENV', 'development');
     const rsbuild = await createRsbuild({
       config: {
         resolve: {
@@ -156,7 +160,7 @@ describe('environment config', () => {
   });
 
   it('should support add single environment plugin', async () => {
-    process.env.NODE_ENV = 'development';
+    rs.stubEnv('NODE_ENV', 'development');
     const plugin: (pluginId: string) => RsbuildPlugin = (pluginId) => ({
       name: 'test-environment',
       setup(api) {
@@ -203,7 +207,7 @@ describe('environment config', () => {
   });
 
   it('should support run specified environment', async () => {
-    process.env.NODE_ENV = 'development';
+    rs.stubEnv('NODE_ENV', 'development');
 
     const pluginLogs: string[] = [];
 
@@ -239,7 +243,7 @@ describe('environment config', () => {
   });
 
   it('should normalize environment config correctly', async () => {
-    process.env.NODE_ENV = 'development';
+    rs.stubEnv('NODE_ENV', 'development');
     const rsbuild = await createRsbuild({
       config: {
         resolve: {
@@ -294,7 +298,7 @@ describe('environment config', () => {
   });
 
   it('should print environment config when inspect config', async () => {
-    process.env.NODE_ENV = 'development';
+    rs.stubEnv('NODE_ENV', 'development');
     const rsbuild = await createRsbuild({
       config: {
         resolve: {
@@ -329,6 +333,7 @@ describe('environment config', () => {
   });
 
   it('tools.rspack / bundlerChain can be configured in environment config', async () => {
+    rs.stubEnv('NODE_ENV', 'development');
     const rsbuild = await createRsbuild({
       config: {
         tools: {
@@ -369,6 +374,7 @@ describe('environment config', () => {
   });
 
   it('dev.hmr can be configured in environment config', async () => {
+    rs.stubEnv('NODE_ENV', 'development');
     const rsbuild = await createRsbuild({
       config: {
         environments: {

--- a/packages/core/tests/html.test.ts
+++ b/packages/core/tests/html.test.ts
@@ -6,6 +6,10 @@ import { pluginHtml } from '../src/plugins/html';
 describe('plugin-html', () => {
   const stubContext = {} as InternalContext;
 
+  afterEach(() => {
+    rs.unstubAllEnvs();
+  });
+
   it('should register html plugin correctly', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginEntry(), pluginHtml(stubContext)],
@@ -69,8 +73,7 @@ describe('plugin-html', () => {
   });
 
   it('should enable minify in production', async () => {
-    const { NODE_ENV } = process.env;
-    process.env.NODE_ENV = 'production';
+    rs.stubEnv('NODE_ENV', 'production');
 
     const rsbuild = await createStubRsbuild({
       plugins: [pluginEntry(), pluginHtml(stubContext)],
@@ -78,8 +81,6 @@ describe('plugin-html', () => {
     const config = await rsbuild.unwrapConfig();
 
     expect(config).toMatchSnapshot();
-
-    process.env.NODE_ENV = NODE_ENV;
   });
 
   it('should allow to modify plugin options by tools.htmlPlugin', async () => {

--- a/packages/core/tests/minimize.test.ts
+++ b/packages/core/tests/minimize.test.ts
@@ -2,8 +2,12 @@ import { createStubRsbuild } from '@scripts/test-helper';
 import { pluginMinimize } from '../src/plugins/minimize';
 
 describe('plugin-minimize', () => {
+  afterEach(() => {
+    rs.unstubAllEnvs();
+  });
+
   it('should not apply minimizer in development', async () => {
-    process.env.NODE_ENV = 'development';
+    rs.stubEnv('NODE_ENV', 'development');
 
     const rsbuild = await createStubRsbuild({
       plugins: [pluginMinimize()],
@@ -12,12 +16,10 @@ describe('plugin-minimize', () => {
     const bundlerConfigs = await rsbuild.initConfigs();
 
     expect(bundlerConfigs[0].optimization?.minimizer).toBeUndefined();
-
-    process.env.NODE_ENV = 'test';
   });
 
   it('should apply minimizer in production', async () => {
-    process.env.NODE_ENV = 'production';
+    rs.stubEnv('NODE_ENV', 'production');
 
     const rsbuild = await createStubRsbuild({
       plugins: [pluginMinimize()],
@@ -62,12 +64,10 @@ describe('plugin-minimize', () => {
       ]
     `,
     );
-
-    process.env.NODE_ENV = 'test';
   });
 
   it('should not apply minimizer for JS when output.minify.js is false', async () => {
-    process.env.NODE_ENV = 'production';
+    rs.stubEnv('NODE_ENV', 'production');
 
     const rsbuild = await createStubRsbuild({
       plugins: [pluginMinimize()],
@@ -86,12 +86,10 @@ describe('plugin-minimize', () => {
     expect(bundlerConfigs[0].optimization?.minimizer?.[0]).toMatchObject({
       name: 'LightningCssMinimizerRspackPlugin',
     });
-
-    process.env.NODE_ENV = 'test';
   });
 
   it('should not minimize when both output.minify.js and output.minify.css are false', async () => {
-    process.env.NODE_ENV = 'production';
+    rs.stubEnv('NODE_ENV', 'production');
 
     const rsbuild = await createStubRsbuild({
       plugins: [pluginMinimize()],
@@ -108,12 +106,10 @@ describe('plugin-minimize', () => {
     const bundlerConfigs = await rsbuild.initConfigs();
 
     expect(bundlerConfigs[0].optimization?.minimize).toBe(false);
-
-    process.env.NODE_ENV = 'test';
   });
 
   it('should not apply minimizer for CSS when output.minify.css is false', async () => {
-    process.env.NODE_ENV = 'production';
+    rs.stubEnv('NODE_ENV', 'production');
 
     const rsbuild = await createStubRsbuild({
       plugins: [pluginMinimize()],
@@ -132,12 +128,10 @@ describe('plugin-minimize', () => {
     expect(bundlerConfigs[0].optimization?.minimizer?.[0]).toMatchObject({
       name: 'SwcJsMinimizerRspackPlugin',
     });
-
-    process.env.NODE_ENV = 'test';
   });
 
   it('should accept and merge options for JS minimizer', async () => {
-    process.env.NODE_ENV = 'production';
+    rs.stubEnv('NODE_ENV', 'production');
 
     const rsbuild = await createStubRsbuild({
       plugins: [pluginMinimize()],
@@ -163,12 +157,10 @@ describe('plugin-minimize', () => {
         },
       ],
     });
-
-    process.env.NODE_ENV = 'test';
   });
 
   it('should dropConsole when performance.removeConsole is true', async () => {
-    process.env.NODE_ENV = 'production';
+    rs.stubEnv('NODE_ENV', 'production');
 
     const rsbuild = await createStubRsbuild({
       plugins: [pluginMinimize()],
@@ -221,12 +213,10 @@ describe('plugin-minimize', () => {
       ]
     `,
     );
-
-    process.env.NODE_ENV = 'test';
   });
 
   it('should remove specific console when performance.removeConsole is array', async () => {
-    process.env.NODE_ENV = 'production';
+    rs.stubEnv('NODE_ENV', 'production');
 
     const rsbuild = await createStubRsbuild({
       plugins: [pluginMinimize()],
@@ -282,12 +272,10 @@ describe('plugin-minimize', () => {
       ]
     `,
     );
-
-    process.env.NODE_ENV = 'test';
   });
 
   it('should set asciiOnly false when output.charset is utf8', async () => {
-    process.env.NODE_ENV = 'production';
+    rs.stubEnv('NODE_ENV', 'production');
 
     const rsbuild = await createStubRsbuild({
       plugins: [pluginMinimize()],
@@ -337,7 +325,5 @@ describe('plugin-minimize', () => {
       ]
     `,
     );
-
-    process.env.NODE_ENV = 'test';
   });
 });

--- a/packages/core/tests/output.test.ts
+++ b/packages/core/tests/output.test.ts
@@ -3,6 +3,10 @@ import { createRsbuild } from '../src';
 import { pluginOutput } from '../src/plugins/output';
 
 describe('plugin-output', () => {
+  afterEach(() => {
+    rs.unstubAllEnvs();
+  });
+
   it('should set output correctly', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginOutput()],
@@ -151,7 +155,7 @@ describe('plugin-output', () => {
   });
 
   it('should replace `<port>` placeholder with default port', async () => {
-    rstest.stubEnv('NODE_ENV', 'development');
+    rs.stubEnv('NODE_ENV', 'development');
     const rsbuild = await createStubRsbuild({
       plugins: [pluginOutput()],
       config: {
@@ -166,7 +170,7 @@ describe('plugin-output', () => {
   });
 
   it('should replace `<port>` placeholder with server.port', async () => {
-    rstest.stubEnv('NODE_ENV', 'development');
+    rs.stubEnv('NODE_ENV', 'development');
     const rsbuild = await createRsbuild({
       config: {
         server: { port: 4000 },
@@ -177,11 +181,10 @@ describe('plugin-output', () => {
     });
     const [config] = await rsbuild.initConfigs();
     expect(config?.output?.publicPath).toEqual('http://example-4000.com:4000/');
-    rstest.unstubAllEnvs();
   });
 
   it('should replace `<port>` placeholder of `output.assetPrefix` with default port', async () => {
-    rstest.stubEnv('NODE_ENV', 'production');
+    rs.stubEnv('NODE_ENV', 'production');
     const rsbuild = await createRsbuild({
       config: {
         output: {
@@ -192,6 +195,5 @@ describe('plugin-output', () => {
 
     const [config] = await rsbuild.initConfigs();
     expect(config?.output?.publicPath).toEqual('http://example.com:3000/');
-    rstest.unstubAllEnvs();
   });
 });

--- a/packages/plugin-react/tests/index.test.ts
+++ b/packages/plugin-react/tests/index.test.ts
@@ -3,6 +3,10 @@ import { createStubRsbuild, matchRules } from '@scripts/test-helper';
 import { pluginReact } from '../src';
 
 describe('plugins/react', () => {
+  afterEach(() => {
+    rs.unstubAllEnvs();
+  });
+
   it('should work with swc-loader', async () => {
     const rsbuild = await createStubRsbuild({
       config: {
@@ -167,7 +171,7 @@ describe('plugins/react', () => {
   });
 
   it('should allow to add react plugin as single environment plugin', async () => {
-    process.env.NODE_ENV = 'production';
+    rs.stubEnv('NODE_ENV', 'production');
 
     const rsbuild = await createStubRsbuild({
       config: {
@@ -196,7 +200,5 @@ describe('plugins/react', () => {
 
     expect(bundlerConfigs[1]).not.toContain('lib-react');
     expect(environmentConfigs[1]).not.toContain('keep_classnames');
-
-    delete process.env.NODE_ENV;
   });
 });

--- a/packages/plugin-svelte/tests/index.test.ts
+++ b/packages/plugin-svelte/tests/index.test.ts
@@ -4,6 +4,10 @@ import { matchRules } from '@scripts/test-helper';
 import { pluginSvelte } from '../src';
 
 describe('plugin-svelte', () => {
+  afterEach(() => {
+    rs.unstubAllEnvs();
+  });
+
   it('should add svelte loader and resolve config properly', async () => {
     const rsbuild = await createRsbuild({
       cwd: __dirname,
@@ -46,8 +50,7 @@ describe('plugin-svelte', () => {
   });
 
   it('should set dev and hotReload to false in production mode', async () => {
-    const { NODE_ENV } = process.env;
-    process.env.NODE_ENV = 'production';
+    rs.stubEnv('NODE_ENV', 'production');
     const rsbuild = await createRsbuild({
       cwd: __dirname,
       config: {
@@ -56,7 +59,6 @@ describe('plugin-svelte', () => {
     });
     const bundlerConfigs = await rsbuild.initConfigs();
     expect(matchRules(bundlerConfigs[0], 'a.svelte')).toMatchSnapshot();
-    process.env.NODE_ENV = NODE_ENV;
   });
 
   it('should turn off HMR by hand correctly', async () => {


### PR DESCRIPTION
## Summary

Replaced direct assignments to `process.env.NODE_ENV` with calls to `rs.stubEnv` in all test files, ensuring a consistent and isolated approach to setting environment variables for each test case. 

## Related Links

- https://rstest.rs/api/runtime-api/rstest/utilities#rsteststubenv

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
