### PR TITLE
feat(core): add setupMiddlewares support for preview mode

### DIFF
--- a/e2e/cases/server/preview-setup-middlewares/index.test.ts
+++ b/e2e/cases/server/preview-setup-middlewares/index.test.ts
@@ -1,0 +1,83 @@
+import { expect, test } from '@e2e/helper';
+
+test('should apply setupMiddlewares in preview mode', async ({
+  page,
+  buildPreview,
+}) => {
+  let middlewareCount = 0;
+
+  await buildPreview({
+    config: {
+      preview: {
+        setupMiddlewares: (middlewares) => {
+          middlewares.unshift((_req, _res, next) => {
+            middlewareCount++;
+            next();
+          });
+        },
+      },
+    },
+  });
+
+  const locator = page.locator('#root');
+  await expect(locator).toHaveText('Hello Rsbuild!');
+  expect(middlewareCount).toBeGreaterThanOrEqual(1);
+});
+
+test('should apply setupMiddlewares.unshift for custom API route', async ({
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview({
+    config: {
+      preview: {
+        setupMiddlewares: (middlewares) => {
+          middlewares.unshift((req, res, next) => {
+            if (req.url === '/api/test') {
+              res.end('api-ok');
+              return;
+            }
+            next();
+          });
+        },
+      },
+    },
+  });
+
+  // Test custom API route via unshift
+  const res = await fetch(`http://localhost:${rsbuild.port}/api/test`);
+  expect(await res.text()).toBe('api-ok');
+});
+
+test('should support multiple setupMiddlewares functions', async ({
+  page,
+  buildPreview,
+}) => {
+  let firstCalled = false;
+  let secondCalled = false;
+
+  await buildPreview({
+    config: {
+      preview: {
+        setupMiddlewares: [
+          (middlewares) => {
+            middlewares.unshift((_req, _res, next) => {
+              firstCalled = true;
+              next();
+            });
+          },
+          (middlewares) => {
+            middlewares.unshift((_req, _res, next) => {
+              secondCalled = true;
+              next();
+            });
+          },
+        ],
+      },
+    },
+  });
+
+  const locator = page.locator('#root');
+  await expect(locator).toHaveText('Hello Rsbuild!');
+  expect(firstCalled).toBe(true);
+  expect(secondCalled).toBe(true);
+});

--- a/e2e/cases/server/preview-setup-middlewares/src/index.js
+++ b/e2e/cases/server/preview-setup-middlewares/src/index.js
@@ -1,0 +1,1 @@
+document.getElementById('root').innerHTML = 'Hello Rsbuild!';

--- a/packages/core/src/defaultConfig.ts
+++ b/packages/core/src/defaultConfig.ts
@@ -29,6 +29,7 @@ import type {
   NormalizedHtmlConfig,
   NormalizedOutputConfig,
   NormalizedPerformanceConfig,
+  NormalizedPreviewConfig,
   NormalizedResolveConfig,
   NormalizedSecurityConfig,
   NormalizedServerConfig,
@@ -98,6 +99,8 @@ const getDefaultServerConfig = (): Omit<
   },
   middlewareMode: false,
 });
+
+const getDefaultPreviewConfig = (): NormalizedPreviewConfig => ({});
 
 let swcHelpersPath: string;
 
@@ -217,6 +220,7 @@ const getDefaultResolveConfig = (): NormalizedResolveConfig => {
 const createDefaultConfig = (): RsbuildConfig => ({
   dev: getDefaultDevConfig(),
   server: getDefaultServerConfig(),
+  preview: getDefaultPreviewConfig(),
   html: getDefaultHtmlConfig(),
   resolve: getDefaultResolveConfig(),
   source: getDefaultSourceConfig(),

--- a/packages/core/src/initConfigs.ts
+++ b/packages/core/src/initConfigs.ts
@@ -280,6 +280,7 @@ export async function initRsbuildConfig({
         ...environmentConfig.dev,
       },
       server: normalizedBaseConfig.server,
+      preview: normalizedBaseConfig.preview,
     };
 
     const { tsconfigPath } = normalizedEnvironmentConfig.source;

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -559,6 +559,23 @@ export type NormalizedServerConfig = {
   'host' | 'publicDir'
 >;
 
+export type PreviewSetupMiddlewaresFn = (middlewares: {
+  unshift: (...handlers: RequestHandler[]) => void;
+  push: (...handlers: RequestHandler[]) => void;
+}) => void;
+
+export interface PreviewConfig {
+  /**
+   * Used to add custom middleware to the preview server.
+   * Unlike `dev.setupMiddlewares`, this does not receive a server context
+   * since preview mode has no HMR or environment API.
+   * @default undefined
+   */
+  setupMiddlewares?: PreviewSetupMiddlewaresFn | PreviewSetupMiddlewaresFn[];
+}
+
+export type NormalizedPreviewConfig = PreviewConfig;
+
 export type SriAlgorithm = 'sha256' | 'sha384' | 'sha512';
 
 export type SriOptions = {
@@ -2098,6 +2115,10 @@ export interface RsbuildConfig extends EnvironmentConfig {
    */
   server?: ServerConfig;
   /**
+   * Options for the preview server (rsbuild preview).
+   */
+  preview?: PreviewConfig;
+  /**
    * Configure Rsbuild config by environment.
    * The key represents the environment name.
    * The value is the Rsbuild config for the specified environment.
@@ -2134,6 +2155,7 @@ export type NormalizedEnvironmentConfig = TwoLevelReadonly<
   Omit<MergedEnvironmentConfig, 'dev'> & {
     dev: NormalizedDevConfig;
     server: NormalizedServerConfig;
+    preview: NormalizedPreviewConfig;
     _privateMeta?: RsbuildConfigMeta;
   }
 >;

--- a/website/docs/en/config/_meta.json
+++ b/website/docs/en/config/_meta.json
@@ -25,6 +25,11 @@
   },
   {
     "type": "dir-section-header",
+    "name": "preview",
+    "label": "Preview options"
+  },
+  {
+    "type": "dir-section-header",
     "name": "resolve",
     "label": "Resolve options"
   },

--- a/website/docs/en/config/preview/setup-middlewares.mdx
+++ b/website/docs/en/config/preview/setup-middlewares.mdx
@@ -1,0 +1,96 @@
+# preview.setupMiddlewares
+
+- **Type:**
+
+```ts
+type PreviewSetupMiddlewaresFn = (middlewares: {
+  unshift: (...handlers: RequestHandler[]) => void;
+  push: (...handlers: RequestHandler[]) => void;
+}) => void;
+
+type SetupMiddlewares = PreviewSetupMiddlewaresFn | PreviewSetupMiddlewaresFn[];
+```
+
+- **Default:** `undefined`
+- **Version:** `>= 2.0.0`
+
+Used to add custom middleware to the preview server.
+
+Unlike [dev.setupMiddlewares](/config/dev/setup-middlewares), this does not receive a server context since preview mode has no HMR or environment API.
+
+## Basic usage
+
+`setupMiddlewares` function receives a `middlewares` object, you can add custom middleware by `unshift` and `push` methods:
+
+- Use `unshift` to prepend middleware to the array, executed earlier than the built-in middleware.
+- Use `push` to append middleware to the array, executed later than the built-in middleware.
+
+```ts title="rsbuild.config.ts"
+export default {
+  preview: {
+    setupMiddlewares: (middlewares) => {
+      middlewares.unshift((req, res, next) => {
+        console.log('first');
+        next();
+      });
+
+      middlewares.push((req, res, next) => {
+        console.log('last');
+        next();
+      });
+    },
+  },
+};
+```
+
+## Authentication example
+
+A common use case is adding authentication middleware for the preview server:
+
+```ts title="rsbuild.config.ts"
+export default {
+  preview: {
+    setupMiddlewares: (middlewares) => {
+      middlewares.unshift((req, res, next) => {
+        const token = req.headers['authorization'];
+
+        if (!isValidToken(token)) {
+          res.writeHead(401, { 'Content-Type': 'text/plain' });
+          res.end('Unauthorized');
+          return;
+        }
+
+        next();
+      });
+    },
+  },
+};
+```
+
+## Multiple functions
+
+`setupMiddlewares` also supports passing an array, each item of which is a function to set up middlewares:
+
+```ts title="rsbuild.config.ts"
+export default {
+  preview: {
+    setupMiddlewares: [
+      (middlewares) => {
+        middlewares.unshift(authMiddleware);
+      },
+      (middlewares) => {
+        middlewares.push(logMiddleware);
+      },
+    ],
+  },
+};
+```
+
+## Difference from dev.setupMiddlewares
+
+| Feature        | dev.setupMiddlewares | preview.setupMiddlewares      |
+| -------------- | -------------------- | ----------------------------- |
+| Mode           | Development          | Preview                       |
+| `sockWrite`    | ✅ Available         | ❌ Not available              |
+| `environments` | ✅ Available         | ❌ Not available              |
+| Use case       | HMR, SSR, etc.       | Authentication, logging, etc. |

--- a/website/docs/zh/config/_meta.json
+++ b/website/docs/zh/config/_meta.json
@@ -25,6 +25,11 @@
   },
   {
     "type": "dir-section-header",
+    "name": "preview",
+    "label": "Preview 选项"
+  },
+  {
+    "type": "dir-section-header",
     "name": "resolve",
     "label": "Resolve 选项"
   },

--- a/website/docs/zh/config/preview/setup-middlewares.mdx
+++ b/website/docs/zh/config/preview/setup-middlewares.mdx
@@ -1,0 +1,96 @@
+# preview.setupMiddlewares
+
+- **类型：**
+
+```ts
+type PreviewSetupMiddlewaresFn = (middlewares: {
+  unshift: (...handlers: RequestHandler[]) => void;
+  push: (...handlers: RequestHandler[]) => void;
+}) => void;
+
+type SetupMiddlewares = PreviewSetupMiddlewaresFn | PreviewSetupMiddlewaresFn[];
+```
+
+- **默认值：** `undefined`
+- **版本：** `>= 2.0.0`
+
+用于给 preview 服务器添加自定义中间件。
+
+与 [dev.setupMiddlewares](/zh/config/dev/setup-middlewares) 不同，此配置不会接收 server context，因为 preview 模式没有 HMR 或 environment API。
+
+## 基本用法
+
+`setupMiddlewares` 函数接收一个 `middlewares` 对象，你可以使用 `unshift` 和 `push` 方法添加自定义中间件：
+
+- 使用 `unshift` 在数组前面添加中间件，将在内置中间件之前执行。
+- 使用 `push` 在数组后面添加中间件，将在内置中间件之后执行。
+
+```ts title="rsbuild.config.ts"
+export default {
+  preview: {
+    setupMiddlewares: (middlewares) => {
+      middlewares.unshift((req, res, next) => {
+        console.log('first');
+        next();
+      });
+
+      middlewares.push((req, res, next) => {
+        console.log('last');
+        next();
+      });
+    },
+  },
+};
+```
+
+## 认证示例
+
+一个常见的使用场景是为 preview 服务器添加认证中间件：
+
+```ts title="rsbuild.config.ts"
+export default {
+  preview: {
+    setupMiddlewares: (middlewares) => {
+      middlewares.unshift((req, res, next) => {
+        const token = req.headers['authorization'];
+
+        if (!isValidToken(token)) {
+          res.writeHead(401, { 'Content-Type': 'text/plain' });
+          res.end('Unauthorized');
+          return;
+        }
+
+        next();
+      });
+    },
+  },
+};
+```
+
+## 多个函数
+
+`setupMiddlewares` 也支持传入数组，数组中的每一项都是一个设置中间件的函数：
+
+```ts title="rsbuild.config.ts"
+export default {
+  preview: {
+    setupMiddlewares: [
+      (middlewares) => {
+        middlewares.unshift(authMiddleware);
+      },
+      (middlewares) => {
+        middlewares.push(logMiddleware);
+      },
+    ],
+  },
+};
+```
+
+## 与 dev.setupMiddlewares 的区别
+
+| 特性           | dev.setupMiddlewares | preview.setupMiddlewares |
+| -------------- | -------------------- | ------------------------ |
+| 模式           | 开发模式             | 预览模式                 |
+| `sockWrite`    | ✅ 可用              | ❌ 不可用                |
+| `environments` | ✅ 可用              | ❌ 不可用                |
+| 使用场景       | HMR、SSR 等          | 认证、日志等             |


### PR DESCRIPTION
Add preview.setupMiddlewares configuration to allow custom middleware in preview server, similar to dev.setupMiddlewares but without HMR and environment context.

Closes #6365

## Summary

- Add new `preview.setupMiddlewares` configuration option for customizing the preview server
- Supports `middlewares.unshift()` and `middlewares.push()` methods (consistent with `dev.setupMiddlewares` API)
- Add `PreviewConfig` and `PreviewSetupMiddlewaresFn` types
- Add E2E tests for the new feature
- Add documentation for both English and Chinese

## Related Links

- Issue: https://github.com/web-infra-dev/rsbuild/issues/6365
- Vite's similar feature: `configurePreviewServer` hook

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).