### PR TITLE
chore: remove webpack dev dependency from core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -94,7 +94,6 @@
     "supports-color": "^10.2.2",
     "tinyglobby": "0.2.14",
     "typescript": "^5.9.3",
-    "webpack": "^5.104.1",
     "webpack-merge": "6.0.1",
     "ws": "^8.19.0"
   },

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -23,7 +23,6 @@ for (const item of prebundleConfig.dependencies) {
 }
 
 const externals: Rspack.Configuration['externals'] = [
-  'webpack',
   '@rspack/core',
   '@rsbuild/core',
   // yaml and tsx are optional dependencies of `postcss-load-config`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -628,9 +628,6 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
-      webpack:
-        specifier: ^5.104.1
-        version: 5.104.1
       webpack-merge:
         specifier: 6.0.1
         version: 6.0.1


### PR DESCRIPTION
## Summary

Remove the unused `webpack dev` dependency from core.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
