### PR TITLE
docs: add Rsbuild v2 documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,6 @@ Rsbuild provides a [rich set of build features](https://rsbuild.rs/guide/start/f
 > The `main` branch is under active development for **Rsbuild 2.0**.  
 > The stable **1.x** releases are maintained in the [v1.x](https://github.com/web-infra-dev/rsbuild/tree/v1.x) branch.
 
-## 🚀 Performance
-
-Powered by Rspack's Rust-based architecture, Rsbuild delivers blazing-fast performance to speed up your development workflow.
-
-⚡️ **Build 1000 React components:**
-
-![benchmark](https://assets.rspack.rs/rsbuild/assets/benchmark-latest.jpeg)
-
-> 📊 Benchmark results from [build-tools-performance](https://github.com/rstackjs/build-tools-performance).
-
 ## 🔥 Features
 
 Rsbuild has the following features:
@@ -47,9 +37,10 @@ Rsbuild has the following features:
 
 - **Framework agnostic**: Rsbuild is not coupled to any frontend UI framework. It supports frameworks like React, Vue, Svelte, Solid, and Preact through plugins, with plans to support more UI frameworks from the community in the future.
 
-## 📚 Getting started
+## 📚 Documentation
 
-To get started with Rsbuild, see the [Quick start](https://rsbuild.rs/guide/start/quick-start).
+- [Rsbuild v2 docs](https://v2.rsbuild.rs)
+- [Rsbuild v1 docs](https://rsbuild.rs/)
 
 ## 🦀 Rstack
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -19,16 +19,6 @@ Rsbuild é uma ferramenta de build de alta performance com base no Rspack. Ele f
 
 Rsbuild provê [ricas funcionalidades de build](https://rsbuild.rs/guide/start/features), incluindo a compilação de TypeScript, JSX, Sass, Less, CSS Modules, Wasm, e outros. Ele também suporta Module Federation, compressão de imagem, checagem de tipos, PostCSS, Lightning CSS, e mais.
 
-## 🚀 Desempenho
-
-Alimentado pela arquitetura baseada em Rust do Rspack, o Rsbuild oferece um desempenho extremamente rápido que irá remodelar seu fluxo de trabalho de desenvolvimento.
-
-⚡️ **Construa 1000 componentes React:**
-
-![benchmark](https://assets.rspack.rs/rsbuild/assets/benchmark-latest.jpeg)
-
-> 📊 Resultados do benchmark do [build-tools-performance](https://github.com/rstackjs/build-tools-performance).
-
 ## 🔥 Recursos
 
 O Rsbuild tem os seguintes recursos:
@@ -43,9 +33,10 @@ O Rsbuild tem os seguintes recursos:
 
 - **Framework Agnóstico**: Rsbuild não está acoplado a nenhuma estrutura de interface do usuário de frontend. Ele oferece suporte a estruturas como React, Vue, Svelte, Solid e Preact por meio de plug-ins, e planeja oferecer suporte a mais estruturas de IU da comunidade no futuro.
 
-## 📚 Primeiros passos
+## 📚 Documentação
 
-Para começar a usar o Rsbuild, consulte a seção [Início Rápido](https://rsbuild.rs/guide/start/quick-start).
+- [Rsbuild v2 docs](https://v2.rsbuild.rs)
+- [Rsbuild v1 docs](https://rsbuild.rs/)
 
 ## 🦀 Rstack
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,16 +19,6 @@ Rsbuild 是由 [Rspack](https://rspack.rs/) 驱动的高性能构建工具，它
 
 Rsbuild 提供 [丰富的构建功能](https://rsbuild.rs/zh/guide/start/features)，包括编译 TypeScript，JSX，Sass，Less，CSS Modules，Wasm，以及其他资源，也支持模块联邦、图片压缩、类型检查、PostCSS，Lightning CSS 等功能。
 
-## 🚀 性能
-
-基于 Rspack 的 Rust 架构，Rsbuild 能够提供极致的构建性能，为你带来全新的开发体验。
-
-⚡️ **构建 1000 个 React 组件：**
-
-![benchmark](https://assets.rspack.rs/rsbuild/assets/benchmark-latest.jpeg)
-
-> 📊 Benchmark 结果来自 [build-tools-performance](https://github.com/rstackjs/build-tools-performance)。
-
 ## 🔥 特性
 
 Rsbuild 具备以下特性：
@@ -43,9 +33,10 @@ Rsbuild 具备以下特性：
 
 - **框架无关**：Rsbuild 不与前端 UI 框架耦合，并通过插件来支持 React、Vue、Svelte、Solid、Preact 等框架，未来也计划支持社区中更多的 UI 框架。
 
-## 📚 快速上手
+## 📚 文档
 
-你可以参考 [快速上手](https://rsbuild.rs/zh/guide/start/quick-start) 来开始体验 Rsbuild。
+- [Rsbuild v2 文档](https://v2.rsbuild.rs/zh/)
+- [Rsbuild v1 文档](https://rsbuild.rs/zh/)
 
 ## 🦀 Rstack
 


### PR DESCRIPTION
## Summary

Removed the performance benchmark section and provide direct links to Rsbuild v1 and v2 documentation in each language.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
