### PR TITLE
fix(cleanOutput): prevent accidental deletion when root path is '/'

### DIFF
--- a/packages/core/src/plugins/appIcon.ts
+++ b/packages/core/src/plugins/appIcon.ts
@@ -22,7 +22,7 @@ type IconExtra = {
 );
 
 export const pluginAppIcon = (): RsbuildPlugin => ({
-  name: 'rsbuild:app-icon',
+  name: 'rsbuild:appIcon',
 
   setup(api) {
     const htmlTagsMap = new Map<string, HtmlBasicTag[]>();
@@ -103,7 +103,7 @@ export const pluginAppIcon = (): RsbuildPlugin => ({
           if (icon.target === 'web-app-manifest' && !appIcon.name) {
             addCompilationError(
               compilation,
-              `${color.dim('[rsbuild:app-icon]')} ${color.yellow(
+              `${color.dim('[rsbuild:appIcon]')} ${color.yellow(
                 '"appIcon.name"',
               )} is required when ${color.yellow('"target"')} is ${color.yellow(
                 '"web-app-manifest"',
@@ -116,7 +116,7 @@ export const pluginAppIcon = (): RsbuildPlugin => ({
             if (!compilation.inputFileSystem) {
               addCompilationError(
                 compilation,
-                `${color.dim('[rsbuild:app-icon]')} Failed to read the icon file as ${color.yellow(
+                `${color.dim('[rsbuild:appIcon]')} Failed to read the icon file as ${color.yellow(
                   '"compilation.inputFileSystem"',
                 )} is not available.`,
               );
@@ -128,7 +128,7 @@ export const pluginAppIcon = (): RsbuildPlugin => ({
             ) {
               addCompilationError(
                 compilation,
-                `${color.dim('[rsbuild:app-icon]')} Failed to find the icon file at ${color.yellow(
+                `${color.dim('[rsbuild:appIcon]')} Failed to find the icon file at ${color.yellow(
                   icon.absolutePath,
                 )}.`,
               );

--- a/packages/core/src/plugins/cleanOutput.ts
+++ b/packages/core/src/plugins/cleanOutput.ts
@@ -133,9 +133,9 @@ export const pluginCleanOutput = (): RsbuildPlugin => ({
 
       // Use `for...of` to handle nested directories correctly
       for (const pathInfo of pathInfos) {
-// Users may mistakenly set `output.distPath.root` to '/'
+        // Users may mistakenly set `output.distPath.root` to '/'
         if (pathInfo.path === '/') {
-          const prefix = color.dim('[rsbuild:cleanDistPath]');
+          const prefix = color.dim('[rsbuild:cleanOutput]');
           throw new Error(
             `${prefix} Refusing to clean output at ${color.cyan(
               `"${pathInfo.path}"`,

--- a/packages/core/src/plugins/nodeAddons.ts
+++ b/packages/core/src/plugins/nodeAddons.ts
@@ -18,7 +18,7 @@ export const pluginNodeAddons = (): RsbuildPlugin => ({
 
         if (filename === null) {
           throw new Error(
-            `${color.dim('[rsbuild:node-addons]')} Failed to load Node.js addon: ${color.yellow(resourcePath)}`,
+            `${color.dim('[rsbuild:nodeAddons]')} Failed to load Node.js addon: ${color.yellow(resourcePath)}`,
           );
         }
 


### PR DESCRIPTION
## Summary

Add a safety check to avoid cleaning the root directory when users mistakenly set `output.distPath.root` to `'/'`. This prevents potential data loss by throwing an error with clear instructions to update the configuration.

## Related Links

- https://github.com/web-infra-dev/rsbuild/discussions/6806#discussioncomment-15715664

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
