### PR TITLE
chore: reduce duplicated parser merge calls

### DIFF
--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -31,10 +31,10 @@ export const pluginBasic = (): RsbuildPlugin => ({
         // Disable performance hints, these logs are too complex
         chain.performance.hints(false);
 
-        // Align with the futureDefaults of webpack 6
         chain.module.parser.merge({
           javascript: {
             exportsPresence: 'error',
+            typeReexportsPresence: 'tolerant',
           },
         });
 
@@ -45,12 +45,6 @@ export const pluginBasic = (): RsbuildPlugin => ({
             .plugin(CHAIN_ID.PLUGIN.HMR)
             .use(rspack.HotModuleReplacementPlugin);
         }
-
-        chain.module.parser.merge({
-          javascript: {
-            typeReexportsPresence: 'tolerant',
-          },
-        });
       },
     );
   },


### PR DESCRIPTION
## Summary

Moved the `typeReexportsPresence: 'tolerant'` option to be merged together with other JavaScript parser settings, rather than in a separate merge call.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
