### PR TITLE
chore: no need to enable asyncWebAssembly

### DIFF
--- a/packages/core/src/plugins/wasm.ts
+++ b/packages/core/src/plugins/wasm.ts
@@ -14,11 +14,6 @@ export const pluginWasm = (): RsbuildPlugin => ({
         getFilename(config, 'wasm', isProd),
       );
 
-      chain.experiments({
-        ...chain.get('experiments'),
-        asyncWebAssembly: true,
-      });
-
       chain.output.webassemblyModuleFilename(filename);
 
       // support new URL('./abc.wasm', import.meta.url)

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -9,9 +9,6 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
       "./src/index.js",
     ],
   },
-  "experiments": {
-    "asyncWebAssembly": true,
-  },
   "infrastructureLogging": {
     "level": "error",
   },

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -9,9 +9,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
       "./src/index.js",
     ],
   },
-  "experiments": {
-    "asyncWebAssembly": true,
-  },
   "infrastructureLogging": {
     "level": "error",
   },
@@ -506,9 +503,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
     "index": [
       "./src/index.js",
     ],
-  },
-  "experiments": {
-    "asyncWebAssembly": true,
   },
   "infrastructureLogging": {
     "level": "error",
@@ -1029,9 +1023,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
 {
   "context": "<ROOT>/packages/core/tests",
   "devtool": "cheap-module-source-map",
-  "experiments": {
-    "asyncWebAssembly": true,
-  },
   "infrastructureLogging": {
     "level": "error",
   },
@@ -1466,9 +1457,6 @@ exports[`tools.rspack > should match snapshot 1`] = `
 {
   "context": "<ROOT>/packages/core/tests",
   "devtool": "cheap-module-source-map",
-  "experiments": {
-    "asyncWebAssembly": true,
-  },
   "infrastructureLogging": {
     "level": "error",
   },

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1440,9 +1440,6 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
   {
     "context": "<ROOT>",
     "devtool": "eval-source-map",
-    "experiments": {
-      "asyncWebAssembly": true,
-    },
     "infrastructureLogging": {
       "level": "error",
     },
@@ -1877,9 +1874,6 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
   {
     "context": "<ROOT>",
     "devtool": "eval",
-    "experiments": {
-      "asyncWebAssembly": true,
-    },
     "infrastructureLogging": {
       "level": "error",
     },

--- a/packages/core/tests/__snapshots__/wasm.test.ts.snap
+++ b/packages/core/tests/__snapshots__/wasm.test.ts.snap
@@ -2,9 +2,6 @@
 
 exports[`plugin-wasm > should add wasm rule properly 1`] = `
 {
-  "experiments": {
-    "asyncWebAssembly": true,
-  },
   "module": {
     "rules": [
       {


### PR DESCRIPTION
## Summary

`asyncWebAssembly` has been enabled in Rspack 2.0 by default.

## Related Links

 https://github.com/web-infra-dev/rspack/pull/12764

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
