### PR TITLE
fix(plugin-less): `parallelLoader` config is no longer needed in Rspack v2

### DIFF
--- a/packages/plugin-less/src/index.ts
+++ b/packages/plugin-less/src/index.ts
@@ -285,7 +285,8 @@ export const pluginLess = (
         }
       });
 
-      if (parallel) {
+      // `experiments.parallelLoader` is no longer required in Rspack 2.0+
+      if (parallel && isV1) {
         chain.experiments({
           ...chain.get('experiments'),
           parallelLoader: true,


### PR DESCRIPTION
## Summary

The `experiments.parallelLoader` config is no longer needed in Rspack v2.

## Related Links

- https://github.com/web-infra-dev/rspack/pull/12658

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
