### PR TITLE
docs: update node version requirements for v2

### DIFF
--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -19,7 +19,7 @@ Use one of the following installation guides to set up a runtime:
 
 :::tip Version requirements
 
-- Rsbuild v2 requires Node.js >= 20.19.0 or >= 22.12.0 (LTS versions recommended).
+- Rsbuild v2 requires Node.js version 20.19+, 22.12+.
 - Rsbuild v1 requires Node.js 18.12.0 or higher.
 
 :::

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -19,7 +19,7 @@ Rsbuild 支持使用 [Node.js](https://nodejs.org/)、[Deno](https://deno.com/) 
 
 :::tip 版本要求
 
-- Rsbuild v2 要求 Node.js >= 20.19.0 或 >= 22.12.0（推荐使用 LTS 版本）。
+- Rsbuild v2 要求 Node.js 版本 20.19+, 22.12+。
 - Rsbuild v1 要求 Node.js 18.12.0 或更高版本。
 
 :::


### PR DESCRIPTION
## Summary

Update Node.js version requirements for Rsbuild v2 (20.19+, 22.12+).

## Related Links

None.

## Checklist

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).