### PR TITLE
chore: no need to set exportsPresence error

### DIFF
--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -33,7 +33,6 @@ export const pluginBasic = (): RsbuildPlugin => ({
 
         chain.module.parser.merge({
           javascript: {
-            exportsPresence: 'error',
             typeReexportsPresence: 'tolerant',
           },
         });

--- a/packages/core/tests/__snapshots__/basic.test.ts.snap
+++ b/packages/core/tests/__snapshots__/basic.test.ts.snap
@@ -10,7 +10,6 @@ exports[`plugin-basic > should apply basic config correctly in development 1`] =
   "module": {
     "parser": {
       "javascript": {
-        "exportsPresence": "error",
         "typeReexportsPresence": "tolerant",
       },
     },
@@ -44,7 +43,6 @@ exports[`plugin-basic > should apply basic config correctly in production 1`] = 
   "module": {
     "parser": {
       "javascript": {
-        "exportsPresence": "error",
         "typeReexportsPresence": "tolerant",
       },
     },

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -20,7 +20,6 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
   "module": {
     "parser": {
       "javascript": {
-        "exportsPresence": "error",
         "typeReexportsPresence": "tolerant",
       },
     },

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -20,7 +20,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   "module": {
     "parser": {
       "javascript": {
-        "exportsPresence": "error",
         "typeReexportsPresence": "tolerant",
       },
     },
@@ -515,7 +514,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
   "module": {
     "parser": {
       "javascript": {
-        "exportsPresence": "error",
         "typeReexportsPresence": "tolerant",
       },
     },
@@ -1030,7 +1028,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   "module": {
     "parser": {
       "javascript": {
-        "exportsPresence": "error",
         "typeReexportsPresence": "tolerant",
       },
     },
@@ -1468,7 +1465,6 @@ exports[`tools.rspack > should match snapshot 1`] = `
   "module": {
     "parser": {
       "javascript": {
-        "exportsPresence": "error",
         "typeReexportsPresence": "tolerant",
       },
     },

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1451,7 +1451,6 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
     "module": {
       "parser": {
         "javascript": {
-          "exportsPresence": "error",
           "typeReexportsPresence": "tolerant",
         },
       },
@@ -1881,7 +1880,6 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
     "module": {
       "parser": {
         "javascript": {
-          "exportsPresence": "error",
           "typeReexportsPresence": "tolerant",
         },
       },

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -117,7 +117,6 @@ exports[`plugins/react > should not apply splitChunks rule when strategy is not 
 
 exports[`plugins/react > should set \`parser.javascript.jsx\` to \`true\` when using \`preserve\` react runtime 1`] = `
 {
-  "exportsPresence": "error",
   "jsx": true,
   "typeReexportsPresence": "tolerant",
 }


### PR DESCRIPTION
## Summary

No need to set `exportsPresence: 'error'` as this has been set by default in Rspack 2.0.

## Related Links

- https://github.com/web-infra-dev/rspack/pull/13002

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
