### PR TITLE
test(e2e): merging duplicate dev/build tests

### DIFF
--- a/e2e/cases/module/glob-import/index.test.ts
+++ b/e2e/cases/module/glob-import/index.test.ts
@@ -1,20 +1,11 @@
 import { expect, test } from '@e2e/helper';
 
-test('should glob import components in dev build correctly', async ({
+test('should glob import components correctly', async ({
   page,
-  dev,
+  runDevAndBuild,
 }) => {
-  await dev();
-
-  await expect(page.locator('#header')).toHaveText('Header');
-  await expect(page.locator('#footer')).toHaveText('Footer');
-});
-
-test('should glob import components in build correctly', async ({
-  page,
-  buildPreview,
-}) => {
-  await buildPreview();
-  await expect(page.locator('#header')).toHaveText('Header');
-  await expect(page.locator('#footer')).toHaveText('Footer');
+  await runDevAndBuild(async () => {
+    await expect(page.locator('#header')).toHaveText('Header');
+    await expect(page.locator('#footer')).toHaveText('Footer');
+  });
 });

--- a/e2e/cases/plugin-react/jsx-runtime-classic/index.test.ts
+++ b/e2e/cases/plugin-react/jsx-runtime-classic/index.test.ts
@@ -1,19 +1,11 @@
 import { expect, test } from '@e2e/helper';
 
-test('should render element with classic JSX runtime in build', async ({
+test('should render element with classic JSX runtime', async ({
   page,
-  buildPreview,
+  runDevAndBuild,
 }) => {
-  await buildPreview();
-  const testEl = page.locator('#test');
-  await expect(testEl).toHaveText('Hello Rsbuild!');
-});
-
-test('should render element with classic JSX runtime in dev', async ({
-  page,
-  dev,
-}) => {
-  await dev();
-  const testEl = page.locator('#test');
-  await expect(testEl).toHaveText('Hello Rsbuild!');
+  await runDevAndBuild(async () => {
+    const testEl = page.locator('#test');
+    await expect(testEl).toHaveText('Hello Rsbuild!');
+  });
 });

--- a/e2e/cases/plugin-svelte/basic/index.test.ts
+++ b/e2e/cases/plugin-svelte/basic/index.test.ts
@@ -1,19 +1,11 @@
 import { expect, test } from '@e2e/helper';
 
-test('should compile basic svelte component properly in build', async ({
+test('should compile basic svelte component properly', async ({
   page,
-  buildPreview,
+  runDevAndBuild,
 }) => {
-  await buildPreview();
-  const title = page.locator('#title');
-  await expect(title).toHaveText('Hello world!');
-});
-
-test('should compile basic svelte component properly in dev', async ({
-  page,
-  dev,
-}) => {
-  await dev();
-  const title = page.locator('#title');
-  await expect(title).toHaveText('Hello world!');
+  await runDevAndBuild(async () => {
+    const title = page.locator('#title');
+    await expect(title).toHaveText('Hello world!');
+  });
 });

--- a/e2e/cases/plugin-svelte/less/index.test.ts
+++ b/e2e/cases/plugin-svelte/less/index.test.ts
@@ -1,23 +1,13 @@
 import { expect, test } from '@e2e/helper';
 
-test('should compile svelte component with less in build', async ({
+test('should compile svelte component with less', async ({
   page,
-  buildPreview,
+  runDevAndBuild,
 }) => {
-  await buildPreview();
-  const title = page.locator('#title');
-  await expect(title).toHaveText('Hello world!');
-  // use the text color to assert the compilation result
-  await expect(title).toHaveCSS('color', 'rgb(255, 62, 0)');
-});
-
-test('should compile svelte component with less in dev', async ({
-  page,
-  dev,
-}) => {
-  await dev();
-  const title = page.locator('#title');
-  await expect(title).toHaveText('Hello world!');
-  // use the text color to assert the compilation result
-  await expect(title).toHaveCSS('color', 'rgb(255, 62, 0)');
+  await runDevAndBuild(async () => {
+    const title = page.locator('#title');
+    await expect(title).toHaveText('Hello world!');
+    // use the text color to assert the compilation result
+    await expect(title).toHaveCSS('color', 'rgb(255, 62, 0)');
+  });
 });

--- a/e2e/cases/plugin-svelte/scss/index.test.ts
+++ b/e2e/cases/plugin-svelte/scss/index.test.ts
@@ -1,23 +1,13 @@
 import { expect, test } from '@e2e/helper';
 
-test('should compile svelte component with sass in build', async ({
+test('should compile svelte component with sass', async ({
   page,
-  buildPreview,
+  runDevAndBuild,
 }) => {
-  await buildPreview();
-  const title = page.locator('#title');
-  await expect(title).toHaveText('Hello world!');
-  // use the text color to assert the compilation result
-  await expect(title).toHaveCSS('color', 'rgb(255, 62, 0)');
-});
-
-test('should compile svelte component with sass in dev', async ({
-  page,
-  dev,
-}) => {
-  await dev();
-  const title = page.locator('#title');
-  await expect(title).toHaveText('Hello world!');
-  // use the text color to assert the compilation result
-  await expect(title).toHaveCSS('color', 'rgb(255, 62, 0)');
+  await runDevAndBuild(async () => {
+    const title = page.locator('#title');
+    await expect(title).toHaveText('Hello world!');
+    // use the text color to assert the compilation result
+    await expect(title).toHaveCSS('color', 'rgb(255, 62, 0)');
+  });
 });

--- a/e2e/cases/plugin-svelte/stylus/index.test.ts
+++ b/e2e/cases/plugin-svelte/stylus/index.test.ts
@@ -1,23 +1,13 @@
 import { expect, test } from '@e2e/helper';
 
-test('should compile svelte component with stylus in build', async ({
+test('should compile svelte component with stylus', async ({
   page,
-  buildPreview,
+  runDevAndBuild,
 }) => {
-  await buildPreview();
-  const title = page.locator('#title');
-  await expect(title).toHaveText('Hello world!');
-  // use the text color to assert the compilation result
-  await expect(title).toHaveCSS('color', 'rgb(255, 62, 0)');
-});
-
-test('should compile svelte component with stylus in dev', async ({
-  page,
-  dev,
-}) => {
-  await dev();
-  const title = page.locator('#title');
-  await expect(title).toHaveText('Hello world!');
-  // use the text color to assert the compilation result
-  await expect(title).toHaveCSS('color', 'rgb(255, 62, 0)');
+  await runDevAndBuild(async () => {
+    const title = page.locator('#title');
+    await expect(title).toHaveText('Hello world!');
+    // use the text color to assert the compilation result
+    await expect(title).toHaveCSS('color', 'rgb(255, 62, 0)');
+  });
 });

--- a/e2e/cases/resolve/pkg-imports/index.test.ts
+++ b/e2e/cases/resolve/pkg-imports/index.test.ts
@@ -1,23 +1,13 @@
 import { expect, test } from '@e2e/helper';
 
-test('should resolve package.json#imports correctly in dev build', async ({
+test('should resolve package.json#imports correctly', async ({
   page,
-  dev,
+  runDevAndBuild,
 }) => {
-  await dev();
-  const foo = page.locator('#foo');
-  await expect(foo).toHaveText('foo');
-  const test = page.locator('#test');
-  await expect(test).toHaveText('test');
-});
-
-test('should resolve package.json#imports correctly in build', async ({
-  page,
-  buildPreview,
-}) => {
-  await buildPreview();
-  const foo = page.locator('#foo');
-  await expect(foo).toHaveText('foo');
-  const test = page.locator('#test');
-  await expect(test).toHaveText('test');
+  await runDevAndBuild(async () => {
+    const foo = page.locator('#foo');
+    await expect(foo).toHaveText('foo');
+    const test = page.locator('#test');
+    await expect(test).toHaveText('test');
+  });
 });

--- a/e2e/cases/source/define/index.test.ts
+++ b/e2e/cases/source/define/index.test.ts
@@ -1,26 +1,13 @@
-import { expect, gotoPage, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-test('should allow to define global variables in development', async ({
-  dev,
+test('should allow to define global variables', async ({
   page,
+  runDevAndBuild,
 }) => {
-  const rsbuild = await dev();
-  await gotoPage(page, rsbuild);
-
-  const testEl = page.locator('#test-el');
-  await expect(testEl).toHaveText('aaaaa');
-});
-
-test('should allow to define global variables in build', async ({
-  page,
-  buildPreview,
-}) => {
-  const rsbuild = await buildPreview();
-
-  await gotoPage(page, rsbuild);
-
-  const testEl = page.locator('#test-el');
-  await expect(testEl).toHaveText('aaaaa');
+  await runDevAndBuild(async () => {
+    const testEl = page.locator('#test-el');
+    await expect(testEl).toHaveText('aaaaa');
+  });
 });
 
 test('should warn when define `process.env`', async ({ buildPreview }) => {

--- a/e2e/cases/source/entry-import-array/index.test.ts
+++ b/e2e/cases/source/entry-import-array/index.test.ts
@@ -1,14 +1,7 @@
 import { expect, test } from '@e2e/helper';
 
-test('should support entry import array in dev', async ({ page, dev }) => {
-  await dev();
-  await expect(page.locator('#app')).toHaveText('first,second');
-});
-
-test('should support entry import array in build', async ({
-  page,
-  buildPreview,
-}) => {
-  await buildPreview();
-  await expect(page.locator('#app')).toHaveText('first,second');
+test('should support entry import array', async ({ page, runDevAndBuild }) => {
+  await runDevAndBuild(async () => {
+    await expect(page.locator('#app')).toHaveText('first,second');
+  });
 });

--- a/e2e/cases/source/pre-entry/index.test.ts
+++ b/e2e/cases/source/pre-entry/index.test.ts
@@ -1,19 +1,11 @@
 import { expect, test } from '@e2e/helper';
 
-test('should allow to configure pre-entry in development', async ({
-  dev,
+test('should allow to configure pre-entry', async ({
   page,
+  runDevAndBuild,
 }) => {
-  await dev();
-  await expect(page.innerHTML('#test-el')).resolves.toBe('aaaaa');
-  await expect(page.evaluate('window.aa')).resolves.toBe(2);
-});
-
-test('should allow to configure pre-entry in build', async ({
-  page,
-  buildPreview,
-}) => {
-  await buildPreview();
-  await expect(page.innerHTML('#test-el')).resolves.toBe('aaaaa');
-  await expect(page.evaluate('window.aa')).resolves.toBe(2);
+  await runDevAndBuild(async () => {
+    await expect(page.innerHTML('#test-el')).resolves.toBe('aaaaa');
+    await expect(page.evaluate('window.aa')).resolves.toBe(2);
+  });
 });

--- a/e2e/cases/syntax-es/using-declaration/index.test.ts
+++ b/e2e/cases/syntax-es/using-declaration/index.test.ts
@@ -1,19 +1,10 @@
 import { expect, test } from '@e2e/helper';
 
-test('should allow to use the `using` declaration for explicit resource management in development', async ({
+test('should allow to use the `using` declaration for explicit resource management', async ({
   page,
-  dev,
+  runDevAndBuild,
 }) => {
-  await dev();
-
-  expect(await page.evaluate('window.disposeCounter')).toEqual(4);
-});
-
-test('should allow to use the `using` declaration for explicit resource management in production', async ({
-  page,
-  buildPreview,
-}) => {
-  await buildPreview();
-
-  expect(await page.evaluate('window.disposeCounter')).toEqual(4);
+  await runDevAndBuild(async () => {
+    expect(await page.evaluate('window.disposeCounter')).toEqual(4);
+  });
 });

--- a/e2e/cases/syntax-ts/optional-chaining/index.test.ts
+++ b/e2e/cases/syntax-ts/optional-chaining/index.test.ts
@@ -1,29 +1,15 @@
 import { expect, test } from '@e2e/helper';
 
-test('should compile optional chaining and nullish coalescing in dev', async ({
+test('should compile optional chaining and nullish coalescing', async ({
   page,
-  dev,
+  runDevAndBuild,
 }) => {
-  await dev();
-
-  expect(await page.evaluate(() => window.optionalChainingTest)).toBe(
-    'john@example.com',
-  );
-  expect(await page.evaluate(() => window.nullishCoalescingTest)).toBe(
-    'No email, fallback',
-  );
-});
-
-test('should compile optional chaining and nullish coalescing in build', async ({
-  page,
-  buildPreview,
-}) => {
-  await buildPreview();
-
-  expect(await page.evaluate(() => window.optionalChainingTest)).toBe(
-    'john@example.com',
-  );
-  expect(await page.evaluate(() => window.nullishCoalescingTest)).toBe(
-    'No email, fallback',
-  );
+  await runDevAndBuild(async () => {
+    expect(await page.evaluate(() => window.optionalChainingTest)).toBe(
+      'john@example.com',
+    );
+    expect(await page.evaluate(() => window.nullishCoalescingTest)).toBe(
+      'No email, fallback',
+    );
+  });
 });

--- a/e2e/cases/workers/new-worker-ts/index.test.ts
+++ b/e2e/cases/workers/new-worker-ts/index.test.ts
@@ -1,23 +1,12 @@
 import { expect, test } from '@e2e/helper';
 
-test('should build a web worker in build using the new Worker syntax', async ({
+test('should build a web worker using the new Worker syntax', async ({
   page,
-  buildPreview,
+  runDevAndBuild,
 }) => {
-  await buildPreview();
-
-  await expect(page.locator('#root')).toHaveText(
-    'The Answer to the Ultimate Question of Life, The Universe, and Everything: 42',
-  );
-});
-
-test('should build a web worker in dev using the new Worker syntax', async ({
-  page,
-  dev,
-}) => {
-  await dev();
-
-  await expect(page.locator('#root')).toHaveText(
-    'The Answer to the Ultimate Question of Life, The Universe, and Everything: 42',
-  );
+  await runDevAndBuild(async () => {
+    await expect(page.locator('#root')).toHaveText(
+      'The Answer to the Ultimate Question of Life, The Universe, and Everything: 42',
+    );
+  });
 });

--- a/e2e/cases/workers/new-worker/index.test.ts
+++ b/e2e/cases/workers/new-worker/index.test.ts
@@ -1,23 +1,12 @@
 import { expect, test } from '@e2e/helper';
 
-test('should build a web worker in build using the new Worker syntax', async ({
+test('should build a web worker using the new Worker syntax', async ({
   page,
-  buildPreview,
+  runDevAndBuild,
 }) => {
-  await buildPreview();
-
-  await expect(page.locator('#root')).toHaveText(
-    'The Answer to the Ultimate Question of Life, The Universe, and Everything: 42',
-  );
-});
-
-test('should build a web worker in dev using the new Worker', async ({
-  page,
-  dev,
-}) => {
-  await dev();
-
-  await expect(page.locator('#root')).toHaveText(
-    'The Answer to the Ultimate Question of Life, The Universe, and Everything: 42',
-  );
+  await runDevAndBuild(async () => {
+    await expect(page.locator('#root')).toHaveText(
+      'The Answer to the Ultimate Question of Life, The Universe, and Everything: 42',
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Use `runDevAndBuild` helper to combine separate dev and build test cases into single tests.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
