### PR TITLE
ci(workflows): disable Windows Defender to improve performance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,12 @@ jobs:
         os: [macos-latest, windows-latest]
 
     steps:
+      # Disable Windows Defender real-time scanning to speed up I/O-heavy builds
+      - name: Disable Windows Defender
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -72,6 +78,12 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
+      # Disable Windows Defender real-time scanning to speed up I/O-heavy builds
+      - name: Disable Windows Defender
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
## Summary

Disable Windows Defender real-time scanning during Windows builds to speed up I/O-heavy operations.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
