### PR TITLE
feat(source-map): add `extract` option

### DIFF
--- a/e2e/cases/source-map/extract/index.test.ts
+++ b/e2e/cases/source-map/extract/index.test.ts
@@ -1,0 +1,78 @@
+import {
+  type Build,
+  expect,
+  getFileContent,
+  mapSourceMapPositions,
+  test,
+} from '@e2e/helper';
+
+const getGeneratedPosition = (code: string, search: string) => {
+  const offset = code.indexOf(search);
+
+  if (offset === -1) {
+    throw new Error(`Failed to find "${search}" in generated output.`);
+  }
+
+  const before = code.slice(0, offset);
+  const lines = before.split('\n');
+
+  return {
+    line: lines.length,
+    column: lines[lines.length - 1].length,
+  };
+};
+
+async function buildWithExtract(
+  build: Build,
+  extract:
+    | boolean
+    | { js?: boolean | { include?: RegExp[]; exclude?: RegExp[] } },
+) {
+  return build({
+    config: {
+      output: {
+        filenameHash: false,
+        minify: false,
+        sourceMap: {
+          js: 'source-map',
+          extract,
+        },
+      },
+    },
+  });
+}
+
+test('should preserve JavaScript source maps from matched files', async ({
+  build,
+}) => {
+  const rsbuild = await buildWithExtract(build, { js: true });
+  const files = rsbuild.getDistFiles({ sourceMaps: true });
+
+  const outputCode = getFileContent(files, 'index.js');
+  const sourceMap = getFileContent(files, 'index.js.map');
+  const generatedPosition = getGeneratedPosition(outputCode, 'from-package-ts');
+
+  const [originalPosition] = await mapSourceMapPositions(sourceMap, [
+    generatedPosition,
+  ]);
+
+  expect(originalPosition.source).toContain(
+    'node_modules/mapped-package/index.ts',
+  );
+});
+
+test('should preserve JavaScript source maps when extract is true', async ({
+  build,
+}) => {
+  const rsbuild = await buildWithExtract(build, true);
+  const files = rsbuild.getDistFiles({ sourceMaps: true });
+
+  const jsOutput = getFileContent(files, 'index.js');
+  const jsSourceMap = getFileContent(files, 'index.js.map');
+
+  const [jsPosition] = await mapSourceMapPositions(jsSourceMap, [
+    getGeneratedPosition(jsOutput, 'from-package-ts'),
+  ]);
+
+  expect(jsPosition.source).toContain('node_modules/mapped-package/index.ts');
+});

--- a/e2e/cases/source-map/extract/index.test.ts
+++ b/e2e/cases/source-map/extract/index.test.ts
@@ -25,6 +25,7 @@ const setupMappedPackage = () => {
   );
   fse.outputFileSync(
     path.join(packageDir, 'index.js.map'),
+    // cspell:disable-next-line
     '{"version":3,"file":"index.js","sourceRoot":"","sources":["index.ts"],"sourcesContent":["export const value = \'from-package-ts\';\\nconsole.log(value);\\n"],"names":[],"mappings":"AAAA,MAAM,CAAC,MAAM,KAAK,GAAG,iBAAiB,CAAC;AACvC,OAAO,CAAC,GAAG,CAAC,KAAK,CAAC,CAAC"}',
   );
   fse.outputFileSync(

--- a/e2e/cases/source-map/extract/index.test.ts
+++ b/e2e/cases/source-map/extract/index.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import {
   type Build,
   expect,
@@ -5,6 +6,32 @@ import {
   mapSourceMapPositions,
   test,
 } from '@e2e/helper';
+import fse from 'fs-extra';
+
+const setupMappedPackage = () => {
+  const packageDir = path.resolve(
+    import.meta.dirname,
+    'node_modules/mapped-package',
+  );
+
+  fse.outputJsonSync(path.join(packageDir, 'package.json'), {
+    name: 'mapped-package',
+    version: '1.0.0',
+    type: 'module',
+  });
+  fse.outputFileSync(
+    path.join(packageDir, 'index.js'),
+    "export const value = 'from-package-ts';\nconsole.log(value);\n//# sourceMappingURL=index.js.map\n",
+  );
+  fse.outputFileSync(
+    path.join(packageDir, 'index.js.map'),
+    '{"version":3,"file":"index.js","sourceRoot":"","sources":["index.ts"],"sourcesContent":["export const value = \'from-package-ts\';\\nconsole.log(value);\\n"],"names":[],"mappings":"AAAA,MAAM,CAAC,MAAM,KAAK,GAAG,iBAAiB,CAAC;AACvC,OAAO,CAAC,GAAG,CAAC,KAAK,CAAC,CAAC"}',
+  );
+  fse.outputFileSync(
+    path.join(packageDir, 'index.ts'),
+    "export const value = 'from-package-ts';\nconsole.log(value);\n",
+  );
+};
 
 const getGeneratedPosition = (code: string, search: string) => {
   const offset = code.indexOf(search);
@@ -28,6 +55,8 @@ async function buildWithExtract(
     | boolean
     | { js?: boolean | { include?: RegExp[]; exclude?: RegExp[] } },
 ) {
+  setupMappedPackage();
+
   return build({
     config: {
       output: {

--- a/e2e/cases/source-map/extract/src/index.js
+++ b/e2e/cases/source-map/extract/src/index.js
@@ -1,0 +1,3 @@
+import { value } from 'mapped-package';
+
+window.test = value;

--- a/packages/core/src/defaultConfig.ts
+++ b/packages/core/src/defaultConfig.ts
@@ -179,6 +179,7 @@ const getDefaultOutputConfig = (): NormalizedOutputConfig => ({
   sourceMap: {
     js: undefined,
     css: false,
+    extract: false,
   },
   filenameHash: true,
   inlineScripts: false,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -188,6 +188,8 @@ export type {
   SetupMiddlewaresFn,
   SourceConfig,
   SourceMap,
+  SourceMapExtract,
+  SourceMapExtractTarget,
   SplitChunks,
   SplitChunksConfig,
   SplitChunksPreset,

--- a/packages/core/src/plugins/sourceMap.ts
+++ b/packages/core/src/plugins/sourceMap.ts
@@ -1,8 +1,11 @@
-import { toPosixPath } from '../helpers/path';
+import { JS_REGEX } from '../constants';
+import { normalizeRuleConditionPath, toPosixPath } from '../helpers/path';
 import type {
   NormalizedEnvironmentConfig,
   RsbuildPlugin,
   Rspack,
+  RspackChain,
+  SourceMapExtractTarget,
 } from '../types';
 
 const getDevtool = (config: NormalizedEnvironmentConfig): Rspack.DevTool => {
@@ -35,6 +38,73 @@ export const pluginSourceMap = (): RsbuildPlugin => ({
       const { sourceMap } = config.output;
       return typeof sourceMap === 'object' && sourceMap.css;
     };
+
+    const normalizeExtractTarget = (
+      target: boolean | SourceMapExtractTarget | undefined,
+    ): false | SourceMapExtractTarget => {
+      if (!target) return false;
+      if (target === true) return {};
+
+      return {
+        include: target.include?.map(normalizeRuleConditionPath),
+        exclude: target.exclude?.map(normalizeRuleConditionPath),
+      };
+    };
+
+    const getExtractConfig = (config: NormalizedEnvironmentConfig) => {
+      const { sourceMap } = config.output;
+
+      if (typeof sourceMap !== 'object' || !sourceMap.extract) return false;
+      if (sourceMap.extract === true) return { js: {} };
+
+      const js = normalizeExtractTarget(sourceMap.extract.js);
+      if (!js) return false;
+
+      return { js } as const;
+    };
+
+    const applyExtractRule = (
+      chain: RspackChain,
+      name: string,
+      test: RegExp,
+      target: false | SourceMapExtractTarget,
+    ) => {
+      if (!target) return;
+
+      const rule = chain.module
+        .rule(name)
+        .test(test)
+        .set('extractSourceMap', true);
+
+      const { include, exclude } = target;
+
+      if (include) {
+        for (const condition of include) {
+          rule.include.add(condition);
+        }
+      }
+
+      if (exclude) {
+        for (const condition of exclude) {
+          rule.exclude.add(condition);
+        }
+      }
+    };
+
+    api.modifyBundlerChain({
+      order: 'pre',
+      handler: (chain, { environment }) => {
+        const extractConfig = getExtractConfig(environment.config);
+        if (!extractConfig) return;
+
+        applyExtractRule(
+          chain,
+          'source-map-extract-js',
+          JS_REGEX,
+          extractConfig.js,
+        );
+      },
+    });
 
     api.modifyBundlerChain((chain, { rspack, environment, isDev, target }) => {
       const { config } = environment;

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1072,6 +1072,28 @@ export type NormalizedDataUriLimit = Required<DataUriLimit>;
 
 export type Polyfill = 'usage' | 'entry' | 'off';
 
+export type SourceMapExtractTarget = {
+  /**
+   * Include files that should extract existing source maps.
+   */
+  include?: RuleSetCondition[];
+  /**
+   * Exclude files that should not extract existing source maps.
+   */
+  exclude?: RuleSetCondition[];
+};
+
+export type SourceMapExtract =
+  | boolean
+  | {
+      /**
+       * Whether to extract source map from matching JavaScript files.
+       * `true` means extract from all files matched by the built-in JS rule.
+       * @default false
+       */
+      js?: boolean | SourceMapExtractTarget;
+    };
+
 export type SourceMap = {
   /**
    * The source map type for JavaScript files.
@@ -1083,6 +1105,11 @@ export type SourceMap = {
    * @default false
    */
   css?: boolean;
+  /**
+   * Whether to extract source maps from matching input files.
+   * @default false
+   */
+  extract?: SourceMapExtract;
 };
 
 export type CSSModulesLocalsConvention =
@@ -1358,6 +1385,7 @@ export interface OutputConfig {
    * const defaultSourceMap = {
    *   js: isDev ? 'cheap-module-source-map' : false,
    *   css: false,
+   *   extract: false,
    * };
    * ```
    */
@@ -1421,6 +1449,7 @@ export interface NormalizedOutputConfig extends OutputConfig {
     | {
         js?: Rspack.Configuration['devtool'];
         css: boolean;
+        extract: SourceMapExtract;
       };
   cleanDistPath: CleanDistPath;
   filenameHash: boolean | string;

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -938,6 +938,7 @@ exports[`environment config > should normalize environment config correctly 1`] 
     "polyfill": "off",
     "sourceMap": {
       "css": false,
+      "extract": false,
       "js": undefined,
     },
     "target": "web",
@@ -1094,6 +1095,7 @@ exports[`environment config > should normalize environment config correctly 2`] 
     "polyfill": "off",
     "sourceMap": {
       "css": false,
+      "extract": false,
       "js": undefined,
     },
     "target": "node",
@@ -1254,6 +1256,7 @@ exports[`environment config > should print environment config when inspecting co
       "polyfill": "off",
       "sourceMap": {
         "css": false,
+        "extract": false,
         "js": undefined,
       },
       "target": "web",
@@ -1410,6 +1413,7 @@ exports[`environment config > should print environment config when inspecting co
       "polyfill": "off",
       "sourceMap": {
         "css": false,
+        "extract": false,
         "js": undefined,
       },
       "target": "web",
@@ -1586,6 +1590,7 @@ exports[`environment config > should support modifying environment config by api
       "polyfill": "off",
       "sourceMap": {
         "css": false,
+        "extract": false,
         "js": undefined,
       },
       "target": "web",
@@ -1742,6 +1747,7 @@ exports[`environment config > should support modifying environment config by api
       "polyfill": "off",
       "sourceMap": {
         "css": false,
+        "extract": false,
         "js": undefined,
       },
       "target": "web",
@@ -1899,6 +1905,7 @@ exports[`environment config > should support modifying environment config by api
       "polyfill": "off",
       "sourceMap": {
         "css": false,
+        "extract": false,
         "js": undefined,
       },
       "target": "web",
@@ -2059,6 +2066,7 @@ exports[`environment config > should support modifying single environment config
       "polyfill": "off",
       "sourceMap": {
         "css": false,
+        "extract": false,
         "js": undefined,
       },
       "target": "web",
@@ -2215,6 +2223,7 @@ exports[`environment config > should support modifying single environment config
       "polyfill": "off",
       "sourceMap": {
         "css": false,
+        "extract": false,
         "js": undefined,
       },
       "target": "web",

--- a/packages/core/tests/sourceMap.test.ts
+++ b/packages/core/tests/sourceMap.test.ts
@@ -1,0 +1,147 @@
+import { createRsbuild, type RsbuildConfig, type Rspack } from '../src';
+import { JS_REGEX } from '../src/constants';
+import { normalizeRuleConditionPath } from '../src/helpers/path';
+
+const isExtractRule = (
+  rule: Rspack.RuleSetRules[number],
+): rule is Rspack.RuleSetRule =>
+  !!rule &&
+  typeof rule === 'object' &&
+  'extractSourceMap' in rule &&
+  rule.extractSourceMap === true;
+
+const getExtractRules = async (
+  config?: RsbuildConfig,
+): Promise<Rspack.RuleSetRule[]> => {
+  const rsbuild = await createRsbuild({
+    config,
+  });
+  const [bundlerConfig] = await rsbuild.initConfigs();
+
+  return bundlerConfig.module?.rules?.filter(isExtractRule) || [];
+};
+
+describe('plugin-source-map', () => {
+  it('should not add extract rules by default', async () => {
+    const rules = await getExtractRules();
+
+    expect(rules).toHaveLength(0);
+  });
+
+  it('should add JavaScript extract rule when output.sourceMap.extract.js is true', async () => {
+    const rules = await getExtractRules({
+      output: {
+        sourceMap: {
+          extract: {
+            js: true,
+          },
+        },
+      },
+    });
+
+    expect(rules).toContainEqual(
+      expect.objectContaining({
+        extractSourceMap: true,
+        test: JS_REGEX,
+      }),
+    );
+  });
+
+  it('should add JavaScript extract rule when output.sourceMap.extract is true', async () => {
+    const rules = await getExtractRules({
+      output: {
+        sourceMap: {
+          extract: true,
+        },
+      },
+    });
+
+    expect(rules).toContainEqual(
+      expect.objectContaining({
+        extractSourceMap: true,
+        test: JS_REGEX,
+      }),
+    );
+    expect(rules).toHaveLength(1);
+  });
+
+  it('should apply include matchers to extract rules', async () => {
+    const include = ['C:/workspace/pkg', /foo/];
+
+    const rules = await getExtractRules({
+      output: {
+        sourceMap: {
+          extract: {
+            js: {
+              include,
+            },
+          },
+        },
+      },
+    });
+
+    const rule = rules.find(
+      (item) =>
+        typeof item === 'object' &&
+        item !== null &&
+        item.test instanceof RegExp &&
+        item.test.toString() === JS_REGEX.toString(),
+    );
+
+    expect(rule).toEqual(
+      expect.objectContaining({
+        include: include.map(normalizeRuleConditionPath),
+      }),
+    );
+  });
+
+  it('should apply exclude matchers to extract rules', async () => {
+    const exclude = ['C:/workspace/pkg/exclude', /bar/];
+
+    const rules = await getExtractRules({
+      output: {
+        sourceMap: {
+          extract: {
+            js: {
+              exclude,
+            },
+          },
+        },
+      },
+    });
+
+    const rule = rules.find(
+      (item) =>
+        typeof item === 'object' &&
+        item !== null &&
+        item.test instanceof RegExp &&
+        item.test.toString() === JS_REGEX.toString(),
+    );
+
+    expect(rule).toEqual(
+      expect.objectContaining({
+        exclude: exclude.map(normalizeRuleConditionPath),
+      }),
+    );
+  });
+
+  it('should keep JavaScript extract rules when output.sourceMap.js is false', async () => {
+    const rules = await getExtractRules({
+      output: {
+        sourceMap: {
+          js: false,
+          extract: {
+            js: true,
+          },
+        },
+      },
+    });
+
+    expect(rules).toContainEqual(
+      expect.objectContaining({
+        extractSourceMap: true,
+        test: JS_REGEX,
+      }),
+    );
+  });
+});

--- a/website/docs/en/config/output/source-map.mdx
+++ b/website/docs/en/config/output/source-map.mdx
@@ -12,6 +12,16 @@ type SourceMap =
   | {
       js?: Rspack.Configuration['devtool'];
       css?: boolean;
+      extract?:
+        | boolean
+        | {
+            js?:
+              | boolean
+              | {
+                  include?: Rspack.RuleSetCondition[];
+                  exclude?: Rspack.RuleSetCondition[];
+                };
+          };
     };
 ```
 
@@ -21,6 +31,7 @@ type SourceMap =
 const defaultSourceMap = {
   js: mode === 'development' ? 'cheap-module-source-map' : false,
   css: false,
+  extract: false,
 };
 ```
 
@@ -128,6 +139,40 @@ export default {
     injectStyles: true,
     sourceMap: {
       css: process.env.NODE_ENV === 'development',
+    },
+  },
+};
+```
+
+## Extract source map
+
+Use `sourceMap.extract` to extract existing source maps from matched JavaScript files. This is useful when a package already ships both `.js` and `.js.map` files.
+
+To enable extraction for all files matched by the built-in JS rule:
+
+```ts title="rsbuild.config.ts"
+export default {
+  output: {
+    sourceMap: {
+      js: 'source-map',
+      extract: true,
+    },
+  },
+};
+```
+
+Use `include` or `exclude` to limit extraction to specific files:
+
+```ts title="rsbuild.config.ts"
+export default {
+  output: {
+    sourceMap: {
+      js: 'source-map',
+      extract: {
+        js: {
+          include: [/node_modules[\\/]some-package[\\/]/],
+        },
+      },
     },
   },
 };


### PR DESCRIPTION
## Summary

Adds a `output.sourceMap.extract` option, so Rspack's `rules[].extractSourceMap` can be enabled.

This implementation supports JS extraction only. I considered CSS extraction as well, but the current CSS pipeline does not preserve upstream CSS source maps end to end. Keeping `sourceMap.extract` as its own namespace still gives a clear place to support CSS in the future if that becomes possible.

## Related Links

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
