### PR TITLE
docs: clarify v2 upgrade guide

### DIFF
--- a/website/docs/en/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/en/guide/upgrade/v1-to-v2.mdx
@@ -20,24 +20,27 @@ After installation, let the Coding Agent guide you through the upgrade.
 
 ## Upgrade Rsbuild to v2
 
-- Upgrade `@rsbuild/core` to the 2.0 RC release:
+- Upgrade `@rsbuild/core` to the 2.0 RC release.
 
-```diff
+- If you use `@rsbuild/plugin-react` or `@rsbuild/plugin-svgr`, upgrade them to the 2.0 RC release as well to keep them compatible with `@rsbuild/core`. For example:
+
+```json
 {
   "devDependencies": {
--   "@rsbuild/core": "^1.0.0",
-+   "@rsbuild/core": "^2.0.0-rc.0"
+    "@rsbuild/core": "^2.0.0-rc.0",
+    "@rsbuild/plugin-react": "^2.0.0-rc.0",
+    "@rsbuild/plugin-svgr": "^2.0.0-rc.0"
   }
 }
 ```
 
-- Upgrade all Rsbuild plugins to their latest versions:
+- For other Rsbuild plugins, we recommend upgrading to the latest version too:
 
 ```bash
-# Upgrade dependencies in the current directory
+# Upgrade Rsbuild dependencies in the current directory
 npx taze major --include /rsbuild/ -w
 
-# Or recursively upgrade the entire monorepo
+# Or recursively upgrade Rsbuild dependencies in the entire monorepo
 npx taze major --include /rsbuild/ -w -r
 ```
 

--- a/website/docs/zh/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/zh/guide/upgrade/v1-to-v2.mdx
@@ -20,24 +20,27 @@ npx skills add rstackjs/agent-skills --skill rsbuild-v2-upgrade
 
 ## 升级 Rsbuild 到 v2
 
-- 将 `@rsbuild/core` 升级到 2.0 RC 版本：
+- 将 `@rsbuild/core` 升级到 2.0 RC 版本。
 
-```diff
+- 如果你使用了 `@rsbuild/plugin-react` 或 `@rsbuild/plugin-svgr`，也需要同时将它们升级到 2.0 RC 版本，以保持与 `@rsbuild/core` 的版本兼容。例如：
+
+```json
 {
   "devDependencies": {
--   "@rsbuild/core": "^1.0.0",
-+   "@rsbuild/core": "^2.0.0-rc.0"
+    "@rsbuild/core": "^2.0.0-rc.0",
+    "@rsbuild/plugin-react": "^2.0.0-rc.0",
+    "@rsbuild/plugin-svgr": "^2.0.0-rc.0"
   }
 }
 ```
 
-- 将 Rsbuild 插件升级到最新版本：
+- 其他 Rsbuild 插件也推荐升级到最新的版本：
 
 ```bash
-# 升级当前目录
+# 升级当前目录中的 Rsbuild 依赖
 npx taze major --include /rsbuild/ -w
 
-# 或递归升级整个 monorepo
+# 或递归升级整个 monorepo 中的 Rsbuild 依赖
 npx taze major --include /rsbuild/ -w -r
 ```
 


### PR DESCRIPTION
## Summary

- Clarify the v2 upgrade guide by showing that `@rsbuild/plugin-react` and `@rsbuild/plugin-svgr` should be upgraded together with `@rsbuild/core` when moving to the 2.0 RC release.
