### PR TITLE
docs: clarify Environment API naming in server setup docs

### DIFF
--- a/website/docs/en/config/server/setup.mdx
+++ b/website/docs/en/config/server/setup.mdx
@@ -95,7 +95,7 @@ type ServerSetupContext =
 
 - `context.action`: `'dev'` means dev server, `'preview'` means preview server.
 - `context.server`: server instance. See [Server API](/api/javascript-api/server-api) for more details.
-- `context.environments`: context information for all environments. Note that this differs from `server.environments`, which is the [Environments API](/api/javascript-api/environment-api).
+- `context.environments`: context information for all environments. Note that this differs from `server.environments`, which is the [Environment API](/api/javascript-api/environment-api).
 
 ## Middleware execution order
 
@@ -119,9 +119,9 @@ export default {
 };
 ```
 
-## Environments API
+## Environment API
 
-In development mode, you can access Rsbuild's [Environments API](/api/javascript-api/environment-api):
+In development mode, you can access Rsbuild's [Environment API](/api/javascript-api/environment-api):
 
 ```ts title="rsbuild.config.ts"
 export default {

--- a/website/docs/zh/config/server/setup.mdx
+++ b/website/docs/zh/config/server/setup.mdx
@@ -95,7 +95,7 @@ type ServerSetupContext =
 
 - `context.action`：`'dev'` 代表开发服务器，`'preview'` 代表预览服务器。
 - `context.server`：服务器实例，参考 [Server API](/api/javascript-api/server-api) 了解更多。
-- `context.environments`：所有环境的上下文信息。需要注意，这与 `server.environments` 不同，后者为 [Environments API](/api/javascript-api/environment-api)。
+- `context.environments`：所有环境的上下文信息。需要注意，这与 `server.environments` 不同，后者为 [Environment API](/api/javascript-api/environment-api)。
 
 ## 中间件执行顺序
 
@@ -119,9 +119,9 @@ export default {
 };
 ```
 
-## Environments API
+## Environment API
 
-在开发模式下，可以访问 Rsbuild 的 [Environments API](/api/javascript-api/environment-api)：
+在开发模式下，可以访问 Rsbuild 的 [Environment API](/api/javascript-api/environment-api)：
 
 ```ts title="rsbuild.config.ts"
 export default {


### PR DESCRIPTION
## Summary

This PR updates the server setup docs to consistently use `Environment API` for the `/api/javascript-api/environment-api` reference. It keeps the English and Chinese docs aligned with the current API naming.

## Related Links

None
