### PR TITLE
fix(core): prioritize common config files in lookup

### DIFF
--- a/packages/core/src/loadConfig.ts
+++ b/packages/core/src/loadConfig.ts
@@ -92,15 +92,15 @@ const resolveConfigPath = (root: string, customConfig?: string) => {
     );
   }
 
+  // Resolve the most commonly used config file types first
+  // to improve lookup performance.
   const CONFIG_FILES = [
-    // `.mjs` and `.ts` are the most used configuration types,
-    // so we resolve them first for performance
-    'rsbuild.config.mjs',
     'rsbuild.config.ts',
     'rsbuild.config.js',
-    'rsbuild.config.cjs',
     'rsbuild.config.mts',
+    'rsbuild.config.mjs',
     'rsbuild.config.cts',
+    'rsbuild.config.cjs',
   ];
 
   for (const file of CONFIG_FILES) {

--- a/website/docs/en/api/javascript-api/core.mdx
+++ b/website/docs/en/api/javascript-api/core.mdx
@@ -160,7 +160,7 @@ function loadConfig(params?: {
 ```ts
 import { loadConfig } from '@rsbuild/core';
 
-// Load `rsbuild.config.*` file by default
+// Load `rsbuild.config.*` from cwd using the default lookup order
 const { content } = await loadConfig();
 
 console.log(content); // -> Rsbuild config object
@@ -171,6 +171,17 @@ const rsbuild = await createRsbuild({
 ```
 
 If the Rsbuild config file does not exist in the cwd directory, the return value of the loadConfig method is `{ content: {}, filePath: null }`.
+
+When `path` is not specified, `loadConfig` searches for config files in the following order:
+
+- `rsbuild.config.ts`
+- `rsbuild.config.js`
+- `rsbuild.config.mts`
+- `rsbuild.config.mjs`
+- `rsbuild.config.cts`
+- `rsbuild.config.cjs`
+
+If multiple config files exist at the same time, `loadConfig` uses the first matching file in this list.
 
 ### Specify the configuration file
 

--- a/website/docs/en/guide/configuration/rsbuild.mdx
+++ b/website/docs/en/guide/configuration/rsbuild.mdx
@@ -59,14 +59,16 @@ You can find detailed descriptions of every option on the [Configure Overview](/
 
 ## Configuration file
 
-When you use the Rsbuild CLI, it looks for a configuration file in the project root in the following order:
+When you use the Rsbuild CLI, or call `loadConfig` without specifying `path`, Rsbuild looks for a configuration file in the project root in the following order:
 
-- rsbuild.config.mjs
 - rsbuild.config.ts
 - rsbuild.config.js
-- rsbuild.config.cjs
 - rsbuild.config.mts
+- rsbuild.config.mjs
 - rsbuild.config.cts
+- rsbuild.config.cjs
+
+If multiple config files exist at the same time, Rsbuild uses the first matching file in this list.
 
 We recommend using `rsbuild.config.ts` and importing the `defineConfig` utility from `@rsbuild/core`. It provides TypeScript hints and autocompletion to help you avoid configuration mistakes.
 

--- a/website/docs/zh/api/javascript-api/core.mdx
+++ b/website/docs/zh/api/javascript-api/core.mdx
@@ -160,7 +160,7 @@ function loadConfig(params?: {
 ```ts
 import { loadConfig } from '@rsbuild/core';
 
-// 默认加载 `rsbuild.config.*` 配置文件
+// 按默认查找顺序从 cwd 加载 `rsbuild.config.*` 配置文件
 const { content } = await loadConfig();
 
 console.log(content); // -> Rsbuild config object
@@ -171,6 +171,17 @@ const rsbuild = await createRsbuild({
 ```
 
 如果 cwd 目录下不存在 Rsbuild 配置文件，loadConfig 方法的返回值为 `{ content: {}, filePath: null }`。
+
+当未指定 `path` 时，`loadConfig` 会按以下顺序查找配置文件：
+
+- `rsbuild.config.ts`
+- `rsbuild.config.js`
+- `rsbuild.config.mts`
+- `rsbuild.config.mjs`
+- `rsbuild.config.cts`
+- `rsbuild.config.cjs`
+
+如果同时存在多个配置文件，`loadConfig` 会使用这个列表中第一个匹配到的文件。
 
 ### 指定配置文件
 

--- a/website/docs/zh/guide/configuration/rsbuild.mdx
+++ b/website/docs/zh/guide/configuration/rsbuild.mdx
@@ -59,14 +59,16 @@ export default {
 
 ## 配置文件
 
-当你使用 Rsbuild 的 CLI 命令时，Rsbuild 会自动读取当前项目根目录下的配置文件，按照以下顺序进行解析：
+当你使用 Rsbuild 的 CLI 命令时，或者在未指定 `path` 的情况下调用 `loadConfig` 时，Rsbuild 会自动读取当前项目根目录下的配置文件，并按以下顺序进行解析：
 
-- rsbuild.config.mjs
 - rsbuild.config.ts
 - rsbuild.config.js
-- rsbuild.config.cjs
 - rsbuild.config.mts
+- rsbuild.config.mjs
 - rsbuild.config.cts
+- rsbuild.config.cjs
+
+如果同时存在多个配置文件，Rsbuild 会使用这个列表中第一个匹配到的文件。
 
 我们推荐使用 `rsbuild.config.ts`，并从 `@rsbuild/core` 中导入 `defineConfig` 工具函数, 它提供了友好的 TypeScript 类型推导和自动补全，可以帮助你避免配置中的错误。
 


### PR DESCRIPTION
## Summary

- prioritize `rsbuild.config.ts` and `rsbuild.config.js` ahead of less common config variants during automatic config lookup
- keep the full set of supported config filenames unchanged while reducing extra filesystem checks in the common case
