### PR TITLE
refactor(core): resolve prefer-const lint errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@scripts/config": "workspace:*",
-    "@rslint/core": "^0.4.0",
+    "@rslint/core": "^0.4.1",
     "@rstest/adapter-rslib": "^0.2.2",
     "@rstest/core": "^0.9.6",
     "@scripts/test-helper": "workspace:*",

--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -417,9 +417,8 @@ async function printFileSizes(
     );
 
     for (const asset of assets) {
-      let { sizeLabel, sizeLabelLength, gzipSizeLabel } = asset;
-      const { filenameLength } = asset;
-      let { filenameLabel } = asset;
+      let { sizeLabel, filenameLabel } = asset;
+      const { sizeLabelLength, gzipSizeLabel, filenameLength } = asset;
 
       if (sizeLabelLength < maxSizeLength) {
         const rightPadding = ' '.repeat(maxSizeLength - sizeLabelLength);

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -211,9 +211,11 @@ export async function createDevServer<
     });
   };
 
-  let fileWatcher: WatchFilesResult | undefined;
-  let devMiddlewares: GetDevMiddlewaresResult | undefined;
-  let buildManager: BuildManager | undefined;
+  const state: {
+    fileWatcher?: WatchFilesResult;
+    devMiddlewares?: GetDevMiddlewaresResult;
+    buildManager?: BuildManager;
+  } = {};
 
   const cleanupGracefulShutdown = middlewareMode
     ? null
@@ -228,7 +230,10 @@ export async function createDevServer<
         removeCleanup(closeServer);
         cleanupGracefulShutdown?.();
         await context.hooks.onCloseDevServer.callBatch();
-        await Promise.all([devMiddlewares?.close(), fileWatcher?.close()]);
+        await Promise.all([
+          state.devMiddlewares?.close(),
+          state.fileWatcher?.close(),
+        ]);
       })();
     }
     return closingPromise;
@@ -280,29 +285,29 @@ export async function createDevServer<
     environmentAPI[environment.name] = {
       context: environment,
       getStats: async () => {
-        if (!buildManager) {
+        if (!state.buildManager) {
           throw new Error(getErrorMsg('getStats'));
         }
         await waitLastCompileDone;
         return lastStats[index];
       },
       loadBundle: async <T>(entryName: string) => {
-        if (!buildManager) {
+        if (!state.buildManager) {
           throw new Error(getErrorMsg('loadBundle'));
         }
         await waitLastCompileDone;
         return cacheableLoadBundle(lastStats[index], entryName, {
-          readFileSync: buildManager.readFileSync,
+          readFileSync: state.buildManager.readFileSync,
           environment,
         }) as T;
       },
       getTransformedHtml: async (entryName: string) => {
-        if (!buildManager) {
+        if (!state.buildManager) {
           throw new Error(getErrorMsg('getTransformedHtml'));
         }
         await waitLastCompileDone;
         return cacheableTransformedHtml(lastStats[index], entryName, {
-          readFileSync: buildManager.readFileSync,
+          readFileSync: state.buildManager.readFileSync,
           environment,
         });
       },
@@ -322,7 +327,7 @@ export async function createDevServer<
       });
 
   const sockWrite: SockWrite = (type, data) =>
-    buildManager?.socketServer.sockWrite({
+    state.buildManager?.socketServer.sockWrite({
       type,
       data,
     } as ServerMessage);
@@ -365,8 +370,8 @@ export async function createDevServer<
             // 404 fallback middleware should be the last middleware
             middlewares.use(notFoundMiddleware);
 
-            if (devMiddlewares) {
-              httpServer.on('upgrade', devMiddlewares.onUpgrade);
+            if (state.devMiddlewares) {
+              httpServer.on('upgrade', state.devMiddlewares.onUpgrade);
             }
 
             logger.debug('listen dev server done');
@@ -392,8 +397,8 @@ export async function createDevServer<
       });
     },
     connectWebSocket: ({ server }: { server: HTTPServer }) => {
-      if (devMiddlewares) {
-        server.on('upgrade', devMiddlewares.onUpgrade);
+      if (state.devMiddlewares) {
+        server.on('upgrade', state.devMiddlewares.onUpgrade);
       }
     },
     close: closeServer,
@@ -423,16 +428,16 @@ export async function createDevServer<
     await beforeCreateCompiler();
   }
 
-  buildManager = runCompile ? await startCompile() : undefined;
+  state.buildManager = runCompile ? await startCompile() : undefined;
 
-  fileWatcher = await setupWatchFiles({
+  state.fileWatcher = await setupWatchFiles({
     config,
-    buildManager,
+    buildManager: state.buildManager,
     root: context.rootPath,
   });
 
-  devMiddlewares = await getDevMiddlewares({
-    buildManager,
+  state.devMiddlewares = await getDevMiddlewares({
+    buildManager: state.buildManager,
     config,
     devServer,
     context,
@@ -440,7 +445,7 @@ export async function createDevServer<
   });
 
   // start watching
-  buildManager?.watch();
+  state.buildManager?.watch();
 
   logger.debug('create dev server done');
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
   .:
     devDependencies:
       '@rslint/core':
-        specifier: ^0.4.0
-        version: 0.4.0(jiti@2.6.1)
+        specifier: ^0.4.1
+        version: 0.4.1(jiti@2.6.1)
       '@rstest/adapter-rslib':
         specifier: ^0.2.2
         version: 0.2.2(@rslib/core@0.21.0)(@rstest/core@0.9.6)(typescript@6.0.2)
@@ -2182,8 +2182,8 @@ packages:
       typescript:
         optional: true
 
-  '@rslint/core@0.4.0':
-    resolution: {integrity: sha512-RoFnhoeTRx7ZY/4pD07F2XYCVI7qx5ocYLvtyhiFwqFXZF8Y1dZakehKlJBe8MpWQ7IQE/TIGcthdonzUJjUhQ==}
+  '@rslint/core@0.4.1':
+    resolution: {integrity: sha512-EaW6A6uvk9vDM3fV926gFUApowhmX6VrmJeHu+ENtnzBBW/nnJGs29tCNd2GKF8g7mbICnD4x9OMYS/UkgF/Ow==}
     hasBin: true
     peerDependencies:
       jiti: ^2.0.0
@@ -2191,33 +2191,33 @@ packages:
       jiti:
         optional: true
 
-  '@rslint/darwin-arm64@0.4.0':
-    resolution: {integrity: sha512-A7rueI2eUNtpBR7SIHRUOJ9cEyHnf3TvzFhKsav0U+s6nMkFUIDc4XFVlynwqhmH++53yoIGkjrlYLbVTOt0Jg==}
+  '@rslint/darwin-arm64@0.4.1':
+    resolution: {integrity: sha512-iUsS/W/ihy9iXC1IqT0MfZfLVK2Iykm4BkbDiMVgDGwCKP5vjQBZfc5eV/e2EOGF60SZbIu2LeD6QSyjOYeU9g==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rslint/darwin-x64@0.4.0':
-    resolution: {integrity: sha512-lrMm7F7OwFDTjG3ZH3ktfhXSAaAsg3z1ExXVme72X5Wrwf88bLo1yXDkCvUjBuWgfpdKGe2eTVaICToEhatE+g==}
+  '@rslint/darwin-x64@0.4.1':
+    resolution: {integrity: sha512-LKlBGS8eYjTDIdXNQSH7euYgbZxvaJR9LgZVP/+O33ky8hG0BDW1jbQ1oFm8DyQIARgIB01UOe9Lmdb88Z0LQA==}
     cpu: [x64]
     os: [darwin]
 
-  '@rslint/linux-arm64@0.4.0':
-    resolution: {integrity: sha512-+6XaVJ3KHjs3VUZ1/Q9OEKEhacxwQ7M1rhjal3mT2WxcqAaDU4zcXvCD1eA12YV5cP8NGaxNqKd0xaIxxQOmJg==}
+  '@rslint/linux-arm64@0.4.1':
+    resolution: {integrity: sha512-uJuy03rRGudGXgXLyvDmX5cLlXTO2It3NzA3G95rdXY52vyIRNrb1Z63yYw7+6MqycJnsnz8LKoDjgfWWqlDsQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@rslint/linux-x64@0.4.0':
-    resolution: {integrity: sha512-nDv0KQ9dff8BCUk+UtPj2QsR53XkwVI5lexH52g1l8viT67WvlmaT44wLSi93DqxqiP1lcy5ZGk7Annt84RztA==}
+  '@rslint/linux-x64@0.4.1':
+    resolution: {integrity: sha512-0VGYCgj82kZ8xJu5ximVO3u1fiA2zAzGRbhwFgjoThyIGiKFaIZhqc7wfEt/z1/aHlWRdIG1c+fWqlomh3U66w==}
     cpu: [x64]
     os: [linux]
 
-  '@rslint/win32-arm64@0.4.0':
-    resolution: {integrity: sha512-o8V+QGQMrf/xoL1ZDGdkbj5Bb9+BeJC71E5TK6snAOyJcDFQeJUjQzkxjdSidIvhQ/HqNDoIvFgcBUu01jRoAw==}
+  '@rslint/win32-arm64@0.4.1':
+    resolution: {integrity: sha512-BztIuv8PAWOGKtTu4T+idy7DMebTlLzdYtND+qt4ba4sIxgz0jEQujmK+zn3rNmu6lLhdVECPZQ6/z6hpIF5yw==}
     cpu: [arm64]
     os: [win32]
 
-  '@rslint/win32-x64@0.4.0':
-    resolution: {integrity: sha512-bfSiSkcVsLmKLnwHtUsb8OXc+ZxKB43Ll3URIFxY/qBv5Ea0OtGqAdaORc9ME0o1blYugsx1UCLWorJoMmE7TQ==}
+  '@rslint/win32-x64@0.4.1':
+    resolution: {integrity: sha512-a3KKGyVxf7lL4VE2v5MogQ29yocrA/24lUsEok2ZKXcdZMf/XRZV5BgXTIGNymnGo9H69QhR+aC1iNHU1Sal8w==}
     cpu: [x64]
     os: [win32]
 
@@ -7085,7 +7085,7 @@ snapshots:
       detect-libc: 2.1.2
       is-glob: 4.0.3
       node-addon-api: 7.1.1
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     optionalDependencies:
       '@parcel/watcher-android-arm64': 2.5.6
       '@parcel/watcher-darwin-arm64': 2.5.6
@@ -7416,34 +7416,34 @@ snapshots:
       - '@typescript/native-preview'
       - core-js
 
-  '@rslint/core@0.4.0(jiti@2.6.1)':
+  '@rslint/core@0.4.1(jiti@2.6.1)':
     dependencies:
       picomatch: 4.0.4
     optionalDependencies:
-      '@rslint/darwin-arm64': 0.4.0
-      '@rslint/darwin-x64': 0.4.0
-      '@rslint/linux-arm64': 0.4.0
-      '@rslint/linux-x64': 0.4.0
-      '@rslint/win32-arm64': 0.4.0
-      '@rslint/win32-x64': 0.4.0
+      '@rslint/darwin-arm64': 0.4.1
+      '@rslint/darwin-x64': 0.4.1
+      '@rslint/linux-arm64': 0.4.1
+      '@rslint/linux-x64': 0.4.1
+      '@rslint/win32-arm64': 0.4.1
+      '@rslint/win32-x64': 0.4.1
       jiti: 2.6.1
 
-  '@rslint/darwin-arm64@0.4.0':
+  '@rslint/darwin-arm64@0.4.1':
     optional: true
 
-  '@rslint/darwin-x64@0.4.0':
+  '@rslint/darwin-x64@0.4.1':
     optional: true
 
-  '@rslint/linux-arm64@0.4.0':
+  '@rslint/linux-arm64@0.4.1':
     optional: true
 
-  '@rslint/linux-x64@0.4.0':
+  '@rslint/linux-x64@0.4.1':
     optional: true
 
-  '@rslint/win32-arm64@0.4.0':
+  '@rslint/win32-arm64@0.4.1':
     optional: true
 
-  '@rslint/win32-x64@0.4.0':
+  '@rslint/win32-x64@0.4.1':
     optional: true
 
   '@rspack/binding-darwin-arm64@1.7.11':

--- a/rslint.config.ts
+++ b/rslint.config.ts
@@ -10,8 +10,6 @@ export default defineConfig([
     },
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
-      // TODO: Rslint bug
-      'prefer-const': 'off',
     },
   },
 ]);


### PR DESCRIPTION
## Summary

This PR fixes `prefer-const` lint errors in `packages/core` by narrowing mutable bindings in `fileSize` and grouping deferred dev server handles into a single `state` object.

## Related Links

None
