### PR TITLE
refactor(core): rename socket server send method

### DIFF
--- a/e2e/cases/javascript-api/server-custom-message/index.test.ts
+++ b/e2e/cases/javascript-api/server-custom-message/index.test.ts
@@ -1,14 +1,14 @@
 import path from 'node:path';
 import { expectPoll, test } from '@e2e/helper';
 
-test('should trigger the client HMR handler when dev server sends a custom message via `sockWrite`', async ({
+test('should trigger the client HMR handler when dev server sends a custom message', async ({
   page,
   dev,
 }) => {
   const { server } = await dev();
   const before = await page.evaluate<number>('window.__count');
 
-  server?.sockWrite('custom', { event: 'count' });
+  server?.environments.web.hot.send('custom', { event: 'count' });
 
   await expectPoll(() => page.evaluate<number>('window.__count')).toBe(
     before + 1,
@@ -35,7 +35,7 @@ test('should dispose old HMR event callbacks after page reload', async ({
 
   // 1) Trigger once and assert callback executed.
   const afterFirst = await page.evaluate<number>('window.__count');
-  server?.sockWrite('custom', { event: 'count' });
+  server?.environments.web.hot.send('custom', { event: 'count' });
   await expectPoll(() => page.evaluate<number>('window.__count')).toBe(
     afterFirst + 1,
   );
@@ -47,7 +47,7 @@ test('should dispose old HMR event callbacks after page reload', async ({
   await expectPoll(() => page.evaluate<number>('window.__count')).toBe(
     afterFirst + 1,
   );
-  server?.sockWrite('custom', { event: 'count' });
+  server?.environments.web.hot.send('custom', { event: 'count' });
   await expectPoll(() => page.evaluate<number>('window.__count')).toBe(
     afterFirst + 2,
   );

--- a/e2e/cases/server/setup-middlewares/index.test.ts
+++ b/e2e/cases/server/setup-middlewares/index.test.ts
@@ -28,7 +28,7 @@ test('should apply custom middleware via `server.setup`', async ({
   expect(count).toBeGreaterThanOrEqual(1);
 });
 
-test('should apply to trigger page reload via the `full-reload` type of sockWrite in server.setup', async ({
+test('should apply to trigger page reload via `environment.hot.send` in server.setup', async ({
   page,
   dev,
 }) => {
@@ -47,7 +47,7 @@ test('should apply to trigger page reload via the `full-reload` type of sockWrit
             count++;
             next();
           });
-          reloadPage = () => server.sockWrite('full-reload');
+          reloadPage = () => server.environments.web.hot.send('full-reload');
         },
       },
     },

--- a/packages/core/src/server/assets-middleware/index.ts
+++ b/packages/core/src/server/assets-middleware/index.ts
@@ -111,7 +111,7 @@ export const setupServerHooks = ({
       fileName.endsWith('.html') &&
       normalizeLiveReload(liveReload).html
     ) {
-      socketServer.sockWrite({ type: 'full-reload' }, token);
+      socketServer.sendMessage({ type: 'full-reload' }, token);
     }
   });
 

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -278,7 +278,7 @@ export async function createDevServer<
   const createHotSend =
     (token?: string): HotSend =>
     (type, data) =>
-      state.buildManager?.socketServer.sockWrite(
+      state.buildManager?.socketServer.sendMessage(
         {
           type,
           data,

--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -248,7 +248,7 @@ export class SocketServer {
       .join('\n\n')
       .trim();
 
-    this.sockWrite(
+    this.sendMessage(
       {
         type: 'errors',
         data: {
@@ -272,7 +272,7 @@ export class SocketServer {
         this.context.logger,
       ),
     );
-    this.sockWrite(
+    this.sendMessage(
       {
         type: 'warnings',
         data: { text: formattedWarnings },
@@ -282,17 +282,17 @@ export class SocketServer {
   }
 
   /**
-   * Write message to each socket
+   * Send a server message to matching client sockets.
    * @param message - The message to send
    * @param token - The token of the socket to send the message to,
    * if not provided, the message will be sent to all sockets
    */
-  public sockWrite(message: ServerMessage, token?: string): void {
+  public sendMessage(message: ServerMessage, token?: string): void {
     const messageStr = JSON.stringify(message);
 
     const sendToSockets = (sockets: Set<WebSocket>) => {
       for (const socket of sockets) {
-        this.send(socket, messageStr);
+        this.sendRawMessage(socket, messageStr);
       }
     };
 
@@ -413,7 +413,7 @@ export class SocketServer {
                     cachedTraceMap,
                   );
 
-            this.sockWrite(
+            this.sendMessage(
               {
                 type: 'resolved-client-error',
                 data: {
@@ -558,7 +558,7 @@ export class SocketServer {
     this.initialChunksMap.set(token, newInitialChunks);
 
     if (shouldReload) {
-      this.sockWrite({ type: 'full-reload' }, token);
+      this.sendMessage({ type: 'full-reload' }, token);
       return;
     }
 
@@ -574,11 +574,11 @@ export class SocketServer {
         warnings.length === 0 &&
         prevHash === stats.hash
       ) {
-        this.sockWrite({ type: 'ok' }, token);
+        this.sendMessage({ type: 'ok' }, token);
         return;
       }
 
-      this.sockWrite(
+      this.sendMessage(
         {
           type: 'hash',
           data: stats.hash,
@@ -597,11 +597,11 @@ export class SocketServer {
       return;
     }
 
-    this.sockWrite({ type: 'ok' }, token);
+    this.sendMessage({ type: 'ok' }, token);
   }
 
-  // send message to connecting socket
-  private send(socket: WebSocket, message: string) {
+  // send a serialized message to a specific socket
+  private sendRawMessage(socket: WebSocket, message: string) {
     if (socket.readyState !== socket.OPEN) {
       return;
     }

--- a/packages/core/src/server/watchFiles.ts
+++ b/packages/core/src/server/watchFiles.ts
@@ -169,7 +169,7 @@ async function startWatchFiles(
   const watcher = await createChokidar(paths, root, options);
 
   watcher.on('change', () => {
-    buildManager.socketServer.sockWrite({
+    buildManager.socketServer.sendMessage({
       type: 'full-reload',
     });
   });


### PR DESCRIPTION
## Summary

- rename the internal `SocketServer.sockWrite` method to `sendMessage` to better match its behavior of sending structured server messages to matching HMR clients
- update the internal call sites to use the new name
- switch non-legacy e2e cases to prefer `environment.web.hot.send`, while keeping the dedicated `sockWrite` compatibility coverage in place

## Related Links

None
