### PR TITLE
docs: clarify hot.send and sockWrite API docs

### DIFF
--- a/website/docs/en/api/javascript-api/environment-api.mdx
+++ b/website/docs/en/api/javascript-api/environment-api.mdx
@@ -229,7 +229,7 @@ type EnvironmentAPI = {
     loadBundle: <T = unknown>(entryName: string) => Promise<T>;
     getTransformedHtml: (entryName: string) => Promise<string>;
     hot: {
-      send: SockWrite;
+      send: HotSend;
     };
   };
 };

--- a/website/docs/en/api/javascript-api/environment-api.mdx
+++ b/website/docs/en/api/javascript-api/environment-api.mdx
@@ -317,18 +317,55 @@ This works the same as [server.sockWrite](/api/javascript-api/server-api#sockwri
 - **Type:**
 
 ```ts
-type SockWrite = {
+type HotSend = {
   (type: 'full-reload', data?: { path?: string }): void;
   (type: 'static-changed'): void;
   (type: 'custom', data: { event: string; data?: any }): void;
 };
 ```
 
-- **Example:**
+#### full-reload
+
+If you send a `'full-reload'` message, the page will reload.
+
+```ts
+if (someCondition) {
+  environments.web.hot.send('full-reload');
+}
+```
+
+When `path` is provided and ends with `.html`, Rsbuild only reloads the page whose current URL matches that HTML path in the current environment.
+
+When `path` is `'*'`, Rsbuild reloads all pages in the current environment.
+
+The HTML path should be relative to the dev server root and should not include `server.base`.
+
+```ts
+environments.web.hot.send('full-reload', {
+  path: '/foo.html',
+});
+```
+
+> `'static-changed'` is an alias of `'full-reload'`.
+
+#### custom
+
+You can also send custom messages via `custom` type with optional data to the browser and handle them via HMR events:
 
 ```ts
 environments.web.hot.send('custom', {
   event: 'count',
   data: { value: 1 },
 });
+```
+
+Rsbuild extends the `on()` method on Rspack’s [import.meta.webpackHot](https://rspack.rs/api/runtime-api/hmr) object. It allows you to listen for custom events in the browser and handle the associated data:
+
+```ts title="client.js"
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.on('count', (data) => {
+    console.log('count update', data.value);
+  });
+  import.meta.webpackHot.accept();
+}
 ```

--- a/website/docs/en/api/javascript-api/server-api.mdx
+++ b/website/docs/en/api/javascript-api/server-api.mdx
@@ -301,5 +301,5 @@ if (someCondition) {
 ```
 
 :::tip
-`sockWrite` is no longer the recommended API for sending messages. Prefer [hot.send](/api/javascript-api/environment-api#hotsend) instead.
+`sockWrite` is not the recommended API for sending messages. Prefer [hot.send](/api/javascript-api/environment-api#hotsend) instead.
 :::

--- a/website/docs/en/api/javascript-api/server-api.mdx
+++ b/website/docs/en/api/javascript-api/server-api.mdx
@@ -284,7 +284,7 @@ console.log(port, urls);
 - **Type:**
 
 ```ts
-type SockWrite = {
+type HotSend = {
   (type: 'full-reload', data?: { path?: string }): void;
   (type: 'static-changed'): void;
   (type: 'custom', data: { event: string; data?: any }): void;
@@ -293,10 +293,6 @@ type SockWrite = {
 
 Sends some message to HMR client, and then the HMR client will take different actions depending on the message type.
 
-#### full-reload
-
-If you send a `'full-reload'` message, the page will reload.
-
 ```ts
 const rsbuildServer = await rsbuild.createDevServer();
 if (someCondition) {
@@ -304,40 +300,6 @@ if (someCondition) {
 }
 ```
 
-When `path` is provided and ends with `.html`, Rsbuild only reloads the page whose current URL matches that HTML path.
-
-When `path` is `'*'`, Rsbuild reloads all pages.
-
-The HTML path should be relative to the dev server root and should not include `server.base`.
-
-```ts
-const rsbuildServer = await rsbuild.createDevServer();
-rsbuildServer.sockWrite('full-reload', {
-  path: '/foo.html',
-});
-```
-
-> `'static-changed'` is an alias of `'full-reload'`.
-
-#### custom
-
-You can also send custom messages via `custom` type with optional data to the browser and handle them via HMR events:
-
-```ts title="server.js"
-const rsbuildServer = await rsbuild.createDevServer();
-rsbuildServer.sockWrite('custom', {
-  event: 'count',
-  data: { value: 1 },
-});
-```
-
-Rsbuild extends the `on()` method on Rspack’s [import.meta.webpackHot](https://rspack.rs/api/runtime-api/hmr) object. It allows you to listen for custom events in the browser and handle the associated data:
-
-```ts title="client.js"
-if (import.meta.webpackHot) {
-  import.meta.webpackHot.on('count', (data) => {
-    console.log('count update', data.value);
-  });
-  import.meta.webpackHot.accept();
-}
-```
+:::tip
+`sockWrite` is no longer the recommended API for sending messages. Prefer [hot.send](/api/javascript-api/environment-api#hotsend) instead.
+:::

--- a/website/docs/zh/api/javascript-api/environment-api.mdx
+++ b/website/docs/zh/api/javascript-api/environment-api.mdx
@@ -230,7 +230,7 @@ type EnvironmentAPI = {
     loadBundle: <T = unknown>(entryName: string) => Promise<T>;
     getTransformedHtml: (entryName: string) => Promise<string>;
     hot: {
-      send: SockWrite;
+      send: HotSend;
     };
   };
 };

--- a/website/docs/zh/api/javascript-api/environment-api.mdx
+++ b/website/docs/zh/api/javascript-api/environment-api.mdx
@@ -318,18 +318,55 @@ const html = await environments.web.getTransformedHtml('main');
 - **类型：**
 
 ```ts
-type SockWrite = {
+type HotSend = {
   (type: 'full-reload', data?: { path?: string }): void;
   (type: 'static-changed'): void;
   (type: 'custom', data: { event: string; data?: any }): void;
 };
 ```
 
-- **示例：**
+#### full-reload
+
+如果你发送一个 `'full-reload'` 的消息，页面将会重新加载。
+
+```ts
+if (someCondition) {
+  environments.web.hot.send('full-reload');
+}
+```
+
+当传入 `path` 且它以 `.html` 结尾时，Rsbuild 只会重新加载当前 environment 中 URL 与该 HTML 路径匹配的页面。
+
+当 `path` 为 `'*'` 时，Rsbuild 会重新加载当前 environment 中的所有页面。
+
+HTML 路径应当相对于 dev server 根路径，并且不应包含 `server.base`。
+
+```ts
+environments.web.hot.send('full-reload', {
+  path: '/foo.html',
+});
+```
+
+> `'static-changed'` 是 `'full-reload'` 的一个别名。
+
+#### custom
+
+你也可以通过 `custom` 类型向浏览器发送自定义消息，并携带可选的 data，然后通过 HMR 事件进行处理：
 
 ```ts
 environments.web.hot.send('custom', {
   event: 'count',
   data: { value: 1 },
 });
+```
+
+Rsbuild 在 Rspack 的 [import.meta.webpackHot](https://rspack.rs/api/runtime-api/hmr) 对象上扩展了 `on()` 方法，它允许你在浏览器端监听自定义事件，并处理数据：
+
+```ts title="client.js"
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.on('count', (data) => {
+    console.log('count update', data.value);
+  });
+  import.meta.webpackHot.accept();
+}
 ```

--- a/website/docs/zh/api/javascript-api/server-api.mdx
+++ b/website/docs/zh/api/javascript-api/server-api.mdx
@@ -282,7 +282,7 @@ console.log(port, urls);
 - **类型:**
 
 ```ts
-type SockWrite = {
+type HotSend = {
   (type: 'full-reload', data?: { path?: string }): void;
   (type: 'static-changed'): void;
   (type: 'custom', data: { event: string; data?: any }): void;
@@ -291,10 +291,6 @@ type SockWrite = {
 
 向 HMR 客户端传递一些消息，HMR 客户端将根据接收到的消息类型进行不同的处理。
 
-#### full-reload
-
-如果你发送一个 `'full-reload'` 的消息，页面将会重新加载。
-
 ```ts
 const rsbuildServer = await rsbuild.createDevServer();
 if (someCondition) {
@@ -302,40 +298,6 @@ if (someCondition) {
 }
 ```
 
-当传入 `path` 且它以 `.html` 结尾时，Rsbuild 只会重新加载当前 URL 与该 HTML 路径匹配的页面。
-
-当 `path` 为 `'*'` 时，Rsbuild 会重新加载所有页面。
-
-HTML 路径应当相对于 dev server 根路径，并且不应包含 `server.base`。
-
-```ts
-const rsbuildServer = await rsbuild.createDevServer();
-rsbuildServer.sockWrite('full-reload', {
-  path: '/foo.html',
-});
-```
-
-> `'static-changed'` 是 `'full-reload'` 的一个别名。
-
-#### custom
-
-你也可以通过 `custom` 类型向浏览器发送自定义消息，并携带可选的 data，然后通过 HMR 事件进行处理：
-
-```ts title="server.js"
-const rsbuildServer = await rsbuild.createDevServer();
-rsbuildServer.sockWrite('custom', {
-  event: 'count',
-  data: { value: 1 },
-});
-```
-
-Rsbuild 在 Rspack 的 [import.meta.webpackHot](https://rspack.rs/api/runtime-api/hmr) 对象上扩展了 `on()` 方法，它允许你在浏览器端监听自定义事件，并处理数据：
-
-```ts title="client.js"
-if (import.meta.webpackHot) {
-  import.meta.webpackHot.on('count', (data) => {
-    console.log('count update', data.value);
-  });
-  import.meta.webpackHot.accept();
-}
-```
+:::tip
+不再是推荐使用 `sockWrite` 作为消息发送 API。建议优先使用 [hot.send](/api/javascript-api/environment-api#hotsend)。
+:::

--- a/website/docs/zh/api/javascript-api/server-api.mdx
+++ b/website/docs/zh/api/javascript-api/server-api.mdx
@@ -299,5 +299,5 @@ if (someCondition) {
 ```
 
 :::tip
-不再是推荐使用 `sockWrite` 作为消息发送 API。建议优先使用 [hot.send](/api/javascript-api/environment-api#hotsend)。
+不推荐使用 `sockWrite` 作为消息发送 API，建议优先使用 [hot.send](/api/javascript-api/environment-api#hotsend)。
 :::


### PR DESCRIPTION
## Summary

This PR clarifies the recommended JavaScript API for sending HMR messages. It moves the detailed `hot.send` documentation to the Environment API page, renames the exposed type to `HotSend`, and updates the `sockWrite` docs to point readers to the new recommended API.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/7475
- https://github.com/web-infra-dev/rsbuild/pull/7476