### PR TITLE
chore: use ESM cspell config

### DIFF
--- a/cspell.config.js
+++ b/cspell.config.js
@@ -1,6 +1,6 @@
-const { banWords } = require('cspell-ban-words');
+import { banWords } from 'cspell-ban-words';
 
-module.exports = {
+export default {
   version: '0.2',
   language: 'en',
   files: ['**/*.{ts,tsx,js,jsx,md,mdx}'],


### PR DESCRIPTION
## Summary

This PR renames the cspell config to `cspell.config.js` and switches it to ESM syntax so it matches the repo's root module type.

## Related Links

None
