### PR TITLE
test(e2e): add loadBundle CJS runner coverage

### DIFF
--- a/e2e/cases/server/load-bundle-cjs/index.test.ts
+++ b/e2e/cases/server/load-bundle-cjs/index.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '@e2e/helper';
+
+test('should load CJS bundle with runtime globals', async ({
+  devOnly,
+  request,
+}) => {
+  const rsbuild = await devOnly();
+  const baseUrl = `http://localhost:${rsbuild.port}`;
+
+  const response1 = await request.get(`${baseUrl}/check`);
+  const response2 = await request.get(`${baseUrl}/check`);
+
+  expect(response1.status()).toBe(200);
+  expect(await response1.text()).toBe('index.js:function');
+  expect(await response2.text()).toBe('index.js:function');
+
+  expect(
+    rsbuild.logs.filter((log) => log.includes('load bundle cjs')).length,
+  ).toBe(1);
+});

--- a/e2e/cases/server/load-bundle-cjs/rsbuild.config.ts
+++ b/e2e/cases/server/load-bundle-cjs/rsbuild.config.ts
@@ -1,0 +1,51 @@
+import { defineConfig, type RequestHandler } from '@rsbuild/core';
+
+export default defineConfig({
+  server: {
+    setup: ({ action, server }) => {
+      if (action !== 'dev') {
+        return;
+      }
+
+      const middleware: RequestHandler = async (req, res, next) => {
+        if (req.method !== 'GET' || req.url !== '/check') {
+          next();
+          return;
+        }
+
+        try {
+          const bundle = await server.environments.node.loadBundle<{
+            getPayload: () => Promise<string>;
+          }>('index');
+
+          res.setHeader('Content-Type', 'text/plain');
+          res.end(await bundle.getPayload());
+        } catch (error) {
+          res.statusCode = 500;
+          res.end(String(error));
+        }
+      };
+
+      server.middlewares.use(middleware);
+    },
+  },
+  environments: {
+    web: {
+      source: {
+        entry: {
+          index: './src/index.js',
+        },
+      },
+    },
+    node: {
+      output: {
+        target: 'node',
+      },
+      source: {
+        entry: {
+          index: './src/index.server.cjs',
+        },
+      },
+    },
+  },
+});

--- a/e2e/cases/server/load-bundle-cjs/rsbuild.config.ts
+++ b/e2e/cases/server/load-bundle-cjs/rsbuild.config.ts
@@ -40,6 +40,7 @@ export default defineConfig({
     node: {
       output: {
         target: 'node',
+        module: false,
       },
       source: {
         entry: {

--- a/e2e/cases/server/load-bundle-cjs/src/index.js
+++ b/e2e/cases/server/load-bundle-cjs/src/index.js
@@ -1,0 +1,1 @@
+document.body.innerHTML = '<div id="root">load-bundle-cjs</div>';

--- a/e2e/cases/server/load-bundle-cjs/src/index.server.cjs
+++ b/e2e/cases/server/load-bundle-cjs/src/index.server.cjs
@@ -1,0 +1,8 @@
+console.log('load bundle cjs');
+
+module.exports.getPayload = async function getPayload() {
+  const path = await import('node:path');
+
+  // Check that queueMicrotask is available inside the loaded CJS bundle.
+  return `${path.basename('/tmp/index.js')}:${typeof queueMicrotask}`;
+};


### PR DESCRIPTION
## Summary

- add a focused server e2e case for `environments.node.loadBundle()` on a CommonJS bundle
- verify the loaded bundle can run with dynamic `import()` and access runner-provided globals like `queueMicrotask`
- keep the case minimal by checking the `/check` response and the existing bundle cache behavior

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/7485