### PR TITLE
docs: clarify runtime-tools dependency in module federation docs

### DIFF
--- a/website/docs/en/config/module-federation/options.mdx
+++ b/website/docs/en/config/module-federation/options.mdx
@@ -2,6 +2,8 @@
 description: "Used to configure the Rspack's Module Federation plugin (Module Federation v1.5)."
 ---
 
+import { PackageManagerTabs } from '@theme';
+
 # moduleFederation.options
 
 - **Type:** [Rspack.ModuleFederationPluginOptions](https://rspack.rs/plugins/webpack/module-federation-plugin#options)
@@ -38,7 +40,11 @@ export default defineConfig({
 });
 ```
 
-Please refer to the [ModuleFederationPlugin](https://rspack.rs/plugins/webpack/module-federation-plugin) document for all available options.
+This option depends on the runtime package [@module-federation/runtime-tools](https://www.npmjs.com/package/@module-federation/runtime-tools), which provides runtime support for Module Federation. Install it first:
+
+<PackageManagerTabs command="add @module-federation/runtime-tools" />
+
+> Refer to the [ModuleFederationPlugin](https://rspack.rs/plugins/webpack/module-federation-plugin) document for all available options.
 
 ## Example
 

--- a/website/docs/en/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/en/guide/upgrade/v1-to-v2.mdx
@@ -117,7 +117,7 @@ If you enabled [output.polyfill](/config/output/polyfill), install `core-js` v3 
 
 ### Module Federation
 
-If you use the [moduleFederation.options](/config/module-federation/options) option, install `@module-federation/runtime-tools` manually in your project. In Rsbuild v2, it is now an optional peer dependency:
+If you use the [moduleFederation.options](/config/module-federation/options) option, install `@module-federation/runtime-tools` manually in your project. In Rsbuild v2, it is an optional peer dependency of `@rspack/core`:
 
 <PackageManagerTabs command="add @module-federation/runtime-tools" />
 

--- a/website/docs/en/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/en/guide/upgrade/v1-to-v2.mdx
@@ -105,13 +105,23 @@ In Node.js 20 and later, the runtime natively supports loading ESM modules via [
 
 > This does not affect Rsbuild's ability to build CommonJS output. All related build behavior and configuration options remain unchanged.
 
-## Polyfill dependency change
+## Dependencies change
 
-[core-js](https://www.npmjs.com/package/core-js) has been changed from a default dependency of `@rsbuild/core` to an optional peer dependency, which reduces the installation size by 1.2 MB.
+### Polyfill
+
+[core-js](https://www.npmjs.com/package/core-js) polyfill has been changed from a default dependency of `@rsbuild/core` to an optional peer dependency, which reduces the installation size by 1.2 MB.
 
 If you enabled [output.polyfill](/config/output/polyfill), install `core-js` v3 in your project:
 
 <PackageManagerTabs command="add core-js" />
+
+### Module Federation
+
+If you use the [moduleFederation.options](/config/module-federation/options) option, install `@module-federation/runtime-tools` manually in your project. In Rsbuild v2, it is now an optional peer dependency:
+
+<PackageManagerTabs command="add @module-federation/runtime-tools" />
+
+This change only affects projects that use Module Federation v1.5 through `moduleFederation.options`. If you are using Module Federation v2, no action is required.
 
 ## Configuration
 

--- a/website/docs/en/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/en/guide/upgrade/v1-to-v2.mdx
@@ -105,7 +105,7 @@ In Node.js 20 and later, the runtime natively supports loading ESM modules via [
 
 > This does not affect Rsbuild's ability to build CommonJS output. All related build behavior and configuration options remain unchanged.
 
-## Dependencies change
+## Dependency changes
 
 ### Polyfill
 

--- a/website/docs/en/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/en/guide/upgrade/v1-to-v2.mdx
@@ -117,7 +117,7 @@ If you enabled [output.polyfill](/config/output/polyfill), install `core-js` v3 
 
 ### Module Federation
 
-If you use the [moduleFederation.options](/config/module-federation/options) option, install `@module-federation/runtime-tools` manually in your project. In Rsbuild v2, it is an optional peer dependency of `@rspack/core`:
+If you use the [moduleFederation.options](/config/module-federation/options) option, install [@module-federation/runtime-tools](https://www.npmjs.com/package/@module-federation/runtime-tools) manually in your project, it is an optional peer dependency of `@rspack/core`:
 
 <PackageManagerTabs command="add @module-federation/runtime-tools" />
 

--- a/website/docs/zh/config/module-federation/options.mdx
+++ b/website/docs/zh/config/module-federation/options.mdx
@@ -2,6 +2,8 @@
 description: '用于配置 Rspack 模块联邦插件（对应模块联邦 v1.5）。'
 ---
 
+import { PackageManagerTabs } from '@theme';
+
 # moduleFederation.options
 
 - **类型：** [Rspack.ModuleFederationPluginOptions](https://rspack.rs/zh/plugins/webpack/module-federation-plugin#options)
@@ -38,7 +40,11 @@ export default defineConfig({
 });
 ```
 
-请参考 [ModuleFederationPlugin](https://rspack.rs/zh/plugins/webpack/module-federation-plugin) 文档来了解所有可用的选项。
+该选项依赖运行时包 [@module-federation/runtime-tools](https://www.npmjs.com/package/@module-federation/runtime-tools)，用于提供模块联邦的运行时支持。请先安装该依赖：
+
+<PackageManagerTabs command="add @module-federation/runtime-tools" />
+
+> 参考 [ModuleFederationPlugin](https://rspack.rs/zh/plugins/webpack/module-federation-plugin) 文档来了解所有可用的选项。
 
 ## 示例
 

--- a/website/docs/zh/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/zh/guide/upgrade/v1-to-v2.mdx
@@ -117,7 +117,7 @@ Rsbuild 2.0 最低支持的 Node.js 版本为 20.19+ 或 22.12+，不再支持 N
 
 ### Module Federation
 
-如果你使用了 [moduleFederation.options](/config/module-federation/options) 选项，请在项目中手动安装 `@module-federation/runtime-tools`。在 Rsbuild v2 中，它现在是 `@rspack/core` 的 optional peer 依赖：
+如果你使用了 [moduleFederation.options](/config/module-federation/options) 选项，请在项目中手动安装 [@module-federation/runtime-tools](https://www.npmjs.com/package/@module-federation/runtime-tools)，它现在是 `@rspack/core` 的 optional peer 依赖：
 
 <PackageManagerTabs command="add @module-federation/runtime-tools" />
 

--- a/website/docs/zh/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/zh/guide/upgrade/v1-to-v2.mdx
@@ -105,13 +105,23 @@ Rsbuild 2.0 最低支持的 Node.js 版本为 20.19+ 或 22.12+，不再支持 N
 
 > 这一变更不影响 Rsbuild 构建 CommonJS 产物的能力，相关的构建行为和配置方式也保持不变。
 
-## Polyfill 依赖变更
+## 依赖变更
 
-[core-js](https://www.npmjs.com/package/core-js) 从 `@rsbuild/core` 的默认依赖变更为可选的 peer 依赖，这减少了 1.2MB 的安装体积。
+### Polyfill
+
+[core-js](https://www.npmjs.com/package/core-js) polyfill 从 `@rsbuild/core` 的默认依赖变更为可选的 peer 依赖，这减少了 1.2MB 的安装体积。
 
 如果你启用了 [output.polyfill](/config/output/polyfill)，请在项目中安装 `core-js` v3：
 
 <PackageManagerTabs command="add core-js" />
+
+### Module Federation
+
+如果你使用了 [moduleFederation.options](/config/module-federation/options) 选项，请在项目中手动安装 `@module-federation/runtime-tools`。在 Rsbuild v2 中，它现在是一个 optional peer 依赖：
+
+<PackageManagerTabs command="add @module-federation/runtime-tools" />
+
+这一变更仅影响通过 `moduleFederation.options` 使用 Module Federation v1.5 的项目。如果你使用的是 Module Federation v2，则不受影响。
 
 ## 配置
 

--- a/website/docs/zh/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/zh/guide/upgrade/v1-to-v2.mdx
@@ -117,7 +117,7 @@ Rsbuild 2.0 最低支持的 Node.js 版本为 20.19+ 或 22.12+，不再支持 N
 
 ### Module Federation
 
-如果你使用了 [moduleFederation.options](/config/module-federation/options) 选项，请在项目中手动安装 `@module-federation/runtime-tools`。在 Rsbuild v2 中，它现在是一个 optional peer 依赖：
+如果你使用了 [moduleFederation.options](/config/module-federation/options) 选项，请在项目中手动安装 `@module-federation/runtime-tools`。在 Rsbuild v2 中，它现在是 `@rspack/core` 的 optional peer 依赖：
 
 <PackageManagerTabs command="add @module-federation/runtime-tools" />
 


### PR DESCRIPTION
## Summary

- clarify that `@module-federation/runtime-tools` must be installed when using `moduleFederation.options`
- add the same upgrade note to the v1-to-v2 migration guide in both English and Chinese docs

## Related Links

- None
