### PR TITLE
feat(create-rsbuild): add rstest-best-practices skill entry

### DIFF
--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -27,7 +27,7 @@
     "start": "node ./dist/index.js"
   },
   "dependencies": {
-    "create-rstack": "1.9.1"
+    "create-rstack": "1.9.2"
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",

--- a/packages/create-rsbuild/src/index.ts
+++ b/packages/create-rsbuild/src/index.ts
@@ -28,7 +28,7 @@ async function getTemplateName({ template }: Argv) {
       message: 'Select framework',
       options: [
         { value: 'vanilla', label: 'Vanilla' },
-        { value: 'react', label: 'React 19' },
+        { value: 'react', label: 'React' },
         { value: 'vue3', label: 'Vue 3' },
         { value: 'vue2', label: 'Vue 2' },
         { value: 'lit', label: 'Lit' },
@@ -174,6 +174,11 @@ create({
     {
       value: 'rsbuild-best-practices',
       label: 'Rsbuild - best practices',
+      source: 'rstackjs/agent-skills',
+    },
+    {
+      value: 'rstest-best-practices',
+      label: 'Rstest - best practices',
       source: 'rstackjs/agent-skills',
     },
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -625,8 +625,8 @@ importers:
   packages/create-rsbuild:
     dependencies:
       create-rstack:
-        specifier: 1.9.1
-        version: 1.9.1
+        specifier: 1.9.2
+        version: 1.9.2
     devDependencies:
       '@rsbuild/core':
         specifier: workspace:*
@@ -3429,8 +3429,8 @@ packages:
       typescript:
         optional: true
 
-  create-rstack@1.9.1:
-    resolution: {integrity: sha512-93fIyIqIrwisw7IvjwZ1NhaE58xylnpWPK1JIZaTRtNDRSwWtdAyGbP9HuACU4rZm/HohN8BU7DAmxGbPK9CBA==}
+  create-rstack@1.9.2:
+    resolution: {integrity: sha512-nN4ThiyEZ/hRgafQRlLDoxJnoBa1m3SErwzxsqUg0Zr5bSQ5DREBhcEOsd7NNbfM4Z6GJAAqJvPge7cwtuFmCQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   cron-parser@4.9.0:
@@ -8477,7 +8477,7 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.2
 
-  create-rstack@1.9.1: {}
+  create-rstack@1.9.2: {}
 
   cron-parser@4.9.0:
     dependencies:

--- a/website/docs/en/guide/framework/react.mdx
+++ b/website/docs/en/guide/framework/react.mdx
@@ -21,7 +21,7 @@ import { PackageManagerTabs } from '@theme';
   }}
 />
 
-Then select `React 19` when prompted to "Select framework".
+Then select `React` when prompted to "Select framework".
 
 ## Use React in an existing project
 

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -59,7 +59,7 @@ When creating an application, you can choose from the following templates provid
 | Template | Official docs                   | Rsbuild integration guide               |
 | -------- | ------------------------------- | --------------------------------------- |
 | vanilla  | Native JavaScript               | -                                       |
-| react    | [React 19](https://react.dev/)  | [Using React](/guide/framework/react)   |
+| react    | [React](https://react.dev/)     | [Using React](/guide/framework/react)   |
 | vue      | [Vue 3](https://vuejs.org/)     | [Using Vue](/guide/framework/vue)       |
 | vue2     | [Vue 2](https://v2.vuejs.org/)  | [Using Vue](/guide/framework/vue)       |
 | lit      | [Lit](https://lit.dev/)         | -                                       |

--- a/website/docs/zh/guide/framework/react.mdx
+++ b/website/docs/zh/guide/framework/react.mdx
@@ -21,7 +21,7 @@ import { PackageManagerTabs } from '@theme';
   }}
 />
 
-然后在 `Select framework` 时选择 `React 19` 即可。
+然后在 `Select framework` 时选择 `React` 即可。
 
 ## 在已有项目中使用 React
 

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -59,7 +59,7 @@ import { PackageManagerTabs } from '@theme';
 | 模板    | 官方文档                        | Rsbuild 集成指南                       |
 | ------- | ------------------------------- | -------------------------------------- |
 | vanilla | 原生 JavaScript                 | -                                      |
-| react   | [React 19](https://react.dev/)  | [使用 React](/guide/framework/react)   |
+| react   | [React](https://react.dev/)     | [使用 React](/guide/framework/react)   |
 | vue     | [Vue 3](https://vuejs.org/)     | [使用 Vue](/guide/framework/vue)       |
 | vue2    | [Vue 2](https://v2.vuejs.org/)  | [使用 Vue](/guide/framework/vue)       |
 | lit     | [Lit](https://lit.dev/)         | -                                      |


### PR DESCRIPTION
## Summary

- update `create-rsbuild` to use `create-rstack@1.9.2`
- sync the interactive React template label and add the `rstest-best-practices` agent skill entry
- align the quick start docs with the updated React template label

## Related Links

- https://github.com/rstackjs/create-rstack/releases/tag/v1.9.2
