### PR TITLE
chore: remove ignored dependencies from renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -80,8 +80,6 @@
   ignoreDeps: [
     // manually handle updates
     'node',
-    '@rspack/core',
-    '@rsbuild/core',
     // some loaders still depend on loader-utils v2
     'loader-utils',
   ],


### PR DESCRIPTION
## Summary

Removing `@rspack/core` and `@rsbuild/core` from the list of dependencies to be ignored by Renovate.