### PR TITLE
feat(create-rsbuild): support create-rstack 2.0.0

### DIFF
--- a/e2e/cases/css/css-modules-export-locals/index.test.ts
+++ b/e2e/cases/css/css-modules-export-locals/index.test.ts
@@ -2,7 +2,7 @@ import { type BuildResult, expect, getFileContent, test } from '@e2e/helper';
 
 declare global {
   interface Window {
-    [key: string]: Record<string, string>;
+    styles: Record<string, string>;
   }
 }
 

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -27,7 +27,7 @@
     "start": "node ./dist/index.js"
   },
   "dependencies": {
-    "create-rstack": "1.9.2"
+    "create-rstack": "2.0.0"
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",

--- a/packages/create-rsbuild/src/index.ts
+++ b/packages/create-rsbuild/src/index.ts
@@ -128,7 +128,8 @@ create({
       value: 'react-compiler',
       label: 'React Compiler - optimization',
       order: 'pre',
-      when: (template) => template === 'react-js' || template === 'react-ts',
+      when: ({ templateName }) =>
+        templateName === 'react-js' || templateName === 'react-ts',
       action: ({ templateName, distFolder }) => {
         const toolFolder = path.join(root, 'template-react-compiler');
         copyFolder({

--- a/packages/create-rsbuild/src/index.ts
+++ b/packages/create-rsbuild/src/index.ts
@@ -129,7 +129,7 @@ create({
       label: 'React Compiler - optimization',
       order: 'pre',
       when: ({ templateName }) =>
-        templateName === 'react-js' || templateName === 'react-ts',
+        ['react-js', 'react-ts'].includes(templateName),
       action: ({ templateName, distFolder }) => {
         const toolFolder = path.join(root, 'template-react-compiler');
         copyFolder({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -625,8 +625,8 @@ importers:
   packages/create-rsbuild:
     dependencies:
       create-rstack:
-        specifier: 1.9.2
-        version: 1.9.2
+        specifier: 2.0.0
+        version: 2.0.0
     devDependencies:
       '@rsbuild/core':
         specifier: workspace:*
@@ -3481,8 +3481,8 @@ packages:
       typescript:
         optional: true
 
-  create-rstack@1.9.2:
-    resolution: {integrity: sha512-nN4ThiyEZ/hRgafQRlLDoxJnoBa1m3SErwzxsqUg0Zr5bSQ5DREBhcEOsd7NNbfM4Z6GJAAqJvPge7cwtuFmCQ==}
+  create-rstack@2.0.0:
+    resolution: {integrity: sha512-4VCqXXBL94CoogOFwCA1DHAg6q4MMSXqMkr7daIQLfQnvcl5UHyTzFVxXyjU2rp4eNaDGMgWZWmBE4dEDdBVnA==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   cron-parser@4.9.0:
@@ -8482,7 +8482,7 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.2
 
-  create-rstack@1.9.2: {}
+  create-rstack@2.0.0: {}
 
   cron-parser@4.9.0:
     dependencies:


### PR DESCRIPTION
## Summary

Upgrade `create-rstack` to `2.0.0` in `create-rsbuild`, adapt the `react-compiler` tool condition to the new callback context, and align the CSS Modules e2e typing with `window.styles`.

## Related Links

https://github.com/rstackjs/create-rstack/releases/tag/v2.0.0