### PR TITLE
chore: use rslint for type checking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,3 @@ jobs:
       - name: Run E2E tests
         if: steps.changes.outputs.changed == 'true'
         run: node --run e2e
-
-      - name: Run E2E type checker
-        if: steps.changes.outputs.changed == 'true'
-        run: cd e2e && node --run type-check

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -7,6 +7,7 @@ This folder contains the E2E test cases of Rsbuild. The E2E suite is powered by 
 - `cases`: Test cases covering different Rsbuild features.
 - `assets`: Common static assets, can be accessed using the `@e2e/assets` package.
 - `scripts`: Shared helpers, can be accessed using the `@e2e/helper` package.
+- `type-tests`: Test cases for type checking, checked via `rslint --type-check`.
 
 ## Commands
 

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -5,8 +5,7 @@
   "version": "1.0.0",
   "scripts": {
     "setup": "pnpm exec playwright install chromium --with-deps",
-    "e2e": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules --no-warnings\" playwright test",
-    "type-check": "tsc && pnpm run --filter @type-tests/* type-check"
+    "e2e": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules --no-warnings\" playwright test"
   },
   "dependencies": {
     "@module-federation/runtime-tools": "2.3.2",

--- a/e2e/type-tests/resolution-bundler/package.json
+++ b/e2e/type-tests/resolution-bundler/package.json
@@ -1,8 +1,5 @@
 {
   "name": "@type-tests/resolution-bundler",
   "private": true,
-  "type": "module",
-  "scripts": {
-    "type-check": "tsc --noEmit"
-  }
+  "type": "module"
 }

--- a/e2e/type-tests/resolution-nodenext/package.json
+++ b/e2e/type-tests/resolution-nodenext/package.json
@@ -1,8 +1,5 @@
 {
   "name": "@type-tests/resolution-nodenext",
   "private": true,
-  "type": "module",
-  "scripts": {
-    "type-check": "tsc --noEmit"
-  }
+  "type": "module"
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "doc": "cd website && node --run dev",
     "e2e": "cd ./e2e && pnpm e2e",
     "format": "prettier --experimental-cli --write . && heading-case --write",
-    "lint": "rslint",
+    "lint": "rslint --type-check",
     "prebundle": "pnpm --parallel --filter \"./packages/*\" run prebundle",
     "prepare": "simple-git-hooks && node --run prebundle && node --run build",
     "sort-package-json": "pnpx sort-package-json \"./package.json\" \"packages/*/package.json\"",
@@ -25,7 +25,7 @@
   "nano-staged": {
     "*.{md,mdx,json,css,less,scss}": "prettier --experimental-cli --write",
     "*.{js,jsx,ts,tsx,mjs,cjs}": [
-      "rslint",
+      "rslint --type-check",
       "prettier --experimental-cli --write"
     ]
   },

--- a/rslint.config.ts
+++ b/rslint.config.ts
@@ -5,7 +5,12 @@ export default defineConfig([
   {
     languageOptions: {
       parserOptions: {
-        project: ['./packages/*/tsconfig.json', './e2e/tsconfig.json'],
+        project: [
+          './packages/*/tsconfig.json',
+          './examples/*/tsconfig.json',
+          './e2e/tsconfig.json',
+          './e2e/type-tests/*/tsconfig.json',
+        ],
       },
     },
     rules: {

--- a/rslint.config.ts
+++ b/rslint.config.ts
@@ -7,6 +7,7 @@ export default defineConfig([
       parserOptions: {
         project: [
           './packages/*/tsconfig.json',
+          './scripts/*/tsconfig.json',
           './examples/*/tsconfig.json',
           './e2e/tsconfig.json',
           './e2e/type-tests/*/tsconfig.json',


### PR DESCRIPTION
## Summary

- Consolidate type checking under `rslint --type-check` so the root lint workflow also covers `examples` and `e2e/type-tests`.
- Remove the redundant E2E type-check scripts and CI job now that the lint entrypoint performs the same validation.

## Related Links

- https://rslint.rs/guide/type-checking
