### PR TITLE
fix(create-rsbuild): gate rstest skill by selected tools

### DIFF
--- a/packages/create-rsbuild/src/index.ts
+++ b/packages/create-rsbuild/src/index.ts
@@ -181,6 +181,7 @@ create({
       value: 'rstest-best-practices',
       label: 'Rstest - best practices',
       source: 'rstackjs/agent-skills',
+      when: ({ tools }) => tools.includes('rstest'),
     },
   ],
 });


### PR DESCRIPTION
## Summary

- Hide the `rstest-best-practices` extra skill unless `rstest` is selected in `create-rsbuild`.
- Keep the suggested skills aligned with the chosen tools so unrelated rstest guidance is not shown.

## Related Links

None
