### PR TITLE
feat(create-rsbuild): add react best practices skill

### DIFF
--- a/packages/create-rsbuild/src/index.ts
+++ b/packages/create-rsbuild/src/index.ts
@@ -186,7 +186,7 @@ create({
       value: 'vercel-react-best-practices',
       label: 'React best practices',
       source: 'vercel-labs/agent-skills',
-      when: ({ templateName }) => templateName.includes('react'),
+      when: ({ templateName }) => templateName.startsWith('react-'),
     },
   ],
 });

--- a/packages/create-rsbuild/src/index.ts
+++ b/packages/create-rsbuild/src/index.ts
@@ -173,14 +173,20 @@ create({
   extraSkills: [
     {
       value: 'rsbuild-best-practices',
-      label: 'Rsbuild - best practices',
+      label: 'Rsbuild best practices',
       source: 'rstackjs/agent-skills',
     },
     {
       value: 'rstest-best-practices',
-      label: 'Rstest - best practices',
+      label: 'Rstest best practices',
       source: 'rstackjs/agent-skills',
       when: ({ tools }) => tools.includes('rstest'),
+    },
+    {
+      value: 'vercel-react-best-practices',
+      label: 'React best practices',
+      source: 'vercel-labs/agent-skills',
+      when: ({ templateName }) => templateName.includes('react'),
     },
   ],
 });


### PR DESCRIPTION
## Summary

- add the `vercel-react-best-practices` extra skill for React templates in `create-rsbuild`
- normalize the existing best-practices labels for consistency
