### PR TITLE
chore: normalize tsconfig output paths

### DIFF
--- a/e2e/cases/css/css-modules-dom/tsconfig.json
+++ b/e2e/cases/css/css-modules-dom/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@scripts/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "outDir": "./dist"
+    "outDir": "dist"
   },
   "include": ["src", "tests", "index.test.ts"]
 }

--- a/e2e/cases/css/inject-styles/tsconfig.json
+++ b/e2e/cases/css/inject-styles/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@scripts/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "outDir": "./dist"
+    "outDir": "dist"
   },
   "include": ["src", "tests"]
 }

--- a/e2e/cases/css/resolve-ts-paths/tsconfig.json
+++ b/e2e/cases/css/resolve-ts-paths/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@scripts/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "outDir": "./dist",
+    "outDir": "dist",
     "paths": {
       "src/*": ["./src/*"]
     }

--- a/e2e/cases/html/minify/tsconfig.json
+++ b/e2e/cases/html/minify/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@scripts/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "outDir": "./dist"
+    "outDir": "dist"
   },
   "include": ["src"]
 }

--- a/e2e/cases/optimization/inline-const/tsconfig.json
+++ b/e2e/cases/optimization/inline-const/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@scripts/config/tsconfig",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "dist"
   },
   "include": ["src", "*.test.ts"]
 }

--- a/e2e/cases/performance/resource-hints-prefetch/tsconfig.json
+++ b/e2e/cases/performance/resource-hints-prefetch/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@scripts/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "outDir": "./dist"
+    "outDir": "dist"
   },
   "include": ["src", "index.test.ts"]
 }

--- a/e2e/cases/performance/resource-hints-preload/tsconfig.json
+++ b/e2e/cases/performance/resource-hints-preload/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@scripts/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "outDir": "./dist"
+    "outDir": "dist"
   },
   "include": ["src", "index.test.ts"]
 }

--- a/e2e/cases/plugin-babel/decorator/tsconfig.json
+++ b/e2e/cases/plugin-babel/decorator/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@scripts/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "outDir": "./dist",
+    "outDir": "dist",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/e2e/cases/plugin-react/disable-fast-refresh/tsconfig.json
+++ b/e2e/cases/plugin-react/disable-fast-refresh/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@scripts/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "outDir": "./dist"
+    "outDir": "dist"
   },
   "include": ["src"]
 }

--- a/e2e/cases/resolve/extension-alias-js/tsconfig.json
+++ b/e2e/cases/resolve/extension-alias-js/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@scripts/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "outDir": "./dist",
+    "outDir": "dist",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/e2e/cases/resolve/extension-alias-jsx/tsconfig.json
+++ b/e2e/cases/resolve/extension-alias-jsx/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@scripts/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "outDir": "./dist",
+    "outDir": "dist",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/e2e/cases/resolve/jsconfig-paths/jsconfig.json
+++ b/e2e/cases/resolve/jsconfig-paths/jsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@scripts/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "outDir": "./dist",
+    "outDir": "dist",
     "paths": {
       "@/common/*": ["./src/common/*"]
     }

--- a/e2e/cases/resolve/tsconfig-paths-references/tsconfig.app.json
+++ b/e2e/cases/resolve/tsconfig-paths-references/tsconfig.app.json
@@ -2,7 +2,7 @@
   "extends": "@scripts/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "outDir": "./dist",
+    "outDir": "dist",
     "paths": {
       "@/common/*": ["./src/common/*"]
     }

--- a/e2e/cases/resolve/tsconfig-paths-reload/tsconfig.json
+++ b/e2e/cases/resolve/tsconfig-paths-reload/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@scripts/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "outDir": "./dist",
+    "outDir": "dist",
     "paths": {
       "@/content": ["./src/foo/test.ts"]
     }

--- a/e2e/cases/resolve/tsconfig-paths-specify-config/tsconfig.custom.json
+++ b/e2e/cases/resolve/tsconfig-paths-specify-config/tsconfig.custom.json
@@ -2,7 +2,7 @@
   "extends": "@scripts/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "outDir": "./dist",
+    "outDir": "dist",
     "paths": {
       "@/common/*": ["./src/common/*"]
     }

--- a/e2e/cases/resolve/tsconfig-paths-specify-config/tsconfig.json
+++ b/e2e/cases/resolve/tsconfig-paths-specify-config/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@scripts/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "outDir": "./dist"
+    "outDir": "dist"
   },
   "include": ["src"]
 }

--- a/e2e/cases/resolve/tsconfig-paths/tsconfig.json
+++ b/e2e/cases/resolve/tsconfig-paths/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@scripts/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "outDir": "./dist",
+    "outDir": "dist",
     "paths": {
       "@/common/*": ["./src/common/*"]
     }

--- a/e2e/cases/source/define/tsconfig.json
+++ b/e2e/cases/source/define/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@scripts/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "outDir": "./dist",
+    "outDir": "dist",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/e2e/cases/syntax-es/top-level-await/tsconfig.json
+++ b/e2e/cases/syntax-es/top-level-await/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@scripts/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "outDir": "./dist",
+    "outDir": "dist",
     "module": "ES2022",
     "target": "ES2017",
     "paths": {

--- a/e2e/cases/syntax-es/using-declaration/tsconfig.json
+++ b/e2e/cases/syntax-es/using-declaration/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@scripts/config/tsconfig",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "dist"
   },
   "include": ["src", "*.test.ts"]
 }

--- a/e2e/cases/syntax-ts/const-enum/tsconfig.json
+++ b/e2e/cases/syntax-ts/const-enum/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@scripts/config/tsconfig",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "dist"
   },
   "include": ["src", "*.test.ts"]
 }

--- a/e2e/cases/syntax-ts/optional-chaining/tsconfig.json
+++ b/e2e/cases/syntax-ts/optional-chaining/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@scripts/config/tsconfig",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "dist"
   },
   "include": ["src", "*.test.ts"]
 }

--- a/e2e/cases/syntax-ts/type-re-exports/tsconfig.json
+++ b/e2e/cases/syntax-ts/type-re-exports/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@scripts/config/tsconfig",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "dist"
   },
   "include": ["src", "*.test.ts"]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "extends": "@scripts/config/tsconfig",
   "compilerOptions": {
-    "outDir": "./dist",
+    "outDir": "dist",
     "rootDir": "src",
-    "declarationDir": "./dist-types",
+    "declarationDir": "dist-types",
     "composite": true,
     "isolatedDeclarations": true,
     "types": ["@rspack/core/module"]

--- a/packages/create-rsbuild/tsconfig.json
+++ b/packages/create-rsbuild/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "@scripts/config/tsconfig-nodenext",
   "compilerOptions": {
-    "outDir": "./dist"
+    "rootDir": "src",
+    "outDir": "dist"
   },
   "include": ["src"]
 }

--- a/packages/plugin-babel/tsconfig.json
+++ b/packages/plugin-babel/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@scripts/config/tsconfig-nodenext",
   "compilerOptions": {
-    "outDir": "./dist",
+    "outDir": "dist",
     "rootDir": "src",
     "composite": true,
     "isolatedDeclarations": true

--- a/packages/plugin-less/tsconfig.json
+++ b/packages/plugin-less/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@scripts/config/tsconfig-nodenext",
   "compilerOptions": {
-    "outDir": "./dist",
+    "outDir": "dist",
     "rootDir": "src",
     "composite": true,
     "isolatedDeclarations": true

--- a/packages/plugin-preact/tsconfig.json
+++ b/packages/plugin-preact/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@scripts/config/tsconfig-nodenext",
   "compilerOptions": {
-    "outDir": "./dist",
+    "outDir": "dist",
     "rootDir": "src",
     "composite": true,
     "isolatedDeclarations": true

--- a/packages/plugin-react/tsconfig.json
+++ b/packages/plugin-react/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@scripts/config/tsconfig-nodenext",
   "compilerOptions": {
-    "outDir": "./dist",
+    "outDir": "dist",
     "rootDir": "src",
     "composite": true,
     "isolatedDeclarations": true

--- a/packages/plugin-sass/tsconfig.json
+++ b/packages/plugin-sass/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@scripts/config/tsconfig-nodenext",
   "compilerOptions": {
-    "outDir": "./dist",
+    "outDir": "dist",
     "rootDir": "src",
     "composite": true,
     "isolatedDeclarations": true

--- a/packages/plugin-solid/tsconfig.json
+++ b/packages/plugin-solid/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@scripts/config/tsconfig-nodenext",
   "compilerOptions": {
-    "outDir": "./dist",
+    "outDir": "dist",
     "rootDir": "src",
     "composite": true,
     "isolatedDeclarations": true

--- a/packages/plugin-stylus/tsconfig.json
+++ b/packages/plugin-stylus/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@scripts/config/tsconfig-nodenext",
   "compilerOptions": {
-    "outDir": "./dist",
+    "outDir": "dist",
     "rootDir": "src",
     "composite": true,
     "isolatedDeclarations": true

--- a/packages/plugin-svelte/tsconfig.json
+++ b/packages/plugin-svelte/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@scripts/config/tsconfig-nodenext",
   "compilerOptions": {
-    "outDir": "./dist",
+    "outDir": "dist",
     "rootDir": "src",
     "composite": true,
     "isolatedDeclarations": true

--- a/packages/plugin-svgr/tsconfig.json
+++ b/packages/plugin-svgr/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@scripts/config/tsconfig-nodenext",
   "compilerOptions": {
-    "outDir": "./dist",
+    "outDir": "dist",
     "rootDir": "src",
     "composite": true,
     "isolatedDeclarations": true

--- a/packages/plugin-vue/tsconfig.json
+++ b/packages/plugin-vue/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@scripts/config/tsconfig-nodenext",
   "compilerOptions": {
-    "outDir": "./dist",
+    "outDir": "dist",
     "rootDir": "src",
     "composite": true,
     "isolatedDeclarations": true

--- a/scripts/test-helper/tsconfig.json
+++ b/scripts/test-helper/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@scripts/config/tsconfig-nodenext",
   "compilerOptions": {
-    "outDir": "./dist",
+    "outDir": "dist",
     "rootDir": "src",
     "composite": true,
     "types": ["@rstest/core/globals"]

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@scripts/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "outDir": "./dist",
+    "outDir": "dist",
     "paths": {
       "@theme": ["./theme"],
       "@components/*": ["./theme/components/*"],


### PR DESCRIPTION
## Summary

- Normalize `outDir` and `declarationDir` values across package, script, website, and e2e tsconfig files by removing the leading `./`.
- Add `rootDir: 'src'` to `packages/create-rsbuild` so its emitted output layout stays aligned with the rest of the workspace.

## Related Links

- None

<!--- Provide links of related issues or pages -->
