### PR TITLE
fix(create-rsbuild): use plugin-react 2.0 RC in react templates

### DIFF
--- a/packages/create-rsbuild/template-react-js/package.json
+++ b/packages/create-rsbuild/template-react-js/package.json
@@ -14,6 +14,6 @@
   },
   "devDependencies": {
     "@rsbuild/core": "^2.0.0-rc.4",
-    "@rsbuild/plugin-react": "^1.4.6"
+    "@rsbuild/plugin-react": "^2.0.0-rc.4"
   }
 }

--- a/packages/create-rsbuild/template-react-ts/package.json
+++ b/packages/create-rsbuild/template-react-ts/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "^2.0.0-rc.4",
-    "@rsbuild/plugin-react": "^1.4.6",
+    "@rsbuild/plugin-react": "^2.0.0-rc.4",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "typescript": "^6.0.2"


### PR DESCRIPTION
## Summary

This PR updates the React JS and TS templates in `create-rsbuild` to use `@rsbuild/plugin-react@^2.0.0-rc.4`, keeping them aligned with `@rsbuild/core@^2.0.0-rc.4` and avoiding potential compatibility issues for fresh projects.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/7505#discussion_r3097788156