### PR TITLE
docs: add React Server Components guide

### DIFF
--- a/website/docs/en/guide/framework/react.mdx
+++ b/website/docs/en/guide/framework/react.mdx
@@ -262,7 +262,7 @@ const App = () => {
 
 To use React Server Components (RSC) in a React application, you can use the [rsbuild-plugin-rsc](https://github.com/rstackjs/rsbuild-plugin-rsc) plugin.
 
-Built on top of the [Environments API](/guide/advanced/environments), this plugin encapsulates the core capabilities required for RSC scenarios, allowing you to organize server and client components within the same application and simplify the integration and configuration process.
+Built on top of [Multi-environment builds](/guide/advanced/environments), this plugin encapsulates the core capabilities required for RSC scenarios, allowing you to organize server and client components within the same application and simplify the integration and configuration process.
 
 ## Performance profiling
 

--- a/website/docs/en/guide/framework/react.mdx
+++ b/website/docs/en/guide/framework/react.mdx
@@ -258,6 +258,12 @@ const App = () => {
 };
 ```
 
+## React Server Components
+
+To use React Server Components (RSC) in a React application, you can integrate them with the [rsbuild-plugin-rsc](https://github.com/rstackjs/rsbuild-plugin-rsc) plugin.
+
+Built on top of the [Environments API](/guide/advanced/environments), this plugin encapsulates the core capabilities required for RSC scenarios, allowing you to organize server and client components within the same application and simplify the integration and configuration process.
+
 ## Performance profiling
 
 ### React Scan

--- a/website/docs/en/guide/framework/react.mdx
+++ b/website/docs/en/guide/framework/react.mdx
@@ -262,7 +262,7 @@ const App = () => {
 
 To use React Server Components (RSC) in a React application, you can use the [rsbuild-plugin-rsc](https://github.com/rstackjs/rsbuild-plugin-rsc) plugin.
 
-Built on top of [Multi-environment builds](/guide/advanced/environments), this plugin encapsulates the core capabilities required for RSC scenarios, allowing you to organize server and client components within the same application and simplify the integration and configuration process.
+Built on top of [Environments API](/guide/advanced/environments#environment-api), this plugin encapsulates the core capabilities required for RSC scenarios, allowing you to organize server and client components within the same application and simplify the integration and configuration process.
 
 ## Performance profiling
 

--- a/website/docs/en/guide/framework/react.mdx
+++ b/website/docs/en/guide/framework/react.mdx
@@ -260,7 +260,7 @@ const App = () => {
 
 ## React Server Components
 
-To use React Server Components (RSC) in a React application, you can integrate them with the [rsbuild-plugin-rsc](https://github.com/rstackjs/rsbuild-plugin-rsc) plugin.
+To use React Server Components (RSC) in a React application, you can use the [rsbuild-plugin-rsc](https://github.com/rstackjs/rsbuild-plugin-rsc) plugin.
 
 Built on top of the [Environments API](/guide/advanced/environments), this plugin encapsulates the core capabilities required for RSC scenarios, allowing you to organize server and client components within the same application and simplify the integration and configuration process.
 

--- a/website/docs/zh/guide/framework/react.mdx
+++ b/website/docs/zh/guide/framework/react.mdx
@@ -262,7 +262,7 @@ const App = () => {
 
 为了在 React 应用中使用 React Server Components（RSC），你可以使用 [rsbuild-plugin-rsc](https://github.com/rstackjs/rsbuild-plugin-rsc) 插件。
 
-该插件基于 [多环境构建](/guide/advanced/environments) 封装了 RSC 场景所需的核心能力，使你能够在同一应用中统一组织服务端组件与客户端组件，简化接入与配置过程。
+该插件基于 [Environments API](/guide/advanced/environments#environment-api) 封装了 RSC 场景所需的核心能力，使你能够在同一应用中统一组织服务端组件与客户端组件，简化接入与配置过程。
 
 ## 性能分析
 

--- a/website/docs/zh/guide/framework/react.mdx
+++ b/website/docs/zh/guide/framework/react.mdx
@@ -262,7 +262,7 @@ const App = () => {
 
 为了在 React 应用中使用 React Server Components（RSC），你可以使用 [rsbuild-plugin-rsc](https://github.com/rstackjs/rsbuild-plugin-rsc) 插件。
 
-该插件基于 [Environments API](/guide/advanced/environments) 封装了 RSC 场景所需的核心能力，使你能够在同一应用中统一组织服务端组件与客户端组件，简化接入与配置过程。
+该插件基于 [多环境构建](/guide/advanced/environments) 封装了 RSC 场景所需的核心能力，使你能够在同一应用中统一组织服务端组件与客户端组件，简化接入与配置过程。
 
 ## 性能分析
 

--- a/website/docs/zh/guide/framework/react.mdx
+++ b/website/docs/zh/guide/framework/react.mdx
@@ -258,6 +258,12 @@ const App = () => {
 };
 ```
 
+## React Server Components
+
+为了在 React 应用中使用 React Server Components（RSC），你可以通过 [rsbuild-plugin-rsc](https://github.com/rstackjs/rsbuild-plugin-rsc) 插件进行集成。
+
+该插件基于 [Environments API](/guide/advanced/environments) 封装了 RSC 场景所需的核心能力，使你能够在同一应用中统一组织服务端组件与客户端组件，简化接入与配置过程。
+
 ## 性能分析
 
 ### React Scan

--- a/website/docs/zh/guide/framework/react.mdx
+++ b/website/docs/zh/guide/framework/react.mdx
@@ -260,7 +260,7 @@ const App = () => {
 
 ## React Server Components
 
-为了在 React 应用中使用 React Server Components（RSC），你可以通过 [rsbuild-plugin-rsc](https://github.com/rstackjs/rsbuild-plugin-rsc) 插件进行集成。
+为了在 React 应用中使用 React Server Components（RSC），你可以使用 [rsbuild-plugin-rsc](https://github.com/rstackjs/rsbuild-plugin-rsc) 插件。
 
 该插件基于 [Environments API](/guide/advanced/environments) 封装了 RSC 场景所需的核心能力，使你能够在同一应用中统一组织服务端组件与客户端组件，简化接入与配置过程。
 


### PR DESCRIPTION
## Summary

- Add a React Server Components section to the React framework guide in both the English and Chinese docs.
- Document that `rsbuild-plugin-rsc` builds on the Environments API to simplify RSC integration in a React app.

## Related Links

None
