### PR TITLE
test(e2e): add case for #/ package imports resolution

### DIFF
--- a/e2e/cases/resolve/pkg-imports-hash-slash/index.test.ts
+++ b/e2e/cases/resolve/pkg-imports-hash-slash/index.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from '@e2e/helper';
+
+test('should resolve package.json#imports keys starting with #/', async ({
+  page,
+  runBothServe,
+}) => {
+  await runBothServe(async () => {
+    const foo = page.locator('#foo');
+    await expect(foo).toHaveText('foo from #/');
+  });
+});

--- a/e2e/cases/resolve/pkg-imports-hash-slash/package.json
+++ b/e2e/cases/resolve/pkg-imports-hash-slash/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@e2e/resolve-pkg-imports-hash-slash",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "imports": {
+    "#/*": "./src/*.js"
+  }
+}

--- a/e2e/cases/resolve/pkg-imports-hash-slash/src/foo.js
+++ b/e2e/cases/resolve/pkg-imports-hash-slash/src/foo.js
@@ -1,0 +1,1 @@
+export const foo = 'foo from #/';

--- a/e2e/cases/resolve/pkg-imports-hash-slash/src/index.js
+++ b/e2e/cases/resolve/pkg-imports-hash-slash/src/index.js
@@ -1,0 +1,6 @@
+import { foo } from '#/foo';
+
+const fooEl = document.createElement('div');
+fooEl.id = 'foo';
+fooEl.innerHTML = foo;
+document.body.appendChild(fooEl);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,6 +258,8 @@ importers:
 
   e2e/cases/resolve/pkg-imports: {}
 
+  e2e/cases/resolve/pkg-imports-hash-slash: {}
+
   e2e/cases/server/custom-server: {}
 
   e2e/cases/server/ssr:


### PR DESCRIPTION
- Add an end-to-end test to verify `package.json` `imports` subpath keys that start with `#/` (e.g. `"#/*": "./src/*.js"`) are resolved correctly by Rsbuild, matching the newer TypeScript subpath syntax (see https://devblogs.microsoft.com/typescript/announcing-typescript-6-0/).
