### PR TITLE
release: v2.0.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/core",
-  "version": "2.0.0-rc.4",
+  "version": "2.0.0",
   "description": "The Rspack-based build tool.",
   "homepage": "https://rsbuild.rs",
   "bugs": {

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rsbuild",
-  "version": "2.0.0-rc.4",
+  "version": "2.0.0",
   "description": "Create a new Rsbuild project",
   "homepage": "https://rsbuild.rs",
   "repository": {

--- a/packages/create-rsbuild/template-lit-js/package.json
+++ b/packages/create-rsbuild/template-lit-js/package.json
@@ -12,6 +12,6 @@
     "lit": "^3.3.2"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.0-rc.4"
+    "@rsbuild/core": "^2.0.0"
   }
 }

--- a/packages/create-rsbuild/template-lit-ts/package.json
+++ b/packages/create-rsbuild/template-lit-ts/package.json
@@ -12,7 +12,7 @@
     "lit": "^3.3.2"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.0-rc.4",
+    "@rsbuild/core": "^2.0.0",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/create-rsbuild/template-preact-js/package.json
+++ b/packages/create-rsbuild/template-preact-js/package.json
@@ -12,7 +12,7 @@
     "preact": "^10.29.1"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.0-rc.4",
+    "@rsbuild/core": "^2.0.0",
     "@rsbuild/plugin-preact": "^1.7.2"
   }
 }

--- a/packages/create-rsbuild/template-preact-ts/package.json
+++ b/packages/create-rsbuild/template-preact-ts/package.json
@@ -12,7 +12,7 @@
     "preact": "^10.29.1"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.0-rc.4",
+    "@rsbuild/core": "^2.0.0",
     "@rsbuild/plugin-preact": "^1.7.2",
     "typescript": "^6.0.3"
   }

--- a/packages/create-rsbuild/template-react-js/package.json
+++ b/packages/create-rsbuild/template-react-js/package.json
@@ -13,7 +13,7 @@
     "react-dom": "^19.2.5"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.0-rc.4",
-    "@rsbuild/plugin-react": "^2.0.0-rc.4"
+    "@rsbuild/core": "^2.0.0",
+    "@rsbuild/plugin-react": "^2.0.0"
   }
 }

--- a/packages/create-rsbuild/template-react-ts/package.json
+++ b/packages/create-rsbuild/template-react-ts/package.json
@@ -13,8 +13,8 @@
     "react-dom": "^19.2.5"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.0-rc.4",
-    "@rsbuild/plugin-react": "^2.0.0-rc.4",
+    "@rsbuild/core": "^2.0.0",
+    "@rsbuild/plugin-react": "^2.0.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "typescript": "^6.0.3"

--- a/packages/create-rsbuild/template-solid-js/package.json
+++ b/packages/create-rsbuild/template-solid-js/package.json
@@ -12,7 +12,7 @@
     "solid-js": "^1.9.12"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.0-rc.4",
+    "@rsbuild/core": "^2.0.0",
     "@rsbuild/plugin-babel": "^1.1.2",
     "@rsbuild/plugin-solid": "^1.1.1"
   }

--- a/packages/create-rsbuild/template-solid-ts/package.json
+++ b/packages/create-rsbuild/template-solid-ts/package.json
@@ -12,7 +12,7 @@
     "solid-js": "^1.9.12"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.0-rc.4",
+    "@rsbuild/core": "^2.0.0",
     "@rsbuild/plugin-babel": "^1.1.2",
     "@rsbuild/plugin-solid": "^1.1.1",
     "typescript": "^6.0.3"

--- a/packages/create-rsbuild/template-svelte-js/package.json
+++ b/packages/create-rsbuild/template-svelte-js/package.json
@@ -12,7 +12,7 @@
     "svelte": "^5.55.4"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.0-rc.4",
+    "@rsbuild/core": "^2.0.0",
     "@rsbuild/plugin-svelte": "^1.1.1"
   }
 }

--- a/packages/create-rsbuild/template-svelte-ts/package.json
+++ b/packages/create-rsbuild/template-svelte-ts/package.json
@@ -13,7 +13,7 @@
     "svelte": "^5.55.4"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.0-rc.4",
+    "@rsbuild/core": "^2.0.0",
     "@rsbuild/plugin-svelte": "^1.1.1",
     "svelte-check": "^4.4.6",
     "typescript": "^6.0.3"

--- a/packages/create-rsbuild/template-vanilla-js/package.json
+++ b/packages/create-rsbuild/template-vanilla-js/package.json
@@ -9,6 +9,6 @@
     "preview": "rsbuild preview"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.0-rc.4"
+    "@rsbuild/core": "^2.0.0"
   }
 }

--- a/packages/create-rsbuild/template-vanilla-ts/package.json
+++ b/packages/create-rsbuild/template-vanilla-ts/package.json
@@ -9,7 +9,7 @@
     "preview": "rsbuild preview"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.0-rc.4",
+    "@rsbuild/core": "^2.0.0",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/create-rsbuild/template-vue-js/package.json
+++ b/packages/create-rsbuild/template-vue-js/package.json
@@ -12,7 +12,7 @@
     "vue": "^3.5.32"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.0-rc.4",
+    "@rsbuild/core": "^2.0.0",
     "@rsbuild/plugin-vue": "^1.2.7"
   }
 }

--- a/packages/create-rsbuild/template-vue-ts/package.json
+++ b/packages/create-rsbuild/template-vue-ts/package.json
@@ -12,7 +12,7 @@
     "vue": "^3.5.32"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.0-rc.4",
+    "@rsbuild/core": "^2.0.0",
     "@rsbuild/plugin-vue": "^1.2.7",
     "typescript": "^6.0.3"
   }

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-react",
-  "version": "2.0.0-rc.4",
+  "version": "2.0.0",
   "description": "React plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svgr",
-  "version": "2.0.0-rc.4",
+  "version": "2.0.0",
   "description": "SVGR plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -24,7 +24,7 @@
     "dev": "rslib -w"
   },
   "dependencies": {
-    "@rsbuild/plugin-react": "workspace:^2.0.0-rc.4",
+    "@rsbuild/plugin-react": "workspace:^2.0.0",
     "@svgr/core": "8.1.0",
     "@svgr/plugin-jsx": "8.1.0",
     "@svgr/plugin-svgo": "8.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -948,7 +948,7 @@ importers:
   packages/plugin-svgr:
     dependencies:
       '@rsbuild/plugin-react':
-        specifier: workspace:^2.0.0-rc.4
+        specifier: workspace:^2.0.0
         version: link:../plugin-react
       '@svgr/core':
         specifier: 8.1.0


### PR DESCRIPTION
## Summary

Release `@rsbuild/core`, `@rsbuild/plugin-react`, `@rsbuild/plugin-svgr`, and `create-rsbuild` as `2.0.0`, and update the `create-rsbuild` templates to use `@rsbuild/core@^2.0.0`.

## Related Links

https://github.com/web-infra-dev/rsbuild/releases/tag/v2.0.0