### PR TITLE
docs: update v1 to v2 upgrade guide for 2.0 release

### DIFF
--- a/website/docs/en/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/en/guide/upgrade/v1-to-v2.mdx
@@ -20,16 +20,16 @@ After installation, let the Coding Agent guide you through the upgrade.
 
 ## Upgrade Rsbuild to v2
 
-- Upgrade `@rsbuild/core` to the 2.0 RC release.
+- Upgrade `@rsbuild/core` to the 2.0 release.
 
-- If you use `@rsbuild/plugin-react` or `@rsbuild/plugin-svgr`, upgrade them to the 2.0 RC release as well to keep them compatible with `@rsbuild/core`. For example:
+- If you use `@rsbuild/plugin-react` or `@rsbuild/plugin-svgr`, upgrade them to the 2.0 release as well to keep them compatible with `@rsbuild/core`. For example:
 
 ```json
 {
   "devDependencies": {
-    "@rsbuild/core": "^2.0.0-rc.0",
-    "@rsbuild/plugin-react": "^2.0.0-rc.0",
-    "@rsbuild/plugin-svgr": "^2.0.0-rc.0"
+    "@rsbuild/core": "^2.0.0",
+    "@rsbuild/plugin-react": "^2.0.0",
+    "@rsbuild/plugin-svgr": "^2.0.0"
   }
 }
 ```

--- a/website/docs/zh/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/zh/guide/upgrade/v1-to-v2.mdx
@@ -20,16 +20,16 @@ npx skills add rstackjs/agent-skills --skill rsbuild-v2-upgrade
 
 ## 升级 Rsbuild 到 v2
 
-- 将 `@rsbuild/core` 升级到 2.0 RC 版本。
+- 将 `@rsbuild/core` 升级到 2.0 版本。
 
-- 如果你使用了 `@rsbuild/plugin-react` 或 `@rsbuild/plugin-svgr`，也需要同时将它们升级到 2.0 RC 版本，以保持与 `@rsbuild/core` 的版本兼容。例如：
+- 如果你使用了 `@rsbuild/plugin-react` 或 `@rsbuild/plugin-svgr`，也需要同时将它们升级到 2.0 版本，以保持与 `@rsbuild/core` 的版本兼容。例如：
 
 ```json
 {
   "devDependencies": {
-    "@rsbuild/core": "^2.0.0-rc.0",
-    "@rsbuild/plugin-react": "^2.0.0-rc.0",
-    "@rsbuild/plugin-svgr": "^2.0.0-rc.0"
+    "@rsbuild/core": "^2.0.0",
+    "@rsbuild/plugin-react": "^2.0.0",
+    "@rsbuild/plugin-svgr": "^2.0.0"
   }
 }
 ```


### PR DESCRIPTION
## Summary

- update the v1-to-v2 upgrade guides to refer to the stable 2.0 release instead of the RC release
- update the dependency examples from `^2.0.0-rc.0` to `^2.0.0`
