### PR TITLE
chore(create-rsbuild): update plugin-react workspace range

### DIFF
--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -33,7 +33,7 @@
     "@rsbuild/core": "workspace:*",
     "@rsbuild/plugin-babel": "workspace:*",
     "@rsbuild/plugin-preact": "workspace:*",
-    "@rsbuild/plugin-react": "workspace:^2.0.0",
+    "@rsbuild/plugin-react": "workspace:*",
     "@rsbuild/plugin-solid": "workspace:*",
     "@rsbuild/plugin-svelte": "workspace:*",
     "@rsbuild/plugin-vue": "workspace:*",

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -33,7 +33,7 @@
     "@rsbuild/core": "workspace:*",
     "@rsbuild/plugin-babel": "workspace:*",
     "@rsbuild/plugin-preact": "workspace:*",
-    "@rsbuild/plugin-react": "workspace:^1.1.0",
+    "@rsbuild/plugin-react": "workspace:^2.0.0",
     "@rsbuild/plugin-solid": "workspace:*",
     "@rsbuild/plugin-svelte": "workspace:*",
     "@rsbuild/plugin-vue": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -640,7 +640,7 @@ importers:
         specifier: workspace:*
         version: link:../plugin-preact
       '@rsbuild/plugin-react':
-        specifier: workspace:^2.0.0
+        specifier: workspace:*
         version: link:../plugin-react
       '@rsbuild/plugin-solid':
         specifier: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -640,7 +640,7 @@ importers:
         specifier: workspace:*
         version: link:../plugin-preact
       '@rsbuild/plugin-react':
-        specifier: workspace:^1.1.0
+        specifier: workspace:^2.0.0
         version: link:../plugin-react
       '@rsbuild/plugin-solid':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

This PR updates the `@rsbuild/plugin-react` workspace range used by `create-rsbuild` from `workspace:^1.1.0` to `workspace:^2.0.0`, and syncs the lockfile so the package metadata stays aligned with the current `@rsbuild/plugin-react` 2.0.0 release.

## Related Links

https://github.com/web-infra-dev/rsbuild/releases/tag/v2.0.0