### PR TITLE
feat(plugin-svgr): support publicPath options in internal assetLoader

### DIFF
--- a/packages/plugin-svgr/src/assetLoader.ts
+++ b/packages/plugin-svgr/src/assetLoader.ts
@@ -9,7 +9,9 @@ type FilenameTemplate =
 export type SvgAssetLoaderOptions = {
   limit: number;
   name: FilenameTemplate;
-  publicPath?: string | ((filename: string) => string);
+  publicPath?:
+    | string
+    | ((url: string, resourcePath: string, context: string) => string);
 };
 
 type RawLoaderDefinition<OptionsType = {}> = ((
@@ -60,9 +62,13 @@ const assetLoader: RawLoaderDefinition<SvgAssetLoaderOptions> = function (
    */
   const publicPathCode =
     typeof publicPath === 'function'
-      ? JSON.stringify(publicPath(filename))
+      ? JSON.stringify(
+          publicPath(filename, this.resourcePath, this.rootContext),
+        )
       : typeof publicPath === 'string'
-        ? JSON.stringify(`${publicPath}${filename}`)
+        ? JSON.stringify(
+            `${publicPath.endsWith('/') ? publicPath : `${publicPath}/`}${filename}`,
+          )
         : `__webpack_public_path__ + ${JSON.stringify(filename)}`;
 
   return `export default ${publicPathCode};`;

--- a/packages/plugin-svgr/src/assetLoader.ts
+++ b/packages/plugin-svgr/src/assetLoader.ts
@@ -9,6 +9,7 @@ type FilenameTemplate =
 export type SvgAssetLoaderOptions = {
   limit: number;
   name: FilenameTemplate;
+  publicPath?: string | ((filename: string) => string);
 };
 
 type RawLoaderDefinition<OptionsType = {}> = ((
@@ -26,7 +27,7 @@ const normalizePath = (value: string) => value.replace(/\\/g, '/');
 const assetLoader: RawLoaderDefinition<SvgAssetLoaderOptions> = function (
   content,
 ) {
-  const { limit, name } = this.getOptions();
+  const { limit, name, publicPath } = this.getOptions();
 
   if (content.length <= limit) {
     const dataUrl = `data:${SVG_MIME_TYPE};base64,${content.toString('base64')}`;
@@ -53,7 +54,18 @@ const assetLoader: RawLoaderDefinition<SvgAssetLoaderOptions> = function (
 
   this.emitFile(filename, content, undefined, assetInfo);
 
-  return `export default __webpack_public_path__ + ${JSON.stringify(filename)};`;
+  /**
+   * Keep compatibility with Rslib, which overrides this loader option
+   * with a function to inject a stable placeholder into library output.
+   */
+  const publicPathCode =
+    typeof publicPath === 'function'
+      ? JSON.stringify(publicPath(filename))
+      : typeof publicPath === 'string'
+        ? JSON.stringify(`${publicPath}${filename}`)
+        : `__webpack_public_path__ + ${JSON.stringify(filename)}`;
+
+  return `export default ${publicPathCode};`;
 };
 
 assetLoader.raw = true;


### PR DESCRIPTION
## Summary

This PR restores compatibility with Rslib's SVGR mixed import flow by allowing `assetLoader` to accept the old function-style `publicPath` option. String-based `publicPath` values and the default `__webpack_public_path__` behavior remain unchanged.

## Related Links

None
