### PR TITLE
docs: fix v1/v2 links and enable v2 announcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Rsbuild has the following features:
 
 ## 📚 Documentation
 
-- [Rsbuild v2 docs](https://v2.rsbuild.rs)
-- [Rsbuild v1 docs](https://rsbuild.rs/)
+- [Rsbuild v2 docs](https://rsbuild.rs)
+- [Rsbuild v1 docs](https://v1.rsbuild.rs/)
 
 ## 🦀 Rstack
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Rsbuild has the following features:
 
 ## 📚 Documentation
 
-- [Rsbuild v2 docs](https://rsbuild.rs)
+- [Rsbuild v2 docs](https://rsbuild.rs/)
 - [Rsbuild v1 docs](https://v1.rsbuild.rs/)
 
 ## 🦀 Rstack

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -35,8 +35,8 @@ O Rsbuild tem os seguintes recursos:
 
 ## 📚 Documentação
 
-- [Rsbuild v2 docs](https://v2.rsbuild.rs)
-- [Rsbuild v1 docs](https://rsbuild.rs/)
+- [Rsbuild v2 docs](https://rsbuild.rs)
+- [Rsbuild v1 docs](https://v1.rsbuild.rs/)
 
 ## 🦀 Rstack
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -35,8 +35,8 @@ O Rsbuild tem os seguintes recursos:
 
 ## 📚 Documentação
 
-- [Rsbuild v2 docs](https://rsbuild.rs)
-- [Rsbuild v1 docs](https://v1.rsbuild.rs/)
+- [Documentação do Rsbuild v2](https://rsbuild.rs/)
+- [Documentação do Rsbuild v1](https://v1.rsbuild.rs/)
 
 ## 🦀 Rstack
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -35,8 +35,8 @@ Rsbuild 具备以下特性：
 
 ## 📚 文档
 
-- [Rsbuild v2 文档](https://v2.rsbuild.rs/zh/)
-- [Rsbuild v1 文档](https://rsbuild.rs/zh/)
+- [Rsbuild v2 文档](https://rsbuild.rs/zh/)
+- [Rsbuild v1 文档](https://v1.rsbuild.rs/zh/)
 
 ## 🦀 Rstack
 

--- a/website/theme/index.tsx
+++ b/website/theme/index.tsx
@@ -10,7 +10,7 @@ import {
 } from '@rspress/plugin-algolia/runtime';
 
 // Enable announcement when we have something to announce
-const ANNOUNCEMENT_URL = '';
+const ANNOUNCEMENT_URL = '/blog/v2-0';
 
 const Layout = () => {
   const { page } = usePage();
@@ -28,10 +28,10 @@ const Layout = () => {
               }
               message={
                 lang === 'en'
-                  ? 'Rsbuild 1.0 has been released!'
-                  : 'Rsbuild 1.0 正式发布！'
+                  ? 'Rsbuild 2.0 has been released!'
+                  : 'Rsbuild 2.0 正式发布！'
               }
-              localStorageKey="rsbuild-announcement-closed"
+              localStorageKey="rsbuild-v2-announcement-closed"
               display={page.pageType === 'home'}
             />
           </NoSSR>


### PR DESCRIPTION
## Summary

- Fix the README links in English, Portuguese, and Chinese so the v2 docs point to `rsbuild.rs` and the v1 docs point to `v1.rsbuild.rs`.
- Re-enable the homepage announcement for the Rsbuild 2.0 release and update its dismissal storage key.

## Related Links

- https://rsbuild.rs/blog/v2-0