### PR TITLE
test(type-tests): add plugin package coverage

### DIFF
--- a/e2e/type-tests/resolution-bundler/index.ts
+++ b/e2e/type-tests/resolution-bundler/index.ts
@@ -1,7 +1,34 @@
 // This folder disables `skipLibCheck` to check the public types of @rsbuild/core.
 import '@rsbuild/core/types';
 import { createRsbuild, defineConfig } from '@rsbuild/core';
+import { pluginBabel } from '@rsbuild/plugin-babel';
+import { pluginLess } from '@rsbuild/plugin-less';
+import { pluginPreact } from '@rsbuild/plugin-preact';
+import { pluginReact } from '@rsbuild/plugin-react';
+import { pluginSass } from '@rsbuild/plugin-sass';
+import { pluginSolid } from '@rsbuild/plugin-solid';
+import { pluginStylus } from '@rsbuild/plugin-stylus';
+import { pluginSvelte } from '@rsbuild/plugin-svelte';
+import { pluginSvgr } from '@rsbuild/plugin-svgr';
+import { pluginVue } from '@rsbuild/plugin-vue';
 
-createRsbuild({});
+const plugins = [
+  pluginBabel(),
+  pluginLess(),
+  pluginPreact(),
+  pluginReact(),
+  pluginSass(),
+  pluginSolid(),
+  pluginStylus(),
+  pluginSvelte(),
+  pluginSvgr(),
+  pluginVue(),
+];
 
-defineConfig({});
+createRsbuild({
+  config: {
+    plugins,
+  },
+});
+
+defineConfig({ plugins });

--- a/e2e/type-tests/resolution-nodenext/index.ts
+++ b/e2e/type-tests/resolution-nodenext/index.ts
@@ -1,7 +1,34 @@
 // This folder disables `skipLibCheck` to check the public types of @rsbuild/core.
 import '@rsbuild/core/types';
 import { createRsbuild, defineConfig } from '@rsbuild/core';
+import { pluginBabel } from '@rsbuild/plugin-babel';
+import { pluginLess } from '@rsbuild/plugin-less';
+import { pluginPreact } from '@rsbuild/plugin-preact';
+import { pluginReact } from '@rsbuild/plugin-react';
+import { pluginSass } from '@rsbuild/plugin-sass';
+import { pluginSolid } from '@rsbuild/plugin-solid';
+import { pluginStylus } from '@rsbuild/plugin-stylus';
+import { pluginSvelte } from '@rsbuild/plugin-svelte';
+import { pluginSvgr } from '@rsbuild/plugin-svgr';
+import { pluginVue } from '@rsbuild/plugin-vue';
 
-createRsbuild({});
+const plugins = [
+  pluginBabel(),
+  pluginLess(),
+  pluginPreact(),
+  pluginReact(),
+  pluginSass(),
+  pluginSolid(),
+  pluginStylus(),
+  pluginSvelte(),
+  pluginSvgr(),
+  pluginVue(),
+];
 
-defineConfig({});
+createRsbuild({
+  config: {
+    plugins,
+  },
+});
+
+defineConfig({ plugins });


### PR DESCRIPTION
## Summary

Add all local `@rsbuild/plugin-*` packages to the two `e2e/type-tests` cases so the public plugin types are checked under both `bundler` and `NodeNext` module resolution
