### PR TITLE
docs: add authors metadata to blog posts

### DIFF
--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -19,6 +19,7 @@ classname
 codegen
 codesandbox
 codeva
+chenjiahan
 compat
 consolas
 contentful

--- a/website/docs/en/blog/index.mdx
+++ b/website/docs/en/blog/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: Rsbuild blogs
-description: 'Rsbuild blog covering release announcements and technical articles from the team.'
+description: 'This page collects blog posts about Rsbuild.'
 sidebar: false
 ---
 
-Browse release announcements and articles from the team.
+This page collects blog posts about Rsbuild. Minor Rsbuild releases are also usually covered on the [Rspack blog](https://rspack.rs/blog/).
 
 import { BlogList } from '@components/BlogList';
 

--- a/website/docs/en/blog/v0-1.mdx
+++ b/website/docs/en/blog/v0-1.mdx
@@ -2,6 +2,11 @@
 description: 'Rsbuild 0.1 introduces an Rspack-based build tool with faster builds, simpler configuration, and multi-framework support.'
 date: 2023-11-22 08:00:00
 sidebar: false
+authors:
+  - name: chenjiahan
+    avatar: 'https://github.com/chenjiahan.png'
+  - name: 9aoy
+    avatar: 'https://github.com/9aoy.png'
 ---
 
 _November 22, 2023_

--- a/website/docs/en/blog/v0-2.mdx
+++ b/website/docs/en/blog/v0-2.mdx
@@ -2,6 +2,11 @@
 description: 'Rsbuild 0.2 updates core configuration such as targets and entry, and redesigns the Babel plugin API.'
 date: 2023-12-11 08:00:00
 sidebar: false
+authors:
+  - name: chenjiahan
+    avatar: 'https://github.com/chenjiahan.png'
+  - name: 9aoy
+    avatar: 'https://github.com/9aoy.png'
 ---
 
 _December 11, 2023_

--- a/website/docs/en/blog/v0-3.mdx
+++ b/website/docs/en/blog/v0-3.mdx
@@ -2,6 +2,11 @@
 description: 'Rsbuild 0.3 adds Module Federation support and updates TOML/YAML plugins, the JavaScript API, and Node target behavior.'
 date: 2024-01-10 08:00:00
 sidebar: false
+authors:
+  - name: chenjiahan
+    avatar: 'https://github.com/chenjiahan.png'
+  - name: 9aoy
+    avatar: 'https://github.com/9aoy.png'
 ---
 
 _January 10, 2024_

--- a/website/docs/en/blog/v0-4.mdx
+++ b/website/docs/en/blog/v0-4.mdx
@@ -2,6 +2,11 @@
 description: 'Rsbuild 0.4 adds built-in Module Federation config and updates plugin hook ordering and default behavior.'
 date: 2024-02-06 08:00:00
 sidebar: false
+authors:
+  - name: chenjiahan
+    avatar: 'https://github.com/chenjiahan.png'
+  - name: 9aoy
+    avatar: 'https://github.com/9aoy.png'
 ---
 
 _February 06, 2024_

--- a/website/docs/en/blog/v0-5.mdx
+++ b/website/docs/en/blog/v0-5.mdx
@@ -2,6 +2,11 @@
 description: 'Rsbuild 0.5 adds Lightning CSS, custom server support, and more flexible minify options.'
 date: 2024-03-19 08:00:00
 sidebar: false
+authors:
+  - name: chenjiahan
+    avatar: 'https://github.com/chenjiahan.png'
+  - name: 9aoy
+    avatar: 'https://github.com/9aoy.png'
 ---
 
 _March 19, 2024_

--- a/website/docs/en/blog/v0-6.mdx
+++ b/website/docs/en/blog/v0-6.mdx
@@ -2,6 +2,11 @@
 description: 'Rsbuild 0.6 enables the error overlay by default, adds Vue JSX HMR, and introduces a new transform API.'
 date: 2024-04-10 18:00:00
 sidebar: false
+authors:
+  - name: chenjiahan
+    avatar: 'https://github.com/chenjiahan.png'
+  - name: 9aoy
+    avatar: 'https://github.com/9aoy.png'
 ---
 
 _April 10, 2024_

--- a/website/docs/en/blog/v0-7.mdx
+++ b/website/docs/en/blog/v0-7.mdx
@@ -2,6 +2,11 @@
 description: 'Rsbuild 0.7 adds Storybook support, faster Sass compilation, and typed CSS Modules.'
 date: 2024-05-28 18:00:00
 sidebar: false
+authors:
+  - name: chenjiahan
+    avatar: 'https://github.com/chenjiahan.png'
+  - name: 9aoy
+    avatar: 'https://github.com/9aoy.png'
 ---
 
 _May 28, 2024_

--- a/website/docs/en/blog/v1-0.mdx
+++ b/website/docs/en/blog/v1-0.mdx
@@ -2,6 +2,11 @@
 description: 'Rsbuild 1.0 officially launches with faster builds, simpler configuration, a growing plugin ecosystem, and broader adoption across Rstack.'
 date: 2024-09-10 18:00:00
 sidebar: false
+authors:
+  - name: chenjiahan
+    avatar: 'https://github.com/chenjiahan.png'
+  - name: 9aoy
+    avatar: 'https://github.com/9aoy.png'
 ---
 
 _September 10, 2024_

--- a/website/docs/en/blog/v2-0.mdx
+++ b/website/docs/en/blog/v2-0.mdx
@@ -2,6 +2,9 @@
 description: 'Rsbuild 2.0 is out, featuring Rspack 2.0, RSC support, and more modern defaults.'
 date: 2026-04-22 12:00:00
 sidebar: false
+authors:
+  - name: chenjiahan
+    avatar: 'https://github.com/chenjiahan.png'
 ---
 
 _April 22, 2026_

--- a/website/docs/zh/blog/index.mdx
+++ b/website/docs/zh/blog/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: Rsbuild 博客
-description: 'Rsbuild 博客，包括团队发布的版本公告与技术文章。'
+description: '汇总了与 Rsbuild 相关的博客文章'
 sidebar: false
 ---
 
-浏览与团队发布的博客和技术文章。
+这里汇总了与 Rsbuild 相关的博客文章。另外，Rsbuild 的 minor 版本更新通常也会直接发布在 [Rspack 博客](https://rspack.rs/zh/blog/) 中。
 
 import { BlogList } from '@components/BlogList';
 

--- a/website/docs/zh/blog/v0-1.mdx
+++ b/website/docs/zh/blog/v0-1.mdx
@@ -2,6 +2,11 @@
 description: 'Rsbuild 0.1 首次发布，带来基于 Rspack 的高性能构建、开箱即用配置和多框架支持。'
 date: 2023-11-22 08:00:00
 sidebar: false
+authors:
+  - name: chenjiahan
+    avatar: 'https://github.com/chenjiahan.png'
+  - name: 9aoy
+    avatar: 'https://github.com/9aoy.png'
 ---
 
 _November 22, 2023_

--- a/website/docs/zh/blog/v0-2.mdx
+++ b/website/docs/zh/blog/v0-2.mdx
@@ -2,6 +2,11 @@
 description: 'Rsbuild 0.2 发布，调整 targets、entry 等核心配置，并重构 Babel 插件选项。'
 date: 2023-12-11 08:00:00
 sidebar: false
+authors:
+  - name: chenjiahan
+    avatar: 'https://github.com/chenjiahan.png'
+  - name: 9aoy
+    avatar: 'https://github.com/9aoy.png'
 ---
 
 _December 11, 2023_

--- a/website/docs/zh/blog/v0-3.mdx
+++ b/website/docs/zh/blog/v0-3.mdx
@@ -2,6 +2,11 @@
 description: 'Rsbuild 0.3 发布，支持模块联邦，并调整 TOML/YAML 插件、JavaScript API 与 Node 产物配置。'
 date: 2024-01-10 08:00:00
 sidebar: false
+authors:
+  - name: chenjiahan
+    avatar: 'https://github.com/chenjiahan.png'
+  - name: 9aoy
+    avatar: 'https://github.com/9aoy.png'
 ---
 
 _January 10, 2024_

--- a/website/docs/zh/blog/v0-4.mdx
+++ b/website/docs/zh/blog/v0-4.mdx
@@ -2,6 +2,11 @@
 description: 'Rsbuild 0.4 发布，提供内置模块联邦配置，并更新插件 Hook 顺序与多项默认行为。'
 date: 2024-02-06 08:00:00
 sidebar: false
+authors:
+  - name: chenjiahan
+    avatar: 'https://github.com/chenjiahan.png'
+  - name: 9aoy
+    avatar: 'https://github.com/9aoy.png'
 ---
 
 _February 06, 2024_

--- a/website/docs/zh/blog/v0-5.mdx
+++ b/website/docs/zh/blog/v0-5.mdx
@@ -2,6 +2,11 @@
 description: 'Rsbuild 0.5 发布，支持 Lightning CSS、自定义 Server 和更灵活的压缩配置。'
 date: 2024-03-19 08:00:00
 sidebar: false
+authors:
+  - name: chenjiahan
+    avatar: 'https://github.com/chenjiahan.png'
+  - name: 9aoy
+    avatar: 'https://github.com/9aoy.png'
 ---
 
 _March 19, 2024_

--- a/website/docs/zh/blog/v0-6.mdx
+++ b/website/docs/zh/blog/v0-6.mdx
@@ -2,6 +2,11 @@
 description: 'Rsbuild 0.6 发布，默认启用 error overlay，支持 Vue JSX HMR，并引入全新的 transform API。'
 date: 2024-04-10 18:00:00
 sidebar: false
+authors:
+  - name: chenjiahan
+    avatar: 'https://github.com/chenjiahan.png'
+  - name: 9aoy
+    avatar: 'https://github.com/9aoy.png'
 ---
 
 _April 10, 2024_

--- a/website/docs/zh/blog/v0-7.mdx
+++ b/website/docs/zh/blog/v0-7.mdx
@@ -2,6 +2,11 @@
 description: 'Rsbuild 0.7 发布，支持 Storybook、更快的 Sass 编译和 CSS Modules 类型生成。'
 date: 2024-05-28 18:00:00
 sidebar: false
+authors:
+  - name: chenjiahan
+    avatar: 'https://github.com/chenjiahan.png'
+  - name: 9aoy
+    avatar: 'https://github.com/9aoy.png'
 ---
 
 _May 28, 2024_

--- a/website/docs/zh/blog/v1-0.mdx
+++ b/website/docs/zh/blog/v1-0.mdx
@@ -2,6 +2,11 @@
 description: 'Rsbuild 1.0 正式发布，围绕更快构建、更易配置和插件生态展开，并介绍性能表现、社区采用与后续规划。'
 date: 2024-09-10 18:00:00
 sidebar: false
+authors:
+  - name: chenjiahan
+    avatar: 'https://github.com/chenjiahan.png'
+  - name: 9aoy
+    avatar: 'https://github.com/9aoy.png'
 ---
 
 _September 10, 2024_

--- a/website/docs/zh/blog/v2-0.mdx
+++ b/website/docs/zh/blog/v2-0.mdx
@@ -2,6 +2,9 @@
 description: 'Rsbuild 2.0 正式发布，升级 Rspack 2.0，引入 RSC 支持和更现代的默认行为。'
 date: 2026-04-22 12:00:00
 sidebar: false
+authors:
+  - name: chenjiahan
+    avatar: 'https://github.com/chenjiahan.png'
 ---
 
 _2026 年 4 月 22 日_


### PR DESCRIPTION
## Summary

- add `authors` frontmatter to the historical blog posts in both English and Chinese docs so the blog pages can show proper attribution
- update the blog index copy to clarify that minor Rsbuild releases are usually announced on the Rspack blog

## Related Links

<!--- Provide links of related issues or pages -->
None