### PR TITLE
chore: enable tsgo in CI

### DIFF
--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -179,8 +179,7 @@ export default defineConfig({
       },
       dts: {
         build: true,
-        // Only use tsgo in local dev for faster build, disable it in CI until it's more stable
-        tsgo: !process.env.CI,
+        tsgo: true,
         alias: {
           // alias to pre-bundled types as they are public API
           cors: './compiled/cors',

--- a/scripts/config/rslib.config.ts
+++ b/scripts/config/rslib.config.ts
@@ -25,8 +25,7 @@ export const esmConfig: LibConfig = {
   syntax: 'es2023',
   dts: {
     build: true,
-    // Only use tsgo in local dev for faster build, disable it in CI until it's more stable
-    tsgo: !process.env.CI,
+    tsgo: true,
   },
   output: {
     minify: nodeMinifyConfig,


### PR DESCRIPTION
## Summary

This PR enables `tsgo` in CI for the declaration builds used by `@rsbuild/core` and the shared Rslib config. It removes the local-only `process.env.CI` gate so local and CI builds exercise the same TypeScript 7.0 Beta path.

## Related Links

- https://devblogs.microsoft.com/typescript/announcing-typescript-7-0-beta/

<!--- Provide links of related issues or pages -->