### PR TITLE
fix(core): print fallback URL when HTML is disabled

### DIFF
--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -111,7 +111,7 @@ export async function createDevServer<
 
   // SSR or backend-integrated apps may not generate HTML upfront. In that case,
   // keep printing the dev server base URL for web targets so users still get
-  // a meaningful address, while node target stay silent.
+  // a meaningful address, while node targets stay silent.
   const fallbackPathname =
     routes.length === 0 &&
     context.environmentList.some((item) => item.config.output.target === 'web')

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -109,6 +109,15 @@ export async function createDevServer<
   const isHttps = Boolean(config.server.https);
   const routes = getRoutes(context);
 
+  // SSR or backend-integrated apps may not generate HTML upfront. In that case,
+  // keep printing the dev server base URL for web targets so users still get
+  // a meaningful address, while node target stay silent.
+  const fallbackPathname =
+    routes.length === 0 &&
+    context.environmentList.some((item) => item.config.output.target === 'web')
+      ? config.server.base
+      : undefined;
+
   context.devServer = {
     hostname: host,
     port,
@@ -195,6 +204,7 @@ export async function createDevServer<
       routes,
       protocol,
       printUrls: config.server.printUrls,
+      fallbackPathname,
       trailingLineBreak: !cliShortcutsEnabled,
       originalConfig: context.originalConfig,
       logger,

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -192,6 +192,7 @@ export function printServerURLs({
   routes,
   protocol,
   printUrls,
+  fallbackPathname,
   trailingLineBreak = true,
   originalConfig,
   logger,
@@ -201,6 +202,7 @@ export function printServerURLs({
   routes: Routes;
   protocol: string;
   printUrls?: PrintUrls;
+  fallbackPathname?: string;
   trailingLineBreak?: boolean;
   originalConfig?: Readonly<RsbuildConfig>;
   logger: Logger;
@@ -241,12 +243,19 @@ export function printServerURLs({
     return null;
   }
 
+  // When there are no HTML routes, print the server base URL as the default
+  // access path.
+  const printableRoutes =
+    routes.length === 0 && !useCustomUrl && fallbackPathname
+      ? [{ entryName: 'index', pathname: formatPrefix(fallbackPathname) }]
+      : routes;
+
   // If no routes and not use custom url, skip printing
-  if (routes.length === 0 && !useCustomUrl) {
+  if (printableRoutes.length === 0 && !useCustomUrl) {
     return null;
   }
 
-  let message = getURLMessages(urls, routes);
+  let message = getURLMessages(urls, printableRoutes);
 
   if (originalConfig && originalConfig.server?.host === undefined) {
     message += `  ➜  ${color.dim('Network:')}  ${color.dim('use')} ${color.bold('--host')} ${color.dim('to expose')}\n`;

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -246,7 +246,7 @@ export function printServerURLs({
   // When there are no HTML routes, print the server base URL as the default
   // access path.
   const printableRoutes =
-    routes.length === 0 && !useCustomUrl && fallbackPathname
+    routes.length === 0 && !useCustomUrl && fallbackPathname !== undefined
       ? [{ entryName: 'index', pathname: formatPrefix(fallbackPathname) }]
       : routes;
 

--- a/packages/core/tests/server.test.ts
+++ b/packages/core/tests/server.test.ts
@@ -248,6 +248,30 @@ test('should print server URLs correctly', () => {
   });
 
   expect(message).toEqual(null);
+
+  message = printServerURLs({
+    port: 3000,
+    protocol: 'http',
+    logger,
+    urls: [
+      {
+        url: 'http://localhost:3000',
+        label: 'local',
+      },
+      {
+        url: 'http://192.168.0.1:3000/',
+        label: 'network',
+      },
+    ],
+    routes: [],
+    fallbackPathname: '/foo',
+  });
+
+  expect(message!).toMatchInlineSnapshot(`
+    "  ➜  local     http://localhost:3000/foo/
+      ➜  network   http://192.168.0.1:3000/foo/
+    "
+  `);
 });
 
 describe('dev server', () => {

--- a/website/docs/en/config/server/print-urls.mdx
+++ b/website/docs/en/config/server/print-urls.mdx
@@ -130,9 +130,11 @@ export default {
 
 ### HTML disabled
 
-If [tools.htmlPlugin](/config/tools/html-plugin) is set to `false`, Rsbuild will not generate HTML files or output the server URL.
+If [tools.htmlPlugin](/config/tools/html-plugin) is set to `false`, Rsbuild will not generate HTML files.
 
-However, you can still print the server URLs using the `server.printUrls` function, which has a higher priority.
+In this case, if there is at least one environment with `output.target: 'web'`, Rsbuild will print the URL corresponding to `server.base` by default. Otherwise, Rsbuild will not print the server URLs.
+
+You can still customize the printed URLs using the `server.printUrls` function, which has a higher priority.
 
 ```ts title="rsbuild.config.ts"
 export default {

--- a/website/docs/zh/config/server/print-urls.mdx
+++ b/website/docs/zh/config/server/print-urls.mdx
@@ -131,9 +131,11 @@ export default {
 
 ### 禁用 HTML
 
-当 [tools.htmlPlugin](/config/tools/html-plugin) 被设置为 `false` 时，Rsbuild 不会生成 HTML 文件，也不会输出 server 的 URL 地址。
+当 [tools.htmlPlugin](/config/tools/html-plugin) 被设置为 `false` 时，Rsbuild 不会生成 HTML 文件。
 
-但你仍然可以通过 `server.printUrls` 函数来输出 URL 地址，它具有更高的优先级。
+此时，如果至少存在一个 `output.target: 'web'` 的环境，Rsbuild 会默认输出 `server.base` 对应的 URL；否则 Rsbuild 不会输出 server 的 URL 地址。
+
+你仍然可以通过 `server.printUrls` 函数来自定义输出的 URL 地址，它具有更高的优先级。
 
 ```ts title="rsbuild.config.ts"
 export default {


### PR DESCRIPTION
## Summary

- print the `server.base` URL when HTML generation is disabled and at least one environment targets the web
- keep non-web apps silent when there is no fallback route to print
