### PR TITLE
chore(types): update swc decorator types

### DIFF
--- a/packages/core/src/plugins/swc.ts
+++ b/packages/core/src/plugins/swc.ts
@@ -313,8 +313,7 @@ function applySwcDecoratorConfig(
     case '2022-03':
     case '2023-11':
       swcConfig.jsc.transform.legacyDecorator = false;
-      // TODO `@swc/types` does not include `2023-11` yet.
-      (swcConfig.jsc.transform.decoratorVersion as string) = version;
+      swcConfig.jsc.transform.decoratorVersion = version;
       break;
     default:
       throw new Error(


### PR DESCRIPTION
## Summary

This PR removes the outdated `decoratorVersion` type assertion because `@swc/types` now includes the correct type for the supported SWC decorator versions, including `2023-11`.
