### PR TITLE
feat(core): support CSS url imports

### DIFF
--- a/e2e/cases/css/url-query/index.test.ts
+++ b/e2e/cases/css/url-query/index.test.ts
@@ -1,0 +1,27 @@
+import { expect, getFileContent, test } from '@e2e/helper';
+
+type CssUrlResult = {
+  styleUrl: string;
+  styleContent: string;
+  targetColor: string;
+};
+
+test('should return transformed CSS URL with `?url`', async ({
+  page,
+  runBothServe,
+}) => {
+  await runBothServe(async ({ mode, result }) => {
+    const { styleUrl, styleContent, targetColor } =
+      await page.evaluate<CssUrlResult>('window.getCssUrlResult()');
+
+    expect(styleUrl).toMatch(/\/static\/css\/style\.css$/);
+    expect(styleContent).toContain('.url-query-class');
+    expect(styleContent).toContain('--postcss-transformed');
+    expect(targetColor).toBe('rgb(0, 0, 0)');
+
+    if (mode === 'build') {
+      const html = getFileContent(result.getDistFiles(), 'index.html');
+      expect(html).not.toMatch(/<link[^>]+rel="stylesheet"/);
+    }
+  });
+});

--- a/e2e/cases/css/url-query/rsbuild.config.ts
+++ b/e2e/cases/css/url-query/rsbuild.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from '@rsbuild/core';
+
+const addPostcssMarker = () => ({
+  postcssPlugin: 'add-postcss-marker',
+  Declaration(decl: { prop: string; cloneBefore: (decl: object) => void }) {
+    if (decl.prop === 'color') {
+      decl.cloneBefore({
+        prop: '--postcss-transformed',
+        value: 'true',
+      });
+    }
+  },
+});
+
+addPostcssMarker.postcss = true;
+
+export default defineConfig({
+  output: {
+    filenameHash: false,
+  },
+  tools: {
+    postcss(_, { addPlugins }) {
+      addPlugins(addPostcssMarker);
+    },
+  },
+});

--- a/e2e/cases/css/url-query/src/index.js
+++ b/e2e/cases/css/url-query/src/index.js
@@ -1,0 +1,13 @@
+import styleUrl from './style.css?url';
+
+const target = document.createElement('div');
+target.id = 'target';
+target.className = 'url-query-class';
+target.textContent = 'CSS URL query';
+document.body.appendChild(target);
+
+window.getCssUrlResult = async () => ({
+  styleUrl,
+  styleContent: await fetch(styleUrl).then((res) => res.text()),
+  targetColor: getComputedStyle(target).color,
+});

--- a/e2e/cases/css/url-query/src/style.css
+++ b/e2e/cases/css/url-query/src/style.css
@@ -1,0 +1,3 @@
+.url-query-class {
+  color: red;
+}

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -172,6 +172,7 @@ export default defineConfig({
       source: {
         entry: {
           index: './src/index.ts',
+          cssUrlLoader: './src/loader/cssUrlLoader.ts',
           ignoreCssLoader: './src/loader/ignoreCssLoader.ts',
           transformLoader: './src/loader/transformLoader.ts',
           transformRawLoader: './src/loader/transformRawLoader.ts',

--- a/packages/core/src/configChain.ts
+++ b/packages/core/src/configChain.ts
@@ -70,6 +70,7 @@ export const CHAIN_ID = {
     /** CSS oneOf rules */
     CSS_MAIN: 'css',
     CSS_RAW: 'css-raw',
+    CSS_URL: 'css-url',
     CSS_INLINE: 'css-inline',
     /** SVG oneOf rules */
     SVG: 'svg',
@@ -85,6 +86,8 @@ export const CHAIN_ID = {
     TS: 'ts',
     /** css-loader */
     CSS: 'css',
+    /** CSS URL loader */
+    CSS_URL: 'css-url',
     /** sass-loader */
     SASS: 'sass',
     /** less-loader */

--- a/packages/core/src/loader/cssUrlLoader.ts
+++ b/packages/core/src/loader/cssUrlLoader.ts
@@ -1,0 +1,148 @@
+import path from 'node:path';
+import type {
+  LoaderDefinitionFunction,
+  PathData,
+  PitchLoaderDefinitionFunction,
+} from '@rspack/core';
+import type { CSSLoaderOptions } from '../types';
+
+type CSSUrlLoaderOptions = {
+  filename: string | ((pathData: PathData) => string);
+  modules: CSSLoaderOptions['modules'];
+};
+
+const CSS_MODULE_REGEX = /\.module\.\w+$/i;
+const HASH_PLACEHOLDER_REGEX =
+  /\[(?:[^:\]]+:)?(?:chunkhash|contenthash|hash|fullhash)(?::[^\]]+)?]/i;
+
+const normalizePath = (value: string) => value.replace(/\\/g, '/');
+
+const isCSSModules = (
+  modules: CSSLoaderOptions['modules'],
+  resourcePath: string,
+  resourceQuery: string,
+  resourceFragment: string,
+) => {
+  if (!modules) {
+    return false;
+  }
+
+  if (modules === true || typeof modules === 'string') {
+    return true;
+  }
+
+  const { auto } = modules;
+
+  if (auto === false) {
+    return false;
+  }
+
+  if (auto instanceof RegExp) {
+    return auto.test(resourcePath);
+  }
+
+  if (typeof auto === 'function') {
+    return auto(resourcePath, resourceQuery, resourceFragment);
+  }
+
+  return CSS_MODULE_REGEX.test(resourcePath);
+};
+
+const getCSSContent = (moduleExports: unknown): string => {
+  const content =
+    moduleExports &&
+    typeof moduleExports === 'object' &&
+    'default' in moduleExports
+      ? moduleExports.default
+      : moduleExports;
+
+  if (typeof content !== 'string') {
+    throw new Error(
+      '[rsbuild:css] Expected CSS ?url imports to export a string.',
+    );
+  }
+
+  return content;
+};
+
+const getContentHash = (
+  loaderContext: ThisParameterType<
+    LoaderDefinitionFunction<CSSUrlLoaderOptions>
+  >,
+  content: string,
+) => {
+  const hash = loaderContext.utils.createHash(
+    loaderContext._compilation.outputOptions.hashFunction,
+  );
+  hash.update(Buffer.from(content));
+
+  return hash.digest(
+    loaderContext._compilation.outputOptions.hashDigest || 'hex',
+  );
+};
+
+const cssUrlLoader: LoaderDefinitionFunction<CSSUrlLoaderOptions> = function (
+  source,
+) {
+  return source;
+};
+
+export const pitch: PitchLoaderDefinitionFunction<CSSUrlLoaderOptions> =
+  async function (remainingRequest) {
+    const options = this.getOptions();
+
+    if (
+      isCSSModules(
+        options.modules,
+        this.resourcePath,
+        this.resourceQuery,
+        this.resourceFragment,
+      )
+    ) {
+      throw new Error(
+        '[rsbuild:css] CSS Modules do not support the ?url query. Use ?inline to import the compiled CSS content as a string.',
+      );
+    }
+
+    const moduleExports = await this.importModule(
+      `${this.resourcePath}.rspack[javascript/auto]!=!!!${remainingRequest}`,
+    );
+    const content = getCSSContent(moduleExports);
+
+    const ext = path.extname(this.resourcePath);
+    const name = path.basename(this.resourcePath, ext);
+    const sourceFilename = normalizePath(
+      path.relative(this.rootContext, this.resourcePath),
+    );
+    const contentHash = getContentHash(this, content);
+    const pathData: PathData = {
+      filename: sourceFilename,
+      contentHash,
+      chunk: {
+        name,
+        hash: contentHash,
+        contentHash: {
+          css: contentHash,
+        },
+      },
+    };
+    const filenameTemplate =
+      typeof options.filename === 'function'
+        ? options.filename(pathData)
+        : options.filename;
+    const { path: filename, info } = this._compilation.getAssetPathWithInfo(
+      filenameTemplate,
+      pathData,
+    );
+
+    this.emitFile(filename, content, undefined, {
+      ...info,
+      immutable:
+        info.immutable || HASH_PLACEHOLDER_REGEX.test(filenameTemplate),
+      sourceFilename,
+    });
+
+    return `export default __webpack_public_path__ + ${JSON.stringify(filename)};`;
+  };
+
+export default cssUrlLoader;

--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -287,6 +287,14 @@ export const pluginCss = (): RsbuildPlugin => ({
           // the module should be treated as an asset module rather than a JS module.
           .dependency({ not: 'url' });
 
+        // Support for `import cssUrl from "a.css?url"`
+        const urlRule = cssRule
+          .oneOf(CHAIN_ID.ONE_OF.CSS_URL)
+          .resourceQuery(/^\?url$/);
+        urlRule
+          .use(CHAIN_ID.USE.CSS_URL)
+          .loader(path.join(LOADER_PATH, 'cssUrlLoader.mjs'));
+
         // Support for `import inlineCss from "a.css?inline"`
         const inlineRule = cssRule
           .oneOf(CHAIN_ID.ONE_OF.CSS_INLINE)
@@ -336,11 +344,11 @@ export const pluginCss = (): RsbuildPlugin => ({
           inline: 0,
         };
 
-        // Update the normal CSS rule and the inline CSS rule
+        // Update CSS rules that share the CSS transform pipeline.
         const updateRules = (
           callback: (
             rule: RspackChain.Rule<RspackChain.Rule>,
-            type: 'main' | 'inline',
+            type: 'main' | 'inline' | 'url',
           ) => void,
           options: { skipMain?: boolean } = {},
         ) => {
@@ -348,6 +356,7 @@ export const pluginCss = (): RsbuildPlugin => ({
             callback(mainRule, 'main');
           }
           callback(inlineRule, 'inline');
+          callback(urlRule, 'url');
         };
 
         const cssLoaderPath = getCompiledPath('css-loader');
@@ -381,7 +390,9 @@ export const pluginCss = (): RsbuildPlugin => ({
               // Inline styles are not processed by Rspack's minimizers,
               // so we need to minify them via `builtin:lightningcss-loader`
               const inlineStyle =
-                type === 'inline' || config.output.injectStyles;
+                type === 'inline' ||
+                type === 'url' ||
+                config.output.injectStyles;
               const minify = inlineStyle && minifyCss;
 
               const lightningcssOptions = getLightningCSSLoaderOptions(
@@ -440,7 +451,7 @@ export const pluginCss = (): RsbuildPlugin => ({
         updateRules((rule, type) => {
           let finalOptions = cssLoaderOptions;
 
-          if (type === 'inline') {
+          if (type === 'inline' || type === 'url') {
             finalOptions = {
               ...cssLoaderOptions,
               exportType: 'string',
@@ -455,12 +466,27 @@ export const pluginCss = (): RsbuildPlugin => ({
           }
           rule.use(CHAIN_ID.USE.CSS).options(finalOptions);
 
-          // CSS imports should always be treated as sideEffects
-          rule.sideEffects(true);
+          if (type !== 'url') {
+            // CSS imports should always be treated as sideEffects.
+            // CSS ?url only exports a URL string and does not apply styles.
+            rule.sideEffects(true);
+          }
 
           // Enable preferRelative by default, which is consistent with the default behavior of css-loader
           // see: https://github.com/webpack/css-loader/blob/579fc13/src/plugins/postcss-import-parser.js#L234
           rule.resolve.preferRelative(true);
+        });
+
+        const cssUrlFilename = getFilename(config, 'css', isProd);
+        const cssUrlPath = config.output.distPath.css;
+
+        urlRule.use(CHAIN_ID.USE.CSS_URL).options({
+          filename:
+            typeof cssUrlFilename === 'function'
+              ? (pathData: Rspack.PathData, assetInfo?: Rspack.AssetInfo) =>
+                  posix.join(cssUrlPath, cssUrlFilename(pathData, assetInfo))
+              : posix.join(cssUrlPath, cssUrlFilename),
+          modules: cssLoaderOptions.modules,
         });
 
         const isStringExport = cssLoaderOptions.exportType === 'string';

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -39,6 +39,48 @@ exports[`default bundler > should use Rspack by default 1`] = `
             "resolve": {
               "preferRelative": true,
             },
+            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "use": [
+              {
+                "loader": "<ROOT>/packages/core/src/cssUrlLoader.mjs",
+                "options": {
+                  "filename": "static/css/[name].css",
+                  "modules": {
+                    "auto": true,
+                    "exportGlobals": false,
+                    "exportLocalsConvention": "camelCase",
+                    "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                    "namedExport": false,
+                  },
+                },
+              },
+              {
+                "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+                "options": {
+                  "exportType": "string",
+                  "importLoaders": 1,
+                  "modules": false,
+                  "sourceMap": false,
+                },
+              },
+              {
+                "loader": "builtin:lightningcss-loader",
+                "options": {
+                  "errorRecovery": true,
+                  "targets": [
+                    "chrome >= 107",
+                    "edge >= 107",
+                    "firefox >= 104",
+                    "safari >= 16",
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            "resolve": {
+              "preferRelative": true,
+            },
             "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
             "sideEffects": true,
             "use": [

--- a/packages/core/tests/__snapshots__/css.test.ts.snap
+++ b/packages/core/tests/__snapshots__/css.test.ts.snap
@@ -11,6 +11,48 @@ exports[`plugin-css > should use custom cssModules rule when using output.cssMod
         "resolve": {
           "preferRelative": true,
         },
+        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/src/cssUrlLoader.mjs",
+            "options": {
+              "filename": "static/css/[name].css",
+              "modules": {
+                "auto": [Function],
+                "exportGlobals": false,
+                "exportLocalsConvention": "camelCase",
+                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                "namedExport": false,
+              },
+            },
+          },
+          {
+            "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+            "options": {
+              "exportType": "string",
+              "importLoaders": 1,
+              "modules": false,
+              "sourceMap": false,
+            },
+          },
+          {
+            "loader": "builtin:lightningcss-loader",
+            "options": {
+              "errorRecovery": true,
+              "targets": [
+                "chrome >= 107",
+                "edge >= 107",
+                "firefox >= 104",
+                "safari >= 16",
+              ],
+            },
+          },
+        ],
+      },
+      {
+        "resolve": {
+          "preferRelative": true,
+        },
         "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
         "sideEffects": true,
         "use": [
@@ -95,6 +137,46 @@ exports[`plugin-css injectStyles > should apply ignoreCssLoader when injectStyle
         "resolve": {
           "preferRelative": true,
         },
+        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/src/cssUrlLoader.mjs",
+            "options": {
+              "filename": "static/css/[name].css",
+              "modules": {
+                "auto": true,
+                "exportGlobals": false,
+                "exportLocalsConvention": "camelCase",
+                "exportOnlyLocals": true,
+                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                "namedExport": false,
+              },
+            },
+          },
+          {
+            "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+            "options": {
+              "exportType": "string",
+              "importLoaders": 1,
+              "modules": false,
+              "sourceMap": false,
+            },
+          },
+          {
+            "loader": "builtin:lightningcss-loader",
+            "options": {
+              "errorRecovery": true,
+              "targets": [
+                "node >= 20",
+              ],
+            },
+          },
+        ],
+      },
+      {
+        "resolve": {
+          "preferRelative": true,
+        },
         "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
         "sideEffects": true,
         "use": [
@@ -161,6 +243,48 @@ exports[`plugin-css injectStyles > should use css-loader + style-loader when inj
       "not": "url",
     },
     "oneOf": [
+      {
+        "resolve": {
+          "preferRelative": true,
+        },
+        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/src/cssUrlLoader.mjs",
+            "options": {
+              "filename": "static/css/[name].css",
+              "modules": {
+                "auto": true,
+                "exportGlobals": false,
+                "exportLocalsConvention": "camelCase",
+                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                "namedExport": false,
+              },
+            },
+          },
+          {
+            "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+            "options": {
+              "exportType": "string",
+              "importLoaders": 1,
+              "modules": false,
+              "sourceMap": false,
+            },
+          },
+          {
+            "loader": "builtin:lightningcss-loader",
+            "options": {
+              "errorRecovery": true,
+              "targets": [
+                "chrome >= 107",
+                "edge >= 107",
+                "firefox >= 104",
+                "safari >= 16",
+              ],
+            },
+          },
+        ],
+      },
       {
         "resolve": {
           "preferRelative": true,
@@ -245,6 +369,63 @@ exports[`should ensure isolation of PostCSS config objects between different bui
       "not": "url",
     },
     "oneOf": [
+      {
+        "resolve": {
+          "preferRelative": true,
+        },
+        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/src/cssUrlLoader.mjs",
+            "options": {
+              "filename": "static/css/[name].css",
+              "modules": {
+                "auto": true,
+                "exportGlobals": false,
+                "exportLocalsConvention": "camelCase",
+                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                "namedExport": false,
+              },
+            },
+          },
+          {
+            "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+            "options": {
+              "exportType": "string",
+              "importLoaders": 2,
+              "modules": false,
+              "sourceMap": false,
+            },
+          },
+          {
+            "loader": "builtin:lightningcss-loader",
+            "options": {
+              "errorRecovery": true,
+              "targets": [
+                "chrome >= 107",
+                "edge >= 107",
+                "firefox >= 104",
+                "safari >= 16",
+              ],
+            },
+          },
+          {
+            "loader": "<ROOT>/packages/core/compiled/postcss-loader/index.js",
+            "options": {
+              "implementation": "<ROOT>/packages/core/compiled/postcss/index.js",
+              "postcssOptions": {
+                "config": false,
+                "plugins": [
+                  {
+                    "postcssPlugin": "foo",
+                  },
+                ],
+              },
+              "sourceMap": false,
+            },
+          },
+        ],
+      },
       {
         "resolve": {
           "preferRelative": true,
@@ -359,6 +540,63 @@ exports[`should ensure isolation of PostCSS config objects between different bui
       "not": "url",
     },
     "oneOf": [
+      {
+        "resolve": {
+          "preferRelative": true,
+        },
+        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/src/cssUrlLoader.mjs",
+            "options": {
+              "filename": "static/css/[name].css",
+              "modules": {
+                "auto": true,
+                "exportGlobals": false,
+                "exportLocalsConvention": "camelCase",
+                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                "namedExport": false,
+              },
+            },
+          },
+          {
+            "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+            "options": {
+              "exportType": "string",
+              "importLoaders": 2,
+              "modules": false,
+              "sourceMap": false,
+            },
+          },
+          {
+            "loader": "builtin:lightningcss-loader",
+            "options": {
+              "errorRecovery": true,
+              "targets": [
+                "chrome >= 107",
+                "edge >= 107",
+                "firefox >= 104",
+                "safari >= 16",
+              ],
+            },
+          },
+          {
+            "loader": "<ROOT>/packages/core/compiled/postcss-loader/index.js",
+            "options": {
+              "implementation": "<ROOT>/packages/core/compiled/postcss/index.js",
+              "postcssOptions": {
+                "config": false,
+                "plugins": [
+                  {
+                    "postcssPlugin": "bar",
+                  },
+                ],
+              },
+              "sourceMap": false,
+            },
+          },
+        ],
+      },
       {
         "resolve": {
           "preferRelative": true,

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -62,6 +62,48 @@ exports[`should apply default plugins correctly 1`] = `
             "resolve": {
               "preferRelative": true,
             },
+            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "use": [
+              {
+                "loader": "<ROOT>/packages/core/src/cssUrlLoader.mjs",
+                "options": {
+                  "filename": "static/css/[name].css",
+                  "modules": {
+                    "auto": true,
+                    "exportGlobals": false,
+                    "exportLocalsConvention": "camelCase",
+                    "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                    "namedExport": false,
+                  },
+                },
+              },
+              {
+                "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+                "options": {
+                  "exportType": "string",
+                  "importLoaders": 1,
+                  "modules": false,
+                  "sourceMap": false,
+                },
+              },
+              {
+                "loader": "builtin:lightningcss-loader",
+                "options": {
+                  "errorRecovery": true,
+                  "targets": [
+                    "chrome >= 107",
+                    "edge >= 107",
+                    "firefox >= 104",
+                    "safari >= 16",
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            "resolve": {
+              "preferRelative": true,
+            },
             "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
             "sideEffects": true,
             "use": [
@@ -490,6 +532,49 @@ exports[`should apply default plugins correctly in production 1`] = `
           "not": "url",
         },
         "oneOf": [
+          {
+            "resolve": {
+              "preferRelative": true,
+            },
+            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "use": [
+              {
+                "loader": "<ROOT>/packages/core/src/cssUrlLoader.mjs",
+                "options": {
+                  "filename": "static/css/[name].[contenthash:10].css",
+                  "modules": {
+                    "auto": true,
+                    "exportGlobals": false,
+                    "exportLocalsConvention": "camelCase",
+                    "localIdentName": "[local]-[hash:base64:6]",
+                    "namedExport": false,
+                  },
+                },
+              },
+              {
+                "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+                "options": {
+                  "exportType": "string",
+                  "importLoaders": 1,
+                  "modules": false,
+                  "sourceMap": false,
+                },
+              },
+              {
+                "loader": "builtin:lightningcss-loader",
+                "options": {
+                  "errorRecovery": true,
+                  "minify": true,
+                  "targets": [
+                    "chrome >= 107",
+                    "edge >= 107",
+                    "firefox >= 104",
+                    "safari >= 16",
+                  ],
+                },
+              },
+            ],
+          },
           {
             "resolve": {
               "preferRelative": true,
@@ -951,6 +1036,46 @@ exports[`should apply default plugins correctly when target is node 1`] = `
             "resolve": {
               "preferRelative": true,
             },
+            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "use": [
+              {
+                "loader": "<ROOT>/packages/core/src/cssUrlLoader.mjs",
+                "options": {
+                  "filename": "static/css/[name].css",
+                  "modules": {
+                    "auto": true,
+                    "exportGlobals": false,
+                    "exportLocalsConvention": "camelCase",
+                    "exportOnlyLocals": true,
+                    "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                    "namedExport": false,
+                  },
+                },
+              },
+              {
+                "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+                "options": {
+                  "exportType": "string",
+                  "importLoaders": 1,
+                  "modules": false,
+                  "sourceMap": false,
+                },
+              },
+              {
+                "loader": "builtin:lightningcss-loader",
+                "options": {
+                  "errorRecovery": true,
+                  "targets": [
+                    "node >= 20",
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            "resolve": {
+              "preferRelative": true,
+            },
             "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
             "sideEffects": true,
             "use": [
@@ -1373,6 +1498,48 @@ exports[`tools.rspack > should match snapshot 1`] = `
           "not": "url",
         },
         "oneOf": [
+          {
+            "resolve": {
+              "preferRelative": true,
+            },
+            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "use": [
+              {
+                "loader": "<ROOT>/packages/core/src/cssUrlLoader.mjs",
+                "options": {
+                  "filename": "static/css/[name].css",
+                  "modules": {
+                    "auto": true,
+                    "exportGlobals": false,
+                    "exportLocalsConvention": "camelCase",
+                    "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                    "namedExport": false,
+                  },
+                },
+              },
+              {
+                "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+                "options": {
+                  "exportType": "string",
+                  "importLoaders": 1,
+                  "modules": false,
+                  "sourceMap": false,
+                },
+              },
+              {
+                "loader": "builtin:lightningcss-loader",
+                "options": {
+                  "errorRecovery": true,
+                  "targets": [
+                    "chrome >= 107",
+                    "edge >= 107",
+                    "firefox >= 104",
+                    "safari >= 16",
+                  ],
+                },
+              },
+            ],
+          },
           {
             "resolve": {
               "preferRelative": true,

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -35,6 +35,48 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
               "resolve": {
                 "preferRelative": true,
               },
+              "resourceQuery": /\\^\\\\\\?url\\$/,
+              "use": [
+                {
+                  "loader": "<ROOT>/packages/core/src/cssUrlLoader.mjs",
+                  "options": {
+                    "filename": "static/css/[name].css",
+                    "modules": {
+                      "auto": true,
+                      "exportGlobals": false,
+                      "exportLocalsConvention": "camelCase",
+                      "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                      "namedExport": false,
+                    },
+                  },
+                },
+                {
+                  "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+                  "options": {
+                    "exportType": "string",
+                    "importLoaders": 1,
+                    "modules": false,
+                    "sourceMap": false,
+                  },
+                },
+                {
+                  "loader": "builtin:lightningcss-loader",
+                  "options": {
+                    "errorRecovery": true,
+                    "targets": [
+                      "chrome >= 107",
+                      "edge >= 107",
+                      "firefox >= 104",
+                      "safari >= 16",
+                    ],
+                  },
+                },
+              ],
+            },
+            {
+              "resolve": {
+                "preferRelative": true,
+              },
               "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
               "sideEffects": true,
               "use": [
@@ -456,6 +498,49 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
             "not": "url",
           },
           "oneOf": [
+            {
+              "resolve": {
+                "preferRelative": true,
+              },
+              "resourceQuery": /\\^\\\\\\?url\\$/,
+              "use": [
+                {
+                  "loader": "<ROOT>/packages/core/src/cssUrlLoader.mjs",
+                  "options": {
+                    "filename": "static/css/[name].css",
+                    "modules": {
+                      "auto": true,
+                      "exportGlobals": false,
+                      "exportLocalsConvention": "camelCase",
+                      "exportOnlyLocals": true,
+                      "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                      "namedExport": false,
+                    },
+                  },
+                },
+                {
+                  "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+                  "options": {
+                    "exportType": "string",
+                    "importLoaders": 1,
+                    "modules": false,
+                    "sourceMap": false,
+                  },
+                },
+                {
+                  "loader": "builtin:lightningcss-loader",
+                  "options": {
+                    "errorRecovery": true,
+                    "targets": [
+                      "chrome >= 107",
+                      "edge >= 107",
+                      "firefox >= 104",
+                      "safari >= 16",
+                    ],
+                  },
+                },
+              ],
+            },
             {
               "resolve": {
                 "preferRelative": true,

--- a/packages/core/types.d.ts
+++ b/packages/core/types.d.ts
@@ -239,10 +239,13 @@ declare module '*.toml' {
 
 /**
  * Imports the file as a URL string.
- * @note Only works for static assets by default.
+ * @note Only works for static assets and CSS files by default.
  * @example
  * import logoUrl from './logo.png?url'
  * console.log(logoUrl) // 'http://example.com/logo.123456.png'
+ *
+ * import cssUrl from './style.css?url'
+ * console.log(cssUrl) // 'http://example.com/style.123456.css'
  */
 declare module '*?url' {
   const content: string;


### PR DESCRIPTION
## Summary

This PR adds support for importing CSS files with `?url`, such as `import styleUrl from "./style.css?url"`. The emitted URL points to CSS content after the normal Rsbuild CSS transform pipeline, including PostCSS and Lightning CSS processing`.

Unlike normal CSS imports, this mode only exports the generated CSS file URL and does not inject a stylesheet into the HTML.
