### PR TITLE
fix(core): pass asset info to CSS url filenames

### DIFF
--- a/e2e/cases/css/url-query-filename-function/index.test.ts
+++ b/e2e/cases/css/url-query-filename-function/index.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '@e2e/helper';
+
+type CssUrlResult = {
+  styleUrl: string;
+  styleContent: string;
+};
+
+test('should pass asset info to CSS URL filename function', async ({
+  page,
+  runBothServe,
+}) => {
+  await runBothServe(async () => {
+    const { styleUrl, styleContent } = await page.evaluate<CssUrlResult>(
+      'window.getCssUrlResult()',
+    );
+
+    expect(styleUrl).toMatch(/\/static\/css\/from-asset-info\/style\.css$/);
+    expect(styleContent).toContain('.filename-function-class');
+  });
+});

--- a/e2e/cases/css/url-query-filename-function/rsbuild.config.ts
+++ b/e2e/cases/css/url-query-filename-function/rsbuild.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    filenameHash: false,
+    filename: {
+      css(_pathData, assetInfo) {
+        if (assetInfo?.sourceFilename === 'src/style.css') {
+          return 'from-asset-info/[name].css';
+        }
+
+        return '[name].css';
+      },
+    },
+  },
+});

--- a/e2e/cases/css/url-query-filename-function/src/index.js
+++ b/e2e/cases/css/url-query-filename-function/src/index.js
@@ -1,0 +1,6 @@
+import styleUrl from './style.css?url';
+
+window.getCssUrlResult = async () => ({
+  styleUrl,
+  styleContent: await fetch(styleUrl).then((res) => res.text()),
+});

--- a/e2e/cases/css/url-query-filename-function/src/style.css
+++ b/e2e/cases/css/url-query-filename-function/src/style.css
@@ -1,0 +1,3 @@
+.filename-function-class {
+  color: red;
+}

--- a/packages/core/src/loader/cssUrlLoader.ts
+++ b/packages/core/src/loader/cssUrlLoader.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import type {
+  AssetInfo,
   LoaderDefinitionFunction,
   PathData,
   PitchLoaderDefinitionFunction,
@@ -7,7 +8,7 @@ import type {
 import type { CSSLoaderOptions } from '../types';
 
 type CSSUrlLoaderOptions = {
-  filename: string | ((pathData: PathData) => string);
+  filename: string | ((pathData: PathData, assetInfo?: AssetInfo) => string);
   modules: CSSLoaderOptions['modules'];
 };
 
@@ -126,9 +127,12 @@ export const pitch: PitchLoaderDefinitionFunction<CSSUrlLoaderOptions> =
         },
       },
     };
+    const assetInfo: AssetInfo = {
+      sourceFilename,
+    };
     const filenameTemplate =
       typeof options.filename === 'function'
-        ? options.filename(pathData)
+        ? options.filename(pathData, assetInfo)
         : options.filename;
     const { path: filename, info } = this._compilation.getAssetPathWithInfo(
       filenameTemplate,
@@ -137,9 +141,9 @@ export const pitch: PitchLoaderDefinitionFunction<CSSUrlLoaderOptions> =
 
     this.emitFile(filename, content, undefined, {
       ...info,
+      ...assetInfo,
       immutable:
         info.immutable || HASH_PLACEHOLDER_REGEX.test(filenameTemplate),
-      sourceFilename,
     });
 
     return `export default __webpack_public_path__ + ${JSON.stringify(filename)};`;


### PR DESCRIPTION
## Summary

This PR fixes CSS `?url` filename functions so they receive the `assetInfo` argument documented for `output.filename.css`. The CSS URL loader now passes `assetInfo.sourceFilename` when resolving the filename template and keeps that asset info on the emitted CSS file.

A focused e2e case verifies that `output.filename.css(pathData, assetInfo)` can route a CSS `?url` asset based on `assetInfo.sourceFilename`.

## Related Links

Follow-up to https://github.com/web-infra-dev/rsbuild/pull/7541