### PR TITLE
test(e2e): cover CSS Modules url query error

### DIFF
--- a/e2e/cases/css/url-query-css-modules/index.test.ts
+++ b/e2e/cases/css/url-query-css-modules/index.test.ts
@@ -1,7 +1,6 @@
 import { expect, test } from '@e2e/helper';
 
-const EXPECTED_ERROR =
-  '[rsbuild:css] CSS Modules do not support the ?url query. Use ?inline to import the compiled CSS content as a string.';
+const EXPECTED_ERROR = 'CSS Modules do not support the ?url query';
 
 test('should throw error when importing CSS Modules with `?url`', async ({
   build,

--- a/e2e/cases/css/url-query-css-modules/index.test.ts
+++ b/e2e/cases/css/url-query-css-modules/index.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@e2e/helper';
+
+const EXPECTED_ERROR =
+  '[rsbuild:css] CSS Modules do not support the ?url query. Use ?inline to import the compiled CSS content as a string.';
+
+test('should throw error when importing CSS Modules with `?url`', async ({
+  build,
+}) => {
+  const rsbuild = await build({
+    catchBuildError: true,
+  });
+
+  expect(rsbuild.buildError).toBeTruthy();
+  await rsbuild.expectLog(EXPECTED_ERROR);
+});

--- a/e2e/cases/css/url-query-css-modules/src/index.js
+++ b/e2e/cases/css/url-query-css-modules/src/index.js
@@ -1,0 +1,3 @@
+import styleUrl from './style.module.css?url';
+
+document.body.textContent = styleUrl;

--- a/e2e/cases/css/url-query-css-modules/src/style.module.css
+++ b/e2e/cases/css/url-query-css-modules/src/style.module.css
@@ -1,0 +1,3 @@
+.title {
+  color: red;
+}


### PR DESCRIPTION
## Summary

This PR adds an e2e regression case for importing CSS Modules with the `?url` query. It verifies the build fails and logs the expected Rsbuild error that CSS Modules do not support `?url`, nudging users toward `?inline`.

## Related Links

None