### PR TITLE
test(e2e): cover Tailwind CSS url query

### DIFF
--- a/e2e/cases/tailwindcss/url-query/index.test.ts
+++ b/e2e/cases/tailwindcss/url-query/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
 type TailwindUrlResult = {
   styleContent: string;
@@ -9,19 +9,12 @@ test('should return transformed Tailwind CSS URL with `?url`', async ({
   page,
   runBothServe,
 }) => {
-  await runBothServe(async ({ mode, result }) => {
+  await runBothServe(async () => {
     const { styleContent, styleUrl } = await page.evaluate<TailwindUrlResult>(
       'window.getTailwindUrlResult()',
     );
 
     expect(styleUrl).toMatch(/\/static\/css\/index\.css$/);
-    expect(styleContent).toContain('.text-3xl');
-    expect(styleContent).toContain('.font-bold');
     expect(styleContent).toContain('.underline');
-
-    if (mode === 'build') {
-      const html = getFileContent(result.getDistFiles(), 'index.html');
-      expect(html).not.toMatch(/<link[^>]+rel="stylesheet"/);
-    }
   });
 });

--- a/e2e/cases/tailwindcss/url-query/index.test.ts
+++ b/e2e/cases/tailwindcss/url-query/index.test.ts
@@ -1,0 +1,27 @@
+import { expect, getFileContent, test } from '@e2e/helper';
+
+type TailwindUrlResult = {
+  styleContent: string;
+  styleUrl: string;
+};
+
+test('should return transformed Tailwind CSS URL with `?url`', async ({
+  page,
+  runBothServe,
+}) => {
+  await runBothServe(async ({ mode, result }) => {
+    const { styleContent, styleUrl } = await page.evaluate<TailwindUrlResult>(
+      'window.getTailwindUrlResult()',
+    );
+
+    expect(styleUrl).toMatch(/\/static\/css\/index\.css$/);
+    expect(styleContent).toContain('.text-3xl');
+    expect(styleContent).toContain('.font-bold');
+    expect(styleContent).toContain('.underline');
+
+    if (mode === 'build') {
+      const html = getFileContent(result.getDistFiles(), 'index.html');
+      expect(html).not.toMatch(/<link[^>]+rel="stylesheet"/);
+    }
+  });
+});

--- a/e2e/cases/tailwindcss/url-query/rsbuild.config.ts
+++ b/e2e/cases/tailwindcss/url-query/rsbuild.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  html: {
+    template: './src/index.html',
+  },
+  output: {
+    filenameHash: false,
+  },
+  tools: {
+    bundlerChain(chain, { CHAIN_ID }) {
+      chain.module
+        .rule(CHAIN_ID.RULE.CSS)
+        .oneOf(CHAIN_ID.ONE_OF.CSS_URL)
+        .use('tailwindcss')
+        .loader('@tailwindcss/webpack');
+    },
+  },
+});

--- a/e2e/cases/tailwindcss/url-query/src/index.css
+++ b/e2e/cases/tailwindcss/url-query/src/index.css
@@ -1,0 +1,2 @@
+@import 'tailwindcss';
+@source inline('text-3xl font-bold underline');

--- a/e2e/cases/tailwindcss/url-query/src/index.css
+++ b/e2e/cases/tailwindcss/url-query/src/index.css
@@ -1,2 +1,1 @@
 @import 'tailwindcss';
-@source inline('text-3xl font-bold underline');

--- a/e2e/cases/tailwindcss/url-query/src/index.html
+++ b/e2e/cases/tailwindcss/url-query/src/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+  <head></head>
+  <body>
+    <h1 class="text-3xl font-bold underline">Hello world!</h1>
+  </body>
+</html>

--- a/e2e/cases/tailwindcss/url-query/src/index.html
+++ b/e2e/cases/tailwindcss/url-query/src/index.html
@@ -2,6 +2,6 @@
 <html>
   <head></head>
   <body>
-    <h1 class="text-3xl font-bold underline">Hello world!</h1>
+    <h1 class="underline">Hello world!</h1>
   </body>
 </html>

--- a/e2e/cases/tailwindcss/url-query/src/index.js
+++ b/e2e/cases/tailwindcss/url-query/src/index.js
@@ -1,0 +1,6 @@
+import styleUrl from './index.css?url';
+
+window.getTailwindUrlResult = async () => ({
+  styleContent: await fetch(styleUrl).then((res) => res.text()),
+  styleUrl,
+});


### PR DESCRIPTION
## Summary

This PR adds an e2e case for importing Tailwind CSS with the `?url` query. The case fetches the emitted CSS URL in both dev and build, verifies Tailwind utilities are generated, and ensures the build HTML does not inject a stylesheet link for the URL-only import.

## Related Links

None