### PR TITLE
refactor(core): simplify CSS url loader request

### DIFF
--- a/packages/core/src/loader/cssUrlLoader.ts
+++ b/packages/core/src/loader/cssUrlLoader.ts
@@ -127,9 +127,7 @@ export const pitch: PitchLoaderDefinitionFunction<CSSUrlLoaderOptions> =
       );
     }
 
-    const moduleExports = await this.importModule(
-      `${this.resourcePath}.rspack[javascript/auto]!=!!!${remainingRequest}`,
-    );
+    const moduleExports = await this.importModule(`!!${remainingRequest}`);
     const content = getCSSContent(moduleExports);
 
     const ext = path.extname(this.resourcePath);


### PR DESCRIPTION
## Summary

`cssUrlLoader` used an inline matchResource request with `.rspack[javascript/auto]` to import the transformed CSS module during pitch. Since this internal import can rely on Rspack's default `javascript/auto` module type, this PR simplifies the request to `!!${remainingRequest}` while keeping the same CSS `?url` behavior.
