### PR TITLE
test(e2e): cover CSS url query edge cases

### DIFF
--- a/e2e/cases/css/url-query-css-modules/index.test.ts
+++ b/e2e/cases/css/url-query-css-modules/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 const EXPECTED_ERROR = 'CSS Modules do not support the ?url query';
 
@@ -11,4 +11,28 @@ test('should throw error when importing CSS Modules with `?url`', async ({
 
   expect(rsbuild.buildError).toBeTruthy();
   await rsbuild.expectLog(EXPECTED_ERROR);
+});
+
+test('should allow `.module.css?url` when CSS Modules auto is disabled', async ({
+  build,
+}) => {
+  const rsbuild = await build({
+    config: {
+      output: {
+        filenameHash: false,
+      },
+      tools: {
+        cssLoader: {
+          modules: {
+            auto: false,
+          },
+        },
+      },
+    },
+  });
+  const files = rsbuild.getDistFiles();
+  const jsContent = getFileContent(files, 'index.js');
+  const cssContent = getFileContent(files, 'style.module.css');
+  expect(jsContent).toContain('static/css/style.module.css');
+  expect(cssContent).toContain('.title{color:red}');
 });

--- a/e2e/cases/css/url-query/index.test.ts
+++ b/e2e/cases/css/url-query/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, findFile, getFileContent, test } from '@e2e/helper';
 
 type CssUrlResult = {
   aStyleContent: string;
@@ -46,4 +46,23 @@ test('should return transformed CSS URL with `?url`', async ({
       expect(html).not.toMatch(/<link[^>]+rel="stylesheet"/);
     }
   });
+});
+
+test('should emit hashed CSS files for `?url` in production', async ({
+  build,
+}) => {
+  const rsbuild = await build({
+    config: {
+      output: {
+        filenameHash: true,
+      },
+    },
+  });
+  const files = rsbuild.getDistFiles();
+  const styleFile = findFile(files, /style\.[a-f0-9]{10}\.css$/, {
+    ignoreHash: false,
+  });
+  const jsContent = getFileContent(files, 'index.js');
+  expect(files[styleFile]).toContain('.url-query-class');
+  expect(jsContent).toMatch(/static\/css\/style\.[a-f0-9]{10}\.css/);
 });

--- a/e2e/cases/css/url-query/index.test.ts
+++ b/e2e/cases/css/url-query/index.test.ts
@@ -64,5 +64,5 @@ test('should emit hashed CSS files for `?url` in production', async ({
   });
   const jsContent = getFileContent(files, 'index.js');
   expect(files[styleFile]).toContain('.url-query-class');
-  expect(jsContent).toMatch(/static\/css\/style\.[a-f0-9]{10}\.css/);
+  expect(jsContent).toMatch(/static\/css\/style\.[a-f0-9]+\.css/);
 });

--- a/e2e/cases/css/url-query/index.test.ts
+++ b/e2e/cases/css/url-query/index.test.ts
@@ -59,7 +59,7 @@ test('should emit hashed CSS files for `?url` in production', async ({
     },
   });
   const files = rsbuild.getDistFiles();
-  const styleFile = findFile(files, /style\.[a-f0-9]{10}\.css$/, {
+  const styleFile = findFile(files, /style\.[a-f0-9]+\.css$/, {
     ignoreHash: false,
   });
   const jsContent = getFileContent(files, 'index.js');


### PR DESCRIPTION
## Summary

This PR adds e2e coverage for CSS `?url` behavior when production filename hashing is enabled and when CSS Modules auto detection is disabled for `.module.css?url` imports.
