### PR TITLE
feat(plugin-sass): support Sass URL query

### DIFF
--- a/e2e/cases/plugin-sass/url-query/index.test.ts
+++ b/e2e/cases/plugin-sass/url-query/index.test.ts
@@ -1,0 +1,27 @@
+import { expect, getFileContent, test } from '@e2e/helper';
+
+type SassUrlResult = {
+  styleContent: string;
+  styleUrl: string;
+  targetColor: string;
+};
+
+test('should return transformed Sass URL with `?url`', async ({
+  page,
+  runBothServe,
+}) => {
+  await runBothServe(async ({ mode, result }) => {
+    const { styleContent, styleUrl, targetColor } =
+      await page.evaluate<SassUrlResult>('window.getSassUrlResult()');
+
+    expect(styleUrl).toMatch(/\/static\/css\/style\.css$/);
+    expect(styleContent).toContain('.url-query-sass');
+    expect(styleContent).toMatch(/\.url-query-sass:{1,2}after/);
+    expect(targetColor).toBe('rgb(0, 0, 0)');
+
+    if (mode === 'build') {
+      const html = getFileContent(result.getDistFiles(), 'index.html');
+      expect(html).not.toMatch(/<link[^>]+rel="stylesheet"/);
+    }
+  });
+});

--- a/e2e/cases/plugin-sass/url-query/rsbuild.config.ts
+++ b/e2e/cases/plugin-sass/url-query/rsbuild.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginSass } from '@rsbuild/plugin-sass';
+
+export default defineConfig({
+  output: {
+    filenameHash: false,
+  },
+  plugins: [pluginSass()],
+});

--- a/e2e/cases/plugin-sass/url-query/src/index.js
+++ b/e2e/cases/plugin-sass/url-query/src/index.js
@@ -1,0 +1,12 @@
+import styleUrl from './style.scss?url';
+
+const target = document.createElement('div');
+target.className = 'url-query-sass';
+target.textContent = 'Sass URL query';
+document.body.appendChild(target);
+
+window.getSassUrlResult = async () => ({
+  styleContent: await fetch(styleUrl).then((res) => res.text()),
+  styleUrl,
+  targetColor: getComputedStyle(target).color,
+});

--- a/e2e/cases/plugin-sass/url-query/src/style.scss
+++ b/e2e/cases/plugin-sass/url-query/src/style.scss
@@ -1,0 +1,11 @@
+$url-query-color: red;
+
+.url-query {
+  &-sass {
+    color: $url-query-color;
+
+    &::after {
+      content: 'compiled';
+    }
+  }
+}

--- a/packages/plugin-sass/src/index.ts
+++ b/packages/plugin-sass/src/index.ts
@@ -104,6 +104,7 @@ export const pluginSass = (
     const CSS_INLINE = 'css-inline';
     const CSS_RAW = 'css-raw';
     const SASS_MAIN = 'sass';
+    const SASS_URL = 'sass-url';
     const SASS_INLINE = 'sass-inline';
     const SASS_RAW = 'sass-raw';
     const isV1 = api.context.version.startsWith('1.');
@@ -132,6 +133,10 @@ export const pluginSass = (
         .resolve.preferRelative(true)
         .end();
 
+      const cssRule = chain.module.rule(CHAIN_ID.RULE.CSS);
+      const cssUrlRuleId = CHAIN_ID.ONE_OF.CSS_URL;
+      const hasCssUrlRule = cssUrlRuleId && cssRule.oneOfs.has(cssUrlRuleId);
+
       if (isV1) {
         chain.module.rule(SASS_RAW).test(include);
         chain.module.rule(SASS_INLINE).test(include);
@@ -142,12 +147,11 @@ export const pluginSass = (
         if (isV1) {
           return chain.module.rule(id);
         }
-        return (
-          id.startsWith('sass')
-            ? sassRule
-            : chain.module.rule(CHAIN_ID.RULE.CSS)
-        ).oneOf(id);
+        return (id.startsWith('sass') ? sassRule : cssRule).oneOf(id);
       };
+
+      // Sass URL for `?url` imports.
+      const sassUrlRule = hasCssUrlRule && getRule(SASS_URL);
 
       // Inline Sass for `?inline` imports
       const sassInlineRule = getRule(SASS_INLINE);
@@ -160,15 +164,19 @@ export const pluginSass = (
       // Main Sass transform
       const sassMainRule = getRule(SASS_MAIN);
 
-      // Update the main rule and the inline rule
+      // Update the main, inline and URL rules.
       const updateRules = (
         callback: (
           rule: RspackChain.Rule<unknown>,
           cssBranchRule: RspackChain.Rule<unknown>,
+          type: 'main' | 'inline' | 'url',
         ) => void,
       ) => {
-        callback(sassMainRule, getRule(CSS_MAIN));
-        callback(sassInlineRule, getRule(CSS_INLINE));
+        if (sassUrlRule) {
+          callback(sassUrlRule, getRule(cssUrlRuleId), 'url');
+        }
+        callback(sassMainRule, getRule(CSS_MAIN), 'main');
+        callback(sassInlineRule, getRule(CSS_INLINE), 'inline');
       };
 
       const sassLoaderPath = path.join(
@@ -189,7 +197,7 @@ export const pluginSass = (
         sourceMap: false,
       };
 
-      updateRules((rule, cssBranchRule) => {
+      updateRules((rule, cssBranchRule, type) => {
         for (const item of excludes) {
           rule.exclude.add(item);
         }
@@ -198,9 +206,10 @@ export const pluginSass = (
         }
 
         // Copy the builtin CSS rules
-        rule
-          .sideEffects(true)
-          .resourceQuery(cssBranchRule.get('resourceQuery'));
+        if (type !== 'url') {
+          rule.sideEffects(true);
+        }
+        rule.resourceQuery(cssBranchRule.get('resourceQuery'));
 
         for (const id of Object.keys(cssBranchRule.uses.entries())) {
           const loader = cssBranchRule.uses.get(id);

--- a/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
@@ -8,6 +8,66 @@ exports[`plugin-sass > should add sass-loader 1`] = `
     },
     "oneOf": [
       {
+        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/dist/cssUrlLoader.mjs",
+            "options": {
+              "filename": "static/css/[name].css",
+              "modules": {
+                "auto": true,
+                "exportGlobals": false,
+                "exportLocalsConvention": "camelCase",
+                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                "namedExport": false,
+              },
+            },
+          },
+          {
+            "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+            "options": {
+              "exportType": "string",
+              "importLoaders": 3,
+              "modules": false,
+              "sourceMap": false,
+            },
+          },
+          {
+            "loader": "builtin:lightningcss-loader",
+            "options": {
+              "errorRecovery": true,
+              "targets": [
+                "chrome >= 107",
+                "edge >= 107",
+                "firefox >= 104",
+                "safari >= 16",
+              ],
+            },
+          },
+          {
+            "loader": "<ROOT>/packages/plugin-sass/compiled/resolve-url-loader/index.js",
+            "options": {
+              "join": [Function],
+              "sourceMap": false,
+            },
+          },
+          {
+            "loader": "<ROOT>/packages/plugin-sass/compiled/sass-loader/index.js",
+            "options": {
+              "api": "modern-compiler",
+              "implementation": "<PNPM_INNER>/sass-embedded/dist/lib/index.js",
+              "sassOptions": {
+                "quietDeps": true,
+                "silenceDeprecations": [
+                  "import",
+                ],
+              },
+              "sourceMap": true,
+            },
+          },
+        ],
+      },
+      {
         "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
         "sideEffects": true,
         "use": [
@@ -130,6 +190,66 @@ exports[`plugin-sass > should add sass-loader and css-loader when injectStyles 1
       "not": "url",
     },
     "oneOf": [
+      {
+        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/dist/cssUrlLoader.mjs",
+            "options": {
+              "filename": "static/css/[name].css",
+              "modules": {
+                "auto": true,
+                "exportGlobals": false,
+                "exportLocalsConvention": "camelCase",
+                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                "namedExport": false,
+              },
+            },
+          },
+          {
+            "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+            "options": {
+              "exportType": "string",
+              "importLoaders": 3,
+              "modules": false,
+              "sourceMap": false,
+            },
+          },
+          {
+            "loader": "builtin:lightningcss-loader",
+            "options": {
+              "errorRecovery": true,
+              "targets": [
+                "chrome >= 107",
+                "edge >= 107",
+                "firefox >= 104",
+                "safari >= 16",
+              ],
+            },
+          },
+          {
+            "loader": "<ROOT>/packages/plugin-sass/compiled/resolve-url-loader/index.js",
+            "options": {
+              "join": [Function],
+              "sourceMap": false,
+            },
+          },
+          {
+            "loader": "<ROOT>/packages/plugin-sass/compiled/sass-loader/index.js",
+            "options": {
+              "api": "modern-compiler",
+              "implementation": "<PNPM_INNER>/sass-embedded/dist/lib/index.js",
+              "sassOptions": {
+                "quietDeps": true,
+                "silenceDeprecations": [
+                  "import",
+                ],
+              },
+              "sourceMap": true,
+            },
+          },
+        ],
+      },
       {
         "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
         "sideEffects": true,
@@ -384,6 +504,69 @@ exports[`plugin-sass > should add sass-loader with excludes 1`] = `
         "exclude": [
           /node_modules/,
         ],
+        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/dist/cssUrlLoader.mjs",
+            "options": {
+              "filename": "static/css/[name].css",
+              "modules": {
+                "auto": true,
+                "exportGlobals": false,
+                "exportLocalsConvention": "camelCase",
+                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                "namedExport": false,
+              },
+            },
+          },
+          {
+            "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+            "options": {
+              "exportType": "string",
+              "importLoaders": 3,
+              "modules": false,
+              "sourceMap": false,
+            },
+          },
+          {
+            "loader": "builtin:lightningcss-loader",
+            "options": {
+              "errorRecovery": true,
+              "targets": [
+                "chrome >= 107",
+                "edge >= 107",
+                "firefox >= 104",
+                "safari >= 16",
+              ],
+            },
+          },
+          {
+            "loader": "<ROOT>/packages/plugin-sass/compiled/resolve-url-loader/index.js",
+            "options": {
+              "join": [Function],
+              "sourceMap": false,
+            },
+          },
+          {
+            "loader": "<ROOT>/packages/plugin-sass/compiled/sass-loader/index.js",
+            "options": {
+              "api": "modern-compiler",
+              "implementation": "<PNPM_INNER>/sass-embedded/dist/lib/index.js",
+              "sassOptions": {
+                "quietDeps": true,
+                "silenceDeprecations": [
+                  "import",
+                ],
+              },
+              "sourceMap": true,
+            },
+          },
+        ],
+      },
+      {
+        "exclude": [
+          /node_modules/,
+        ],
         "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
         "sideEffects": true,
         "use": [
@@ -509,6 +692,67 @@ exports[`plugin-sass > should allow to use legacy API and mute deprecation warni
       "not": "url",
     },
     "oneOf": [
+      {
+        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/dist/cssUrlLoader.mjs",
+            "options": {
+              "filename": "static/css/[name].css",
+              "modules": {
+                "auto": true,
+                "exportGlobals": false,
+                "exportLocalsConvention": "camelCase",
+                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                "namedExport": false,
+              },
+            },
+          },
+          {
+            "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+            "options": {
+              "exportType": "string",
+              "importLoaders": 3,
+              "modules": false,
+              "sourceMap": false,
+            },
+          },
+          {
+            "loader": "builtin:lightningcss-loader",
+            "options": {
+              "errorRecovery": true,
+              "targets": [
+                "chrome >= 107",
+                "edge >= 107",
+                "firefox >= 104",
+                "safari >= 16",
+              ],
+            },
+          },
+          {
+            "loader": "<ROOT>/packages/plugin-sass/compiled/resolve-url-loader/index.js",
+            "options": {
+              "join": [Function],
+              "sourceMap": false,
+            },
+          },
+          {
+            "loader": "<ROOT>/packages/plugin-sass/compiled/sass-loader/index.js",
+            "options": {
+              "api": "legacy",
+              "implementation": "<PNPM_INNER>/sass-embedded/dist/lib/index.js",
+              "sassOptions": {
+                "quietDeps": true,
+                "silenceDeprecations": [
+                  "import",
+                  "legacy-js-api",
+                ],
+              },
+              "sourceMap": true,
+            },
+          },
+        ],
+      },
       {
         "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
         "sideEffects": true,


### PR DESCRIPTION
## Summary

This PR adds `?url` handling for Sass files so Sass imports can use the CSS URL pipeline without injecting a stylesheet into HTML. It also adds plugin snapshots and an e2e case for the Sass URL query behavior.

## Related Links

None