### PR TITLE
chore: update renovate range strategy

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,7 @@
     "schedule:weekly",
     "helpers:pinGitHubActionDigests"
   ],
+  "rangeStrategy": "bump",
   "packageRules": [
     {
       "groupName": "Babel",


### PR DESCRIPTION
## Summary

This PR configures Renovate to bump npm dependency ranges when newer versions already satisfy the existing range. This prevents Renovate PRs from updating only `pnpm-lock.yaml` while leaving package.json ranges stale.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/7555