### PR TITLE
feat(plugin-less): support Less URL query

### DIFF
--- a/e2e/cases/plugin-less/url-query/index.test.ts
+++ b/e2e/cases/plugin-less/url-query/index.test.ts
@@ -1,0 +1,27 @@
+import { expect, getFileContent, test } from '@e2e/helper';
+
+type LessUrlResult = {
+  styleContent: string;
+  styleUrl: string;
+  targetColor: string;
+};
+
+test('should return transformed Less URL with `?url`', async ({
+  page,
+  runBothServe,
+}) => {
+  await runBothServe(async ({ mode, result }) => {
+    const { styleContent, styleUrl, targetColor } =
+      await page.evaluate<LessUrlResult>('window.getLessUrlResult()');
+
+    expect(styleUrl).toMatch(/\/static\/css\/style\.css$/);
+    expect(styleContent).toContain('.url-query-less');
+    expect(styleContent).toMatch(/\.url-query-less:{1,2}after/);
+    expect(targetColor).toBe('rgb(0, 0, 0)');
+
+    if (mode === 'build') {
+      const html = getFileContent(result.getDistFiles(), 'index.html');
+      expect(html).not.toMatch(/<link[^>]+rel="stylesheet"/);
+    }
+  });
+});

--- a/e2e/cases/plugin-less/url-query/rsbuild.config.ts
+++ b/e2e/cases/plugin-less/url-query/rsbuild.config.ts
@@ -1,0 +1,8 @@
+import { pluginLess } from '@rsbuild/plugin-less';
+
+export default {
+  output: {
+    filenameHash: false,
+  },
+  plugins: [pluginLess()],
+};

--- a/e2e/cases/plugin-less/url-query/src/index.js
+++ b/e2e/cases/plugin-less/url-query/src/index.js
@@ -1,0 +1,12 @@
+import styleUrl from './style.less?url';
+
+const target = document.createElement('div');
+target.className = 'url-query-less';
+target.textContent = 'Less URL query';
+document.body.appendChild(target);
+
+window.getLessUrlResult = async () => ({
+  styleContent: await fetch(styleUrl).then((res) => res.text()),
+  styleUrl,
+  targetColor: getComputedStyle(target).color,
+});

--- a/e2e/cases/plugin-less/url-query/src/style.less
+++ b/e2e/cases/plugin-less/url-query/src/style.less
@@ -1,0 +1,11 @@
+@url-query-color: red;
+
+.url-query {
+  &-less {
+    color: @url-query-color;
+
+    &::after {
+      content: 'compiled';
+    }
+  }
+}

--- a/packages/plugin-less/src/index.ts
+++ b/packages/plugin-less/src/index.ts
@@ -183,6 +183,7 @@ export const pluginLess = (
     const CSS_INLINE = 'css-inline';
     const CSS_RAW = 'css-raw';
     const LESS_MAIN = 'less';
+    const LESS_URL = 'less-url';
     const LESS_INLINE = 'less-inline';
     const LESS_RAW = 'less-raw';
     const isV1 = api.context.version.startsWith('1.');
@@ -214,6 +215,13 @@ export const pluginLess = (
         ).oneOf(id);
       };
 
+      const cssRule = chain.module.rule(CHAIN_ID.RULE.CSS);
+      const cssUrlRuleId = CHAIN_ID.ONE_OF.CSS_URL;
+      const hasCssUrlRule = cssUrlRuleId && cssRule.oneOfs.has(cssUrlRuleId);
+
+      // Less URL for `?url` imports.
+      const lessUrlRule = hasCssUrlRule && getRule(LESS_URL);
+
       // Inline Less for `?inline` imports
       const lessInlineRule = getRule(LESS_INLINE);
 
@@ -232,20 +240,24 @@ export const pluginLess = (
         api.context.rootPath,
       );
 
-      // Update the main rule and the inline rule
+      // Update the main, inline and URL rules.
       const updateRules = (
         callback: (
           rule: RspackChain.Rule<unknown>,
           cssBranchRule: RspackChain.Rule<unknown>,
+          type: 'main' | 'inline' | 'url',
         ) => void,
       ) => {
-        callback(lessMainRule, getRule(CSS_MAIN));
-        callback(lessInlineRule, getRule(CSS_INLINE));
+        if (lessUrlRule) {
+          callback(lessUrlRule, getRule(cssUrlRuleId), 'url');
+        }
+        callback(lessMainRule, getRule(CSS_MAIN), 'main');
+        callback(lessInlineRule, getRule(CSS_INLINE), 'inline');
       };
 
       const lessLoaderPath = require.resolve('less-loader');
 
-      updateRules((rule, cssBranchRule) => {
+      updateRules((rule, cssBranchRule, type) => {
         for (const item of excludes) {
           rule.exclude.add(item);
         }
@@ -254,9 +266,10 @@ export const pluginLess = (
         }
 
         // Copy the builtin CSS rules
-        rule
-          .sideEffects(true)
-          .resourceQuery(cssBranchRule.get('resourceQuery'));
+        if (type !== 'url') {
+          rule.sideEffects(true);
+        }
+        rule.resourceQuery(cssBranchRule.get('resourceQuery'));
 
         for (const id of Object.keys(cssBranchRule.uses.entries())) {
           const loader = cssBranchRule.uses.get(id);

--- a/packages/plugin-less/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-less/tests/__snapshots__/index.test.ts.snap
@@ -8,6 +8,57 @@ exports[`plugin-less > should add less-loader 1`] = `
     },
     "oneOf": [
       {
+        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/dist/cssUrlLoader.mjs",
+            "options": {
+              "filename": "static/css/[name].css",
+              "modules": {
+                "auto": true,
+                "exportGlobals": false,
+                "exportLocalsConvention": "camelCase",
+                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                "namedExport": false,
+              },
+            },
+          },
+          {
+            "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+            "options": {
+              "exportType": "string",
+              "importLoaders": 2,
+              "modules": false,
+              "sourceMap": false,
+            },
+          },
+          {
+            "loader": "builtin:lightningcss-loader",
+            "options": {
+              "errorRecovery": true,
+              "targets": [
+                "chrome >= 107",
+                "edge >= 107",
+                "firefox >= 104",
+                "safari >= 16",
+              ],
+            },
+          },
+          {
+            "loader": "<PNPM_INNER>/less-loader/dist/cjs.js",
+            "options": {
+              "lessOptions": {
+                "javascriptEnabled": true,
+                "paths": [
+                  "<ROOT>/node_modules",
+                ],
+              },
+              "sourceMap": false,
+            },
+          },
+        ],
+      },
+      {
         "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
         "sideEffects": true,
         "use": [
@@ -112,6 +163,57 @@ exports[`plugin-less > should add less-loader and css-loader when injectStyles 1
       "not": "url",
     },
     "oneOf": [
+      {
+        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/dist/cssUrlLoader.mjs",
+            "options": {
+              "filename": "static/css/[name].css",
+              "modules": {
+                "auto": true,
+                "exportGlobals": false,
+                "exportLocalsConvention": "camelCase",
+                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                "namedExport": false,
+              },
+            },
+          },
+          {
+            "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+            "options": {
+              "exportType": "string",
+              "importLoaders": 2,
+              "modules": false,
+              "sourceMap": false,
+            },
+          },
+          {
+            "loader": "builtin:lightningcss-loader",
+            "options": {
+              "errorRecovery": true,
+              "targets": [
+                "chrome >= 107",
+                "edge >= 107",
+                "firefox >= 104",
+                "safari >= 16",
+              ],
+            },
+          },
+          {
+            "loader": "<PNPM_INNER>/less-loader/dist/cjs.js",
+            "options": {
+              "lessOptions": {
+                "javascriptEnabled": true,
+                "paths": [
+                  "<ROOT>/node_modules",
+                ],
+              },
+              "sourceMap": false,
+            },
+          },
+        ],
+      },
       {
         "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
         "sideEffects": true,
@@ -330,6 +432,60 @@ exports[`plugin-less > should add less-loader with excludes 1`] = `
         "exclude": [
           /node_modules/,
         ],
+        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/dist/cssUrlLoader.mjs",
+            "options": {
+              "filename": "static/css/[name].css",
+              "modules": {
+                "auto": true,
+                "exportGlobals": false,
+                "exportLocalsConvention": "camelCase",
+                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                "namedExport": false,
+              },
+            },
+          },
+          {
+            "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+            "options": {
+              "exportType": "string",
+              "importLoaders": 2,
+              "modules": false,
+              "sourceMap": false,
+            },
+          },
+          {
+            "loader": "builtin:lightningcss-loader",
+            "options": {
+              "errorRecovery": true,
+              "targets": [
+                "chrome >= 107",
+                "edge >= 107",
+                "firefox >= 104",
+                "safari >= 16",
+              ],
+            },
+          },
+          {
+            "loader": "<PNPM_INNER>/less-loader/dist/cjs.js",
+            "options": {
+              "lessOptions": {
+                "javascriptEnabled": true,
+                "paths": [
+                  "<ROOT>/node_modules",
+                ],
+              },
+              "sourceMap": false,
+            },
+          },
+        ],
+      },
+      {
+        "exclude": [
+          /node_modules/,
+        ],
         "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
         "sideEffects": true,
         "use": [
@@ -438,6 +594,57 @@ exports[`plugin-less > should add less-loader with tools.less 1`] = `
     },
     "oneOf": [
       {
+        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/dist/cssUrlLoader.mjs",
+            "options": {
+              "filename": "static/css/[name].css",
+              "modules": {
+                "auto": true,
+                "exportGlobals": false,
+                "exportLocalsConvention": "camelCase",
+                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                "namedExport": false,
+              },
+            },
+          },
+          {
+            "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+            "options": {
+              "exportType": "string",
+              "importLoaders": 2,
+              "modules": false,
+              "sourceMap": false,
+            },
+          },
+          {
+            "loader": "builtin:lightningcss-loader",
+            "options": {
+              "errorRecovery": true,
+              "targets": [
+                "chrome >= 107",
+                "edge >= 107",
+                "firefox >= 104",
+                "safari >= 16",
+              ],
+            },
+          },
+          {
+            "loader": "<PNPM_INNER>/less-loader/dist/cjs.js",
+            "options": {
+              "lessOptions": {
+                "javascriptEnabled": false,
+                "paths": [
+                  "<ROOT>/node_modules",
+                ],
+              },
+              "sourceMap": false,
+            },
+          },
+        ],
+      },
+      {
         "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
         "sideEffects": true,
         "use": [
@@ -542,6 +749,64 @@ exports[`plugin-less > should allow to use Less plugins 1`] = `
       "not": "url",
     },
     "oneOf": [
+      {
+        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/dist/cssUrlLoader.mjs",
+            "options": {
+              "filename": "static/css/[name].css",
+              "modules": {
+                "auto": true,
+                "exportGlobals": false,
+                "exportLocalsConvention": "camelCase",
+                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                "namedExport": false,
+              },
+            },
+          },
+          {
+            "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+            "options": {
+              "exportType": "string",
+              "importLoaders": 2,
+              "modules": false,
+              "sourceMap": false,
+            },
+          },
+          {
+            "loader": "builtin:lightningcss-loader",
+            "options": {
+              "errorRecovery": true,
+              "targets": [
+                "chrome >= 107",
+                "edge >= 107",
+                "firefox >= 104",
+                "safari >= 16",
+              ],
+            },
+          },
+          {
+            "loader": "<PNPM_INNER>/less-loader/dist/cjs.js",
+            "options": {
+              "lessOptions": {
+                "javascriptEnabled": true,
+                "paths": [
+                  "<ROOT>/node_modules",
+                ],
+                "plugins": [
+                  MockPlugin {
+                    "options": {
+                      "foo": "bar",
+                    },
+                  },
+                ],
+              },
+              "sourceMap": false,
+            },
+          },
+        ],
+      },
       {
         "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
         "sideEffects": true,


### PR DESCRIPTION
## Summary

This PR adds support for importing Less files with the `?url` resource query, so Less can use the existing CSS URL pipeline and return an emitted CSS asset URL without injecting a stylesheet. It also updates plugin snapshots and adds an e2e case for Less URL query behavior.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/7554