### PR TITLE
feat(plugin-stylus): support Stylus URL query

### DIFF
--- a/e2e/cases/plugin-stylus/url-query/index.test.ts
+++ b/e2e/cases/plugin-stylus/url-query/index.test.ts
@@ -1,0 +1,27 @@
+import { expect, getFileContent, test } from '@e2e/helper';
+
+type StylusUrlResult = {
+  styleContent: string;
+  styleUrl: string;
+  targetColor: string;
+};
+
+test('should return transformed Stylus URL with `?url`', async ({
+  page,
+  runBothServe,
+}) => {
+  await runBothServe(async ({ mode, result }) => {
+    const { styleContent, styleUrl, targetColor } =
+      await page.evaluate<StylusUrlResult>('window.getStylusUrlResult()');
+
+    expect(styleUrl).toMatch(/\/static\/css\/style\.css$/);
+    expect(styleContent).toContain('.url-query-stylus');
+    expect(styleContent).toMatch(/\.url-query-stylus:{1,2}after/);
+    expect(targetColor).toBe('rgb(0, 0, 0)');
+
+    if (mode === 'build') {
+      const html = getFileContent(result.getDistFiles(), 'index.html');
+      expect(html).not.toMatch(/<link[^>]+rel="stylesheet"/);
+    }
+  });
+});

--- a/e2e/cases/plugin-stylus/url-query/rsbuild.config.ts
+++ b/e2e/cases/plugin-stylus/url-query/rsbuild.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginStylus } from '@rsbuild/plugin-stylus';
+
+export default defineConfig({
+  output: {
+    filenameHash: false,
+  },
+  plugins: [pluginStylus()],
+});

--- a/e2e/cases/plugin-stylus/url-query/src/index.js
+++ b/e2e/cases/plugin-stylus/url-query/src/index.js
@@ -1,0 +1,12 @@
+import styleUrl from './style.styl?url';
+
+const target = document.createElement('div');
+target.className = 'url-query-stylus';
+target.textContent = 'Stylus URL query';
+document.body.appendChild(target);
+
+window.getStylusUrlResult = async () => ({
+  styleContent: await fetch(styleUrl).then((res) => res.text()),
+  styleUrl,
+  targetColor: getComputedStyle(target).color,
+});

--- a/e2e/cases/plugin-stylus/url-query/src/style.styl
+++ b/e2e/cases/plugin-stylus/url-query/src/style.styl
@@ -1,0 +1,8 @@
+$url-query-color = red
+
+.url-query
+  &-stylus
+    color $url-query-color
+
+    &::after
+      content 'compiled'

--- a/packages/plugin-stylus/src/index.ts
+++ b/packages/plugin-stylus/src/index.ts
@@ -76,6 +76,7 @@ export const pluginStylus = (options?: PluginStylusOptions): RsbuildPlugin => ({
     const CSS_INLINE = 'css-inline';
     const CSS_RAW = 'css-raw';
     const STYLUS_MAIN = 'stylus';
+    const STYLUS_URL = 'stylus-url';
     const STYLUS_INLINE = 'stylus-inline';
     const STYLUS_RAW = 'stylus-raw';
     const isV1 = api.context.version.startsWith('1.');
@@ -100,6 +101,10 @@ export const pluginStylus = (options?: PluginStylusOptions): RsbuildPlugin => ({
         .resolve.preferRelative(true)
         .end();
 
+      const cssRule = chain.module.rule(CHAIN_ID.RULE.CSS);
+      const cssUrlRuleId = CHAIN_ID.ONE_OF.CSS_URL;
+      const hasCssUrlRule = cssUrlRuleId && cssRule.oneOfs.has(cssUrlRuleId);
+
       if (isV1) {
         chain.module.rule(STYLUS_RAW).test(test);
         chain.module.rule(STYLUS_INLINE).test(test);
@@ -110,12 +115,11 @@ export const pluginStylus = (options?: PluginStylusOptions): RsbuildPlugin => ({
         if (isV1) {
           return chain.module.rule(id);
         }
-        return (
-          id.startsWith('stylus')
-            ? stylusRule
-            : chain.module.rule(CHAIN_ID.RULE.CSS)
-        ).oneOf(id);
+        return (id.startsWith('stylus') ? stylusRule : cssRule).oneOf(id);
       };
+
+      // Stylus URL for `?url` imports.
+      const stylusUrlRule = hasCssUrlRule && getRule(STYLUS_URL);
 
       // Inline Stylus for `?inline` imports
       const stylusInlineRule = getRule(STYLUS_INLINE);
@@ -128,22 +132,27 @@ export const pluginStylus = (options?: PluginStylusOptions): RsbuildPlugin => ({
       // Main Stylus transform
       const stylusMainRule = getRule(STYLUS_MAIN);
 
-      // Update the main rule and the inline rule
+      // Update the main, inline and URL rules.
       const updateRules = (
         callback: (
           rule: RspackChain.Rule<unknown>,
           cssBranchRule: RspackChain.Rule<unknown>,
+          type: 'main' | 'inline' | 'url',
         ) => void,
       ) => {
-        callback(stylusMainRule, getRule(CSS_MAIN));
-        callback(stylusInlineRule, getRule(CSS_INLINE));
+        if (stylusUrlRule) {
+          callback(stylusUrlRule, getRule(cssUrlRuleId), 'url');
+        }
+        callback(stylusMainRule, getRule(CSS_MAIN), 'main');
+        callback(stylusInlineRule, getRule(CSS_INLINE), 'inline');
       };
 
-      updateRules((rule, cssBranchRule) => {
+      updateRules((rule, cssBranchRule, type) => {
         // Copy the builtin CSS rules
-        rule
-          .sideEffects(true)
-          .resourceQuery(cssBranchRule.get('resourceQuery'));
+        if (type !== 'url') {
+          rule.sideEffects(true);
+        }
+        rule.resourceQuery(cssBranchRule.get('resourceQuery'));
 
         for (const id of Object.keys(cssBranchRule.uses.entries())) {
           const loader = cssBranchRule.uses.get(id);

--- a/packages/plugin-stylus/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-stylus/tests/__snapshots__/index.test.ts.snap
@@ -8,6 +8,51 @@ exports[`plugin-stylus > should add stylus loader config correctly 1`] = `
     },
     "oneOf": [
       {
+        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/dist/cssUrlLoader.mjs",
+            "options": {
+              "filename": "static/css/[name].css",
+              "modules": {
+                "auto": true,
+                "exportGlobals": false,
+                "exportLocalsConvention": "camelCase",
+                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                "namedExport": false,
+              },
+            },
+          },
+          {
+            "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+            "options": {
+              "exportType": "string",
+              "importLoaders": 2,
+              "modules": false,
+              "sourceMap": false,
+            },
+          },
+          {
+            "loader": "builtin:lightningcss-loader",
+            "options": {
+              "errorRecovery": true,
+              "targets": [
+                "chrome >= 107",
+                "edge >= 107",
+                "firefox >= 104",
+                "safari >= 16",
+              ],
+            },
+          },
+          {
+            "loader": "<PNPM_INNER>/stylus-loader/dist/cjs.js",
+            "options": {
+              "sourceMap": false,
+            },
+          },
+        ],
+      },
+      {
         "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
         "sideEffects": true,
         "use": [
@@ -197,6 +242,54 @@ exports[`plugin-stylus > should allow to configure stylus options 1`] = `
       "not": "url",
     },
     "oneOf": [
+      {
+        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/dist/cssUrlLoader.mjs",
+            "options": {
+              "filename": "static/css/[name].css",
+              "modules": {
+                "auto": true,
+                "exportGlobals": false,
+                "exportLocalsConvention": "camelCase",
+                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                "namedExport": false,
+              },
+            },
+          },
+          {
+            "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+            "options": {
+              "exportType": "string",
+              "importLoaders": 2,
+              "modules": false,
+              "sourceMap": false,
+            },
+          },
+          {
+            "loader": "builtin:lightningcss-loader",
+            "options": {
+              "errorRecovery": true,
+              "targets": [
+                "chrome >= 107",
+                "edge >= 107",
+                "firefox >= 104",
+                "safari >= 16",
+              ],
+            },
+          },
+          {
+            "loader": "<PNPM_INNER>/stylus-loader/dist/cjs.js",
+            "options": {
+              "sourceMap": false,
+              "stylusOptions": {
+                "lineNumbers": false,
+              },
+            },
+          },
+        ],
+      },
       {
         "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
         "sideEffects": true,


### PR DESCRIPTION
## Summary

This PR adds support for importing Stylus files with `?url`, allowing compiled Stylus output to use the CSS URL pipeline and return an emitted CSS asset URL without injecting styles into HTML. It also adds plugin snapshots and an e2e case for the Stylus URL query behavior.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/7554