### PR TITLE
fix(core): filter Rspack runtime stack frames

### DIFF
--- a/e2e/cases/browser-logs/stack-trace-full-rspack-runtime/index.test.ts
+++ b/e2e/cases/browser-logs/stack-trace-full-rspack-runtime/index.test.ts
@@ -1,11 +1,9 @@
 import { test } from '@e2e/helper';
 
-test('should display stack frame for Rspack runtime modules', async ({
+test('should hide Rspack runtime stack frame when non-runtime stack exists', async ({
   dev,
 }) => {
   const rsbuild = await dev();
   await rsbuild.expectLog('[browser] Uncaught Error: foo');
-  await rsbuild.expectLog(
-    /at __webpack_require__\.O \(webpack\/runtime\/on_chunk_loaded:\d+:\d+\)/,
-  );
+  rsbuild.expectNoLog(/__webpack_require__|webpack\/runtime\//);
 });

--- a/e2e/cases/browser-logs/stack-trace-full/index.test.ts
+++ b/e2e/cases/browser-logs/stack-trace-full/index.test.ts
@@ -3,8 +3,7 @@ import { test } from '@e2e/helper';
 // Omitted some parts of the stack trace as they are not static
 const EXPECTED_LOG = `error   [browser] Uncaught Error: foo
     at foo (src/foo.js:2:0)
-    at src/index.js:3:0
-    at __webpack_require__`;
+    at src/index.js:3:0`;
 
 test('should display formatted full stack trace', async ({ dev }) => {
   const rsbuild = await dev();

--- a/e2e/cases/overlay/runtime-error-stack-filter/index.test.ts
+++ b/e2e/cases/overlay/runtime-error-stack-filter/index.test.ts
@@ -1,0 +1,15 @@
+import { expect, OVERLAY_ID, test } from '@e2e/helper';
+
+test('should hide Rspack runtime stack when user stack exists', async ({
+  page,
+  dev,
+}) => {
+  await dev();
+
+  const content = page.locator(OVERLAY_ID).locator('.content');
+
+  await expect(content).toContainText('Uncaught Error: Entry runtime error');
+  await expect(content).toContainText(/src[\\/]index\.js/);
+  await expect(content).not.toContainText('__webpack_require__');
+  await expect(content).not.toContainText('webpack/runtime/');
+});

--- a/e2e/cases/overlay/runtime-error-stack-filter/rsbuild.config.ts
+++ b/e2e/cases/overlay/runtime-error-stack-filter/rsbuild.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+
+export default defineConfig({
+  plugins: [pluginReact()],
+  dev: {
+    client: {
+      overlay: {
+        runtime: true,
+      },
+    },
+  },
+});

--- a/e2e/cases/overlay/runtime-error-stack-filter/src/index.js
+++ b/e2e/cases/overlay/runtime-error-stack-filter/src/index.js
@@ -1,0 +1,1 @@
+throw new Error('Entry runtime error');

--- a/packages/core/src/server/browserLogs.ts
+++ b/packages/core/src/server/browserLogs.ts
@@ -21,6 +21,14 @@ const isValidMethodName = (methodName: string) => {
   return methodName !== '<unknown>' && !/[\\/]/.test(methodName);
 };
 
+const isRspackRuntimeStack = (value?: string): boolean => {
+  if (!value) {
+    return false;
+  }
+
+  return value.includes('__webpack_require__') || isRspackRuntimeModule(value);
+};
+
 export type CachedTraceMap = Map<string, TraceMap>;
 
 /**
@@ -184,17 +192,22 @@ const formatFullStack = async (
   fs: Rspack.OutputFileSystem,
   cachedTraceMap: CachedTraceMap,
 ) => {
-  let result = '';
+  const formattedFrames: {
+    text: string;
+    isRspackRuntime: boolean;
+    hasLocation: boolean;
+  }[] = [];
 
   for (const frame of stackFrames) {
     const parsedFrame = await parseFrame(frame, fs, context, cachedTraceMap);
     const { methodName } = frame;
-    const parts: (string | undefined)[] = [];
+    const parts: string[] = [];
 
     if (isValidMethodName(methodName)) {
       parts.push(methodName);
     }
 
+    let location: string | undefined;
     let parsed = false;
     if (parsedFrame) {
       const { sourceMapPath, originalPosition } = parsedFrame;
@@ -204,6 +217,7 @@ const formatFullStack = async (
         context,
       );
       if (originalLocation) {
+        location = originalLocation;
         parts.push(originalLocation);
         parsed = true;
       }
@@ -214,19 +228,32 @@ const formatFullStack = async (
     if (!parsed && isVerbose(context.logger)) {
       const frameString = formatFrameLocation(frame);
       if (frameString) {
+        location = frameString;
         parts.push(frameString);
       }
     }
 
-    if (parts[0]) {
-      result += `\n    at ${parts[0]}`;
-    }
-    if (parts[1]) {
-      result += ` (${parts[1]})`;
+    const [first, second] = parts;
+    if (first) {
+      const isRspackRuntime =
+        isRspackRuntimeStack(methodName) || isRspackRuntimeStack(location);
+      formattedFrames.push({
+        text: second ? `\n    at ${first} (${second})` : `\n    at ${first}`,
+        isRspackRuntime,
+        hasLocation: location !== undefined,
+      });
     }
   }
 
-  return result;
+  // Hide Rspack runtime frames only when other useful stack frames with locations exist.
+  const shouldFilterRspackRuntime = formattedFrames.some(
+    (frame) => !frame.isRspackRuntime && frame.hasLocation,
+  );
+
+  return formattedFrames
+    .filter((frame) => !(shouldFilterRspackRuntime && frame.isRspackRuntime))
+    .map((frame) => frame.text)
+    .join('');
 };
 
 /**

--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -402,6 +402,7 @@ export class SocketServer {
           if (typeof client.overlay === 'object' && client.overlay.runtime) {
             // Always display full stack trace for runtime errors
             const resolvedLog =
+              // Reuse the formatted full log to avoid parsing the stack again.
               stackTrace === 'full'
                 ? log
                 : await formatBrowserErrorLog(


### PR DESCRIPTION
## Summary

- Filter Rspack runtime stack frames from full browser error stacks when other frames are available.
- Apply the same formatting to terminal browser logs and runtime error overlay, while preserving runtime-only stacks.
