### PR TITLE
feat(core): add overlay errors option

### DIFF
--- a/e2e/cases/overlay/build-errors-disabled/index.test.ts
+++ b/e2e/cases/overlay/build-errors-disabled/index.test.ts
@@ -1,0 +1,59 @@
+import { join } from 'node:path';
+import {
+  expect,
+  HMR_CONNECTED_LOG,
+  MODULE_BUILD_FAILED_LOG,
+  OVERLAY_ID,
+  test,
+} from '@e2e/helper';
+
+test('should allow disabling build error overlay independently', async ({
+  page,
+  dev,
+  editFile,
+  logHelper,
+  copySrcDir,
+}) => {
+  const tempSrc = await copySrcDir();
+  const { expectLog, addLog } = logHelper;
+
+  page.on('console', (consoleMessage) => {
+    addLog(consoleMessage.text());
+  });
+
+  await dev({
+    config: {
+      source: {
+        entry: {
+          index: join(tempSrc, 'index.jsx'),
+        },
+      },
+    },
+  });
+
+  await expectLog(HMR_CONNECTED_LOG);
+
+  const errorOverlay = page.locator(OVERLAY_ID);
+  await expect(errorOverlay).not.toBeAttached();
+
+  await editFile(join(tempSrc, 'App.jsx'), (code) =>
+    code.replace('</div>', '</a>'),
+  );
+
+  await expectLog(MODULE_BUILD_FAILED_LOG);
+  await expect(errorOverlay).not.toBeAttached();
+
+  await editFile(
+    join(tempSrc, 'App.jsx'),
+    () => `const App = () => {
+  throw new Error('Runtime error with build error overlay disabled');
+  return <div>Hello</div>;
+};
+
+export default App;
+`,
+  );
+
+  await expectLog('Runtime error with build error overlay disabled');
+  await expect(errorOverlay.locator('.title')).toHaveText('Runtime errors');
+});

--- a/e2e/cases/overlay/build-errors-disabled/rsbuild.config.ts
+++ b/e2e/cases/overlay/build-errors-disabled/rsbuild.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+
+export default defineConfig({
+  plugins: [pluginReact()],
+  dev: {
+    client: {
+      overlay: {
+        errors: false,
+        runtime: true,
+      },
+    },
+  },
+});

--- a/e2e/cases/overlay/build-errors-disabled/src/App.jsx
+++ b/e2e/cases/overlay/build-errors-disabled/src/App.jsx
@@ -1,0 +1,5 @@
+const App = () => {
+  return <div>Hello</div>;
+};
+
+export default App;

--- a/e2e/cases/overlay/build-errors-disabled/src/index.jsx
+++ b/e2e/cases/overlay/build-errors-disabled/src/index.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/packages/core/src/client/hmr.ts
+++ b/packages/core/src/client/hmr.ts
@@ -155,8 +155,6 @@ export function init(
         (typeof overlay === 'object' && overlay.errors !== false))
     ) {
       createOverlay('Build failed', html);
-    } else if (clearOverlay) {
-      clearOverlay();
     }
   }
 

--- a/packages/core/src/client/hmr.ts
+++ b/packages/core/src/client/hmr.ts
@@ -148,8 +148,15 @@ export function init(
       logger.error(error);
     }
 
-    if (createOverlay) {
+    const { overlay } = config;
+    if (
+      createOverlay &&
+      (overlay === true ||
+        (typeof overlay === 'object' && overlay.errors !== false))
+    ) {
       createOverlay('Build failed', html);
+    } else if (clearOverlay) {
+      clearOverlay();
     }
   }
 

--- a/packages/core/src/helpers/overlayConfig.ts
+++ b/packages/core/src/helpers/overlayConfig.ts
@@ -1,0 +1,13 @@
+import type { ClientConfig } from '../types';
+
+export const isBuildOverlayEnabled = (
+  overlay: ClientConfig['overlay'],
+): boolean =>
+  overlay === true || (typeof overlay === 'object' && overlay.errors !== false);
+
+export const isRuntimeOverlayEnabled = (
+  overlay: ClientConfig['overlay'],
+): boolean => typeof overlay === 'object' && overlay.runtime === true;
+
+export const isOverlayEnabled = (overlay: ClientConfig['overlay']): boolean =>
+  isBuildOverlayEnabled(overlay) || isRuntimeOverlayEnabled(overlay);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -142,6 +142,7 @@ export type {
   OnDevCompileDoneFn,
   OnExitFn,
   OutputConfig,
+  OverlayOptions,
   OutputStructure,
   PerformanceConfig,
   PluginManager,

--- a/packages/core/src/server/assets-middleware/index.ts
+++ b/packages/core/src/server/assets-middleware/index.ts
@@ -17,6 +17,7 @@ import {
 import { CLIENT_PATH } from '../../constants';
 import { createVirtualModule, pick } from '../../helpers';
 import { applyToCompiler, isMultiCompiler } from '../../helpers/compiler';
+import { isOverlayEnabled } from '../../helpers/overlayConfig';
 import { toPosixPath } from '../../helpers/path';
 import type {
   InternalContext,
@@ -206,7 +207,7 @@ function applyHMREntry({
   }
 
   const hmrEntry = `import { init } from '${toPosixPath(join(CLIENT_PATH, 'hmr.js'))}';
-${config.dev.client.overlay ? `import '${toPosixPath(join(CLIENT_PATH, 'overlay.js'))}';` : ''}
+${isOverlayEnabled(config.dev.client.overlay) ? `import '${toPosixPath(join(CLIENT_PATH, 'overlay.js'))}';` : ''}
 init(
   '${token}',
   ${JSON.stringify(clientConfig)},

--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -5,6 +5,7 @@ import type { WebSocket, WebSocketServer } from 'ws';
 import { BROWSER_LOG_PREFIX, DEFAULT_STACK_TRACE } from '../constants.js';
 import { color, isObject } from '../helpers';
 import { formatStatsError } from '../helpers/format';
+import { isRuntimeOverlayEnabled } from '../helpers/overlayConfig';
 import { getStatsErrors, getStatsWarnings } from '../helpers/stats';
 import type {
   DevConfig,
@@ -236,7 +237,7 @@ export class SocketServer {
   }
 
   /**
-   * Send error messages to the client and render error overlay
+   * Send error messages to the client.
    */
   public sendError(errors: Rspack.StatsError[], token: string): void {
     const { rootPath } = this.context;
@@ -399,7 +400,7 @@ export class SocketServer {
           }
 
           // Render runtime errors in overlay
-          if (typeof client.overlay === 'object' && client.overlay.runtime) {
+          if (isRuntimeOverlayEnabled(client.overlay)) {
             // Always display full stack trace for runtime errors
             const resolvedLog =
               // Reuse the formatted full log to avoid parsing the stack again.

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1834,6 +1834,19 @@ export type SetupMiddlewaresFn = (
   server: SetupMiddlewaresContext,
 ) => void;
 
+export type OverlayOptions = {
+  /**
+   * Whether to show build errors in the overlay.
+   * @default true
+   */
+  errors?: boolean;
+  /**
+   * Whether to show runtime errors in the overlay.
+   * @default false
+   */
+  runtime?: boolean;
+};
+
 export type ClientConfig = {
   /**
    * The path for the WebSocket request.
@@ -1861,18 +1874,10 @@ export type ClientConfig = {
    */
   reconnect?: number;
   /**
-   * Whether to display an error overlay in the browser when a compilation error occurs.
+   * Whether to display an error overlay in the browser.
    * @default true
    */
-  overlay?:
-    | boolean
-    | {
-        /**
-         * Whether to show runtime errors in the overlay.
-         * @default false
-         */
-        runtime?: boolean;
-      };
+  overlay?: boolean | OverlayOptions;
   /**
    * Controls the log level for client-side logging in the browser console.
    * @default 'info'

--- a/website/docs/en/config/dev/client.mdx
+++ b/website/docs/en/config/dev/client.mdx
@@ -20,8 +20,8 @@ type Client = {
   host?: string;
   // The maximum number of reconnection attempts after a WebSocket request is disconnected.
   reconnect?: number;
-  // Whether to display an error overlay in the browser when a compilation error occurs
-  overlay?: boolean | { runtime?: boolean };
+  // Whether to display an error overlay in the browser
+  overlay?: boolean | { errors?: boolean; runtime?: boolean };
   // Controls the log level for client-side logging in the browser console
   logLevel?: 'info' | 'warn' | 'error' | 'silent';
 };
@@ -95,7 +95,7 @@ Hot-update files are considered to be static assets. If you need to configure th
 
 ### overlay
 
-- **Type:** `boolean`
+- **Type:** `boolean | { errors?: boolean; runtime?: boolean }`
 - **Default:** `true`
 
 The `dev.client.overlay` option allows you to choose whether or not to enable the error overlay feature.
@@ -118,7 +118,31 @@ export default {
 
 When `overlay` is configured as an object, it allows more fine-grained control over errors from different sources.
 
+#### overlay.errors
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+`overlay.errors` controls whether build errors are rendered in the overlay.
+
+When this option is disabled, build errors will still be printed in the browser console, but the error overlay will not be displayed.
+
+```ts title="rsbuild.config.ts"
+export default {
+  dev: {
+    client: {
+      overlay: {
+        errors: false,
+      },
+    },
+  },
+};
+```
+
 #### overlay.runtime
+
+- **Type:** `boolean`
+- **Default:** `false`
 
 `overlay.runtime` controls whether runtime errors that occur in the browser are rendered in the overlay.
 
@@ -192,3 +216,4 @@ Setting this value to `0` disables automatic reconnection. In this case, the con
 | ------- | ------------------------------ |
 | v1.6.13 | Added `logLevel` option        |
 | v1.7.0  | Added `overlay.runtime` option |
+| v2.0.3  | Added `overlay.errors` option  |

--- a/website/docs/zh/config/dev/client.mdx
+++ b/website/docs/zh/config/dev/client.mdx
@@ -20,8 +20,8 @@ type Client = {
   host?: string;
   // WebSocket 请求断开后的最大重连次数
   reconnect?: number;
-  // 当出现编译错误时，是否在浏览器中显示 error overlay
-  overlay?: boolean | { runtime?: boolean };
+  // 是否在浏览器中显示 error overlay
+  overlay?: boolean | { errors?: boolean; runtime?: boolean };
   // 控制浏览器控制台中日志的级别
   logLevel?: 'info' | 'warn' | 'error' | 'silent';
 };
@@ -93,7 +93,7 @@ hot-update 文件属于静态资源，如果你需要配置 hot-update 文件的
 
 ### overlay
 
-- **类型：** `boolean | { runtime?: boolean }`
+- **类型：** `boolean | { errors?: boolean; runtime?: boolean }`
 - **默认值：** `true`
 
 通过 `dev.client.overlay` 选项，可以选择是否启用错误浮层。
@@ -116,7 +116,31 @@ export default {
 
 当 `overlay` 配置为对象时，可以对不同来源的错误进行更精细的控制。
 
+#### overlay.errors
+
+- **类型：** `boolean`
+- **默认值：** `true`
+
+`overlay.errors` 用于控制是否将构建错误渲染到浮层中。
+
+当禁用该选项时，构建错误仍会打印到浏览器控制台，但不会显示错误浮层：
+
+```ts title="rsbuild.config.ts"
+export default {
+  dev: {
+    client: {
+      overlay: {
+        errors: false,
+      },
+    },
+  },
+};
+```
+
 #### overlay.runtime
+
+- **类型：** `boolean`
+- **默认值：** `false`
 
 `overlay.runtime` 用于控制是否将浏览器里产生的运行时错误渲染到浮层中。
 
@@ -190,3 +214,4 @@ export default {
 | ------- | --------------------------- |
 | v1.6.13 | 新增 `logLevel` 选项        |
 | v1.7.0  | 新增 `overlay.runtime` 选项 |
+| v2.0.3  | 新增 `overlay.errors` 选项  |


### PR DESCRIPTION
## Summary

This PR adds `dev.client.overlay.errors` so users can keep runtime error overlays enabled while suppressing build error overlays. Build errors continue to be logged in the browser console, and the overlay client is only injected when at least one overlay source is enabled. It also updates the client config types, docs, and e2e coverage.