### PR TITLE
test: fix environment hot send e2e

### DIFF
--- a/e2e/cases/javascript-api/environment-hot-send/index.test.ts
+++ b/e2e/cases/javascript-api/environment-hot-send/index.test.ts
@@ -8,6 +8,7 @@ test('should send HMR messages to the matched environment only', async ({
   const rsbuild = await createRsbuild({
     cwd: import.meta.dirname,
     config: {
+      mode: 'development',
       server: {
         port: await getRandomPort(),
       },


### PR DESCRIPTION
## Summary

This PR fixes the `environment-hot-send` e2e case so it always creates its direct `createDevServer()` instance in development mode. Without an explicit mode, the test can inherit `NODE_ENV=production` from earlier build tests in the same Playwright worker, disabling the HMR runtime and making `hot.send` assertions flaky in suite runs.