### PR TITLE
feat(core): support filtering overlay build errors

### DIFF
--- a/e2e/cases/overlay/build-errors-filter/index.test.ts
+++ b/e2e/cases/overlay/build-errors-filter/index.test.ts
@@ -1,0 +1,69 @@
+import { join } from 'node:path';
+import {
+  expect,
+  HMR_CONNECTED_LOG,
+  OVERLAY_ID,
+  OVERLAY_TITLE_BUILD_FAILED,
+  test,
+} from '@e2e/helper';
+
+test('should filter build errors from overlay', async ({
+  page,
+  dev,
+  editFile,
+  logHelper,
+  copySrcDir,
+}) => {
+  const tempSrc = await copySrcDir();
+  const { expectLog, addLog } = logHelper;
+
+  page.on('console', (consoleMessage) => {
+    addLog(consoleMessage.text());
+  });
+
+  await dev({
+    config: {
+      source: {
+        entry: {
+          index: join(tempSrc, 'index.tsx'),
+        },
+      },
+    },
+  });
+
+  await expectLog(HMR_CONNECTED_LOG);
+
+  const errorOverlay = page.locator(OVERLAY_ID);
+  await expect(errorOverlay).not.toBeAttached();
+
+  await editFile(
+    join(tempSrc, 'App.tsx'),
+    () => `import filtered from 'filtered-overlay-error';
+
+const App = () => <div>{filtered}</div>;
+
+export default App;
+`,
+  );
+
+  await expectLog("Can't resolve 'filtered-overlay-error'");
+  await expect(errorOverlay).not.toBeAttached();
+
+  await editFile(
+    join(tempSrc, 'App.tsx'),
+    () => `import shown from 'shown-overlay-error';
+
+const App = () => <div>{shown}</div>;
+
+export default App;
+`,
+  );
+
+  await expectLog("Can't resolve 'shown-overlay-error'");
+  await expect(errorOverlay.locator('.title')).toHaveText(
+    OVERLAY_TITLE_BUILD_FAILED,
+  );
+  await expect(errorOverlay).toContainText(
+    "Can't resolve 'shown-overlay-error'",
+  );
+});

--- a/e2e/cases/overlay/build-errors-filter/rsbuild.config.ts
+++ b/e2e/cases/overlay/build-errors-filter/rsbuild.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+
+export default defineConfig({
+  plugins: [pluginReact()],
+  dev: {
+    client: {
+      overlay: {
+        errors: (error) => !error.message.includes('filtered-overlay-error'),
+      },
+    },
+  },
+});

--- a/e2e/cases/overlay/build-errors-filter/src/App.tsx
+++ b/e2e/cases/overlay/build-errors-filter/src/App.tsx
@@ -1,0 +1,3 @@
+const App = () => <div>Hello</div>;
+
+export default App;

--- a/e2e/cases/overlay/build-errors-filter/src/index.tsx
+++ b/e2e/cases/overlay/build-errors-filter/src/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root')!);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/packages/core/src/client/hmr.ts
+++ b/packages/core/src/client/hmr.ts
@@ -154,7 +154,11 @@ export function init(
       (overlay === true ||
         (typeof overlay === 'object' && overlay.errors !== false))
     ) {
-      createOverlay('Build failed', html);
+      if (html) {
+        createOverlay('Build failed', html);
+      } else {
+        clearOverlay?.();
+      }
     }
   }
 

--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -244,7 +244,23 @@ export class SocketServer {
     const formattedErrors = errors.map((item) =>
       formatStatsError(item, rootPath, 'error', this.context.logger),
     );
-    const html = formattedErrors
+
+    const environment = this.getEnvironmentByToken(token);
+    const overlay = environment?.config.dev.client.overlay;
+    let overlayErrors = formattedErrors;
+
+    if (
+      overlay &&
+      typeof overlay === 'object' &&
+      typeof overlay.errors === 'function'
+    ) {
+      const { errors: filter } = overlay;
+      overlayErrors = formattedErrors.filter((error) =>
+        filter(new Error(error)),
+      );
+    }
+
+    const html = overlayErrors
       .map((error) => renderErrorToHtml(error, rootPath))
       .join('\n\n')
       .trim();

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1836,10 +1836,12 @@ export type SetupMiddlewaresFn = (
 
 export type OverlayOptions = {
   /**
-   * Whether to show build errors in the overlay.
+   * Whether to show build errors in the overlay. You can pass a filter
+   * function to control which formatted build errors are rendered.
+   * Return false from the filter function to hide a specific error.
    * @default true
    */
-  errors?: boolean;
+  errors?: boolean | ((error: Error) => boolean);
   /**
    * Whether to show runtime errors in the overlay.
    * @default false

--- a/website/docs/en/config/dev/client.mdx
+++ b/website/docs/en/config/dev/client.mdx
@@ -21,7 +21,7 @@ type Client = {
   // The maximum number of reconnection attempts after a WebSocket request is disconnected.
   reconnect?: number;
   // Whether to display an error overlay in the browser
-  overlay?: boolean | { errors?: boolean; runtime?: boolean };
+  overlay?: boolean | OverlayOptions;
   // Controls the log level for client-side logging in the browser console
   logLevel?: 'info' | 'warn' | 'error' | 'silent';
 };
@@ -95,7 +95,7 @@ Hot-update files are considered to be static assets. If you need to configure th
 
 ### overlay
 
-- **Type:** `boolean | { errors?: boolean; runtime?: boolean }`
+- **Type:** `boolean | { errors?: boolean | ((error: Error) => boolean); runtime?: boolean }`
 - **Default:** `true`
 
 The `dev.client.overlay` option allows you to choose whether or not to enable the error overlay feature.
@@ -120,7 +120,7 @@ When `overlay` is configured as an object, it allows more fine-grained control o
 
 #### overlay.errors
 
-- **Type:** `boolean`
+- **Type:** `boolean | ((error: Error) => boolean)`
 - **Default:** `true`
 
 `overlay.errors` controls whether build errors are rendered in the overlay.
@@ -133,6 +133,20 @@ export default {
     client: {
       overlay: {
         errors: false,
+      },
+    },
+  },
+};
+```
+
+You can also pass a filter function to control which formatted build errors are rendered. When a build error is filtered out, it will still be printed in the browser console, but will not be displayed in the error overlay.
+
+```ts title="rsbuild.config.ts"
+export default {
+  dev: {
+    client: {
+      overlay: {
+        errors: (error) => !error.message.includes('Ignore this error'),
       },
     },
   },

--- a/website/docs/zh/config/dev/client.mdx
+++ b/website/docs/zh/config/dev/client.mdx
@@ -21,7 +21,7 @@ type Client = {
   // WebSocket 请求断开后的最大重连次数
   reconnect?: number;
   // 是否在浏览器中显示 error overlay
-  overlay?: boolean | { errors?: boolean; runtime?: boolean };
+  overlay?: boolean | OverlayOptions;
   // 控制浏览器控制台中日志的级别
   logLevel?: 'info' | 'warn' | 'error' | 'silent';
 };
@@ -93,7 +93,7 @@ hot-update 文件属于静态资源，如果你需要配置 hot-update 文件的
 
 ### overlay
 
-- **类型：** `boolean | { errors?: boolean; runtime?: boolean }`
+- **类型：** `boolean | { errors?: boolean | ((error: Error) => boolean); runtime?: boolean }`
 - **默认值：** `true`
 
 通过 `dev.client.overlay` 选项，可以选择是否启用错误浮层。
@@ -118,7 +118,7 @@ export default {
 
 #### overlay.errors
 
-- **类型：** `boolean`
+- **类型：** `boolean | ((error: Error) => boolean)`
 - **默认值：** `true`
 
 `overlay.errors` 用于控制是否将构建错误渲染到浮层中。
@@ -131,6 +131,20 @@ export default {
     client: {
       overlay: {
         errors: false,
+      },
+    },
+  },
+};
+```
+
+你也可以传入一个过滤函数，用于控制哪些格式化后的构建错误会渲染到浮层中。当某个构建错误被过滤掉时，它仍会打印到浏览器控制台，但不会显示在错误浮层中：
+
+```ts title="rsbuild.config.ts"
+export default {
+  dev: {
+    client: {
+      overlay: {
+        errors: (error) => !error.message.includes('Ignore this error'),
       },
     },
   },


### PR DESCRIPTION
## Summary

This PR adds support for passing a filter function to `dev.client.overlay.errors` so formatted build errors can be printed to the browser console without being rendered in the error overlay. It also updates the overlay client to clear stale build-error overlays when all formatted errors are filtered out, documents the new option shape, and adds e2e coverage for filtered and displayed build errors.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/7507