### PR TITLE
docs: add CSS url query docs

### DIFF
--- a/website/docs/en/guide/styling/css-usage.mdx
+++ b/website/docs/en/guide/styling/css-usage.mdx
@@ -210,3 +210,26 @@ Using `import "*.css?raw"` has the following behaviors:
 - Rsbuild >= 1.3.0 supports the `?raw` query parameter.
 
 :::
+
+### url
+
+Rsbuild supports importing the URL of a compiled CSS file in JavaScript by using the `?url` query parameter.
+
+```ts title="src/index.js"
+import styleUrl from './style.css?url';
+
+console.log(styleUrl); // Output the URL of the compiled CSS file
+```
+
+Using `import "*.css?url"` has the following behaviors:
+
+- Get the URL of the compiled CSS file, processed by Lightning CSS, PostCSS and CSS preprocessors
+- The CSS file will be emitted as a separate asset
+- The CSS styles will not be automatically applied to the page
+
+:::tip
+
+- Rsbuild's Sass, Less, and Stylus plugins also support the `?url` query parameter.
+- Rsbuild >= 2.0.2 supports the `?url` query parameter.
+
+:::

--- a/website/docs/en/guide/styling/css-usage.mdx
+++ b/website/docs/en/guide/styling/css-usage.mdx
@@ -215,7 +215,7 @@ Using `import "*.css?raw"` has the following behaviors:
 
 Rsbuild supports importing the URL of a compiled CSS file in JavaScript by using the `?url` query parameter.
 
-```ts title="src/index.js"
+```js title="src/index.js"
 import styleUrl from './style.css?url';
 
 console.log(styleUrl); // Output the URL of the compiled CSS file

--- a/website/docs/en/guide/styling/css-usage.mdx
+++ b/website/docs/en/guide/styling/css-usage.mdx
@@ -227,6 +227,12 @@ Using `import "*.css?url"` has the following behaviors:
 - The CSS file will be emitted as a separate asset
 - The CSS styles will not be automatically applied to the page
 
+:::note
+
+The `?url` query parameter does not support CSS Modules, such as `.module.css?url`. CSS Modules are compiled as class name mappings, while `?url` needs to emit a compiled CSS asset and return its URL. If you need to import the compiled CSS content as a string, use `?inline` instead. To use `?url` with a `.module.css` filename, disable CSS Modules matching for that file through [output.cssModules.auto](/config/output/css-modules#cssmodulesauto).
+
+:::
+
 :::tip
 
 - Rsbuild's Sass, Less, and Stylus plugins also support the `?url` query parameter.

--- a/website/docs/en/guide/styling/css-usage.mdx
+++ b/website/docs/en/guide/styling/css-usage.mdx
@@ -227,15 +227,10 @@ Using `import "*.css?url"` has the following behaviors:
 - The CSS file will be emitted as a separate asset
 - The CSS styles will not be automatically applied to the page
 
-:::note
-
-The `?url` query parameter does not support CSS Modules, such as `.module.css?url`. CSS Modules are compiled as class name mappings, while `?url` needs to emit a compiled CSS asset and return its URL. If you need to import the compiled CSS content as a string, use `?inline` instead. To use `?url` with a `.module.css` filename, disable CSS Modules matching for that file through [output.cssModules.auto](/config/output/css-modules#cssmodulesauto).
-
-:::
-
 :::tip
 
 - Rsbuild's Sass, Less, and Stylus plugins also support the `?url` query parameter.
+- The `?url` query parameter does not support CSS Modules, such as `.module.css?url`, because CSS Modules are compiled as class name mappings instead of an emitted CSS asset URL. Use `?inline` to import compiled CSS content as a string, or disable CSS Modules matching for that file through [output.cssModules.auto](/config/output/css-modules#cssmodulesauto).
 - Rsbuild >= 2.0.2 supports the `?url` query parameter.
 
 :::

--- a/website/docs/zh/guide/styling/css-usage.mdx
+++ b/website/docs/zh/guide/styling/css-usage.mdx
@@ -227,15 +227,10 @@ console.log(styleUrl); // 输出编译后 CSS 文件的 URL
 - CSS 文件会作为单独的资源输出
 - CSS 样式不会自动应用到页面中
 
-:::note
-
-`?url` 查询参数不支持 CSS Modules，比如 `.module.css?url`。CSS Modules 会被编译为 class name 映射，而 `?url` 需要输出编译后的 CSS 资源并返回它的 URL。如果你需要将编译后的 CSS 内容作为字符串导入，请改用 `?inline`。如果你希望对 `.module.css` 文件使用 `?url`，请通过 [output.cssModules.auto](/config/output/css-modules#cssmodulesauto) 关闭该文件的 CSS Modules 匹配。
-
-:::
-
 :::tip
 
 - Rsbuild 的 Sass、Less 和 Stylus 插件也支持 `?url` 查询参数。
+- `?url` 查询参数不支持 CSS Modules，比如 `.module.css?url`，因为 CSS Modules 会被编译为 class name 映射，而不是输出 CSS 资源 URL。请使用 `?inline` 将编译后的 CSS 内容作为字符串导入，或通过 [output.cssModules.auto](/config/output/css-modules#cssmodulesauto) 关闭该文件的 CSS Modules 匹配。
 - Rsbuild >= 2.0.2 支持 `?url` 查询参数。
 
 :::

--- a/website/docs/zh/guide/styling/css-usage.mdx
+++ b/website/docs/zh/guide/styling/css-usage.mdx
@@ -227,6 +227,12 @@ console.log(styleUrl); // 输出编译后 CSS 文件的 URL
 - CSS 文件会作为单独的资源输出
 - CSS 样式不会自动应用到页面中
 
+:::note
+
+`?url` 查询参数不支持 CSS Modules，比如 `.module.css?url`。CSS Modules 会被编译为 class name 映射，而 `?url` 需要输出编译后的 CSS 资源并返回它的 URL。如果你需要将编译后的 CSS 内容作为字符串导入，请改用 `?inline`。如果你希望对 `.module.css` 文件使用 `?url`，请通过 [output.cssModules.auto](/config/output/css-modules#cssmodulesauto) 关闭该文件的 CSS Modules 匹配。
+
+:::
+
 :::tip
 
 - Rsbuild 的 Sass、Less 和 Stylus 插件也支持 `?url` 查询参数。

--- a/website/docs/zh/guide/styling/css-usage.mdx
+++ b/website/docs/zh/guide/styling/css-usage.mdx
@@ -210,3 +210,26 @@ console.log(rawCss); // 输出 CSS 文件的原始内容
 - Rsbuild >= 1.3.0 支持 `?raw` 查询参数。
 
 :::
+
+### url
+
+Rsbuild 支持通过 `?url` 查询参数引用 CSS 文件编译后的 URL，并将其作为字符串导入到 JavaScript 中。
+
+```ts title="src/index.js"
+import styleUrl from './style.css?url';
+
+console.log(styleUrl); // 输出编译后 CSS 文件的 URL
+```
+
+使用 `import "*.css?url"` 的行为如下：
+
+- 获取 CSS 文件编译后的 URL，该 CSS 文件经过 Lightning CSS、PostCSS 和 CSS 预处理器的处理
+- CSS 文件会作为单独的资源输出
+- CSS 样式不会自动应用到页面中
+
+:::tip
+
+- Rsbuild 的 Sass、Less 和 Stylus 插件也支持 `?url` 查询参数。
+- Rsbuild >= 2.0.2 支持 `?url` 查询参数。
+
+:::

--- a/website/docs/zh/guide/styling/css-usage.mdx
+++ b/website/docs/zh/guide/styling/css-usage.mdx
@@ -215,7 +215,7 @@ console.log(rawCss); // 输出 CSS 文件的原始内容
 
 Rsbuild 支持通过 `?url` 查询参数引用 CSS 文件编译后的 URL，并将其作为字符串导入到 JavaScript 中。
 
-```ts title="src/index.js"
+```js title="src/index.js"
 import styleUrl from './style.css?url';
 
 console.log(styleUrl); // 输出编译后 CSS 文件的 URL


### PR DESCRIPTION
## Summary

This PR updates the CSS usage docs to describe the `?url` query parameter for CSS imports. It clarifies that CSS `?url` imports return the compiled CSS file URL, emit a separate CSS asset, do not automatically apply styles to the page, and are supported in Rsbuild >= 2.0.2.