### PR TITLE
fix(core): override merged overlay error filters

### DIFF
--- a/packages/core/src/mergeConfig.ts
+++ b/packages/core/src/mergeConfig.ts
@@ -13,6 +13,7 @@ const OVERRIDE_PATHS = new Set([
   'resolve.conditionNames',
   'resolve.mainFields',
   'dev.writeToDisk',
+  'dev.client.overlay.errors',
   'provider',
   'customLogger',
 ]);

--- a/packages/core/tests/mergeConfig.test.ts
+++ b/packages/core/tests/mergeConfig.test.ts
@@ -322,6 +322,41 @@ describe('mergeRsbuildConfig', () => {
     });
   });
 
+  it('should merge dev.client.overlay.errors correctly', () => {
+    const fn1 = () => false;
+    const fn2 = () => true;
+    expect(
+      mergeRsbuildConfig(
+        {
+          dev: {
+            client: {
+              overlay: {
+                errors: fn1,
+              },
+            },
+          },
+        },
+        {
+          dev: {
+            client: {
+              overlay: {
+                errors: fn2,
+              },
+            },
+          },
+        },
+      ),
+    ).toEqual({
+      dev: {
+        client: {
+          overlay: {
+            errors: fn2,
+          },
+        },
+      },
+    });
+  });
+
   it('should merge Rspack plugins as expected', () => {
     class A {
       a = 1;


### PR DESCRIPTION
## Summary

This PR fixes `dev.client.overlay.errors` config merging so environment or later config overrides keep a single filter function instead of becoming a function array. It adds the option to merge override paths and covers the behavior with a minimal `mergeRsbuildConfig` test.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/7568#discussion_r3154668800