### PR TITLE
fix(core): support url query with params

### DIFF
--- a/e2e/cases/assets/assets-url/index.test.ts
+++ b/e2e/cases/assets/assets-url/index.test.ts
@@ -11,4 +11,9 @@ test('should return the asset URL with `?url`', async ({
       `document.getElementById('test-img').src.includes('static/image/icon')`,
     ),
   ).resolves.toBeTruthy();
+  await expect(
+    page.evaluate(
+      `document.getElementById('test-img-with-query').src.includes('static/image/icon')`,
+    ),
+  ).resolves.toBeTruthy();
 });

--- a/e2e/cases/assets/assets-url/src/App.jsx
+++ b/e2e/cases/assets/assets-url/src/App.jsx
@@ -1,10 +1,12 @@
 import img from '@e2e/assets/icon.png?url';
+import imgWithQuery from '@e2e/assets/icon.png?url&variant=small';
 
 function App() {
   return (
     <div>
       <div id="test">Hello Rsbuild!</div>
       <img id="test-img" src={img} alt="test" />
+      <img id="test-img-with-query" src={imgWithQuery} alt="test" />
     </div>
   );
 }

--- a/e2e/cases/css/url-query/index.test.ts
+++ b/e2e/cases/css/url-query/index.test.ts
@@ -9,6 +9,12 @@ type CssUrlResult = {
   externalStyleUrl: string;
   styleUrl: string;
   styleContent: string;
+  urlLeadingQueryContent: string;
+  urlLeadingQueryUrl: string;
+  urlTrailingQueryContent: string;
+  urlTrailingQueryUrl: string;
+  urlValueQueryContent: string;
+  urlValueQueryUrl: string;
   targetColor: string;
 };
 
@@ -26,6 +32,12 @@ test('should return transformed CSS URL with `?url`', async ({
       externalStyleUrl,
       styleUrl,
       styleContent,
+      urlLeadingQueryContent,
+      urlLeadingQueryUrl,
+      urlTrailingQueryContent,
+      urlTrailingQueryUrl,
+      urlValueQueryContent,
+      urlValueQueryUrl,
       targetColor,
     } = await page.evaluate<CssUrlResult>('window.getCssUrlResult()');
 
@@ -39,6 +51,16 @@ test('should return transformed CSS URL with `?url`', async ({
     expect(aStyleUrl).not.toBe(bStyleUrl);
     expect(externalStyleUrl).toMatch(/\/static\/css\/shared\/external\.css$/);
     expect(externalStyleContent).toContain('.external-url-query');
+    expect(urlLeadingQueryUrl).toMatch(
+      /\/static\/css\/url-leading-query\.css$/,
+    );
+    expect(urlLeadingQueryContent).toContain('.url-leading-query');
+    expect(urlTrailingQueryUrl).toMatch(
+      /\/static\/css\/url-trailing-query\.css$/,
+    );
+    expect(urlTrailingQueryContent).toContain('.url-trailing-query');
+    expect(urlValueQueryUrl).toMatch(/\/static\/css\/url-value-query\.css$/);
+    expect(urlValueQueryContent).toContain('.url-value-query');
     expect(targetColor).toBe('rgb(0, 0, 0)');
 
     if (mode === 'build') {

--- a/e2e/cases/css/url-query/src/index.js
+++ b/e2e/cases/css/url-query/src/index.js
@@ -1,6 +1,9 @@
 import aStyleUrl from './a/index.css?url';
 import bStyleUrl from './b/index.css?url';
 import externalStyleUrl from '../shared/external.css?url';
+import urlLeadingQueryUrl from './url-leading-query.css?other=value&url';
+import urlTrailingQueryUrl from './url-trailing-query.css?url&other=value';
+import urlValueQueryUrl from './url-value-query.css?url=1';
 import styleUrl from './style.css?url';
 
 const target = document.createElement('div');
@@ -18,5 +21,15 @@ window.getCssUrlResult = async () => ({
   externalStyleUrl,
   styleUrl,
   styleContent: await fetch(styleUrl).then((res) => res.text()),
+  urlLeadingQueryContent: await fetch(urlLeadingQueryUrl).then((res) =>
+    res.text(),
+  ),
+  urlLeadingQueryUrl,
+  urlTrailingQueryContent: await fetch(urlTrailingQueryUrl).then((res) =>
+    res.text(),
+  ),
+  urlTrailingQueryUrl,
+  urlValueQueryContent: await fetch(urlValueQueryUrl).then((res) => res.text()),
+  urlValueQueryUrl,
   targetColor: getComputedStyle(target).color,
 });

--- a/e2e/cases/css/url-query/src/url-leading-query.css
+++ b/e2e/cases/css/url-query/src/url-leading-query.css
@@ -1,0 +1,3 @@
+.url-leading-query {
+  color: red;
+}

--- a/e2e/cases/css/url-query/src/url-trailing-query.css
+++ b/e2e/cases/css/url-query/src/url-trailing-query.css
@@ -1,0 +1,3 @@
+.url-trailing-query {
+  color: green;
+}

--- a/e2e/cases/css/url-query/src/url-value-query.css
+++ b/e2e/cases/css/url-query/src/url-value-query.css
@@ -1,0 +1,3 @@
+.url-value-query {
+  color: blue;
+}

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -64,6 +64,11 @@ export const RAW_QUERY_REGEX: RegExp = /[?&]raw(?:&|=|$)/;
  * Matches patterns like: `?inline`, `?inline&other=value`, `?other=value&inline`, `?inline=value`
  */
 export const INLINE_QUERY_REGEX: RegExp = /[?&]inline(?:&|=|$)/;
+/**
+ * Regular expression to match the 'url' query parameter.
+ * Matches patterns like: `?url`, `?url&other=value`, `?other=value&url`, `?url=value`
+ */
+export const URL_QUERY_REGEX: RegExp = /[?&]url(?:&|=|$)/;
 export const NODE_MODULES_REGEX: RegExp = /[\\/]node_modules[\\/]/;
 
 // Plugins

--- a/packages/core/src/plugins/asset.ts
+++ b/packages/core/src/plugins/asset.ts
@@ -10,6 +10,7 @@ import {
   IMAGE_EXTENSIONS,
   INLINE_QUERY_REGEX,
   RAW_QUERY_REGEX,
+  URL_QUERY_REGEX,
   VIDEO_EXTENSIONS,
 } from '../constants';
 import { getFilename } from '../helpers';
@@ -42,7 +43,7 @@ const chainStaticAssetRule = ({
   rule
     .oneOf(`${assetType}-asset-url`)
     .type('asset/resource')
-    .resourceQuery(/^\?url$/)
+    .resourceQuery(URL_QUERY_REGEX)
     .set('generator', generatorOptions);
 
   // get inlined base64 content: "foo.png?inline"

--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -9,6 +9,7 @@ import {
   INLINE_QUERY_REGEX,
   LOADER_PATH,
   RAW_QUERY_REGEX,
+  URL_QUERY_REGEX,
 } from '../constants';
 import { castArray, color, getFilename } from '../helpers';
 import { getCompiledPath } from '../helpers/path';
@@ -290,7 +291,7 @@ export const pluginCss = (): RsbuildPlugin => ({
         // Support for `import cssUrl from "a.css?url"`
         const urlRule = cssRule
           .oneOf(CHAIN_ID.ONE_OF.CSS_URL)
-          .resourceQuery(/^\?url$/);
+          .resourceQuery(URL_QUERY_REGEX);
         urlRule
           .use(CHAIN_ID.USE.CSS_URL)
           .loader(path.join(LOADER_PATH, 'cssUrlLoader.mjs'));

--- a/packages/core/tests/__snapshots__/asset.test.ts.snap
+++ b/packages/core/tests/__snapshots__/asset.test.ts.snap
@@ -8,7 +8,7 @@ exports[`plugin-asset > should add image rules correctly 1`] = `
         "generator": {
           "filename": "static/image/[name].[contenthash:10][ext]",
         },
-        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
         "type": "asset/resource",
       },
       {
@@ -44,7 +44,7 @@ exports[`plugin-asset > should add image rules correctly 2`] = `
         "generator": {
           "filename": "[name].[contenthash:10][ext]",
         },
-        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
         "type": "asset/resource",
       },
       {
@@ -80,7 +80,7 @@ exports[`plugin-asset > should allow using distPath.image to modify dist path 1`
         "generator": {
           "filename": "foo/[name].[contenthash:10][ext]",
         },
-        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
         "type": "asset/resource",
       },
       {
@@ -116,7 +116,7 @@ exports[`plugin-asset > should allow using filename.image to modify filename 1`]
         "generator": {
           "filename": "static/image/foo[ext]",
         },
-        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
         "type": "asset/resource",
       },
       {

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -39,7 +39,7 @@ exports[`default bundler > should use Rspack by default 1`] = `
             "resolve": {
               "preferRelative": true,
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "use": [
               {
                 "loader": "<ROOT>/packages/core/src/cssUrlLoader.mjs",
@@ -266,7 +266,7 @@ exports[`default bundler > should use Rspack by default 1`] = `
             "generator": {
               "filename": "static/image/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -297,7 +297,7 @@ exports[`default bundler > should use Rspack by default 1`] = `
             "generator": {
               "filename": "static/svg/[name].[contenthash:10].svg",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -328,7 +328,7 @@ exports[`default bundler > should use Rspack by default 1`] = `
             "generator": {
               "filename": "static/media/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -359,7 +359,7 @@ exports[`default bundler > should use Rspack by default 1`] = `
             "generator": {
               "filename": "static/font/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {

--- a/packages/core/tests/__snapshots__/css.test.ts.snap
+++ b/packages/core/tests/__snapshots__/css.test.ts.snap
@@ -11,7 +11,7 @@ exports[`plugin-css > should use custom cssModules rule when using output.cssMod
         "resolve": {
           "preferRelative": true,
         },
-        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
         "use": [
           {
             "loader": "<ROOT>/packages/core/src/cssUrlLoader.mjs",
@@ -137,7 +137,7 @@ exports[`plugin-css injectStyles > should apply ignoreCssLoader when injectStyle
         "resolve": {
           "preferRelative": true,
         },
-        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
         "use": [
           {
             "loader": "<ROOT>/packages/core/src/cssUrlLoader.mjs",
@@ -247,7 +247,7 @@ exports[`plugin-css injectStyles > should use css-loader + style-loader when inj
         "resolve": {
           "preferRelative": true,
         },
-        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
         "use": [
           {
             "loader": "<ROOT>/packages/core/src/cssUrlLoader.mjs",
@@ -373,7 +373,7 @@ exports[`should ensure isolation of PostCSS config objects between different bui
         "resolve": {
           "preferRelative": true,
         },
-        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
         "use": [
           {
             "loader": "<ROOT>/packages/core/src/cssUrlLoader.mjs",
@@ -544,7 +544,7 @@ exports[`should ensure isolation of PostCSS config objects between different bui
         "resolve": {
           "preferRelative": true,
         },
-        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
         "use": [
           {
             "loader": "<ROOT>/packages/core/src/cssUrlLoader.mjs",

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -62,7 +62,7 @@ exports[`should apply default plugins correctly 1`] = `
             "resolve": {
               "preferRelative": true,
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "use": [
               {
                 "loader": "<ROOT>/packages/core/src/cssUrlLoader.mjs",
@@ -289,7 +289,7 @@ exports[`should apply default plugins correctly 1`] = `
             "generator": {
               "filename": "static/image/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -320,7 +320,7 @@ exports[`should apply default plugins correctly 1`] = `
             "generator": {
               "filename": "static/svg/[name].[contenthash:10].svg",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -351,7 +351,7 @@ exports[`should apply default plugins correctly 1`] = `
             "generator": {
               "filename": "static/media/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -382,7 +382,7 @@ exports[`should apply default plugins correctly 1`] = `
             "generator": {
               "filename": "static/font/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -536,7 +536,7 @@ exports[`should apply default plugins correctly in production 1`] = `
             "resolve": {
               "preferRelative": true,
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "use": [
               {
                 "loader": "<ROOT>/packages/core/src/cssUrlLoader.mjs",
@@ -764,7 +764,7 @@ exports[`should apply default plugins correctly in production 1`] = `
             "generator": {
               "filename": "static/image/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -795,7 +795,7 @@ exports[`should apply default plugins correctly in production 1`] = `
             "generator": {
               "filename": "static/svg/[name].[contenthash:10].svg",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -826,7 +826,7 @@ exports[`should apply default plugins correctly in production 1`] = `
             "generator": {
               "filename": "static/media/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -857,7 +857,7 @@ exports[`should apply default plugins correctly in production 1`] = `
             "generator": {
               "filename": "static/font/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -1036,7 +1036,7 @@ exports[`should apply default plugins correctly when target is node 1`] = `
             "resolve": {
               "preferRelative": true,
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "use": [
               {
                 "loader": "<ROOT>/packages/core/src/cssUrlLoader.mjs",
@@ -1240,7 +1240,7 @@ exports[`should apply default plugins correctly when target is node 1`] = `
             "generator": {
               "filename": "static/image/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -1271,7 +1271,7 @@ exports[`should apply default plugins correctly when target is node 1`] = `
             "generator": {
               "filename": "static/svg/[name].[contenthash:10].svg",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -1302,7 +1302,7 @@ exports[`should apply default plugins correctly when target is node 1`] = `
             "generator": {
               "filename": "static/media/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -1333,7 +1333,7 @@ exports[`should apply default plugins correctly when target is node 1`] = `
             "generator": {
               "filename": "static/font/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -1502,7 +1502,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "resolve": {
               "preferRelative": true,
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "use": [
               {
                 "loader": "<ROOT>/packages/core/src/cssUrlLoader.mjs",
@@ -1729,7 +1729,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "generator": {
               "filename": "static/image/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -1760,7 +1760,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "generator": {
               "filename": "static/svg/[name].[contenthash:10].svg",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -1791,7 +1791,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "generator": {
               "filename": "static/media/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -1822,7 +1822,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "generator": {
               "filename": "static/font/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -35,7 +35,7 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
               "resolve": {
                 "preferRelative": true,
               },
-              "resourceQuery": /\\^\\\\\\?url\\$/,
+              "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
               "use": [
                 {
                   "loader": "<ROOT>/packages/core/src/cssUrlLoader.mjs",
@@ -262,7 +262,7 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
               "generator": {
                 "filename": "static/image/[name].[contenthash:10][ext]",
               },
-              "resourceQuery": /\\^\\\\\\?url\\$/,
+              "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
               "type": "asset/resource",
             },
             {
@@ -293,7 +293,7 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
               "generator": {
                 "filename": "static/svg/[name].[contenthash:10].svg",
               },
-              "resourceQuery": /\\^\\\\\\?url\\$/,
+              "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
               "type": "asset/resource",
             },
             {
@@ -324,7 +324,7 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
               "generator": {
                 "filename": "static/media/[name].[contenthash:10][ext]",
               },
-              "resourceQuery": /\\^\\\\\\?url\\$/,
+              "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
               "type": "asset/resource",
             },
             {
@@ -355,7 +355,7 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
               "generator": {
                 "filename": "static/font/[name].[contenthash:10][ext]",
               },
-              "resourceQuery": /\\^\\\\\\?url\\$/,
+              "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
               "type": "asset/resource",
             },
             {
@@ -502,7 +502,7 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
               "resolve": {
                 "preferRelative": true,
               },
-              "resourceQuery": /\\^\\\\\\?url\\$/,
+              "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
               "use": [
                 {
                   "loader": "<ROOT>/packages/core/src/cssUrlLoader.mjs",
@@ -712,7 +712,7 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
               "generator": {
                 "filename": "static/image/[name].[contenthash:10][ext]",
               },
-              "resourceQuery": /\\^\\\\\\?url\\$/,
+              "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
               "type": "asset/resource",
             },
             {
@@ -743,7 +743,7 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
               "generator": {
                 "filename": "static/svg/[name].[contenthash:10].svg",
               },
-              "resourceQuery": /\\^\\\\\\?url\\$/,
+              "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
               "type": "asset/resource",
             },
             {
@@ -774,7 +774,7 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
               "generator": {
                 "filename": "static/media/[name].[contenthash:10][ext]",
               },
-              "resourceQuery": /\\^\\\\\\?url\\$/,
+              "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
               "type": "asset/resource",
             },
             {
@@ -805,7 +805,7 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
               "generator": {
                 "filename": "static/font/[name].[contenthash:10][ext]",
               },
-              "resourceQuery": /\\^\\\\\\?url\\$/,
+              "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
               "type": "asset/resource",
             },
             {

--- a/packages/plugin-less/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-less/tests/__snapshots__/index.test.ts.snap
@@ -8,7 +8,7 @@ exports[`plugin-less > should add less-loader 1`] = `
     },
     "oneOf": [
       {
-        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
         "use": [
           {
             "loader": "<ROOT>/packages/core/dist/cssUrlLoader.mjs",
@@ -164,7 +164,7 @@ exports[`plugin-less > should add less-loader and css-loader when injectStyles 1
     },
     "oneOf": [
       {
-        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
         "use": [
           {
             "loader": "<ROOT>/packages/core/dist/cssUrlLoader.mjs",
@@ -432,7 +432,7 @@ exports[`plugin-less > should add less-loader with excludes 1`] = `
         "exclude": [
           /node_modules/,
         ],
-        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
         "use": [
           {
             "loader": "<ROOT>/packages/core/dist/cssUrlLoader.mjs",
@@ -594,7 +594,7 @@ exports[`plugin-less > should add less-loader with tools.less 1`] = `
     },
     "oneOf": [
       {
-        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
         "use": [
           {
             "loader": "<ROOT>/packages/core/dist/cssUrlLoader.mjs",
@@ -750,7 +750,7 @@ exports[`plugin-less > should allow to use Less plugins 1`] = `
     },
     "oneOf": [
       {
-        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
         "use": [
           {
             "loader": "<ROOT>/packages/core/dist/cssUrlLoader.mjs",

--- a/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
@@ -8,7 +8,7 @@ exports[`plugin-sass > should add sass-loader 1`] = `
     },
     "oneOf": [
       {
-        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
         "use": [
           {
             "loader": "<ROOT>/packages/core/dist/cssUrlLoader.mjs",
@@ -191,7 +191,7 @@ exports[`plugin-sass > should add sass-loader and css-loader when injectStyles 1
     },
     "oneOf": [
       {
-        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
         "use": [
           {
             "loader": "<ROOT>/packages/core/dist/cssUrlLoader.mjs",
@@ -504,7 +504,7 @@ exports[`plugin-sass > should add sass-loader with excludes 1`] = `
         "exclude": [
           /node_modules/,
         ],
-        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
         "use": [
           {
             "loader": "<ROOT>/packages/core/dist/cssUrlLoader.mjs",
@@ -693,7 +693,7 @@ exports[`plugin-sass > should allow to use legacy API and mute deprecation warni
     },
     "oneOf": [
       {
-        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
         "use": [
           {
             "loader": "<ROOT>/packages/core/dist/cssUrlLoader.mjs",

--- a/packages/plugin-stylus/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-stylus/tests/__snapshots__/index.test.ts.snap
@@ -8,7 +8,7 @@ exports[`plugin-stylus > should add stylus loader config correctly 1`] = `
     },
     "oneOf": [
       {
-        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
         "use": [
           {
             "loader": "<ROOT>/packages/core/dist/cssUrlLoader.mjs",
@@ -243,7 +243,7 @@ exports[`plugin-stylus > should allow to configure stylus options 1`] = `
     },
     "oneOf": [
       {
-        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
         "use": [
           {
             "loader": "<ROOT>/packages/core/dist/cssUrlLoader.mjs",


### PR DESCRIPTION
## Summary

This PR allows `?url` imports to be combined with other resource query parameters, matching the existing `?inline` and `?raw` behavior. It adds a shared URL query regex and applies it to CSS and static asset rules, with e2e coverage for CSS and asset URL imports that include additional query parameters.