### PR TITLE
docs: update optional tools in quick start

### DIFF
--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -73,25 +73,18 @@ When creating an application, you can choose from the following templates provid
 
 ### Optional tools
 
-`create-rsbuild` can help you set up commonly used tools, including [Rstest](https://rstest.rs), [Biome](https://github.com/biomejs/biome), [ESLint](https://github.com/eslint/eslint), [Prettier](https://github.com/prettier/prettier), [Tailwind CSS](https://tailwindcss.com) and [Storybook](https://storybook.js.org/). Use the arrow keys to navigate and the space bar to select. Press Enter without selecting anything to skip these tools.
+`create-rsbuild` can help you set up the following commonly used tools. Use the arrow keys to navigate and the space bar to select. Press Enter without selecting anything to skip these tools.
 
-```
-◆  Select additional tools (Use <space> to select, <enter> to continue)
-│  ◻ Rstest - testing
-│  ◻ Biome - linting & formatting
-│  ◻ ESLint - linting
-│  ◻ Prettier - formatting
-│  ◻ Tailwind CSS - styling
-│  ◻ Storybook - component development
-└
-```
-
-:::tip
-
-- Biome provides similar linting and formatting features to ESLint and Prettier. If you select Biome, you typically won't need to add ESLint or Prettier.
-- When you select a React template, you can also select [React Compiler](/guide/framework/react#react-compiler) as an optional tool to enable React Compiler support.
-
-:::
+| Tool                                                    | Use                                        |
+| ------------------------------------------------------- | ------------------------------------------ |
+| [Rstest](https://github.com/web-infra-dev/rstest)       | Testing                                    |
+| [Rslint](https://github.com/web-infra-dev/rslint)       | Linting                                    |
+| [ESLint](https://github.com/eslint/eslint)              | Linting                                    |
+| [Prettier](https://github.com/prettier/prettier)        | Formatting                                 |
+| [Biome](https://github.com/biomejs/biome)               | Linting and formatting                     |
+| [Storybook](https://storybook.js.org/)                  | Component development                      |
+| [Tailwind CSS](https://tailwindcss.com)                 | Styling                                    |
+| [React Compiler](/guide/framework/react#react-compiler) | Optimizing React apps, React template only |
 
 ### Current directory
 

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -73,25 +73,18 @@ import { PackageManagerTabs } from '@theme';
 
 ### 可选工具
 
-`create-rsbuild` 能够帮助你设置一些常用的工具，包括 [Rstest](https://rstest.rs)、[Biome](https://github.com/biomejs/biome)、[ESLint](https://github.com/eslint/eslint)、[prettier](https://github.com/prettier/prettier)、[Tailwind CSS](https://tailwindcss.com) 和 [Storybook](https://storybook.js.org/)，你可以使用上下箭头和空格进行选择。如果你不需要这些工具，可以直接按回车跳过。
+`create-rsbuild` 能够帮助你设置以下常用工具，你可以使用上下箭头和空格进行选择。如果你不需要这些工具，可以直接按回车跳过。
 
-```
-◆  Select additional tools (Use <space> to select, <enter> to continue)
-│  ◻ Rstest - testing
-│  ◻ Biome - linting & formatting
-│  ◻ ESLint - linting
-│  ◻ Prettier - formatting
-│  ◻ Tailwind CSS - styling
-│  ◻ Storybook - component development
-└
-```
-
-:::tip
-
-- Biome 提供与 ESLint 和 Prettier 相似的代码检查和格式化功能。如果你选择了 Biome，通常就不需要再选择 ESLint 或 Prettier 了。
-- 如果你选择了 React 模板，还可以额外选择 [React Compiler](/guide/framework/react#react-compiler) 作为可选工具以启用 React Compiler 支持。
-
-:::
+| 工具                                                    | 用途                           |
+| ------------------------------------------------------- | ------------------------------ |
+| [Rstest](https://github.com/web-infra-dev/rstest)       | 测试                           |
+| [Rslint](https://github.com/web-infra-dev/rslint)       | 代码检查                       |
+| [ESLint](https://github.com/eslint/eslint)              | 代码检查                       |
+| [Prettier](https://github.com/prettier/prettier)        | 代码格式化                     |
+| [Biome](https://github.com/biomejs/biome)               | 代码检查和格式化               |
+| [Storybook](https://storybook.js.org/)                  | 组件开发                       |
+| [Tailwind CSS](https://tailwindcss.com)                 | 样式                           |
+| [React Compiler](/guide/framework/react#react-compiler) | 优化 React 应用，仅 React 模板 |
 
 ### 当前目录
 


### PR DESCRIPTION
## Summary

This PR updates the quick-start optional tools section to reflect the current create-rsbuild choices. It replaces the outdated prompt snapshot with a table that includes Rslint and React Compiler, and keeps the English and Chinese docs aligned.
