### PR TITLE
feat(create-rsbuild): support rslint template mapping

### DIFF
--- a/e2e/cases/create-rsbuild/tools.test.ts
+++ b/e2e/cases/create-rsbuild/tools.test.ts
@@ -107,6 +107,51 @@ test('should create React project with ESLint as expected', async () => {
   await clean();
 });
 
+test('should create React project with Rslint as expected', async () => {
+  const { dir, pkgJson, clean } = await createAndValidate(
+    import.meta.dirname,
+    'react-ts',
+    {
+      name: 'test-temp-react-rslint',
+      tools: ['rslint'],
+      clean: false,
+    },
+  );
+  expect(pkgJson.devDependencies['@rslint/core']).toBeTruthy();
+
+  const configFile = join(dir, 'rslint.config.ts');
+  expect(existsSync(configFile)).toBeTruthy();
+
+  const configContent = readFileSync(configFile, 'utf-8');
+  expect(
+    configContent.includes('reactPlugin.configs.recommended'),
+  ).toBeTruthy();
+  expect(configContent.includes('ts.configs.recommended')).toBeTruthy();
+  await clean();
+});
+
+test('should create Vue project with vanilla Rslint as expected', async () => {
+  const { dir, pkgJson, clean } = await createAndValidate(
+    import.meta.dirname,
+    'vue-js',
+    {
+      name: 'test-temp-vue-rslint',
+      tools: ['rslint'],
+      clean: false,
+    },
+  );
+  expect(pkgJson.devDependencies['@rslint/core']).toBeTruthy();
+
+  const configFile = join(dir, 'rslint.config.ts');
+  expect(existsSync(configFile)).toBeTruthy();
+
+  const configContent = readFileSync(configFile, 'utf-8');
+  expect(configContent.includes('js.configs.recommended')).toBeTruthy();
+  expect(configContent.includes('reactPlugin')).toBeFalsy();
+  expect(configContent.includes('ts.configs.recommended')).toBeFalsy();
+  await clean();
+});
+
 test('should create Vue project with ESLint as expected', async () => {
   const { dir, pkgJson, clean } = await createAndValidate(
     import.meta.dirname,

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -27,7 +27,7 @@
     "start": "node ./dist/index.js"
   },
   "dependencies": {
-    "create-rstack": "2.0.1"
+    "create-rstack": "2.1.1"
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",

--- a/packages/create-rsbuild/src/index.ts
+++ b/packages/create-rsbuild/src/index.ts
@@ -6,6 +6,7 @@ import {
   copyFolder,
   create,
   type ESLintTemplateName,
+  type RslintTemplateName,
   select,
 } from 'create-rstack';
 
@@ -86,6 +87,16 @@ function mapRstestTemplate(templateName: string): string {
   }
 }
 
+function mapRslintTemplate(templateName: string): RslintTemplateName {
+  switch (templateName) {
+    case 'react-js':
+    case 'react-ts':
+      return templateName;
+    default:
+      return `vanilla-${templateName.split('-')[1]}` as RslintTemplateName;
+  }
+}
+
 const root = path.join(import.meta.dirname, '..');
 
 create({
@@ -105,6 +116,7 @@ create({
   ],
   getTemplateName,
   mapESLintTemplate,
+  mapRslintTemplate,
   extraTools: [
     {
       value: 'rstest',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -627,8 +627,8 @@ importers:
   packages/create-rsbuild:
     dependencies:
       create-rstack:
-        specifier: 2.0.1
-        version: 2.0.1
+        specifier: 2.1.1
+        version: 2.1.1
     devDependencies:
       '@rsbuild/core':
         specifier: workspace:*
@@ -3495,8 +3495,8 @@ packages:
       typescript:
         optional: true
 
-  create-rstack@2.0.1:
-    resolution: {integrity: sha512-J5YQviohaHIyCEID4fZa4dxurMRJDpGs2GJBHO82RM8URUbOhf9k9UkKbbwNOwVXFKlPRQgOtuQyiJwz1f0IvA==}
+  create-rstack@2.1.1:
+    resolution: {integrity: sha512-fYIgIQXml9HmgcqnIo2fqBsql4f1+6dGYzznwg5+fc8dXcdPvukdYgOg4wZsmXha6qvneAjLm9/1O/2CeXYvfQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   cron-parser@4.9.0:
@@ -8516,7 +8516,7 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  create-rstack@2.0.1: {}
+  create-rstack@2.1.1: {}
 
   cron-parser@4.9.0:
     dependencies:


### PR DESCRIPTION
## Summary

This PR upgrades `create-rstack` to v2.1.1 so `create-rsbuild` can use the new Rslint template support. It adds `mapRslintTemplate` to route React templates to React-specific Rslint configs and all other frameworks to the matching vanilla JS/TS configs, with e2e coverage for both paths.

## Related Links

https://github.com/rstackjs/create-rstack/releases/tag/v2.1.1