### PR TITLE
test(types): remove problematic plugin checks

### DIFF
--- a/e2e/type-tests/resolution-bundler/index.ts
+++ b/e2e/type-tests/resolution-bundler/index.ts
@@ -5,24 +5,16 @@ import { pluginBabel } from '@rsbuild/plugin-babel';
 import { pluginLess } from '@rsbuild/plugin-less';
 import { pluginPreact } from '@rsbuild/plugin-preact';
 import { pluginReact } from '@rsbuild/plugin-react';
-import { pluginSass } from '@rsbuild/plugin-sass';
 import { pluginSolid } from '@rsbuild/plugin-solid';
 import { pluginStylus } from '@rsbuild/plugin-stylus';
-import { pluginSvelte } from '@rsbuild/plugin-svelte';
-import { pluginSvgr } from '@rsbuild/plugin-svgr';
-import { pluginVue } from '@rsbuild/plugin-vue';
 
 const plugins = [
   pluginBabel(),
   pluginLess(),
   pluginPreact(),
   pluginReact(),
-  pluginSass(),
   pluginSolid(),
   pluginStylus(),
-  pluginSvelte(),
-  pluginSvgr(),
-  pluginVue(),
 ];
 
 createRsbuild({

--- a/e2e/type-tests/resolution-nodenext/index.ts
+++ b/e2e/type-tests/resolution-nodenext/index.ts
@@ -5,24 +5,16 @@ import { pluginBabel } from '@rsbuild/plugin-babel';
 import { pluginLess } from '@rsbuild/plugin-less';
 import { pluginPreact } from '@rsbuild/plugin-preact';
 import { pluginReact } from '@rsbuild/plugin-react';
-import { pluginSass } from '@rsbuild/plugin-sass';
 import { pluginSolid } from '@rsbuild/plugin-solid';
 import { pluginStylus } from '@rsbuild/plugin-stylus';
-import { pluginSvelte } from '@rsbuild/plugin-svelte';
-import { pluginSvgr } from '@rsbuild/plugin-svgr';
-import { pluginVue } from '@rsbuild/plugin-vue';
 
 const plugins = [
   pluginBabel(),
   pluginLess(),
   pluginPreact(),
   pluginReact(),
-  pluginSass(),
   pluginSolid(),
   pluginStylus(),
-  pluginSvelte(),
-  pluginSvgr(),
-  pluginVue(),
 ];
 
 createRsbuild({


### PR DESCRIPTION
## Summary

This PR removes type-test coverage for plugins whose third-party dependencies currently expose broken or missing declaration references when `skipLibCheck` is disabled. The remaining type tests still cover Rsbuild core plus stable plugin integrations under both bundler and NodeNext resolution modes.

```
../../../node_modules/.pnpm/@svgr+babel-plugin-transform-svg-component@8.0.0_@babel+core@7.29.0/node_modules/index.d.ts:1:44 - error TS7016: Could not find a declaration file for module '@babel/core'. '/Users/chenjiahan/Project/rsbuild/node_modules/.pnpm/@babel+core@7.29.0/node_modules/index.js' implicitly has an 'any' type.
  If the '@babel/core' package actually exposes this module, consider sending a pull request to amend 'https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/babel__core'

1 import { types, ConfigAPI, NodePath } from '@babel/core';
```