### PR TITLE
fix(plugin-styles): remove unused reduce-configs dep

### DIFF
--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -27,7 +27,6 @@
   },
   "dependencies": {
     "deepmerge": "^4.3.1",
-    "reduce-configs": "^1.1.2",
     "stylus": "0.64.0",
     "stylus-loader": "8.1.3"
   },

--- a/packages/plugin-stylus/src/index.ts
+++ b/packages/plugin-stylus/src/index.ts
@@ -1,7 +1,6 @@
 import { createRequire } from 'node:module';
 import type { RsbuildPlugin, RspackChain } from '@rsbuild/core';
 import deepmerge from 'deepmerge';
-import { reduceConfigs } from 'reduce-configs';
 
 const require = createRequire(import.meta.url);
 
@@ -85,13 +84,10 @@ export const pluginStylus = (options?: PluginStylusOptions): RsbuildPlugin => ({
       const { config } = environment;
 
       const { sourceMap } = config.output;
-      const mergedOptions = reduceConfigs({
-        initial: {
-          sourceMap: typeof sourceMap === 'boolean' ? sourceMap : sourceMap.css,
-        },
-        config: options,
-        mergeFn: deepmerge,
-      });
+      const mergedOptions = {
+        sourceMap: typeof sourceMap === 'boolean' ? sourceMap : sourceMap.css,
+        ...options,
+      };
 
       const test = /\.styl(us)?$/;
       const stylusRule = chain.module

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -885,9 +885,6 @@ importers:
       deepmerge:
         specifier: ^4.3.1
         version: 4.3.1
-      reduce-configs:
-        specifier: ^1.1.2
-        version: 1.1.2
       stylus:
         specifier: 0.64.0
         version: 0.64.0


### PR DESCRIPTION
## Summary

Remove the unused `reduce-configs` dependency from `@rsbuild/plugin-stylus`. The plugin only needs to apply a default `sourceMap` boolean before spreading user options, while `deepmerge` remains in place for cloning copied CSS loader options.