### PR TITLE
chore: ignore node engine updates in renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -34,6 +34,12 @@
       "matchPackageNames": ["*"]
     },
     {
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["engines"],
+      "matchPackageNames": ["node"],
+      "enabled": false
+    },
+    {
       "matchDepTypes": ["peerDependencies"],
       "enabled": false
     }


### PR DESCRIPTION
## Summary

This PR prevents Renovate from updating the Node.js engine requirement in package manifests by disabling npm manager updates for the engines.node entry. This keeps the supported Node.js runtime range under explicit project control while preserving normal dependency updates.