### PR TITLE
feat(plugin-solid): add solid resolve condition

### DIFF
--- a/packages/plugin-solid/src/index.ts
+++ b/packages/plugin-solid/src/index.ts
@@ -20,6 +20,14 @@ export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
     name: PLUGIN_SOLID_NAME,
 
     setup(api) {
+      api.modifyEnvironmentConfig((config) => {
+        const conditionNames = config.resolve.conditionNames ?? ['...'];
+        // Prefer Solid-specific exports while preserving user conditions or Rspack defaults.
+        config.resolve.conditionNames = conditionNames.includes('solid')
+          ? conditionNames
+          : ['solid', ...conditionNames];
+      });
+
       api.modifyBundlerChain(
         (chain, { CHAIN_ID, environment, isProd, target }) => {
           const environmentConfig = environment.config;

--- a/packages/plugin-solid/tests/index.test.ts
+++ b/packages/plugin-solid/tests/index.test.ts
@@ -21,6 +21,35 @@ describe('plugin-solid', () => {
     expect(matchRules(config[0], 'a.tsx')[0]).toMatchSnapshot();
   });
 
+  it('should add solid resolve condition', async () => {
+    const rsbuild = await createRsbuild({
+      config: {
+        ...rsbuildConfig,
+        plugins: [pluginSolid()],
+      },
+    });
+    const config = await rsbuild.initConfigs();
+    expect(config[0].resolve?.conditionNames).toEqual(['solid', '...']);
+  });
+
+  it('should preserve user resolve condition names', async () => {
+    const rsbuild = await createRsbuild({
+      config: {
+        ...rsbuildConfig,
+        resolve: {
+          conditionNames: ['custom', 'import'],
+        },
+        plugins: [pluginSolid()],
+      },
+    });
+    const config = await rsbuild.initConfigs();
+    expect(config[0].resolve?.conditionNames).toEqual([
+      'solid',
+      'custom',
+      'import',
+    ]);
+  });
+
   it('should allow to configure solid preset options', async () => {
     const rsbuild = await createRsbuild({
       config: {

--- a/website/docs/en/plugins/list/plugin-solid.mdx
+++ b/website/docs/en/plugins/list/plugin-solid.mdx
@@ -51,6 +51,12 @@ Babel compilation will introduce extra overhead, in the example above, we use `i
 
 :::
 
+## Resolution behavior
+
+The Solid plugin adds `solid` to Rsbuild's [resolve.conditionNames](/config/resolve/condition-names). This allows package exports to resolve Solid-specific entries when they are available.
+
+If you configure `resolve.conditionNames`, the plugin preserves your configured values and prepends `solid`.
+
 ## Options
 
 To customize the compilation behavior of Solid, use the following options.

--- a/website/docs/zh/plugins/list/plugin-solid.mdx
+++ b/website/docs/zh/plugins/list/plugin-solid.mdx
@@ -47,6 +47,12 @@ Babel 编译会产生额外的编译开销，在上述例子中，我们通过 `
 
 :::
 
+## 解析行为
+
+Solid 插件会将 `solid` 添加到 Rsbuild 的 [resolve.conditionNames](/config/resolve/condition-names) 中，使 package exports 可以解析到 Solid 专属的入口。
+
+如果你配置了 `resolve.conditionNames`，插件会保留已有配置，并在前面添加 `solid`。
+
 ## 选项
 
 如果你需要自定义 Solid 的编译行为，可以使用以下配置项。


### PR DESCRIPTION
## Summary

This PR updates `@rsbuild/plugin-solid` to add the `solid` condition through Rsbuild's `resolve.conditionNames`, allowing package exports to resolve Solid-specific entries when available. It preserves user-provided condition names, falls back to Rspack defaults with `...`, and documents the behavior in the Solid plugin docs.