### PR TITLE
feat(plugin-solid): add hot option

### DIFF
--- a/packages/plugin-solid/src/index.ts
+++ b/packages/plugin-solid/src/index.ts
@@ -7,6 +7,11 @@ const require = createRequire(import.meta.url);
 
 export type PluginSolidOptions = {
   /**
+   * Whether to inject Solid Refresh for HMR in development mode.
+   * @default true
+   */
+  hot?: boolean;
+  /**
    * Options passed to `babel-preset-solid`.
    * @see https://npmjs.com/package/babel-preset-solid
    */
@@ -16,6 +21,8 @@ export type PluginSolidOptions = {
 export const PLUGIN_SOLID_NAME = 'rsbuild:solid';
 
 export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
+  const { hot = true } = options;
+
   return {
     name: PLUGIN_SOLID_NAME,
 
@@ -45,7 +52,7 @@ export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
               babelOptions.parserOpts = { plugins: ['jsx', 'typescript'] };
 
               const usingHMR =
-                !isProd && environmentConfig.dev.hmr && target === 'web';
+                hot && !isProd && environmentConfig.dev.hmr && target === 'web';
               if (usingHMR) {
                 babelOptions.plugins ??= [];
                 babelOptions.plugins.push([

--- a/packages/plugin-solid/tests/index.test.ts
+++ b/packages/plugin-solid/tests/index.test.ts
@@ -50,6 +50,23 @@ describe('plugin-solid', () => {
     ]);
   });
 
+  it('should allow disabling solid refresh', async () => {
+    const rsbuild = await createRsbuild({
+      config: {
+        ...rsbuildConfig,
+        plugins: [pluginSolid({ hot: false }), pluginBabel()],
+      },
+    });
+    const config = await rsbuild.initConfigs();
+
+    expect(
+      JSON.stringify(matchRules(config[0], 'a.tsx')[0]).includes(
+        'solid-refresh',
+      ),
+    ).toEqual(false);
+    expect(config[0].resolve?.alias?.['solid-refresh']).toEqual(undefined);
+  });
+
   it('should allow to configure solid preset options', async () => {
     const rsbuild = await createRsbuild({
       config: {

--- a/website/docs/en/plugins/list/plugin-solid.mdx
+++ b/website/docs/en/plugins/list/plugin-solid.mdx
@@ -61,6 +61,20 @@ If you configure `resolve.conditionNames`, the plugin preserves your configured 
 
 To customize the compilation behavior of Solid, use the following options.
 
+### hot
+
+Whether to inject [Solid Refresh](https://github.com/solidjs/solid-refresh) for HMR in development mode. This only takes effect when Rsbuild HMR is enabled and does not affect production builds.
+
+- **Type:** `boolean`
+- **Default:** `true`
+- **Example:**
+
+```ts
+pluginSolid({
+  hot: false,
+});
+```
+
 ### solidPresetOptions
 
 These options are passed to `babel-preset-solid`. For details, see the [babel-preset-solid documentation](https://npmjs.com/package/babel-preset-solid).

--- a/website/docs/zh/plugins/list/plugin-solid.mdx
+++ b/website/docs/zh/plugins/list/plugin-solid.mdx
@@ -57,6 +57,20 @@ Solid 插件会将 `solid` 添加到 Rsbuild 的 [resolve.conditionNames](/confi
 
 如果你需要自定义 Solid 的编译行为，可以使用以下配置项。
 
+### hot
+
+是否在开发模式下注入 [Solid Refresh](https://github.com/solidjs/solid-refresh) 以支持 HMR。该选项仅在 Rsbuild HMR 启用时生效，不会影响生产环境构建。
+
+- **类型：** `boolean`
+- **默认值：** `true`
+- **示例：**
+
+```ts
+pluginSolid({
+  hot: false,
+});
+```
+
 ### solidPresetOptions
 
 传递给 `babel-preset-solid` 的选项，请查阅 [babel-preset-solid 文档](https://npmjs.com/package/babel-preset-solid) 来了解具体用法。


### PR DESCRIPTION
## Summary

This PR adds a `hot` option to `@rsbuild/plugin-solid` so users can disable Solid Refresh injection without turning off Rsbuild HMR. The default remains enabled, and the docs now describe how to set `hot: false`.