### PR TITLE
fix(plugin-solid): use rspack esm refresh mode

### DIFF
--- a/packages/plugin-solid/src/index.ts
+++ b/packages/plugin-solid/src/index.ts
@@ -57,6 +57,7 @@ export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
                 babelOptions.plugins ??= [];
                 babelOptions.plugins.push([
                   require.resolve('solid-refresh/babel'),
+                  { bundler: 'rspack-esm' },
                 ]);
 
                 chain.resolve.alias.set(

--- a/packages/plugin-solid/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-solid/tests/__snapshots__/index.test.ts.snap
@@ -76,6 +76,9 @@ exports[`plugin-solid > should allow to configure solid preset options 1`] = `
               ],
               [
                 "<PNPM_INNER>/solid-refresh/dist/babel.cjs",
+                {
+                  "bundler": "rspack-esm",
+                },
               ],
             ],
             "presets": [
@@ -172,6 +175,9 @@ exports[`plugin-solid > should apply solid preset correctly 1`] = `
               ],
               [
                 "<PNPM_INNER>/solid-refresh/dist/babel.cjs",
+                {
+                  "bundler": "rspack-esm",
+                },
               ],
             ],
             "presets": [


### PR DESCRIPTION
## Summary

This PR updates `@rsbuild/plugin-solid` to pass `{ bundler: 'rspack-esm' }` to `solid-refresh/babel`, so Solid Refresh uses Rspack's ESM HMR interface instead of the default `module.hot` mode. The existing plugin snapshot coverage is updated to record the Solid Refresh Babel option.

## Related Links

https://github.com/solidjs/solid-refresh#webpack--rspack