### PR TITLE
feat(plugin-solid): add dev option

### DIFF
--- a/packages/plugin-solid/src/index.ts
+++ b/packages/plugin-solid/src/index.ts
@@ -7,6 +7,11 @@ const require = createRequire(import.meta.url);
 
 export type PluginSolidOptions = {
   /**
+   * Whether to resolve Solid's development runtime in development mode.
+   * @default true
+   */
+  dev?: boolean;
+  /**
    * Whether to inject Solid Refresh for HMR in development mode.
    * @default true
    */
@@ -21,7 +26,7 @@ export type PluginSolidOptions = {
 export const PLUGIN_SOLID_NAME = 'rsbuild:solid';
 
 export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
-  const { hot = true } = options;
+  const { dev, hot = true } = options;
 
   return {
     name: PLUGIN_SOLID_NAME,
@@ -29,10 +34,17 @@ export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
     setup(api) {
       api.modifyEnvironmentConfig((config) => {
         const conditionNames = config.resolve.conditionNames ?? ['...'];
+        const useDevRuntime =
+          dev === true || (dev !== false && config.mode === 'development');
+
         // Prefer Solid-specific exports while preserving user conditions or Rspack defaults.
-        config.resolve.conditionNames = conditionNames.includes('solid')
-          ? conditionNames
-          : ['solid', ...conditionNames];
+        config.resolve.conditionNames = [
+          ...new Set([
+            'solid',
+            ...(useDevRuntime ? ['development'] : []),
+            ...conditionNames,
+          ]),
+        ];
       });
 
       api.modifyBundlerChain(

--- a/packages/plugin-solid/src/index.ts
+++ b/packages/plugin-solid/src/index.ts
@@ -34,8 +34,7 @@ export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
     setup(api) {
       api.modifyEnvironmentConfig((config) => {
         const conditionNames = config.resolve.conditionNames ?? ['...'];
-        const useDevRuntime =
-          dev === true || (dev !== false && config.mode === 'development');
+        const useDevRuntime = dev ?? config.mode === 'development';
 
         // Prefer Solid-specific exports while preserving user conditions or Rspack defaults.
         config.resolve.conditionNames = [

--- a/packages/plugin-solid/src/index.ts
+++ b/packages/plugin-solid/src/index.ts
@@ -7,8 +7,8 @@ const require = createRequire(import.meta.url);
 
 export type PluginSolidOptions = {
   /**
-   * Whether to resolve Solid's development runtime in development mode.
-   * @default true
+   * Whether to resolve Solid's development runtime.
+   * @default `true` in development mode, `false` in production mode
    */
   dev?: boolean;
   /**

--- a/packages/plugin-solid/tests/index.test.ts
+++ b/packages/plugin-solid/tests/index.test.ts
@@ -72,6 +72,7 @@ describe('plugin-solid', () => {
     const rsbuild = await createRsbuild({
       config: {
         ...rsbuildConfig,
+        mode: 'development',
         plugins: [pluginSolid({ dev: false })],
       },
     });

--- a/packages/plugin-solid/tests/index.test.ts
+++ b/packages/plugin-solid/tests/index.test.ts
@@ -32,10 +32,27 @@ describe('plugin-solid', () => {
     expect(config[0].resolve?.conditionNames).toEqual(['solid', '...']);
   });
 
+  it('should add development resolve condition in development mode', async () => {
+    const rsbuild = await createRsbuild({
+      config: {
+        ...rsbuildConfig,
+        mode: 'development',
+        plugins: [pluginSolid()],
+      },
+    });
+    const config = await rsbuild.initConfigs();
+    expect(config[0].resolve?.conditionNames).toEqual([
+      'solid',
+      'development',
+      '...',
+    ]);
+  });
+
   it('should preserve user resolve condition names', async () => {
     const rsbuild = await createRsbuild({
       config: {
         ...rsbuildConfig,
+        mode: 'development',
         resolve: {
           conditionNames: ['custom', 'import'],
         },
@@ -45,8 +62,48 @@ describe('plugin-solid', () => {
     const config = await rsbuild.initConfigs();
     expect(config[0].resolve?.conditionNames).toEqual([
       'solid',
+      'development',
       'custom',
       'import',
+    ]);
+  });
+
+  it('should allow disabling solid development condition', async () => {
+    const rsbuild = await createRsbuild({
+      config: {
+        ...rsbuildConfig,
+        plugins: [pluginSolid({ dev: false })],
+      },
+    });
+    const config = await rsbuild.initConfigs();
+    expect(config[0].resolve?.conditionNames).toEqual(['solid', '...']);
+  });
+
+  it('should not add development condition in production mode by default', async () => {
+    const rsbuild = await createRsbuild({
+      config: {
+        ...rsbuildConfig,
+        mode: 'production',
+        plugins: [pluginSolid()],
+      },
+    });
+    const config = await rsbuild.initConfigs();
+    expect(config[0].resolve?.conditionNames).toEqual(['solid', '...']);
+  });
+
+  it('should allow forcing solid development condition in production mode', async () => {
+    const rsbuild = await createRsbuild({
+      config: {
+        ...rsbuildConfig,
+        mode: 'production',
+        plugins: [pluginSolid({ dev: true })],
+      },
+    });
+    const config = await rsbuild.initConfigs();
+    expect(config[0].resolve?.conditionNames).toEqual([
+      'solid',
+      'development',
+      '...',
     ]);
   });
 

--- a/website/docs/en/plugins/list/plugin-solid.mdx
+++ b/website/docs/en/plugins/list/plugin-solid.mdx
@@ -55,11 +55,27 @@ Babel compilation will introduce extra overhead, in the example above, we use `i
 
 The Solid plugin adds `solid` to Rsbuild's [resolve.conditionNames](/config/resolve/condition-names). This allows package exports to resolve Solid-specific entries when they are available.
 
-If you configure `resolve.conditionNames`, the plugin preserves your configured values and prepends `solid`.
+In development mode, the plugin also adds `development` to resolve Solid's development runtime. You can disable this behavior with [`dev: false`](#dev).
+
+If you configure `resolve.conditionNames`, the plugin preserves your configured values and prepends these Solid conditions.
 
 ## Options
 
 To customize the compilation behavior of Solid, use the following options.
+
+### dev
+
+Whether to resolve Solid's development runtime in development mode. Set it to `false` to disable the `development` condition, or set it to `true` to force the `development` condition in production mode.
+
+- **Type:** `boolean`
+- **Default:** `true` in development mode, `false` in production mode
+- **Example:**
+
+```ts
+pluginSolid({
+  dev: false,
+});
+```
 
 ### hot
 

--- a/website/docs/zh/plugins/list/plugin-solid.mdx
+++ b/website/docs/zh/plugins/list/plugin-solid.mdx
@@ -51,11 +51,27 @@ Babel 编译会产生额外的编译开销，在上述例子中，我们通过 `
 
 Solid 插件会将 `solid` 添加到 Rsbuild 的 [resolve.conditionNames](/config/resolve/condition-names) 中，使 package exports 可以解析到 Solid 专属的入口。
 
-如果你配置了 `resolve.conditionNames`，插件会保留已有配置，并在前面添加 `solid`。
+在开发模式下，插件还会添加 `development`，用于解析 Solid 的开发环境运行时。你可以通过 [`dev: false`](#dev) 关闭该行为。
+
+如果你配置了 `resolve.conditionNames`，插件会保留已有配置，并在前面添加这些 Solid 条件。
 
 ## 选项
 
 如果你需要自定义 Solid 的编译行为，可以使用以下配置项。
+
+### dev
+
+是否在开发模式下解析 Solid 的开发环境运行时。设置为 `false` 可以禁用 `development` condition，设置为 `true` 可以在生产模式下强制启用 `development` condition。
+
+- **类型：** `boolean`
+- **默认值：** 开发模式下为 `true`，生产模式下为 `false`
+- **示例：**
+
+```ts
+pluginSolid({
+  dev: false,
+});
+```
 
 ### hot
 


### PR DESCRIPTION
## Summary

This PR adds a `dev` option to `@rsbuild/plugin-solid` so Solid's development runtime can be resolved through the `development` condition in development mode. The option can disable that condition with `dev: false` or force it in production with `dev: true`, while preserving user-provided `resolve.conditionNames`.