### PR TITLE
feat(plugin-solid): add refresh disabled option

### DIFF
--- a/packages/plugin-solid/src/index.ts
+++ b/packages/plugin-solid/src/index.ts
@@ -12,10 +12,15 @@ export type PluginSolidOptions = {
    */
   dev?: boolean;
   /**
-   * Whether to inject Solid Refresh for HMR in development mode.
-   * @default true
+   * Configure Solid Refresh for HMR in development mode.
    */
-  hot?: boolean;
+  refresh?: {
+    /**
+     * Whether to disable Solid Refresh while keeping Rsbuild HMR enabled.
+     * @default false
+     */
+    disabled?: boolean;
+  };
   /**
    * Options passed to `babel-preset-solid`.
    * @see https://npmjs.com/package/babel-preset-solid
@@ -26,7 +31,7 @@ export type PluginSolidOptions = {
 export const PLUGIN_SOLID_NAME = 'rsbuild:solid';
 
 export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
-  const { dev, hot = true } = options;
+  const { dev } = options;
 
   return {
     name: PLUGIN_SOLID_NAME,
@@ -62,8 +67,12 @@ export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
               ];
               babelOptions.parserOpts = { plugins: ['jsx', 'typescript'] };
 
+              // `refresh.disabled` only disables Solid Refresh transforms; Rsbuild HMR can stay enabled.
               const usingHMR =
-                hot && !isProd && environmentConfig.dev.hmr && target === 'web';
+                options.refresh?.disabled !== true &&
+                !isProd &&
+                environmentConfig.dev.hmr &&
+                target === 'web';
               if (usingHMR) {
                 babelOptions.plugins ??= [];
                 babelOptions.plugins.push([

--- a/packages/plugin-solid/tests/index.test.ts
+++ b/packages/plugin-solid/tests/index.test.ts
@@ -108,11 +108,11 @@ describe('plugin-solid', () => {
     ]);
   });
 
-  it('should allow disabling solid refresh', async () => {
+  it('should allow disabling solid refresh via refresh.disabled', async () => {
     const rsbuild = await createRsbuild({
       config: {
         ...rsbuildConfig,
-        plugins: [pluginSolid({ hot: false }), pluginBabel()],
+        plugins: [pluginSolid({ refresh: { disabled: true } }), pluginBabel()],
       },
     });
     const config = await rsbuild.initConfigs();

--- a/website/docs/en/plugins/list/plugin-solid.mdx
+++ b/website/docs/en/plugins/list/plugin-solid.mdx
@@ -77,17 +77,19 @@ pluginSolid({
 });
 ```
 
-### hot
+### refresh.disabled
 
-Whether to inject [Solid Refresh](https://github.com/solidjs/solid-refresh) for HMR in development mode. This only takes effect when Rsbuild HMR is enabled and does not affect production builds.
+Whether to disable [Solid Refresh](https://github.com/solidjs/solid-refresh) for HMR in development mode. This only controls Solid Refresh injection and does not disable Rsbuild HMR.
 
 - **Type:** `boolean`
-- **Default:** `true`
+- **Default:** `false`
 - **Example:**
 
 ```ts
 pluginSolid({
-  hot: false,
+  refresh: {
+    disabled: true,
+  },
 });
 ```
 

--- a/website/docs/zh/plugins/list/plugin-solid.mdx
+++ b/website/docs/zh/plugins/list/plugin-solid.mdx
@@ -73,17 +73,19 @@ pluginSolid({
 });
 ```
 
-### hot
+### refresh.disabled
 
-是否在开发模式下注入 [Solid Refresh](https://github.com/solidjs/solid-refresh) 以支持 HMR。该选项仅在 Rsbuild HMR 启用时生效，不会影响生产环境构建。
+是否在开发模式下禁用 [Solid Refresh](https://github.com/solidjs/solid-refresh) HMR。该选项只控制 Solid Refresh 注入，不会禁用 Rsbuild HMR。
 
 - **类型：** `boolean`
-- **默认值：** `true`
+- **默认值：** `false`
 - **示例：**
 
 ```ts
 pluginSolid({
-  hot: false,
+  refresh: {
+    disabled: true,
+  },
 });
 ```
 


### PR DESCRIPTION
## Summary

This PR aligns `@rsbuild/plugin-solid` with `vite-plugin-solid@next` by replacing the unreleased `hot` option with `refresh.disabled`. `refresh.disabled: true` disables Solid Refresh transforms and the runtime alias while keeping Rsbuild HMR enabled, so this is not a breaking change for a published API. It also updates the focused tests and plugin docs.

## Related Links

https://github.com/solidjs/vite-plugin-solid/tree/next