### PR TITLE
feat(plugin-solid): add ssr option

### DIFF
--- a/packages/plugin-solid/src/index.ts
+++ b/packages/plugin-solid/src/index.ts
@@ -12,6 +12,11 @@ export type PluginSolidOptions = {
    */
   dev?: boolean;
   /**
+   * Whether to generate output for Solid SSR.
+   * @default false
+   */
+  ssr?: boolean;
+  /**
    * Configure Solid Refresh for HMR in development mode.
    */
   refresh?: {
@@ -31,7 +36,7 @@ export type PluginSolidOptions = {
 export const PLUGIN_SOLID_NAME = 'rsbuild:solid';
 
 export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
-  const { dev } = options;
+  const { dev, ssr, solidPresetOptions } = options;
 
   return {
     name: PLUGIN_SOLID_NAME,
@@ -59,10 +64,20 @@ export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
             chain,
             CHAIN_ID,
             modifier: (babelOptions) => {
+              // Apply SSR defaults before user options so explicit values can override them.
+              const defaultPresetOptions: SolidPresetOptions = ssr
+                ? target === 'node'
+                  ? { generate: 'ssr', hydratable: true }
+                  : { generate: 'dom', hydratable: true }
+                : {};
+
               babelOptions.presets = [
                 [
                   require.resolve('babel-preset-solid'),
-                  options.solidPresetOptions || {},
+                  {
+                    ...defaultPresetOptions,
+                    ...(solidPresetOptions || {}),
+                  },
                 ],
               ];
               babelOptions.parserOpts = { plugins: ['jsx', 'typescript'] };

--- a/packages/plugin-solid/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-solid/tests/__snapshots__/index.test.ts.snap
@@ -1,5 +1,95 @@
 // Rstest Snapshot v1
 
+exports[`plugin-solid > should allow solid preset options to override ssr defaults 1`] = `
+{
+  "dependency": {
+    "not": "url",
+  },
+  "include": [
+    {
+      "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
+    },
+    /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
+  ],
+  "oneOf": [
+    {
+      "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+      "type": "asset/source",
+    },
+    {
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "builtin:swc-loader",
+          "options": {
+            "collectTypeScriptInfo": {
+              "exportedEnum": false,
+              "typeExports": true,
+            },
+            "detectSyntax": "auto",
+            "env": {
+              "targets": [
+                "node >= 20",
+              ],
+            },
+            "isModule": "unknown",
+            "jsc": {
+              "experimental": {
+                "cacheRoot": "<ROOT>/node_modules/.cache/.swc",
+                "keepImportAttributes": true,
+              },
+              "externalHelpers": true,
+              "output": {
+                "charset": "utf8",
+              },
+              "parser": {
+                "decorators": true,
+              },
+              "transform": {
+                "decoratorVersion": "2023-11",
+                "legacyDecorator": false,
+              },
+            },
+          },
+        },
+        {
+          "loader": "<ROOT>/packages/plugin-babel/compiled/babel-loader/index.js",
+          "options": {
+            "babelrc": false,
+            "compact": false,
+            "configFile": false,
+            "parserOpts": {
+              "plugins": [
+                "jsx",
+                "typescript",
+              ],
+            },
+            "plugins": [
+              [
+                "<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+                {
+                  "version": "2023-11",
+                },
+              ],
+            ],
+            "presets": [
+              [
+                "<PNPM_INNER>/babel-preset-solid/index.js",
+                {
+                  "generate": "universal",
+                  "hydratable": false,
+                },
+              ],
+            ],
+          },
+        },
+      ],
+    },
+  ],
+  "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+}
+`;
+
 exports[`plugin-solid > should allow to configure solid preset options 1`] = `
 {
   "dependency": {
@@ -184,6 +274,195 @@ exports[`plugin-solid > should apply solid preset correctly 1`] = `
               [
                 "<PNPM_INNER>/babel-preset-solid/index.js",
                 {},
+              ],
+            ],
+          },
+        },
+      ],
+    },
+  ],
+  "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+}
+`;
+
+exports[`plugin-solid > should use hydratable dom output for ssr option on web target 1`] = `
+{
+  "dependency": {
+    "not": "url",
+  },
+  "include": [
+    {
+      "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
+    },
+    /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
+  ],
+  "oneOf": [
+    {
+      "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+      "type": "asset/source",
+    },
+    {
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "builtin:swc-loader",
+          "options": {
+            "collectTypeScriptInfo": {
+              "exportedEnum": false,
+              "typeExports": true,
+            },
+            "detectSyntax": "auto",
+            "env": {
+              "targets": [
+                "chrome >= 107",
+                "edge >= 107",
+                "firefox >= 104",
+                "safari >= 16",
+              ],
+            },
+            "isModule": "unknown",
+            "jsc": {
+              "experimental": {
+                "cacheRoot": "<ROOT>/node_modules/.cache/.swc",
+                "keepImportAttributes": true,
+              },
+              "externalHelpers": true,
+              "output": {
+                "charset": "utf8",
+              },
+              "parser": {
+                "decorators": true,
+              },
+              "transform": {
+                "decoratorVersion": "2023-11",
+                "legacyDecorator": false,
+              },
+            },
+          },
+        },
+        {
+          "loader": "<ROOT>/packages/plugin-babel/compiled/babel-loader/index.js",
+          "options": {
+            "babelrc": false,
+            "compact": false,
+            "configFile": false,
+            "parserOpts": {
+              "plugins": [
+                "jsx",
+                "typescript",
+              ],
+            },
+            "plugins": [
+              [
+                "<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+                {
+                  "version": "2023-11",
+                },
+              ],
+              [
+                "<PNPM_INNER>/solid-refresh/dist/babel.cjs",
+                {
+                  "bundler": "rspack-esm",
+                },
+              ],
+            ],
+            "presets": [
+              [
+                "<PNPM_INNER>/babel-preset-solid/index.js",
+                {
+                  "generate": "dom",
+                  "hydratable": true,
+                },
+              ],
+            ],
+          },
+        },
+      ],
+    },
+  ],
+  "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+}
+`;
+
+exports[`plugin-solid > should use ssr output for ssr option on node target 1`] = `
+{
+  "dependency": {
+    "not": "url",
+  },
+  "include": [
+    {
+      "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
+    },
+    /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
+  ],
+  "oneOf": [
+    {
+      "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+      "type": "asset/source",
+    },
+    {
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "builtin:swc-loader",
+          "options": {
+            "collectTypeScriptInfo": {
+              "exportedEnum": false,
+              "typeExports": true,
+            },
+            "detectSyntax": "auto",
+            "env": {
+              "targets": [
+                "node >= 20",
+              ],
+            },
+            "isModule": "unknown",
+            "jsc": {
+              "experimental": {
+                "cacheRoot": "<ROOT>/node_modules/.cache/.swc",
+                "keepImportAttributes": true,
+              },
+              "externalHelpers": true,
+              "output": {
+                "charset": "utf8",
+              },
+              "parser": {
+                "decorators": true,
+              },
+              "transform": {
+                "decoratorVersion": "2023-11",
+                "legacyDecorator": false,
+              },
+            },
+          },
+        },
+        {
+          "loader": "<ROOT>/packages/plugin-babel/compiled/babel-loader/index.js",
+          "options": {
+            "babelrc": false,
+            "compact": false,
+            "configFile": false,
+            "parserOpts": {
+              "plugins": [
+                "jsx",
+                "typescript",
+              ],
+            },
+            "plugins": [
+              [
+                "<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+                {
+                  "version": "2023-11",
+                },
+              ],
+            ],
+            "presets": [
+              [
+                "<PNPM_INNER>/babel-preset-solid/index.js",
+                {
+                  "generate": "ssr",
+                  "hydratable": true,
+                },
               ],
             ],
           },

--- a/packages/plugin-solid/tests/index.test.ts
+++ b/packages/plugin-solid/tests/index.test.ts
@@ -125,6 +125,57 @@ describe('plugin-solid', () => {
     expect(config[0].resolve?.alias?.['solid-refresh']).toEqual(undefined);
   });
 
+  it('should use hydratable dom output for ssr option on web target', async () => {
+    const rsbuild = await createRsbuild({
+      config: {
+        ...rsbuildConfig,
+        plugins: [pluginSolid({ ssr: true }), pluginBabel()],
+      },
+    });
+    const config = await rsbuild.initConfigs();
+    const rule = matchRules(config[0], 'a.tsx')[0] as RuleWithBabelPreset;
+    expect(rule).toMatchSnapshot();
+  });
+
+  it('should use ssr output for ssr option on node target', async () => {
+    const rsbuild = await createRsbuild({
+      config: {
+        ...rsbuildConfig,
+        output: {
+          target: 'node',
+        },
+        plugins: [pluginSolid({ ssr: true }), pluginBabel()],
+      },
+    });
+    const config = await rsbuild.initConfigs();
+    const rule = matchRules(config[0], 'a.tsx')[0] as RuleWithBabelPreset;
+    expect(rule).toMatchSnapshot();
+  });
+
+  it('should allow solid preset options to override ssr defaults', async () => {
+    const rsbuild = await createRsbuild({
+      config: {
+        ...rsbuildConfig,
+        output: {
+          target: 'node',
+        },
+        plugins: [
+          pluginSolid({
+            ssr: true,
+            solidPresetOptions: {
+              generate: 'universal',
+              hydratable: false,
+            },
+          }),
+          pluginBabel(),
+        ],
+      },
+    });
+    const config = await rsbuild.initConfigs();
+    const rule = matchRules(config[0], 'a.tsx')[0] as RuleWithBabelPreset;
+    expect(rule).toMatchSnapshot();
+  });
+
   it('should allow to configure solid preset options', async () => {
     const rsbuild = await createRsbuild({
       config: {

--- a/packages/plugin-solid/tests/index.test.ts
+++ b/packages/plugin-solid/tests/index.test.ts
@@ -122,7 +122,6 @@ describe('plugin-solid', () => {
         'solid-refresh',
       ),
     ).toEqual(false);
-    expect(config[0].resolve?.alias?.['solid-refresh']).toEqual(undefined);
   });
 
   it('should use hydratable dom output for ssr option on web target', async () => {
@@ -133,7 +132,7 @@ describe('plugin-solid', () => {
       },
     });
     const config = await rsbuild.initConfigs();
-    const rule = matchRules(config[0], 'a.tsx')[0] as RuleWithBabelPreset;
+    const rule = matchRules(config[0], 'a.tsx')[0];
     expect(rule).toMatchSnapshot();
   });
 
@@ -148,7 +147,7 @@ describe('plugin-solid', () => {
       },
     });
     const config = await rsbuild.initConfigs();
-    const rule = matchRules(config[0], 'a.tsx')[0] as RuleWithBabelPreset;
+    const rule = matchRules(config[0], 'a.tsx')[0];
     expect(rule).toMatchSnapshot();
   });
 
@@ -172,7 +171,7 @@ describe('plugin-solid', () => {
       },
     });
     const config = await rsbuild.initConfigs();
-    const rule = matchRules(config[0], 'a.tsx')[0] as RuleWithBabelPreset;
+    const rule = matchRules(config[0], 'a.tsx')[0];
     expect(rule).toMatchSnapshot();
   });
 

--- a/website/docs/en/plugins/list/plugin-solid.mdx
+++ b/website/docs/en/plugins/list/plugin-solid.mdx
@@ -93,6 +93,22 @@ pluginSolid({
 });
 ```
 
+### ssr
+
+Whether to generate output for Solid SSR. When enabled, the plugin uses `generate: 'ssr'` and `hydratable: true` for Node.js targets, and uses `generate: 'dom'` and `hydratable: true` for other targets.
+
+Values in `solidPresetOptions` will override these defaults.
+
+- **Type:** `boolean`
+- **Default:** `false`
+- **Example:**
+
+```ts
+pluginSolid({
+  ssr: true,
+});
+```
+
 ### solidPresetOptions
 
 These options are passed to `babel-preset-solid`. For details, see the [babel-preset-solid documentation](https://npmjs.com/package/babel-preset-solid).

--- a/website/docs/zh/plugins/list/plugin-solid.mdx
+++ b/website/docs/zh/plugins/list/plugin-solid.mdx
@@ -89,6 +89,22 @@ pluginSolid({
 });
 ```
 
+### ssr
+
+是否生成 Solid SSR 输出。启用后，插件会为 Node.js target 设置 `generate: 'ssr'` 和 `hydratable: true`，为其他 target 设置 `generate: 'dom'` 和 `hydratable: true`。
+
+`solidPresetOptions` 中的配置会覆盖这些默认值。
+
+- **类型：** `boolean`
+- **默认值：** `false`
+- **示例：**
+
+```ts
+pluginSolid({
+  ssr: true,
+});
+```
+
 ### solidPresetOptions
 
 传递给 `babel-preset-solid` 的选项，请查阅 [babel-preset-solid 文档](https://npmjs.com/package/babel-preset-solid) 来了解具体用法。


### PR DESCRIPTION
## Summary

This PR adds an `ssr` option to `@rsbuild/plugin-solid` so Solid compiler defaults can be selected per Rsbuild target. When enabled, Node.js targets use `generate: 'ssr'` with hydration markers, while web targets use hydratable DOM output. Explicit `solidPresetOptions` still override these defaults.

## Related Links

https://github.com/solidjs/vite-plugin-solid/tree/next