### PR TITLE
feat(plugin-solid): add solid option

### DIFF
--- a/packages/plugin-solid/src/index.ts
+++ b/packages/plugin-solid/src/index.ts
@@ -30,13 +30,19 @@ export type PluginSolidOptions = {
    * Options passed to `babel-preset-solid`.
    * @see https://npmjs.com/package/babel-preset-solid
    */
+  solid?: SolidPresetOptions;
+  /**
+   * Options passed to `babel-preset-solid`.
+   * If both `solid` and `solidPresetOptions` are set, `solid` takes precedence.
+   * @deprecated Use `solid` instead.
+   */
   solidPresetOptions?: SolidPresetOptions;
 };
 
 export const PLUGIN_SOLID_NAME = 'rsbuild:solid';
 
 export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
-  const { dev, ssr, solidPresetOptions } = options;
+  const { dev, solid, solidPresetOptions, ssr } = options;
 
   return {
     name: PLUGIN_SOLID_NAME,
@@ -77,6 +83,7 @@ export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
                   {
                     ...defaultPresetOptions,
                     ...(solidPresetOptions || {}),
+                    ...(solid || {}),
                   },
                 ],
               ];

--- a/packages/plugin-solid/src/index.ts
+++ b/packages/plugin-solid/src/index.ts
@@ -82,8 +82,8 @@ export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
                   require.resolve('babel-preset-solid'),
                   {
                     ...defaultPresetOptions,
-                    ...(solidPresetOptions || {}),
-                    ...(solid || {}),
+                    ...solidPresetOptions,
+                    ...solid,
                   },
                 ],
               ];

--- a/packages/plugin-solid/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-solid/tests/__snapshots__/index.test.ts.snap
@@ -1,6 +1,105 @@
 // Rstest Snapshot v1
 
-exports[`plugin-solid > should allow solid preset options to override ssr defaults 1`] = `
+exports[`plugin-solid > should allow deprecated solidPresetOptions alias 1`] = `
+{
+  "dependency": {
+    "not": "url",
+  },
+  "include": [
+    {
+      "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
+    },
+    /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
+  ],
+  "oneOf": [
+    {
+      "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+      "type": "asset/source",
+    },
+    {
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "builtin:swc-loader",
+          "options": {
+            "collectTypeScriptInfo": {
+              "exportedEnum": false,
+              "typeExports": true,
+            },
+            "detectSyntax": "auto",
+            "env": {
+              "targets": [
+                "chrome >= 107",
+                "edge >= 107",
+                "firefox >= 104",
+                "safari >= 16",
+              ],
+            },
+            "isModule": "unknown",
+            "jsc": {
+              "experimental": {
+                "cacheRoot": "<ROOT>/node_modules/.cache/.swc",
+                "keepImportAttributes": true,
+              },
+              "externalHelpers": true,
+              "output": {
+                "charset": "utf8",
+              },
+              "parser": {
+                "decorators": true,
+              },
+              "transform": {
+                "decoratorVersion": "2023-11",
+                "legacyDecorator": false,
+              },
+            },
+          },
+        },
+        {
+          "loader": "<ROOT>/packages/plugin-babel/compiled/babel-loader/index.js",
+          "options": {
+            "babelrc": false,
+            "compact": false,
+            "configFile": false,
+            "parserOpts": {
+              "plugins": [
+                "jsx",
+                "typescript",
+              ],
+            },
+            "plugins": [
+              [
+                "<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+                {
+                  "version": "2023-11",
+                },
+              ],
+              [
+                "<PNPM_INNER>/solid-refresh/dist/babel.cjs",
+                {
+                  "bundler": "rspack-esm",
+                },
+              ],
+            ],
+            "presets": [
+              [
+                "<PNPM_INNER>/babel-preset-solid/index.js",
+                {
+                  "generate": "ssr",
+                  "hydratable": true,
+                },
+              ],
+            ],
+          },
+        },
+      ],
+    },
+  ],
+  "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+}
+`;
+
+exports[`plugin-solid > should allow solid options to override ssr defaults 1`] = `
 {
   "dependency": {
     "not": "url",
@@ -90,7 +189,7 @@ exports[`plugin-solid > should allow solid preset options to override ssr defaul
 }
 `;
 
-exports[`plugin-solid > should allow to configure solid preset options 1`] = `
+exports[`plugin-solid > should allow to configure solid options 1`] = `
 {
   "dependency": {
     "not": "url",

--- a/packages/plugin-solid/tests/index.test.ts
+++ b/packages/plugin-solid/tests/index.test.ts
@@ -151,7 +151,7 @@ describe('plugin-solid', () => {
     expect(rule).toMatchSnapshot();
   });
 
-  it('should allow solid preset options to override ssr defaults', async () => {
+  it('should allow solid options to override ssr defaults', async () => {
     const rsbuild = await createRsbuild({
       config: {
         ...rsbuildConfig,
@@ -161,7 +161,7 @@ describe('plugin-solid', () => {
         plugins: [
           pluginSolid({
             ssr: true,
-            solidPresetOptions: {
+            solid: {
               generate: 'universal',
               hydratable: false,
             },
@@ -175,7 +175,26 @@ describe('plugin-solid', () => {
     expect(rule).toMatchSnapshot();
   });
 
-  it('should allow to configure solid preset options', async () => {
+  it('should allow to configure solid options', async () => {
+    const rsbuild = await createRsbuild({
+      config: {
+        ...rsbuildConfig,
+        plugins: [
+          pluginSolid({
+            solid: {
+              generate: 'ssr',
+              hydratable: true,
+            },
+          }),
+          pluginBabel(),
+        ],
+      },
+    });
+    const config = await rsbuild.initConfigs();
+    expect(matchRules(config[0], 'a.tsx')[0]).toMatchSnapshot();
+  });
+
+  it('should allow deprecated solidPresetOptions alias', async () => {
     const rsbuild = await createRsbuild({
       config: {
         ...rsbuildConfig,

--- a/website/docs/en/plugins/list/plugin-solid.mdx
+++ b/website/docs/en/plugins/list/plugin-solid.mdx
@@ -97,7 +97,7 @@ pluginSolid({
 
 Whether to generate output for Solid SSR. When enabled, the plugin uses `generate: 'ssr'` and `hydratable: true` for Node.js targets, and uses `generate: 'dom'` and `hydratable: true` for other targets.
 
-Values in `solidPresetOptions` will override these defaults.
+Values in [`solid`](#solid) will override these defaults.
 
 - **Type:** `boolean`
 - **Default:** `false`
@@ -109,7 +109,7 @@ pluginSolid({
 });
 ```
 
-### solidPresetOptions
+### solid
 
 These options are passed to `babel-preset-solid`. For details, see the [babel-preset-solid documentation](https://npmjs.com/package/babel-preset-solid).
 
@@ -119,9 +119,11 @@ These options are passed to `babel-preset-solid`. For details, see the [babel-pr
 
 ```ts
 pluginSolid({
-  solidPresetOptions: {
+  solid: {
     generate: 'ssr',
     hydratable: true,
   },
 });
 ```
+
+> `solidPresetOptions` is a deprecated alias for `solid`. Use `solid` instead. If both options are set, `solid` takes precedence.

--- a/website/docs/zh/plugins/list/plugin-solid.mdx
+++ b/website/docs/zh/plugins/list/plugin-solid.mdx
@@ -93,7 +93,7 @@ pluginSolid({
 
 是否生成 Solid SSR 输出。启用后，插件会为 Node.js target 设置 `generate: 'ssr'` 和 `hydratable: true`，为其他 target 设置 `generate: 'dom'` 和 `hydratable: true`。
 
-`solidPresetOptions` 中的配置会覆盖这些默认值。
+[`solid`](#solid) 中的配置会覆盖这些默认值。
 
 - **类型：** `boolean`
 - **默认值：** `false`
@@ -105,7 +105,7 @@ pluginSolid({
 });
 ```
 
-### solidPresetOptions
+### solid
 
 传递给 `babel-preset-solid` 的选项，请查阅 [babel-preset-solid 文档](https://npmjs.com/package/babel-preset-solid) 来了解具体用法。
 
@@ -115,9 +115,11 @@ pluginSolid({
 
 ```ts
 pluginSolid({
-  solidPresetOptions: {
+  solid: {
     generate: 'ssr',
     hydratable: true,
   },
 });
 ```
+
+> `solidPresetOptions` 是 `solid` 的废弃别名，请使用 `solid` 代替。如果两个选项同时设置，则 `solid` 优先生效。


### PR DESCRIPTION
## Summary

This PR aligns `@rsbuild/plugin-solid` with `vite-plugin-solid@next` by adding `solid` as the canonical option for `babel-preset-solid` options. The existing `solidPresetOptions` option remains available as a deprecated alias for compatibility, and `solid` takes precedence when both are configured. It also updates the plugin tests and documentation for the new option.

## Related Links

https://github.com/solidjs/vite-plugin-solid/tree/next