### PR TITLE
docs(v1): add algolia site verification meta tag

### DIFF
--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -20,7 +20,9 @@ const description = 'The Rspack-based build tool';
 
 export default defineConfig({
   plugins: [
-    pluginAlgolia(),
+    pluginAlgolia({
+      verificationContent: '65929C33AE3BE529',
+    }),
     pluginLlms(),
     pluginSitemap({
       siteUrl,


### PR DESCRIPTION
Add Algolia site verification meta tag for search indexing.

Related: https://github.com/web-infra-dev/rspack/pull/13818