### PR TITLE
docs(v1): update algolia indexName to rsbuild-v1

### DIFF
--- a/website/theme/index.tsx
+++ b/website/theme/index.tsx
@@ -75,7 +75,7 @@ const Search = () => {
       docSearchProps={{
         appId: 'LBYJGZQY5U', // cspell:disable-line
         apiKey: 'ecb541ceb2b67d7f23e12e6fb4772c0f', // cspell:disable-line
-        indexName: 'rsbuild',
+        indexName: 'rsbuild-v1',
         searchParameters: {
           facetFilters: [`lang:${lang}`],
         },


### PR DESCRIPTION
Update the Algolia search indexName to `rsbuild-v1` for the v1 documentation site.

Related PR in Rspack: https://github.com/web-infra-dev/rspack/pull/13924