### PR TITLE
test(e2e): cover filenameHash for node target

### DIFF
--- a/e2e/cases/output/filename-hash-node-target/index.test.ts
+++ b/e2e/cases/output/filename-hash-node-target/index.test.ts
@@ -1,0 +1,29 @@
+import { expect, getFileContent, test } from '@e2e/helper';
+
+test('should allow to force filename hash for node target', async ({
+  build,
+}) => {
+  const rsbuild = await build({
+    config: {
+      output: {
+        target: 'node',
+        filenameHash: {
+          enable: 'always',
+          format: 'contenthash:8',
+        },
+      },
+    },
+  });
+
+  const files = rsbuild.getDistFiles();
+  const filenames = Object.keys(files);
+  expect(filenames.some((key) => /\/index\.js$/.test(key))).toBeFalsy();
+
+  const indexJs = getFileContent(
+    files,
+    (key) => /\/index\.\w{8}\.js$/.test(key),
+    { ignoreHash: false },
+  );
+
+  expect(indexJs).toContain('filename hash for node target');
+});

--- a/e2e/cases/output/filename-hash-node-target/src/index.js
+++ b/e2e/cases/output/filename-hash-node-target/src/index.js
@@ -1,0 +1,1 @@
+console.log('filename hash for node target');


### PR DESCRIPTION
## Summary

This PR adds an e2e case covering `output.filenameHash` with `enable: always` and `target: node`, ensuring the emitted Node entry keeps a content hash in its filename instead of falling back to `index.js`.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/7603