### PR TITLE
chore(deps): upgrade pnpm to v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
     "simple-git-hooks": "^2.13.1",
     "typescript": "^6.0.3"
   },
-  "packageManager": "pnpm@10.33.2",
+  "packageManager": "pnpm@11.0.6",
   "engines": {
     "node": ">=22.18.0",
-    "pnpm": ">=10.33.2"
+    "pnpm": ">=11.0.0"
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,3 +28,12 @@ allowBuilds:
   core-js: false
   simple-git-hooks: false
   svelte-preprocess: false
+
+minimumReleaseAgeExclude:
+- '@rspack/*'
+- '@rsbuild/*'
+- '@rslib/*'
+- '@rspress/*'
+- '@rstest/*'
+- '@rsdoctor/*'
+- '@rslint/*'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,5 +26,5 @@ strictPeerDependencies: false
 allowBuilds:
   '@parcel/watcher': true
   core-js: false
-  simple-git-hooks: true
+  simple-git-hooks: false
   svelte-preprocess: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,3 +22,9 @@ patchedDependencies:
   postcss-loader@8.2.1: patches/postcss-loader@8.2.1.patch
 
 strictPeerDependencies: false
+
+allowBuilds:
+  '@parcel/watcher': true
+  core-js: false
+  simple-git-hooks: true
+  svelte-preprocess: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,10 +30,10 @@ allowBuilds:
   svelte-preprocess: false
 
 minimumReleaseAgeExclude:
-- '@rspack/*'
-- '@rsbuild/*'
-- '@rslib/*'
-- '@rspress/*'
-- '@rstest/*'
-- '@rsdoctor/*'
-- '@rslint/*'
+  - '@rspack/*'
+  - '@rsbuild/*'
+  - '@rslib/*'
+  - '@rspress/*'
+  - '@rstest/*'
+  - '@rsdoctor/*'
+  - '@rslint/*'


### PR DESCRIPTION
## Summary

This PR upgrades the project package manager declaration to pnpm 11 and moves build-script permissions to `allowBuilds`, which is required after pnpm 11 removed the previous build dependency settings.

## Related Links

https://github.com/pnpm/pnpm/releases/tag/v11.0.0