### PR TITLE
test: align rspack config naming

### DIFF
--- a/e2e/cases/config/inspect-config/index.test.ts
+++ b/e2e/cases/config/inspect-config/index.test.ts
@@ -23,7 +23,7 @@ const rsbuildNodeConfig = path.resolve(
   import.meta.dirname,
   './dist/.rsbuild/rsbuild.config.node.mjs',
 );
-const bundlerConfig = path.resolve(
+const rspackConfig = path.resolve(
   import.meta.dirname,
   `./dist/.rsbuild/rspack.config.web.mjs`,
 );
@@ -46,12 +46,12 @@ test('should generate config files when writeToDisk is true', async ({
     writeToDisk: true,
   });
 
-  expect(fs.existsSync(bundlerConfig)).toBeTruthy();
+  expect(fs.existsSync(rspackConfig)).toBeTruthy();
   expect(fs.existsSync(rsbuildConfig)).toBeTruthy();
   await expectLog(INSPECT_LOG);
 
   await fse.remove(rsbuildConfig);
-  await fse.remove(bundlerConfig);
+  await fse.remove(rspackConfig);
 });
 
 test('should generate config files correctly when output is specified', async ({
@@ -67,7 +67,7 @@ test('should generate config files correctly when output is specified', async ({
     outputPath: 'foo',
   });
 
-  const bundlerConfig = path.resolve(
+  const rspackConfig = path.resolve(
     import.meta.dirname,
     `./dist/foo/rspack.config.web.mjs`,
   );
@@ -77,12 +77,12 @@ test('should generate config files correctly when output is specified', async ({
     './dist/foo/rsbuild.config.mjs',
   );
 
-  expect(fs.existsSync(bundlerConfig)).toBeTruthy();
+  expect(fs.existsSync(rspackConfig)).toBeTruthy();
   expect(fs.existsSync(rsbuildConfig)).toBeTruthy();
   await expectLog(INSPECT_LOG);
 
   await fse.remove(rsbuildConfig);
-  await fse.remove(bundlerConfig);
+  await fse.remove(rspackConfig);
 });
 
 test('should generate bundler config for node when target contains node', async ({
@@ -108,13 +108,13 @@ test('should generate bundler config for node when target contains node', async 
   });
 
   expect(fs.existsSync(rsbuildNodeConfig)).toBeTruthy();
-  expect(fs.existsSync(bundlerConfig)).toBeTruthy();
+  expect(fs.existsSync(rspackConfig)).toBeTruthy();
   expect(fs.existsSync(bundlerNodeConfig)).toBeTruthy();
   await expectLog(INSPECT_LOG);
 
   await fse.remove(rsbuildConfig);
   await fse.remove(rsbuildNodeConfig);
-  await fse.remove(bundlerConfig);
+  await fse.remove(rspackConfig);
   await fse.remove(bundlerNodeConfig);
 });
 
@@ -127,7 +127,7 @@ test('should not generate config files when writeToDisk is false', async () => {
   });
 
   expect(fs.existsSync(rsbuildConfig)).toBeFalsy();
-  expect(fs.existsSync(bundlerConfig)).toBeFalsy();
+  expect(fs.existsSync(rspackConfig)).toBeFalsy();
 });
 
 test('should allow to specify absolute output path', async ({ logHelper }) => {

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -316,20 +316,18 @@ export async function createRsbuild(
   const inspectConfig: InspectConfig = async (inspectOptions) => {
     initAction();
 
-    const bundlerConfigs = (
-      await baseInitConfigs({
-        context,
-        pluginManager,
-        rsbuildOptions: resolvedOptions,
-      })
-    ).rspackConfigs;
+    const { rspackConfigs } = await baseInitConfigs({
+      context,
+      pluginManager,
+      rsbuildOptions: resolvedOptions,
+    });
 
     return baseInspectConfig({
       context,
       pluginManager,
       rsbuildOptions: resolvedOptions,
       inspectOptions,
-      bundlerConfigs,
+      bundlerConfigs: rspackConfigs,
     });
   };
 

--- a/packages/core/tests/builder.test.ts
+++ b/packages/core/tests/builder.test.ts
@@ -17,9 +17,9 @@ describe('default bundler', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
+    const rspackConfigs = await rsbuild.initConfigs();
 
-    expect(bundlerConfigs[0]).toMatchSnapshot();
+    expect(rspackConfigs[0]).toMatchSnapshot();
   });
 });
 

--- a/packages/core/tests/css.test.ts
+++ b/packages/core/tests/css.test.ts
@@ -52,9 +52,9 @@ describe('plugin-css', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
+    const rspackConfigs = await rsbuild.initConfigs();
 
-    expect(JSON.stringify(bundlerConfigs[0])).toContain('"sourceMap":true');
+    expect(JSON.stringify(rspackConfigs[0])).toContain('"sourceMap":true');
   });
 
   it('should disable source map when output.sourceMap.css is false', async () => {
@@ -68,9 +68,9 @@ describe('plugin-css', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
+    const rspackConfigs = await rsbuild.initConfigs();
 
-    expect(JSON.stringify(bundlerConfigs[0])).toContain('"sourceMap":false');
+    expect(JSON.stringify(rspackConfigs[0])).toContain('"sourceMap":false');
   });
 
   it('should disable source map in production by default', async () => {
@@ -78,9 +78,9 @@ describe('plugin-css', () => {
 
     const rsbuild = await createRsbuild();
 
-    const bundlerConfigs = await rsbuild.initConfigs();
+    const rspackConfigs = await rsbuild.initConfigs();
 
-    expect(JSON.stringify(bundlerConfigs[0])).toContain('"sourceMap":false');
+    expect(JSON.stringify(rspackConfigs[0])).toContain('"sourceMap":false');
   });
 
   it('should allow customizing cssModules.localIdentName', async () => {
@@ -94,9 +94,9 @@ describe('plugin-css', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
+    const rspackConfigs = await rsbuild.initConfigs();
 
-    expect(JSON.stringify(bundlerConfigs[0])).toContain(
+    expect(JSON.stringify(rspackConfigs[0])).toContain(
       '"localIdentName":"[hash]"',
     );
   });
@@ -111,8 +111,8 @@ describe('plugin-css', () => {
         },
       },
     });
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(matchRules(bundlerConfigs[0], 'a.module.css')).toMatchSnapshot();
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(matchRules(rspackConfigs[0], 'a.module.css')).toMatchSnapshot();
   });
 });
 
@@ -126,9 +126,9 @@ describe('plugin-css injectStyles', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
+    const rspackConfigs = await rsbuild.initConfigs();
 
-    expect(matchRules(bundlerConfigs[0], 'a.css')).toMatchSnapshot();
+    expect(matchRules(rspackConfigs[0], 'a.css')).toMatchSnapshot();
   });
 
   it('should apply ignoreCssLoader when injectStyles is true and target is node', async () => {
@@ -141,9 +141,9 @@ describe('plugin-css injectStyles', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
+    const rspackConfigs = await rsbuild.initConfigs();
 
-    expect(matchRules(bundlerConfigs[0], 'a.css')).toMatchSnapshot();
+    expect(matchRules(rspackConfigs[0], 'a.css')).toMatchSnapshot();
   });
 });
 
@@ -175,7 +175,7 @@ it('should ensure isolation of PostCSS config objects between different builds',
     },
   });
 
-  const bundlerConfigs = await rsbuild.initConfigs();
-  expect(matchRules(bundlerConfigs[0], 'a.css')).toMatchSnapshot();
-  expect(matchRules(bundlerConfigs[1], 'a.css')).toMatchSnapshot();
+  const rspackConfigs = await rsbuild.initConfigs();
+  expect(matchRules(rspackConfigs[0], 'a.css')).toMatchSnapshot();
+  expect(matchRules(rspackConfigs[1], 'a.css')).toMatchSnapshot();
 });

--- a/packages/core/tests/default.test.ts
+++ b/packages/core/tests/default.test.ts
@@ -9,8 +9,8 @@ it('should apply default plugins correctly', async () => {
   rs.stubEnv('NODE_ENV', 'development');
   const rsbuild = await createRsbuild();
 
-  const bundlerConfigs = await rsbuild.initConfigs();
-  expect(bundlerConfigs[0]).toMatchSnapshot();
+  const rspackConfigs = await rsbuild.initConfigs();
+  expect(rspackConfigs[0]).toMatchSnapshot();
 });
 
 it('should apply default plugins correctly in production', async () => {
@@ -18,8 +18,8 @@ it('should apply default plugins correctly in production', async () => {
 
   const rsbuild = await createRsbuild();
 
-  const bundlerConfigs = await rsbuild.initConfigs();
-  expect(bundlerConfigs[0]).toMatchSnapshot();
+  const rspackConfigs = await rsbuild.initConfigs();
+  expect(rspackConfigs[0]).toMatchSnapshot();
 });
 
 it('should apply default plugins correctly when target is node', async () => {
@@ -33,9 +33,9 @@ it('should apply default plugins correctly when target is node', async () => {
     },
   });
 
-  const bundlerConfigs = await rsbuild.initConfigs();
+  const rspackConfigs = await rsbuild.initConfigs();
 
-  expect(bundlerConfigs[0]).toMatchSnapshot();
+  expect(rspackConfigs[0]).toMatchSnapshot();
 });
 
 describe('tools.rspack', () => {
@@ -70,9 +70,9 @@ describe('tools.rspack', () => {
         },
       },
     });
-    const bundlerConfigs = await rsbuild.initConfigs();
+    const rspackConfigs = await rsbuild.initConfigs();
 
-    expect(bundlerConfigs[0]).toMatchSnapshot();
+    expect(rspackConfigs[0]).toMatchSnapshot();
   });
 });
 
@@ -98,9 +98,9 @@ describe('bundler API', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(bundlerConfigs[0].target).toBe('node');
-    expect(bundlerConfigs[0].devtool).toBe('hidden-source-map');
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(rspackConfigs[0].target).toBe('node');
+    expect(rspackConfigs[0].devtool).toBe('hidden-source-map');
   });
 
   it('should format modifyBundlerChain rules correctly', async () => {
@@ -124,8 +124,8 @@ describe('bundler API', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(matchRules(bundlerConfigs[0], 'a.yaml')).toMatchSnapshot();
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(matchRules(rspackConfigs[0], 'a.yaml')).toMatchSnapshot();
   });
 
   it('should support using builtinLoader in modifyBundlerChain', async () => {
@@ -149,8 +149,8 @@ describe('bundler API', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(matchRules(bundlerConfigs[0], 'a.yaml')).toMatchSnapshot();
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(matchRules(rspackConfigs[0], 'a.yaml')).toMatchSnapshot();
   });
 });
 

--- a/packages/core/tests/minimize.test.ts
+++ b/packages/core/tests/minimize.test.ts
@@ -10,9 +10,9 @@ describe('plugin-minimize', () => {
 
     const rsbuild = await createRsbuild();
 
-    const bundlerConfigs = await rsbuild.initConfigs();
+    const rspackConfigs = await rsbuild.initConfigs();
 
-    expect(bundlerConfigs[0].optimization?.minimizer).toBeUndefined();
+    expect(rspackConfigs[0].optimization?.minimizer).toBeUndefined();
   });
 
   it('should apply minimizer in production', async () => {
@@ -20,9 +20,9 @@ describe('plugin-minimize', () => {
 
     const rsbuild = await createRsbuild();
 
-    const bundlerConfigs = await rsbuild.initConfigs();
+    const rspackConfigs = await rsbuild.initConfigs();
 
-    expect(bundlerConfigs[0].optimization?.minimizer).toMatchSnapshot();
+    expect(rspackConfigs[0].optimization?.minimizer).toMatchSnapshot();
   });
 
   it('should not apply minimizer for JS when output.minify.js is false', async () => {
@@ -38,10 +38,10 @@ describe('plugin-minimize', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
+    const rspackConfigs = await rsbuild.initConfigs();
 
-    expect(bundlerConfigs[0].optimization?.minimizer?.length).toBe(1);
-    expect(bundlerConfigs[0].optimization?.minimizer?.[0]).toMatchObject({
+    expect(rspackConfigs[0].optimization?.minimizer?.length).toBe(1);
+    expect(rspackConfigs[0].optimization?.minimizer?.[0]).toMatchObject({
       name: 'LightningCssMinimizerRspackPlugin',
     });
   });
@@ -60,9 +60,9 @@ describe('plugin-minimize', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
+    const rspackConfigs = await rsbuild.initConfigs();
 
-    expect(bundlerConfigs[0].optimization?.minimize).toBe(false);
+    expect(rspackConfigs[0].optimization?.minimize).toBe(false);
   });
 
   it('should not apply minimizer for CSS when output.minify.css is false', async () => {
@@ -78,10 +78,10 @@ describe('plugin-minimize', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
+    const rspackConfigs = await rsbuild.initConfigs();
 
-    expect(bundlerConfigs[0].optimization?.minimizer?.length).toBe(1);
-    expect(bundlerConfigs[0].optimization?.minimizer?.[0]).toMatchObject({
+    expect(rspackConfigs[0].optimization?.minimizer?.length).toBe(1);
+    expect(rspackConfigs[0].optimization?.minimizer?.[0]).toMatchObject({
       name: 'SwcJsMinimizerRspackPlugin',
     });
   });
@@ -101,11 +101,11 @@ describe('plugin-minimize', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
+    const rspackConfigs = await rsbuild.initConfigs();
 
     // implicit assert the order of minimizers here,
     // could also be a guard for the order of minimizers
-    expect(bundlerConfigs[0].optimization?.minimizer?.[0]).toMatchObject({
+    expect(rspackConfigs[0].optimization?.minimizer?.[0]).toMatchObject({
       _args: [
         {
           exclude: 'no_js_minify',
@@ -125,9 +125,9 @@ describe('plugin-minimize', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
+    const rspackConfigs = await rsbuild.initConfigs();
 
-    expect(bundlerConfigs[0].optimization?.minimizer).toMatchSnapshot();
+    expect(rspackConfigs[0].optimization?.minimizer).toMatchSnapshot();
   });
 
   it('should remove specific console when performance.removeConsole is array', async () => {
@@ -141,8 +141,8 @@ describe('plugin-minimize', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(bundlerConfigs[0].optimization?.minimizer).toMatchSnapshot();
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(rspackConfigs[0].optimization?.minimizer).toMatchSnapshot();
   });
 
   it('should set asciiOnly false when output.charset is utf8', async () => {
@@ -156,7 +156,7 @@ describe('plugin-minimize', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(bundlerConfigs[0].optimization?.minimizer).toMatchSnapshot();
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(rspackConfigs[0].optimization?.minimizer).toMatchSnapshot();
   });
 });

--- a/packages/core/tests/output.test.ts
+++ b/packages/core/tests/output.test.ts
@@ -9,8 +9,8 @@ describe('plugin-output', () => {
   it('should set output correctly', async () => {
     const rsbuild = await createRsbuild();
 
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(bundlerConfigs[0].output).toMatchSnapshot();
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(rspackConfigs[0].output).toMatchSnapshot();
   });
 
   it('should allow enabling filename hash in development mode', async () => {
@@ -26,8 +26,8 @@ describe('plugin-output', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
-    const [config] = bundlerConfigs;
+    const rspackConfigs = await rsbuild.initConfigs();
+    const [config] = rspackConfigs;
 
     expect(config.output).toMatchSnapshot();
     expect(matchPlugin(config, 'CssExtractRspackPlugin')).toMatchObject({
@@ -51,8 +51,8 @@ describe('plugin-output', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
-    const [config] = bundlerConfigs;
+    const rspackConfigs = await rsbuild.initConfigs();
+    const [config] = rspackConfigs;
 
     expect(config.output).toMatchSnapshot();
     expect(matchPlugin(config, 'CssExtractRspackPlugin')).toMatchObject({
@@ -76,8 +76,8 @@ describe('plugin-output', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
-    const [config] = bundlerConfigs;
+    const rspackConfigs = await rsbuild.initConfigs();
+    const [config] = rspackConfigs;
 
     expect(config.output).toMatchSnapshot();
     expect(matchPlugin(config, 'CssExtractRspackPlugin')).toMatchObject({
@@ -100,8 +100,8 @@ describe('plugin-output', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(bundlerConfigs[0].output).toMatchSnapshot();
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(rspackConfigs[0].output).toMatchSnapshot();
   });
 
   it('should allow setting distPath.js and distPath.css to empty string', async () => {
@@ -116,8 +116,8 @@ describe('plugin-output', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(bundlerConfigs[0].output).toMatchSnapshot();
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(rspackConfigs[0].output).toMatchSnapshot();
   });
 
   it('should allow customizing async js path via distPath.jsAsync', async () => {
@@ -131,8 +131,8 @@ describe('plugin-output', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(bundlerConfigs[0].output?.chunkFilename).toEqual(
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(rspackConfigs[0].output?.chunkFilename).toEqual(
       'custom/js/[name].js',
     );
   });
@@ -149,8 +149,8 @@ describe('plugin-output', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(bundlerConfigs[0].output).toMatchSnapshot();
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(rspackConfigs[0].output).toMatchSnapshot();
   });
 
   it('should apply output config when target is node', async () => {
@@ -169,8 +169,8 @@ describe('plugin-output', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(bundlerConfigs[0].output).toMatchSnapshot();
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(rspackConfigs[0].output).toMatchSnapshot();
   });
 
   it('should allow using copy plugin', async () => {
@@ -188,10 +188,8 @@ describe('plugin-output', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(
-      matchPlugin(bundlerConfigs[0], 'CopyRspackPlugin'),
-    ).toMatchSnapshot();
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(matchPlugin(rspackConfigs[0], 'CopyRspackPlugin')).toMatchSnapshot();
   });
 
   it('should allow using copy plugin with multiple configurations', async () => {
@@ -217,10 +215,8 @@ describe('plugin-output', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(
-      matchPlugin(bundlerConfigs[0], 'CopyRspackPlugin'),
-    ).toMatchSnapshot();
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(matchPlugin(rspackConfigs[0], 'CopyRspackPlugin')).toMatchSnapshot();
   });
 
   it('should replace `<port>` placeholder with default port', async () => {

--- a/packages/core/tests/resolve.test.ts
+++ b/packages/core/tests/resolve.test.ts
@@ -4,9 +4,9 @@ describe('plugin-resolve', () => {
   it('should apply default extensions correctly', async () => {
     const rsbuild = await createRsbuild();
 
-    const bundlerConfigs = await rsbuild.initConfigs();
+    const rspackConfigs = await rsbuild.initConfigs();
 
-    expect(bundlerConfigs[0].resolve?.extensions).toEqual([
+    expect(rspackConfigs[0].resolve?.extensions).toEqual([
       '.ts',
       '.tsx',
       '.mjs',
@@ -25,8 +25,8 @@ describe('plugin-resolve', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(bundlerConfigs[0].resolve?.extensions).toEqual(['.ts', '.js']);
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(rspackConfigs[0].resolve?.extensions).toEqual(['.ts', '.js']);
   });
 
   it('should not apply tsConfigPath when aliasStrategy is "prefer-alias"', async () => {
@@ -38,9 +38,9 @@ describe('plugin-resolve', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
+    const rspackConfigs = await rsbuild.initConfigs();
 
-    expect(bundlerConfigs[0].resolve?.tsConfig).toBeUndefined();
+    expect(rspackConfigs[0].resolve?.tsConfig).toBeUndefined();
   });
 
   it('should allow using resolve.alias to configure alias', async () => {
@@ -53,10 +53,10 @@ describe('plugin-resolve', () => {
         },
       },
     });
-    const bundlerConfigs = await rsbuild.initConfigs();
+    const rspackConfigs = await rsbuild.initConfigs();
 
     expect(
-      (bundlerConfigs[0].resolve?.alias as Record<string, string>)?.foo,
+      (rspackConfigs[0].resolve?.alias as Record<string, string>)?.foo,
     ).toEqual('bar');
   });
 
@@ -72,9 +72,9 @@ describe('plugin-resolve', () => {
         },
       },
     });
-    const bundlerConfigs = await rsbuild.initConfigs();
+    const rspackConfigs = await rsbuild.initConfigs();
 
-    expect(bundlerConfigs[0].resolve?.alias).toEqual({
+    expect(rspackConfigs[0].resolve?.alias).toEqual({
       foo: 'bar',
     });
   });

--- a/packages/core/tests/swc.test.ts
+++ b/packages/core/tests/swc.test.ts
@@ -130,10 +130,10 @@ describe('plugin-swc', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
+    const rspackConfigs = await rsbuild.initConfigs();
 
-    for (const bundlerConfig of bundlerConfigs) {
-      expect(matchRules(bundlerConfig, 'a.js')).toMatchSnapshot();
+    for (const rspackConfig of rspackConfigs) {
+      expect(matchRules(rspackConfig, 'a.js')).toMatchSnapshot();
     }
   });
 
@@ -153,10 +153,10 @@ describe('plugin-swc', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
+    const rspackConfigs = await rsbuild.initConfigs();
 
-    for (const bundlerConfig of bundlerConfigs) {
-      expect(matchRules(bundlerConfig, 'a.js')).toMatchSnapshot();
+    for (const rspackConfig of rspackConfigs) {
+      expect(matchRules(rspackConfig, 'a.js')).toMatchSnapshot();
     }
   });
 
@@ -197,10 +197,10 @@ describe('plugin-swc', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
+    const rspackConfigs = await rsbuild.initConfigs();
 
-    for (const bundlerConfig of bundlerConfigs) {
-      expect(matchRules(bundlerConfig, 'a.js')).toMatchSnapshot();
+    for (const rspackConfig of rspackConfigs) {
+      expect(matchRules(rspackConfig, 'a.js')).toMatchSnapshot();
     }
   });
 });
@@ -215,8 +215,8 @@ async function matchConfigSnapshot(config: RsbuildConfig) {
     config,
     cwd: defaultCwd,
   });
-  const bundlerConfigs = await rsbuild.initConfigs();
+  const rspackConfigs = await rsbuild.initConfigs();
   expect(
-    bundlerConfigs.map((bundlerConfig) => matchRules(bundlerConfig, 'a.js')),
+    rspackConfigs.map((rspackConfig) => matchRules(rspackConfig, 'a.js')),
   ).toMatchSnapshot();
 }

--- a/packages/plugin-babel/tests/index.test.ts
+++ b/packages/plugin-babel/tests/index.test.ts
@@ -79,9 +79,9 @@ describe('plugins/babel', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
-    for (const bundlerConfig of bundlerConfigs) {
-      expect(matchRules(bundlerConfig, 'a.tsx')[0]).toMatchSnapshot();
+    const rspackConfigs = await rsbuild.initConfigs();
+    for (const rspackConfig of rspackConfigs) {
+      expect(matchRules(rspackConfig, 'a.tsx')[0]).toMatchSnapshot();
     }
   });
 

--- a/packages/plugin-less/tests/index.test.ts
+++ b/packages/plugin-less/tests/index.test.ts
@@ -11,8 +11,8 @@ describe('plugin-less', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(matchRules(bundlerConfigs[0], 'a.less')).toMatchSnapshot();
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(matchRules(rspackConfigs[0], 'a.less')).toMatchSnapshot();
   });
 
   it('should add less-loader for Rsbuild v1', async () => {
@@ -22,9 +22,9 @@ describe('plugin-less', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
+    const rspackConfigs = await rsbuild.initConfigs();
     expect(
-      matchRules(bundlerConfigs[0] as Rspack.Configuration, 'a.less'),
+      matchRules(rspackConfigs[0] as Rspack.Configuration, 'a.less'),
     ).toMatchSnapshot();
   });
 
@@ -38,8 +38,8 @@ describe('plugin-less', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(matchRules(bundlerConfigs[0], 'a.less')).toMatchSnapshot();
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(matchRules(rspackConfigs[0], 'a.less')).toMatchSnapshot();
   });
 
   it('should add less-loader with tools.less', async () => {
@@ -57,8 +57,8 @@ describe('plugin-less', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(matchRules(bundlerConfigs[0], 'a.less')).toMatchSnapshot();
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(matchRules(rspackConfigs[0], 'a.less')).toMatchSnapshot();
   });
 
   it('should add less-loader with excludes', async () => {
@@ -74,8 +74,8 @@ describe('plugin-less', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(matchRules(bundlerConfigs[0], 'a.less')).toMatchSnapshot();
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(matchRules(rspackConfigs[0], 'a.less')).toMatchSnapshot();
   });
 
   it('should allow to use Less plugins', async () => {
@@ -102,9 +102,9 @@ describe('plugin-less', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
+    const rspackConfigs = await rsbuild.initConfigs();
 
-    expect(matchRules(bundlerConfigs[0], 'a.less')).toMatchSnapshot();
+    expect(matchRules(rspackConfigs[0], 'a.less')).toMatchSnapshot();
   });
 
   it('should allow to add multiple less rules', async () => {
@@ -121,8 +121,8 @@ describe('plugin-less', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(matchRules(bundlerConfigs[0], 'a.less').length).toBe(1);
-    expect(matchRules(bundlerConfigs[0], 'b.less').length).toBe(2);
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(matchRules(rspackConfigs[0], 'a.less').length).toBe(1);
+    expect(matchRules(rspackConfigs[0], 'b.less').length).toBe(2);
   });
 });

--- a/packages/plugin-sass/tests/index.test.ts
+++ b/packages/plugin-sass/tests/index.test.ts
@@ -11,8 +11,8 @@ describe('plugin-sass', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(matchRules(bundlerConfigs[0], 'a.scss')).toMatchSnapshot();
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(matchRules(rspackConfigs[0], 'a.scss')).toMatchSnapshot();
   });
 
   it('should add sass-loader for Rsbuild v1', async () => {
@@ -22,9 +22,9 @@ describe('plugin-sass', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
+    const rspackConfigs = await rsbuild.initConfigs();
     expect(
-      matchRules(bundlerConfigs[0] as Rspack.Configuration, 'a.scss'),
+      matchRules(rspackConfigs[0] as Rspack.Configuration, 'a.scss'),
     ).toMatchSnapshot();
   });
 
@@ -38,8 +38,8 @@ describe('plugin-sass', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(matchRules(bundlerConfigs[0], 'a.scss')).toMatchSnapshot();
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(matchRules(rspackConfigs[0], 'a.scss')).toMatchSnapshot();
   });
 
   it('should add sass-loader with excludes', async () => {
@@ -55,8 +55,8 @@ describe('plugin-sass', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(matchRules(bundlerConfigs[0], 'a.scss')).toMatchSnapshot();
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(matchRules(rspackConfigs[0], 'a.scss')).toMatchSnapshot();
   });
 
   it('should allow to use legacy API and mute deprecation warnings', async () => {
@@ -72,8 +72,8 @@ describe('plugin-sass', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(matchRules(bundlerConfigs[0], 'a.scss')).toMatchSnapshot();
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(matchRules(rspackConfigs[0], 'a.scss')).toMatchSnapshot();
   });
 
   it('should allow to add multiple sass rules', async () => {
@@ -90,8 +90,8 @@ describe('plugin-sass', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(matchRules(bundlerConfigs[0], 'a.scss').length).toBe(1);
-    expect(matchRules(bundlerConfigs[0], 'b.scss').length).toBe(2);
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(matchRules(rspackConfigs[0], 'a.scss').length).toBe(1);
+    expect(matchRules(rspackConfigs[0], 'b.scss').length).toBe(2);
   });
 });

--- a/packages/plugin-stylus/tests/index.test.ts
+++ b/packages/plugin-stylus/tests/index.test.ts
@@ -11,8 +11,8 @@ describe('plugin-stylus', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(matchRules(bundlerConfigs[0], 'a.styl')).toMatchSnapshot();
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(matchRules(rspackConfigs[0], 'a.styl')).toMatchSnapshot();
   });
 
   it('should add stylus loader for Rsbuild v1', async () => {
@@ -22,9 +22,9 @@ describe('plugin-stylus', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
+    const rspackConfigs = await rsbuild.initConfigs();
     expect(
-      matchRules(bundlerConfigs[0] as Rspack.Configuration, 'a.styl'),
+      matchRules(rspackConfigs[0] as Rspack.Configuration, 'a.styl'),
     ).toMatchSnapshot();
   });
 
@@ -40,7 +40,7 @@ describe('plugin-stylus', () => {
         ],
       },
     });
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(matchRules(bundlerConfigs[0], 'a.styl')).toMatchSnapshot();
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(matchRules(rspackConfigs[0], 'a.styl')).toMatchSnapshot();
   });
 });

--- a/packages/plugin-svelte/tests/index.test.ts
+++ b/packages/plugin-svelte/tests/index.test.ts
@@ -16,9 +16,9 @@ describe('plugin-svelte', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(matchRules(bundlerConfigs[0], 'a.svelte')).toMatchSnapshot();
-    expect(bundlerConfigs[0].resolve).toMatchSnapshot();
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(matchRules(rspackConfigs[0], 'a.svelte')).toMatchSnapshot();
+    expect(rspackConfigs[0].resolve).toMatchSnapshot();
   });
 
   it('should add svelte loader and resolve config properly for Rsbuild v1', async () => {
@@ -29,11 +29,11 @@ describe('plugin-svelte', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
+    const rspackConfigs = await rsbuild.initConfigs();
     expect(
-      matchRules(bundlerConfigs[0] as Rspack.Configuration, 'a.svelte'),
+      matchRules(rspackConfigs[0] as Rspack.Configuration, 'a.svelte'),
     ).toMatchSnapshot();
-    expect(bundlerConfigs[0].resolve).toMatchSnapshot();
+    expect(rspackConfigs[0].resolve).toMatchSnapshot();
   });
 
   it('should add rule for `.svelte.js` and `.svelte.ts` as expected', async () => {
@@ -44,9 +44,9 @@ describe('plugin-svelte', () => {
       },
     });
 
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(matchRules(bundlerConfigs[0], 'a.svelte.js')).toMatchSnapshot();
-    expect(matchRules(bundlerConfigs[0], 'a.svelte.ts')).toMatchSnapshot();
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(matchRules(rspackConfigs[0], 'a.svelte.js')).toMatchSnapshot();
+    expect(matchRules(rspackConfigs[0], 'a.svelte.ts')).toMatchSnapshot();
   });
 
   it('should set dev and hotReload to false in production mode', async () => {
@@ -57,8 +57,8 @@ describe('plugin-svelte', () => {
         plugins: [pluginSvelte()],
       },
     });
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(matchRules(bundlerConfigs[0], 'a.svelte')).toMatchSnapshot();
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(matchRules(rspackConfigs[0], 'a.svelte')).toMatchSnapshot();
   });
 
   it('should turn off HMR by hand correctly', async () => {
@@ -71,8 +71,8 @@ describe('plugin-svelte', () => {
         plugins: [pluginSvelte()],
       },
     });
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(matchRules(bundlerConfigs[0], 'a.svelte')).toMatchSnapshot();
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(matchRules(rspackConfigs[0], 'a.svelte')).toMatchSnapshot();
   });
 
   it('should override default svelte-loader options throw options.svelteLoaderOptions', async () => {
@@ -88,8 +88,8 @@ describe('plugin-svelte', () => {
         ],
       },
     });
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(matchRules(bundlerConfigs[0], 'a.svelte')).toMatchSnapshot();
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(matchRules(rspackConfigs[0], 'a.svelte')).toMatchSnapshot();
   });
 
   it('should support pass custom preprocess options', async () => {
@@ -115,7 +115,7 @@ describe('plugin-svelte', () => {
         ],
       },
     });
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(matchRules(bundlerConfigs[0], 'a.svelte')).toMatchSnapshot();
+    const rspackConfigs = await rsbuild.initConfigs();
+    expect(matchRules(rspackConfigs[0], 'a.svelte')).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
## Summary

This PR clarifies Rsbuild internal Rspack config naming by destructuring `rspackConfigs` from `baseInitConfigs` and aligning related core, plugin, and e2e tests with the Rspack-specific terminology.