### PR TITLE
test(e2e): cover solid decorators

### DIFF
--- a/e2e/cases/plugin-solid/decorator/index.test.ts
+++ b/e2e/cases/plugin-solid/decorator/index.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from '@e2e/helper';
+
+test('should build solid component with decorators', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview();
+
+  await expect(page.locator('#decorator')).toHaveText('decorator works');
+});

--- a/e2e/cases/plugin-solid/decorator/rsbuild.config.ts
+++ b/e2e/cases/plugin-solid/decorator/rsbuild.config.ts
@@ -1,0 +1,11 @@
+import { pluginBabel } from '@rsbuild/plugin-babel';
+import { pluginSolid } from '@rsbuild/plugin-solid';
+
+export default {
+  plugins: [
+    pluginBabel({
+      include: /\.(?:jsx|tsx)$/,
+    }),
+    pluginSolid(),
+  ],
+};

--- a/e2e/cases/plugin-solid/decorator/src/index.jsx
+++ b/e2e/cases/plugin-solid/decorator/src/index.jsx
@@ -1,0 +1,16 @@
+import { render } from 'solid-js/web';
+
+function withMessage(Component) {
+  return class extends Component {
+    message = 'decorator works';
+  };
+}
+
+@withMessage
+class ViewModel {}
+
+const viewModel = new ViewModel();
+
+const App = () => <div id="decorator">{viewModel.message}</div>;
+
+render(App, document.getElementById('root'));


### PR DESCRIPTION
## Summary

This PR replaces the parserOpts change with a minimal e2e fixture that builds a Solid JSX component containing decorator syntax through pluginSolid and pluginBabel. The coverage verifies the existing Babel decorators integration without forcing the decorators parser plugin in plugin-solid, which avoids conflicting with legacy decorator configurations.