### PR TITLE
fix: support header array passed to gzipMiddlware's writeHead

### DIFF
--- a/packages/core/src/server/gzipMiddleware.ts
+++ b/packages/core/src/server/gzipMiddleware.ts
@@ -1,9 +1,47 @@
-import type { ServerResponse } from 'node:http';
+import type {
+  OutgoingHttpHeader,
+  OutgoingHttpHeaders,
+  ServerResponse,
+} from 'node:http';
 import zlib from 'node:zlib';
 import type { CompressOptions, RequestHandler } from '../types';
 
 const ENCODING_REGEX = /\bgzip\b/;
 const CONTENT_TYPE_REGEX = /text|javascript|\/json|xml/i;
+type WriteHeadHeaders = OutgoingHttpHeaders | OutgoingHttpHeader[];
+
+const setWriteHeadHeaders = (
+  res: ServerResponse,
+  headers: WriteHeadHeaders,
+) => {
+  if (Array.isArray(headers)) {
+    const seen = new Set<string>();
+
+    for (let index = 0; index < headers.length; index += 2) {
+      const key = String(headers[index]);
+      const value = headers[index + 1];
+
+      if (value !== undefined) {
+        const lowerKey = key.toLowerCase();
+        if (!seen.has(lowerKey)) {
+          seen.add(lowerKey);
+          res.removeHeader(key);
+        }
+
+        res.appendHeader(key, Array.isArray(value) ? value : String(value));
+      }
+    }
+    return;
+  }
+
+  for (const key of Object.keys(headers)) {
+    const value = headers[key];
+
+    if (value !== undefined) {
+      res.setHeader(key, value);
+    }
+  }
+};
 
 const shouldCompress = (res: ServerResponse) => {
   // already compressed
@@ -55,7 +93,8 @@ export function gzipMiddleware({
       }
       started = true;
 
-      if (shouldCompress(res)) {
+      const compress = shouldCompress(res);
+      if (compress) {
         res.setHeader('Content-Encoding', 'gzip');
         res.removeHeader('Content-Length');
 
@@ -91,24 +130,23 @@ export function gzipMiddleware({
       }
     };
 
-    res.writeHead = (status, reason, headers?) => {
+    res.writeHead = (
+      status: number,
+      reason?: string | WriteHeadHeaders,
+      headers?: WriteHeadHeaders,
+    ) => {
       writeHeadStatus = status;
-
-      if (typeof reason === 'string') {
-        writeHeadMessage = reason;
-      }
+      writeHeadMessage = typeof reason === 'string' ? reason : undefined;
 
       const resolvedHeaders = typeof reason === 'string' ? headers : reason;
       if (resolvedHeaders) {
-        for (const [key, value] of Object.entries(resolvedHeaders)) {
-          res.setHeader(key, value);
-        }
+        setWriteHeadHeaders(res, resolvedHeaders);
       }
 
       return res;
     };
 
-    res.write = (...args: unknown[]) => {
+    res.write = (...args: any[]) => {
       start();
       return gzip
         ? gzip.write(...(args as Parameters<typeof write>))
@@ -117,9 +155,12 @@ export function gzipMiddleware({
 
     res.end = (...args: any[]) => {
       start();
-      return gzip
-        ? (gzip.end as unknown as typeof end)(...args)
-        : end.apply(res, args as Parameters<typeof end>);
+      if (gzip) {
+        (gzip.end as (...args: any[]) => void)(...args);
+        return res;
+      }
+
+      return end.apply(res, args as Parameters<typeof end>);
     };
 
     res.on = (type, listener) => {

--- a/packages/core/tests/gzipMiddleware.test.ts
+++ b/packages/core/tests/gzipMiddleware.test.ts
@@ -1,0 +1,152 @@
+import { createServer } from 'node:http';
+import { gzipMiddleware } from '../src/server/gzipMiddleware';
+import type { Server } from 'node:http';
+
+const closeServer = (server: Server) => {
+  return new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+};
+
+const listen = (server: Server) => {
+  return new Promise<number>((resolve) => {
+    server.listen(0, () => {
+      const address = server.address();
+      if (typeof address === 'object' && address) {
+        resolve(address.port);
+      }
+    });
+  });
+};
+
+test('should support raw header arrays passed to writeHead', async () => {
+  const server = createServer((req, res) => {
+    gzipMiddleware()(req, res, () => {
+      res.writeHead(200, 'OK', [
+        'Content-Type',
+        'text/plain; charset=utf-8',
+        'X-Test-Header',
+        'ok',
+      ]);
+      res.end('hello '.repeat(300));
+    });
+  });
+
+  const port = await listen(server);
+
+  try {
+    const response = await fetch(`http://localhost:${port}`, {
+      headers: {
+        'accept-encoding': 'gzip',
+      },
+    });
+    await response.text();
+
+    expect(response.headers.get('content-type')).toBe(
+      'text/plain; charset=utf-8',
+    );
+    expect(response.headers.get('x-test-header')).toBe('ok');
+    expect(response.headers.get('content-encoding')).toBe('gzip');
+    expect(response.headers.get('0')).toBeNull();
+    expect(response.headers.get('1')).toBeNull();
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test('should preserve set-cookie entries from raw header arrays', async () => {
+  const server = createServer((req, res) => {
+    gzipMiddleware()(req, res, () => {
+      res.writeHead(200, 'OK', [
+        'Content-Type',
+        'text/plain; charset=utf-8',
+        'Set-Cookie',
+        'a=1',
+        'Set-Cookie',
+        'b=2',
+      ]);
+      res.end('hello '.repeat(300));
+    });
+  });
+
+  const port = await listen(server);
+
+  try {
+    const response = await fetch(`http://localhost:${port}`, {
+      headers: {
+        'accept-encoding': 'gzip',
+      },
+    });
+    await response.text();
+
+    expect(response.headers.getSetCookie()).toEqual(['a=1', 'b=2']);
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test('should remove writeHead compression headers when response is gzipped', async () => {
+  const server = createServer((req, res) => {
+    gzipMiddleware()(req, res, () => {
+      res.writeHead(200, 'OK', [
+        'Content-Type',
+        'text/plain; charset=utf-8',
+        'Content-Length',
+        '1800',
+      ]);
+      res.end('hello '.repeat(300));
+    });
+  });
+
+  const port = await listen(server);
+
+  try {
+    const response = await fetch(`http://localhost:${port}`, {
+      headers: {
+        'accept-encoding': 'gzip',
+      },
+    });
+    await response.text();
+
+    expect(response.headers.get('content-encoding')).toBe('gzip');
+    expect(response.headers.get('content-length')).toBeNull();
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test('should not compress responses with writeHead content-encoding', async () => {
+  const server = createServer((req, res) => {
+    gzipMiddleware()(req, res, () => {
+      res.writeHead(200, 'OK', [
+        'Content-Type',
+        'text/plain; charset=utf-8',
+        'Content-Encoding',
+        'identity',
+      ]);
+      res.end('hello '.repeat(300));
+    });
+  });
+
+  const port = await listen(server);
+
+  try {
+    const response = await fetch(`http://localhost:${port}`, {
+      headers: {
+        'accept-encoding': 'gzip',
+      },
+    });
+    await response.text();
+
+    expect(response.headers.get('content-encoding')).toBe('identity');
+  } finally {
+    await closeServer(server);
+  }
+});


### PR DESCRIPTION
## Summary

when passing a header array to gzipMiddleware's writeHead, this results in headers like this:

```tsx
Headers {
  '0': 'content-type',
  '1': 'text/html; charset=utf-8',
  vary: 'Origin',
  date: 'Tue, 05 May 2026 04:30:34 GMT',
  connection: 'keep-alive',
  'keep-alive': 'timeout=5',
  'transfer-encoding': 'chunked'
}
```

While the correct headers would be:

```tsx
Headers {
  vary: 'Origin',
  'content-type': 'text/html; charset=utf-8',
  date: 'Tue, 05 May 2026 04:30:46 GMT',
  connection: 'keep-alive',
  'keep-alive': 'timeout=5',
  'transfer-encoding': 'chunked'
}
``` 

This PR fixes this.

## Related Links

see https://github.com/TanStack/router/issues/7344
I disabled compression for now in TanStack Start as a workaround

<!--- Provide links of related issues or pages -->
