### PR TITLE
Revert "chore(deps): upgrade pnpm to v11 (#7607)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
     "simple-git-hooks": "^2.13.1",
     "typescript": "^6.0.3"
   },
-  "packageManager": "pnpm@11.0.6",
+  "packageManager": "pnpm@10.33.2",
   "engines": {
     "node": ">=22.18.0",
-    "pnpm": ">=11.0.0"
+    "pnpm": ">=10.33.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,12 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  css-loader@7.1.4: b504d70330b6625a20bc0cb1428c9787350fe6413c2947f42bd88ff22123a019
-  postcss-loader@8.2.1: 4829849d58d8366cd82cbdab1947d15f9e6d33e70f1e3d5310daffff152dff14
+  css-loader@7.1.4:
+    hash: b504d70330b6625a20bc0cb1428c9787350fe6413c2947f42bd88ff22123a019
+    path: patches/css-loader@7.1.4.patch
+  postcss-loader@8.2.1:
+    hash: 4829849d58d8366cd82cbdab1947d15f9e6d33e70f1e3d5310daffff152dff14
+    path: patches/postcss-loader@8.2.1.patch
 
 importers:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,3 +22,18 @@ patchedDependencies:
   postcss-loader@8.2.1: patches/postcss-loader@8.2.1.patch
 
 strictPeerDependencies: false
+
+allowBuilds:
+  '@parcel/watcher': true
+  core-js: false
+  simple-git-hooks: false
+  svelte-preprocess: false
+
+minimumReleaseAgeExclude:
+  - '@rspack/*'
+  - '@rsbuild/*'
+  - '@rslib/*'
+  - '@rspress/*'
+  - '@rstest/*'
+  - '@rsdoctor/*'
+  - '@rslint/*'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,18 +22,3 @@ patchedDependencies:
   postcss-loader@8.2.1: patches/postcss-loader@8.2.1.patch
 
 strictPeerDependencies: false
-
-allowBuilds:
-  '@parcel/watcher': true
-  core-js: false
-  simple-git-hooks: false
-  svelte-preprocess: false
-
-minimumReleaseAgeExclude:
-  - '@rspack/*'
-  - '@rsbuild/*'
-  - '@rslib/*'
-  - '@rspress/*'
-  - '@rstest/*'
-  - '@rsdoctor/*'
-  - '@rslint/*'


### PR DESCRIPTION
This reverts commit dfafa98438981e6748aa6e42911bc87b32d25aa4.

## Summary

After upgrading to pnpm v11, `pnpm publish` no longer respects `"files": ["template-*", "dist", "bin.js"]`. This looks like a bug in `pnpm publish`.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/7614
