### PR TITLE
chore: add rstest VS Code extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
   "recommendations": [
     "rstack.rslint",
+    "rstack.rstest",
     "esbenp.prettier-vscode",
     "unifiedjs.vscode-mdx"
   ]


### PR DESCRIPTION
## Summary

This PR recommends the Rstest VS Code extension in the workspace configuration so contributors can get editor support for the project's test runner alongside the existing Rslint and Prettier recommendations.