### PR TITLE
chore: update VS Code TypeScript SDK setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,7 +15,7 @@
   },
   "mdx.validate.validateFileLinks": "ignore",
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "typescript.tsdk": "node_modules/typescript/lib",
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
   "json.schemas": [
     {
       "fileMatch": ["**/_meta.json"],


### PR DESCRIPTION
## Summary

This PR updates the workspace VS Code TypeScript SDK setting to use the current `js/ts.tsdk.path` key while preserving the existing project TypeScript SDK path.

https://code.visualstudio.com/docs/typescript/typescript-transpiling#_using-the-workspace-version-of-typescript