### PR TITLE
test(e2e): avoid custom server port collision

### DIFF
--- a/e2e/cases/server/custom-server/scripts/pureServer.js
+++ b/e2e/cases/server/custom-server/scripts/pureServer.js
@@ -1,14 +1,18 @@
 import { createConnectHandler } from '@e2e/helper/server';
+import { getRandomPort } from '@e2e/helper';
 import { createAdaptorServer } from '@hono/node-server';
 import { createRsbuild } from '@rsbuild/core';
 import { Hono } from 'hono';
 
 // Start custom dev server without compile
 export async function startDevServerPure(fixtures) {
+  const customServerPort = await getRandomPort();
+
   const rsbuild = await createRsbuild({
     cwd: fixtures,
     config: {
       server: {
+        port: customServerPort,
         htmlFallback: false,
         middlewareMode: true,
         setup: ({ action, server }) => {
@@ -42,7 +46,7 @@ export async function startDevServerPure(fixtures) {
   const server = createAdaptorServer({ fetch: app.fetch });
 
   await new Promise((resolve) => {
-    server.listen(rsbuildServer.port, resolve);
+    server.listen({ host: 'localhost', port: rsbuildServer.port }, resolve);
   });
   await rsbuildServer.afterListen();
 

--- a/e2e/cases/server/custom-server/scripts/server.js
+++ b/e2e/cases/server/custom-server/scripts/server.js
@@ -1,13 +1,17 @@
 import { createConnectHandler } from '@e2e/helper/server';
+import { getRandomPort } from '@e2e/helper';
 import { createAdaptorServer } from '@hono/node-server';
 import { createRsbuild } from '@rsbuild/core';
 import { Hono } from 'hono';
 
 export async function startDevServer(fixtures) {
+  const customServerPort = await getRandomPort();
+
   const rsbuild = await createRsbuild({
     cwd: fixtures,
     config: {
       server: {
+        port: customServerPort,
         htmlFallback: false,
         middlewareMode: true,
       },
@@ -27,7 +31,7 @@ export async function startDevServer(fixtures) {
   const server = createAdaptorServer({ fetch: app.fetch });
 
   await new Promise((resolve) => {
-    server.listen(port, resolve);
+    server.listen({ host: 'localhost', port }, resolve);
   });
   await rsbuildServer.afterListen();
 


### PR DESCRIPTION
## Summary

This PR fixes a flaky Windows e2e failure in the custom server case where both scripts could rely on the default Rsbuild port 3000. The custom server tests now allocate a random port and pass it through to Rsbuild and the Hono server, keeping the middleware-mode coverage while avoiding port collisions in parallel CI runs.