### PR TITLE
test(html): add function option coverage

### DIFF
--- a/e2e/cases/html/meta/index.test.ts
+++ b/e2e/cases/html/meta/index.test.ts
@@ -35,7 +35,6 @@ test('should generate meta tags via function for each entry', async ({
       html: {
         meta({ entryName }) {
           return {
-            charset: { charset: 'utf-8' },
             description: `${entryName} page`,
             'og:title': {
               property: 'og:title',

--- a/e2e/cases/html/meta/index.test.ts
+++ b/e2e/cases/html/meta/index.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { expect, getFileContent, normalizeNewlines, test } from '@e2e/helper';
 
 test('should not inject charset meta if template already contains it', async ({
@@ -18,4 +19,40 @@ test('should not inject charset meta if template already contains it', async ({
   </body>
 </html>
 `);
+});
+
+test('should generate meta tags via function for each entry', async ({
+  build,
+}) => {
+  const rsbuild = await build({
+    config: {
+      source: {
+        entry: {
+          foo: path.resolve(import.meta.dirname, './src/index.js'),
+          bar: path.resolve(import.meta.dirname, './src/index.js'),
+        },
+      },
+      html: {
+        meta({ entryName }) {
+          return {
+            charset: { charset: 'utf-8' },
+            description: `${entryName} page`,
+            'og:title': {
+              property: 'og:title',
+              content: entryName,
+            },
+          };
+        },
+      },
+    },
+  });
+  const files = rsbuild.getDistFiles();
+
+  const fooHtml = getFileContent(files, 'foo.html');
+  expect(fooHtml).toContain('<meta name="description" content="foo page">');
+  expect(fooHtml).toContain('<meta property="og:title" content="foo">');
+
+  const barHtml = getFileContent(files, 'bar.html');
+  expect(barHtml).toContain('<meta name="description" content="bar page">');
+  expect(barHtml).toContain('<meta property="og:title" content="bar">');
 });

--- a/e2e/cases/html/template/index.test.ts
+++ b/e2e/cases/html/template/index.test.ts
@@ -57,6 +57,40 @@ test('should allow to access templateParameters', async ({
   await expect(page.evaluate('window.foo')).resolves.toBe('bar');
 });
 
+test('should allow templateParameters to be a function', async ({ build }) => {
+  const rsbuild = await build({
+    config: {
+      source: {
+        entry: {
+          index: path.resolve(import.meta.dirname, './src/index.js'),
+          foo: path.resolve(import.meta.dirname, './src/foo.js'),
+        },
+      },
+      html: {
+        template({ entryName }) {
+          return entryName === 'foo'
+            ? './static/foo.html'
+            : './static/index.html';
+        },
+        templateParameters(defaultValue, { entryName }) {
+          return {
+            ...defaultValue,
+            foo: `${entryName}-foo`,
+            type: `${entryName}-type`,
+          };
+        },
+      },
+    },
+  });
+  const files = rsbuild.getDistFiles();
+
+  const indexHtml = getFileContent(files, 'index.html');
+  expect(indexHtml).toContain("window.foo = 'index-foo';");
+
+  const fooHtml = getFileContent(files, 'foo.html');
+  expect(fooHtml).toContain("window.type = 'foo-type';");
+});
+
 test('should set template via tools.htmlPlugin correctly', async ({
   build,
 }) => {


### PR DESCRIPTION
## Summary

This PR adds e2e coverage for function-based HTML options so multi-entry builds verify entry-specific values. It checks that `html.meta` can generate per-entry meta tags and that function `templateParameters` can customize template data per entry.