### PR TITLE
test: run configure-rspack in both serve modes

### DIFF
--- a/e2e/cases/config/configure-rspack/index.test.ts
+++ b/e2e/cases/config/configure-rspack/index.test.ts
@@ -2,49 +2,82 @@ import { expect, test } from '@e2e/helper';
 
 test('should allow to use tools.rspack to configure Rspack', async ({
   page,
-  buildPreview,
+  runBothServe,
 }) => {
-  await buildPreview({
-    config: {
-      tools: {
-        rspack: (config, { rspack }) => {
-          config.plugins.push(
-            new rspack.DefinePlugin({
-              ENABLE_TEST: JSON.stringify(true),
-            }),
-          );
+  await runBothServe(
+    async () => {
+      const testEl = page.locator('#test-el');
+      await expect(testEl).toHaveText('aaaaa');
+    },
+    {
+      config: {
+        tools: {
+          rspack: (config, { rspack }) => {
+            config.plugins.push(
+              new rspack.DefinePlugin({
+                ENABLE_TEST: JSON.stringify(true),
+              }),
+            );
+          },
         },
       },
     },
-  });
-
-  const testEl = page.locator('#test-el');
-  await expect(testEl).toHaveText('aaaaa');
+  );
 });
 
 test('should allow to use async tools.rspack to configure Rspack', async ({
   page,
-  buildPreview,
+  runBothServe,
 }) => {
-  await buildPreview({
-    config: {
-      tools: {
-        rspack: async (config, { rspack }) => {
-          return new Promise<void>((resolve) => {
-            setTimeout(() => {
+  await runBothServe(
+    async () => {
+      const testEl = page.locator('#test-el');
+      await expect(testEl).toHaveText('aaaaa');
+    },
+    {
+      config: {
+        tools: {
+          rspack: async (config, { rspack }) => {
+            return new Promise<void>((resolve) => {
+              setTimeout(() => {
+                config.plugins.push(
+                  new rspack.DefinePlugin({
+                    ENABLE_TEST: JSON.stringify(true),
+                  }),
+                );
+                resolve();
+              }, 0);
+            });
+          },
+        },
+      },
+    },
+  );
+});
+
+test('should allow tools.rspack to be an array', async ({
+  page,
+  runBothServe,
+}) => {
+  await runBothServe(
+    async () => {
+      const testEl = page.locator('#test-el');
+      await expect(testEl).toHaveText('aaaaa');
+    },
+    {
+      config: {
+        tools: {
+          rspack: [
+            (config, { rspack }) => {
               config.plugins.push(
                 new rspack.DefinePlugin({
                   ENABLE_TEST: JSON.stringify(true),
                 }),
               );
-              resolve();
-            }, 0);
-          });
+            },
+          ],
         },
       },
     },
-  });
-
-  const testEl = page.locator('#test-el');
-  await expect(testEl).toHaveText('aaaaa');
+  );
 });


### PR DESCRIPTION
## Summary

This PR updates the configure-rspack e2e case to run shared assertions through runBothServe, covering both the dev server and build preview paths for tools.rspack configuration, including sync, async, and array forms.