### PR TITLE
fix(plugin-vue): align CSS Modules hashes for SSR

### DIFF
--- a/e2e/cases/plugin-vue/sfc-css-modules-multi-target/index.test.ts
+++ b/e2e/cases/plugin-vue/sfc-css-modules-multi-target/index.test.ts
@@ -1,0 +1,26 @@
+import { expect, getFileContent, test } from '@e2e/helper';
+
+const getClassName = (content: string, localName: string) => {
+  const matched = content.match(new RegExp(`${localName}-[\\w-]{6}`));
+  expect(matched).toBeTruthy();
+  return matched![0];
+};
+
+test('should keep CSS Modules identifiers consistent between web and node targets', async ({
+  build,
+}) => {
+  const rsbuild = await build();
+  const files = rsbuild.getDistFiles();
+
+  const clientCss = getFileContent(
+    files,
+    (file) => file.includes('/web/') && file.endsWith('.css'),
+  );
+  const serverJs = getFileContent(
+    files,
+    (file) => file.includes('/node/') && file.endsWith('/index.js'),
+  );
+
+  expect(getClassName(serverJs, 'red')).toBe(getClassName(clientCss, 'red'));
+  expect(getClassName(serverJs, 'blue')).toBe(getClassName(clientCss, 'blue'));
+});

--- a/e2e/cases/plugin-vue/sfc-css-modules-multi-target/rsbuild.config.ts
+++ b/e2e/cases/plugin-vue/sfc-css-modules-multi-target/rsbuild.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginVue } from '@rsbuild/plugin-vue';
+
+export default defineConfig({
+  plugins: [pluginVue()],
+  environments: {
+    web: {
+      source: {
+        entry: {
+          index: './src/index.js',
+        },
+      },
+      output: {
+        target: 'web',
+        distPath: {
+          root: './dist/web',
+        },
+      },
+    },
+    node: {
+      source: {
+        entry: {
+          index: './src/index.js',
+        },
+      },
+      output: {
+        target: 'node',
+        distPath: {
+          root: './dist/node',
+        },
+      },
+    },
+  },
+});

--- a/e2e/cases/plugin-vue/sfc-css-modules-multi-target/src/App.vue
+++ b/e2e/cases/plugin-vue/sfc-css-modules-multi-target/src/App.vue
@@ -1,0 +1,13 @@
+<template>
+  <p :class="[$style.red, $style.blue]">Blue</p>
+</template>
+
+<style module>
+.red {
+  color: red;
+}
+
+.blue {
+  color: blue;
+}
+</style>

--- a/e2e/cases/plugin-vue/sfc-css-modules-multi-target/src/index.js
+++ b/e2e/cases/plugin-vue/sfc-css-modules-multi-target/src/index.js
@@ -1,0 +1,4 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+
+createApp(App).mount('#root');

--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -82,7 +82,7 @@ export function pluginVue(options: PluginVueOptions = {}): RsbuildPlugin {
         return merged;
       });
 
-      api.modifyBundlerChain((chain, { CHAIN_ID }) => {
+      api.modifyBundlerChain((chain, { CHAIN_ID, environment, target }) => {
         chain.resolve.extensions.add('.vue');
 
         const userLoaderOptions = options.vueLoaderOptions ?? {};
@@ -90,12 +90,15 @@ export function pluginVue(options: PluginVueOptions = {}): RsbuildPlugin {
           preserveWhitespace: false,
           ...userLoaderOptions.compilerOptions,
         };
+        const emitCss = environment.config.output.emitCss ?? target === 'web';
         const vueLoaderOptions = {
           // Always treat this as a client build when invoked from Rstest,
           // since tests are executed in a DOM-based environment.
           isServerBuild:
             api.context.callerName === 'rstest' ? false : undefined,
-          experimentalInlineMatchResource: true,
+          // Keep non-emitting targets on the original SFC resource so CSS Modules
+          // hashes match the client build during SSR hydration.
+          experimentalInlineMatchResource: emitCss,
           ...userLoaderOptions,
           compilerOptions,
         };


### PR DESCRIPTION
## Summary

This PR fixes Vue SFC CSS Modules class name mismatches between web and node SSR builds. For non-CSS-emitting targets, `plugin-vue` keeps the original SFC resource as the default match resource so `css-loader` generates the same hashes as the client build.

## Related Links

Fixes #5519