### PR TITLE
test: cover Less import CSS source maps

### DIFF
--- a/e2e/cases/source-map/less-import/index.test.ts
+++ b/e2e/cases/source-map/less-import/index.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { expect, findFile, mapSourceMapPositions, test } from '@e2e/helper';
+
+const normalizePath = (source: string | null) =>
+  source?.replace(/\\/g, '/') ?? '';
+
+const isImportedLess = (source: string | null) =>
+  /(^|\/)src\/imported\.less$/.test(normalizePath(source));
+
+const getGeneratedPosition = (code: string, pattern: RegExp) => {
+  const match = pattern.exec(code);
+  expect(match).not.toBeNull();
+
+  const beforeMatch = code.slice(0, match!.index).split('\n');
+
+  return {
+    line: beforeMatch.length,
+    column: beforeMatch[beforeMatch.length - 1].length,
+  };
+};
+
+test('should map imported Less sources correctly in CSS source map', async ({
+  devOnly,
+}) => {
+  const rsbuild = await devOnly();
+  const files = rsbuild.getDistFiles({ sourceMaps: true });
+  const css = files[findFile(files, 'index.css')];
+  const cssMap = files[findFile(files, 'index.css.map')];
+
+  const [originalPosition] = await mapSourceMapPositions(cssMap, [
+    getGeneratedPosition(css, /\.imported-panel/),
+  ]);
+
+  const importedSource = readFileSync(
+    join(import.meta.dirname, 'src/imported.less'),
+    'utf-8',
+  );
+  const sourceMap = JSON.parse(cssMap) as {
+    sources: string[];
+    sourcesContent: string[];
+  };
+  const importedSourceIndex = sourceMap.sources.findIndex((source) =>
+    isImportedLess(source),
+  );
+
+  expect(isImportedLess(originalPosition.source)).toBe(true);
+  expect(originalPosition.line).toBe(1);
+  expect(originalPosition.column).toBe(
+    importedSource.split('\n')[0].indexOf('.imported-panel'),
+  );
+  expect(importedSourceIndex).toBeGreaterThanOrEqual(0);
+  expect(sourceMap.sourcesContent[importedSourceIndex]).toBe(importedSource);
+});

--- a/e2e/cases/source-map/less-import/index.test.ts
+++ b/e2e/cases/source-map/less-import/index.test.ts
@@ -1,6 +1,12 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { expect, findFile, mapSourceMapPositions, test } from '@e2e/helper';
+import {
+  expect,
+  findFile,
+  mapSourceMapPositions,
+  normalizeNewlines,
+  test,
+} from '@e2e/helper';
 
 const normalizePath = (source: string | null) =>
   source?.replace(/\\/g, '/') ?? '';
@@ -50,5 +56,7 @@ test('should map imported Less sources correctly in CSS source map', async ({
     importedSource.split('\n')[0].indexOf('.imported-panel'),
   );
   expect(importedSourceIndex).toBeGreaterThanOrEqual(0);
-  expect(sourceMap.sourcesContent[importedSourceIndex]).toBe(importedSource);
+  expect(normalizeNewlines(sourceMap.sourcesContent[importedSourceIndex])).toBe(
+    normalizeNewlines(importedSource),
+  );
 });

--- a/e2e/cases/source-map/less-import/rsbuild.config.ts
+++ b/e2e/cases/source-map/less-import/rsbuild.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginLess } from '@rsbuild/plugin-less';
+
+export default defineConfig({
+  plugins: [pluginLess()],
+  output: {
+    filenameHash: false,
+    minify: false,
+    sourceMap: {
+      css: true,
+    },
+  },
+});

--- a/e2e/cases/source-map/less-import/src/imported.less
+++ b/e2e/cases/source-map/less-import/src/imported.less
@@ -1,0 +1,3 @@
+.imported-panel {
+  color: #654321;
+}

--- a/e2e/cases/source-map/less-import/src/index.js
+++ b/e2e/cases/source-map/less-import/src/index.js
@@ -1,0 +1,1 @@
+import './index.less';

--- a/e2e/cases/source-map/less-import/src/index.less
+++ b/e2e/cases/source-map/less-import/src/index.less
@@ -1,0 +1,5 @@
+@import './imported.less';
+
+.entry-style {
+  color: #fedcba;
+}


### PR DESCRIPTION
## Summary

This PR adds an e2e fixture for Less `@import` CSS source maps. The case enables CSS source maps, imports a Less file from the entry stylesheet, and verifies the generated CSS source map points the imported selector back to `src/imported.less` with the expected source content.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/4451
