### PR TITLE
test: add e2e config coverage cases

### DIFF
--- a/e2e/cases/html/output-structure/index.test.ts
+++ b/e2e/cases/html/output-structure/index.test.ts
@@ -12,3 +12,26 @@ test('should output nested HTML structure when html.outputStructure is `nested`'
 
   expect(fs.existsSync(pagePath)).toBeTruthy();
 });
+
+test('should output nested HTML for multiple entries', async ({ build }) => {
+  const rsbuild = await build({
+    config: {
+      source: {
+        entry: {
+          foo: './src/foo.js',
+          bar: './src/bar.js',
+        },
+      },
+      output: {
+        filenameHash: false,
+      },
+    },
+  });
+
+  for (const entry of ['foo', 'bar']) {
+    const pagePath = join(rsbuild.distPath, entry, 'index.html');
+    const html = await fs.promises.readFile(pagePath, 'utf-8');
+
+    expect(html).toContain(`/static/js/${entry}.js`);
+  }
+});

--- a/e2e/cases/html/output-structure/src/bar.js
+++ b/e2e/cases/html/output-structure/src/bar.js
@@ -1,0 +1,1 @@
+console.log('bar');

--- a/e2e/cases/html/output-structure/src/foo.js
+++ b/e2e/cases/html/output-structure/src/foo.js
@@ -1,0 +1,1 @@
+console.log('foo');

--- a/e2e/cases/output/copy/index.test.ts
+++ b/e2e/cases/output/copy/index.test.ts
@@ -41,6 +41,32 @@ test('should copy asset from src to dist folder correctly', async ({
   ).toBeTruthy();
 });
 
+test('should transform copied assets', async ({ build }) => {
+  await build({
+    config: {
+      output: {
+        copy: [
+          {
+            from: 'foo.txt',
+            to: 'transformed/foo.txt',
+            context: join(import.meta.dirname, 'src'),
+            transform(content) {
+              return content.toString().toUpperCase();
+            },
+          },
+        ],
+      },
+    },
+  });
+
+  expect(
+    fs.readFileSync(
+      join(import.meta.dirname, 'dist/transformed/foo.txt'),
+      'utf-8',
+    ),
+  ).toBe('BAR');
+});
+
 test('should copy asset to dist sub-folder correctly', async ({ build }) => {
   await build({
     config: {

--- a/e2e/cases/server/headers/index.test.ts
+++ b/e2e/cases/server/headers/index.test.ts
@@ -10,3 +10,27 @@ test('should apply server.headers to served responses', async ({
     expect(response.headers()['x-frame-options']).toBe('DENY');
   });
 });
+
+test('should apply array values in server.headers', async ({
+  request,
+  runBothServe,
+}) => {
+  await runBothServe(
+    async ({ result }) => {
+      const response = await request.get(`http://localhost:${result.port}/`);
+      expect(response.headers()['x-rsbuild-list'].split(/,\s*/)).toEqual([
+        'one',
+        'two',
+      ]);
+    },
+    {
+      config: {
+        server: {
+          headers: {
+            'x-rsbuild-list': ['one', 'two'],
+          },
+        },
+      },
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Adds focused e2e coverage for configuration behavior that previously had only partial coverage: array values in `server.headers`, nested HTML output for multiple entries, and `output.copy` transforms.