### PR TITLE
fix(core): skip compression for 'text/event-stream'

### DIFF
--- a/e2e/cases/server/proxy-sse/index.test.ts
+++ b/e2e/cases/server/proxy-sse/index.test.ts
@@ -1,19 +1,10 @@
 import { expect, getRandomPort, test } from '@e2e/helper';
+import { promisify } from 'node:util';
 import zlib from 'node:zlib';
 import { createAdaptorServer } from '@hono/node-server';
 import { Hono } from 'hono';
 
-const gunzip = (buffer: Buffer) => {
-  return new Promise<Buffer>((resolve, reject) => {
-    zlib.gunzip(buffer, (error, result) => {
-      if (error) {
-        reject(error);
-        return;
-      }
-      resolve(result);
-    });
-  });
-};
+const gunzip = promisify(zlib.gunzip);
 
 test('should proxy SSE request', async ({ dev, page }) => {
   const ssePort = await getRandomPort();
@@ -120,7 +111,7 @@ test('should not gzip proxied SSE responses', async ({ dev, request }) => {
       },
     });
     const headers = response.headers();
-    const rawBody = Buffer.from(await response.body());
+    const rawBody = await response.body();
     const text = headers['content-encoding'] === 'gzip'
       ? (await gunzip(rawBody)).toString('utf8')
       : rawBody.toString('utf8');

--- a/e2e/cases/server/proxy-sse/index.test.ts
+++ b/e2e/cases/server/proxy-sse/index.test.ts
@@ -1,6 +1,19 @@
 import { expect, getRandomPort, test } from '@e2e/helper';
+import zlib from 'node:zlib';
 import { createAdaptorServer } from '@hono/node-server';
 import { Hono } from 'hono';
+
+const gunzip = (buffer: Buffer) => {
+  return new Promise<Buffer>((resolve, reject) => {
+    zlib.gunzip(buffer, (error, result) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve(result);
+    });
+  });
+};
 
 test('should proxy SSE request', async ({ dev, page }) => {
   const ssePort = await getRandomPort();
@@ -35,32 +48,88 @@ test('should proxy SSE request', async ({ dev, page }) => {
     server.listen(ssePort, () => resolve());
   });
 
-  const sseUrl = `http://localhost:${rsbuild.port}/api/sse`;
+  try {
+    const sseUrl = `http://localhost:${rsbuild.port}/api/sse`;
 
-  const result = await page.evaluate(async (url) => {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 2000);
+    const result = await page.evaluate(async (url) => {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 2000);
 
-    try {
-      const response = await fetch(url, { signal: controller.signal });
-      const reader = response.body!.getReader();
-      const { value } = await reader.read();
-      const text = new TextDecoder().decode(value);
+      try {
+        const response = await fetch(url, { signal: controller.signal });
+        const reader = response.body!.getReader();
+        const { value } = await reader.read();
+        const text = new TextDecoder().decode(value);
 
-      return {
-        ok: response.ok,
-        contentType: response.headers.get('content-type'),
-        text,
-      };
-    } finally {
-      clearTimeout(timeoutId);
-    }
-  }, sseUrl);
+        return {
+          ok: response.ok,
+          contentType: response.headers.get('content-type'),
+          text,
+        };
+      } finally {
+        clearTimeout(timeoutId);
+      }
+    }, sseUrl);
 
-  expect(result.ok).toBe(true);
-  expect(result.contentType).toBe('text/event-stream');
-  expect(result.text).toContain('Hello SSE1');
-  expect(result.text).toContain('Hello SSE2');
+    expect(result.ok).toBe(true);
+    expect(result.contentType).toBe('text/event-stream');
+    expect(result.text).toContain('Hello SSE1');
+    expect(result.text).toContain('Hello SSE2');
+  } finally {
+    server.close();
+  }
+});
 
-  server.close();
+test('should not gzip proxied SSE responses', async ({ dev, request }) => {
+  const ssePort = await getRandomPort();
+  const rsbuild = await dev({
+    config: {
+      server: {
+        proxy: {
+          '/api': {
+            target: `http://localhost:${ssePort}`,
+            pathRewrite: { '^/api': '' },
+          },
+        },
+      },
+    },
+  });
+
+  const app = new Hono();
+
+  app.get('/sse', () => {
+    return new Response('data: Hello SSE1\n\ndata: Hello SSE2\n\n', {
+      headers: {
+        'Content-Type': 'text/event-stream; charset=utf-8',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+      },
+    });
+  });
+
+  const server = createAdaptorServer({ fetch: app.fetch });
+
+  await new Promise<void>((resolve) => {
+    server.listen(ssePort, () => resolve());
+  });
+
+  try {
+    const response = await request.get(`http://localhost:${rsbuild.port}/api/sse`, {
+      headers: {
+        'accept-encoding': 'gzip',
+      },
+    });
+    const headers = response.headers();
+    const rawBody = Buffer.from(await response.body());
+    const text = headers['content-encoding'] === 'gzip'
+      ? (await gunzip(rawBody)).toString('utf8')
+      : rawBody.toString('utf8');
+
+    expect(headers['content-encoding']).toEqual(undefined);
+    expect(headers['content-type']).toContain('text/event-stream');
+    expect(text).toContain('Hello SSE1');
+    expect(text).toContain('Hello SSE2');
+  } finally {
+    server.close();
+  }
 });

--- a/packages/core/src/server/gzipMiddleware.ts
+++ b/packages/core/src/server/gzipMiddleware.ts
@@ -8,6 +8,7 @@ import type { CompressOptions, RequestHandler } from '../types';
 
 const ENCODING_REGEX = /\bgzip\b/;
 const CONTENT_TYPE_REGEX = /text|javascript|\/json|xml/i;
+const SSE_CONTENT_TYPE_REGEX = /(?:^|;)\s*text\/event-stream(?:\s*(?:;|$))/i;
 type WriteHeadHeaders = OutgoingHttpHeaders | OutgoingHttpHeader[];
 
 const setWriteHeadHeaders = (
@@ -50,6 +51,10 @@ const shouldCompress = (res: ServerResponse) => {
   }
 
   const contentType = String(res.getHeader('Content-Type'));
+  if (contentType && SSE_CONTENT_TYPE_REGEX.test(contentType)) {
+    return false;
+  }
+
   if (contentType && !CONTENT_TYPE_REGEX.test(contentType)) {
     return false;
   }

--- a/packages/core/tests/gzipMiddleware.test.ts
+++ b/packages/core/tests/gzipMiddleware.test.ts
@@ -150,3 +150,36 @@ test('should not compress responses with writeHead content-encoding', async () =
     await closeServer(server);
   }
 });
+
+test('should not compress text/event-stream responses', async () => {
+  const server = createServer((req, res) => {
+    gzipMiddleware()(req, res, () => {
+      res.writeHead(200, 'OK', [
+        'Content-Type',
+        'text/event-stream; charset=utf-8',
+        'Cache-Control',
+        'no-cache',
+      ]);
+      res.end('data: hello\n\n');
+    });
+  });
+
+  const port = await listen(server);
+
+  try {
+    const response = await fetch(`http://localhost:${port}`, {
+      headers: {
+        'accept-encoding': 'gzip',
+      },
+    });
+    const text = await response.text();
+
+    expect(response.headers.get('content-encoding')).toBeNull();
+    expect(response.headers.get('content-type')).toBe(
+      'text/event-stream; charset=utf-8',
+    );
+    expect(text).toBe('data: hello\n\n');
+  } finally {
+    await closeServer(server);
+  }
+});


### PR DESCRIPTION
Rsbuild currently treats `text/event-stream` as a normal `text/*` response in the default gzip compression logic.

When an SSE endpoint is accessed through the dev server proxy, the upstream response may still be gzipped before being sent back to the browser. For EventSource and other streaming scenarios that depend on timely flushing, this can delay event delivery or cause real-time updates to behave incorrectly.

This PR updates gzipMiddleware to skip gzip compression for text/event-stream responses by default, and adds unit and e2e coverage for the SSE compression behavior.
