### PR TITLE
chore: strengthen pnpm install safety

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,11 +24,14 @@ patchedDependencies:
 strictPeerDependencies: false
 
 allowBuilds:
-  '@parcel/watcher': true
+  '@parcel/watcher': false
   core-js: false
   simple-git-hooks: false
   svelte-preprocess: false
+strictDepBuilds: true
 
+# Reduce the risk of installing compromised packages
+minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - '@rspack/*'
   - '@rsbuild/*'


### PR DESCRIPTION
## Summary

This PR strengthens pnpm install safety by disabling the @parcel/watcher build script, enabling strict dependency build checks, and adding a minimum release age for installed packages.