### PR TITLE
chore: update renovate security config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,8 @@
   "extends": [
     "config:recommended",
     "schedule:weekly",
-    "helpers:pinGitHubActionDigests"
+    "helpers:pinGitHubActionDigests",
+    "github>rstackjs/renovate:security"
   ],
   "rangeStrategy": "bump",
   "packageRules": [

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,24 +11,17 @@ packages:
   - '!**/test-temp-*/**'
   - '!**/_node_modules/**'
 
-engineStrict: true
-
-hoistPattern: []
-
-dedupePeers: true
-
-patchedDependencies:
-  css-loader@7.1.4: patches/css-loader@7.1.4.patch
-  postcss-loader@8.2.1: patches/postcss-loader@8.2.1.patch
-
-strictPeerDependencies: false
-
 allowBuilds:
   '@parcel/watcher': false
   core-js: false
   simple-git-hooks: false
   svelte-preprocess: false
-strictDepBuilds: true
+
+dedupePeers: true
+
+engineStrict: true
+
+hoistPattern: []
 
 # Reduce the risk of installing compromised packages
 minimumReleaseAge: 1440
@@ -40,3 +33,11 @@ minimumReleaseAgeExclude:
   - '@rstest/*'
   - '@rsdoctor/*'
   - '@rslint/*'
+
+patchedDependencies:
+  css-loader@7.1.4: patches/css-loader@7.1.4.patch
+  postcss-loader@8.2.1: patches/postcss-loader@8.2.1.patch
+
+strictDepBuilds: true
+
+strictPeerDependencies: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,6 +38,7 @@ patchedDependencies:
   css-loader@7.1.4: patches/css-loader@7.1.4.patch
   postcss-loader@8.2.1: patches/postcss-loader@8.2.1.patch
 
+# Prevent un-reviewed build scripts
 strictDepBuilds: true
 
 strictPeerDependencies: false


### PR DESCRIPTION
## Summary

This PR extends the Renovate configuration with the shared Rstack security preset and keeps pnpm install safety settings grouped in the workspace config.

## Related Links

https://github.com/rstackjs/renovate/blob/main/security.json