### PR TITLE
test: add inline source map e2e case

### DIFF
--- a/e2e/cases/source-map/inline/index.test.ts
+++ b/e2e/cases/source-map/inline/index.test.ts
@@ -1,0 +1,45 @@
+import { expect, getFileContent, test } from '@e2e/helper';
+
+const parseInlineSourceMap = (code: string): { sources: string[] } => {
+  const match = code.match(
+    /sourceMappingURL=data:application\/json;charset=utf-8;base64,([A-Za-z0-9+/=]+)/,
+  );
+
+  if (!match) {
+    throw new Error('Inline source map not found.');
+  }
+
+  return JSON.parse(Buffer.from(match[1], 'base64').toString('utf-8')) as {
+    sources: string[];
+  };
+};
+
+test('should replace source map filename templates in inline source map', async ({
+  devOnly,
+}) => {
+  const rsbuild = await devOnly({
+    config: {
+      output: {
+        target: 'node',
+        sourceMap: true,
+      },
+      tools: {
+        rspack(config) {
+          config.devtool = 'inline-cheap-module-source-map';
+        },
+      },
+    },
+  });
+
+  const files = rsbuild.getDistFiles({ sourceMaps: true });
+  const indexJs = getFileContent(files, 'index.js');
+  const sourceMap = parseInlineSourceMap(indexJs);
+
+  expect(indexJs).not.toContain('[relative-resource-path]');
+  expect(sourceMap.sources).toContain('../src/index.js');
+  expect(
+    sourceMap.sources.some((source) =>
+      source.includes('[relative-resource-path]'),
+    ),
+  ).toBeFalsy();
+});

--- a/e2e/cases/source-map/inline/src/index.js
+++ b/e2e/cases/source-map/inline/src/index.js
@@ -1,0 +1,1 @@
+console.log('inline source map');


### PR DESCRIPTION
## Summary

Adds a dedicated inline source map e2e case covering the Node target + `inline-cheap-module-source-map` setup from #7533, ensuring source map filename templates are resolved to real source paths instead of leaking `[relative-resource-path]`.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/7533
