### PR TITLE
docs: update JavaScript API references

### DIFF
--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -229,7 +229,7 @@ export type RsbuildInstance = {
        * Remove the plugin in the specified environment.
        * If environment is not specified, remove it in all environments.
        */
-      environment: string;
+      environment?: string;
     },
   ) => void;
   /**

--- a/website/docs/en/api/javascript-api/core.mdx
+++ b/website/docs/en/api/javascript-api/core.mdx
@@ -286,7 +286,7 @@ type LoadEnvResult = {
   cleanup: () => void;
 };
 
-function loadEnv(options: LoadEnvOptions): LoadEnvResult;
+function loadEnv(options?: LoadEnvOptions): LoadEnvResult;
 ````
 
 - **Example:**
@@ -511,9 +511,11 @@ function ensureAssetPrefix(
   // URL string to be processed, can be a relative path or an absolute URL
   url: string,
   // URL prefix to be appended
-  assetPrefix: string
+  assetPrefix?: Rspack.PublicPath,
 ) => string;
 ```
+
+If `assetPrefix` is not passed, Rsbuild uses the default asset prefix `/`. If `assetPrefix` is `'auto'` or a function, this helper returns the input URL unchanged.
 
 - **Example:**
 

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -579,7 +579,7 @@ function RemovePlugins(
      * Remove the plugin in the specified environment.
      * If environment is not specified, remove it in all environments.
      */
-    environment: string;
+    environment?: string;
   },
 ): void;
 ```

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -572,18 +572,27 @@ This method needs to be called before compiling. If it is called after compiling
 - **Type:**
 
 ```ts
-function RemovePlugins(pluginNames: string[]): void;
+function RemovePlugins(
+  pluginNames: string[],
+  options?: {
+    /**
+     * Remove the plugin in the specified environment.
+     * If environment is not specified, remove it in all environments.
+     */
+    environment: string;
+  },
+): void;
 ```
 
 - **Example:**
 
 ```ts
 // add plugin
-const pluginFoo = pluginFoo();
-rsbuild.addPlugins(pluginFoo);
+const foo = pluginFoo();
+rsbuild.addPlugins([foo]);
 
 // remove plugin
-rsbuild.removePlugins([pluginFoo.name]);
+rsbuild.removePlugins([foo.name]);
 ```
 
 ## rsbuild.isPluginExists

--- a/website/docs/zh/api/javascript-api/core.mdx
+++ b/website/docs/zh/api/javascript-api/core.mdx
@@ -286,7 +286,7 @@ type LoadEnvResult = {
   cleanup: () => void;
 };
 
-function loadEnv(options: LoadEnvOptions): LoadEnvResult;
+function loadEnv(options?: LoadEnvOptions): LoadEnvResult;
 ````
 
 - **示例：**
@@ -512,9 +512,11 @@ function ensureAssetPrefix(
   // 需要处理的 URL 字符串。可以是相对路径或绝对 URL
   url: string,
   // 需要拼接的 URL 前缀
-  assetPrefix: string
+  assetPrefix?: Rspack.PublicPath,
 ) => string;
 ```
+
+如果未传入 `assetPrefix`，Rsbuild 会使用默认的资源前缀 `/`。如果 `assetPrefix` 为 `'auto'` 或函数，该函数会直接返回传入的 URL。
 
 - **示例：**
 

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -580,7 +580,7 @@ function RemovePlugins(
      * 移除指定 environment 中的插件。
      * 如果未指定 environment，则会从所有 environment 中移除。
      */
-    environment: string;
+    environment?: string;
   },
 ): void;
 ```

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -1,5 +1,5 @@
 ---
-description: 'Rsbuild JavaScript API 参考，涵盖rsbuild.context、rsbuild.environments、rsbuild.build等核心接口和用法。'
+description: 'Rsbuild JavaScript API 参考，涵盖 rsbuild.context、rsbuild.build 等核心接口和用法。'
 ---
 
 # Rsbuild instance
@@ -178,28 +178,6 @@ if (rsbuild.context.action === 'dev') {
 const rsbuild = await createRsbuild();
 
 rsbuild.logger.info('build started');
-```
-
-## rsbuild.environments
-
-### target
-
-构建产物类型，对应 Rsbuild 的 [output.target](/config/output/target) 配置。
-
-- **类型：**
-
-```ts
-type RsbuildTarget = 'web' | 'node' | 'web-worker';
-```
-
-### tsconfigPath
-
-tsconfig.json 文件的绝对路径，若项目中不存在 tsconfig.json 文件，则为 `undefined`。
-
-- **类型：**
-
-```ts
-type TsconfigPath = string | undefined;
 ```
 
 ## rsbuild.build
@@ -595,18 +573,27 @@ console.log(rsbuild.getPlugins({ environment: 'web' }));
 - **类型：**
 
 ```ts
-function RemovePlugins(pluginNames: string[]): void;
+function RemovePlugins(
+  pluginNames: string[],
+  options?: {
+    /**
+     * 移除指定 environment 中的插件。
+     * 如果未指定 environment，则会从所有 environment 中移除。
+     */
+    environment: string;
+  },
+): void;
 ```
 
 - **示例：**
 
 ```ts
 // 添加插件
-const pluginFoo = pluginFoo();
-rsbuild.addPlugins(pluginFoo);
+const foo = pluginFoo();
+rsbuild.addPlugins([foo]);
 
 // 移除插件
-rsbuild.removePlugins([pluginFoo.name]);
+rsbuild.removePlugins([foo.name]);
 ```
 
 ## rsbuild.isPluginExists


### PR DESCRIPTION
## Summary

This PR updates the JavaScript API docs to match the current API signatures and behavior. It marks `loadEnv` options and `ensureAssetPrefix` asset prefix as optional, documents the default `ensureAssetPrefix` handling, updates `removePlugins` options and examples, and removes outdated Chinese `rsbuild.environments` details.