### PR TITLE
docs: correct manifest config type docs

### DIFF
--- a/website/docs/en/config/output/manifest.mdx
+++ b/website/docs/en/config/output/manifest.mdx
@@ -4,7 +4,7 @@ description: 'The manifest file contains information about all assets and the ma
 
 # output.manifest
 
-- **Type:** `string | boolean`
+- **Type:** `string | boolean | ManifestObjectConfig`
 - **Default:** `false`
 
 Configure how to generate the manifest file.
@@ -91,17 +91,17 @@ type ManifestList = {
       html?: FilePath[];
       /**
        * Additional assets associated with this entry.
-       * For example images、fonts、source maps and other non JS or CSS files.
+       * For example, images, fonts, source maps and other non JS or CSS files.
        */
       assets?: FilePath[];
     };
-    /**
-     * Subresource Integrity (SRI) hashes for emitted assets.
-     * The key is the asset file path, and the value is its integrity hash.
-     * This field is available only when the `security.sri` option is enabled.
-     */
-    integrity: Record<string, string>;
   };
+  /**
+   * Subresource Integrity (SRI) hashes for emitted assets.
+   * The key is the asset file path, and the value is its integrity hash.
+   * This field is available only when the `security.sri` option is enabled.
+   */
+  integrity: Record<string, string>;
 };
 ```
 

--- a/website/docs/zh/config/output/manifest.mdx
+++ b/website/docs/zh/config/output/manifest.mdx
@@ -95,13 +95,13 @@ type ManifestList = {
        */
       assets?: FilePath[];
     };
-    /**
-     * 所有产物文件的子资源完整性（SRI）哈希值
-     * key 为文件路径，value 为对应的完整性哈希
-     * 仅在启用 `security.sri` 选项时才会生成该字段
-     */
-    integrity: Record<string, string>;
   };
+  /**
+   * 所有产物文件的子资源完整性（SRI）哈希值
+   * key 为文件路径，value 为对应的完整性哈希
+   * 仅在启用 `security.sri` 选项时才会生成该字段
+   */
+  integrity: Record<string, string>;
 };
 ```
 


### PR DESCRIPTION
## Summary

This PR corrects the output.manifest docs so the documented option type includes object configuration and the generated manifest type example places SRI integrity hashes at the top level, matching the documented manifest shape.