### PR TITLE
docs: update source include and exclude types

### DIFF
--- a/website/docs/en/config/source/exclude.mdx
+++ b/website/docs/en/config/source/exclude.mdx
@@ -4,7 +4,7 @@ description: 'Exclude JavaScript or TypeScript files that do not need to be comp
 
 # source.exclude
 
-- **Type:** [Rspack.RuleSetCondition](https://rspack.rs/config/module-rules#condition)
+- **Type:** [Rspack.RuleSetCondition](https://rspack.rs/config/module-rules#condition)`[]`
 - **Default:** `[]`
 
 Exclude JavaScript or TypeScript files that do not need to be compiled by [SWC](/guide/configuration/swc).

--- a/website/docs/en/config/source/include.mdx
+++ b/website/docs/en/config/source/include.mdx
@@ -4,7 +4,7 @@ description: 'Specify additional JavaScript files that need to be compiled by SW
 
 # source.include
 
-- **Type:** [Rspack.RuleSetCondition](https://rspack.rs/config/module-rules#condition)
+- **Type:** [Rspack.RuleSetCondition](https://rspack.rs/config/module-rules#condition)`[]`
 
 Specify additional JavaScript files that need to be compiled by [SWC](/guide/configuration/swc).
 
@@ -112,7 +112,7 @@ export default {
 
 This is because most of the npm packages in `node_modules` are already compiled, and it is usually unnecessary to recompile them. Compiling the entire `node_modules` will increase compilation time and may cause unexpected errors in certain npm packages, such as `core-js`, which may result in runtime exceptions after compilation.
 
-If you are willing to accept the increase in compilation time, you can use the following configuration to compile all JavaScript files but exclude `core-js':
+If you are willing to accept the increase in compilation time, you can use the following configuration to compile all JavaScript files but exclude `core-js`:
 
 ```ts title="rsbuild.config.ts"
 export default {

--- a/website/docs/zh/config/source/exclude.mdx
+++ b/website/docs/zh/config/source/exclude.mdx
@@ -4,7 +4,7 @@ description: '排除不需要被 SWC 编译的 JavaScript 或 TypeScript 文件�
 
 # source.exclude
 
-- **类型：** [Rspack.RuleSetCondition](https://rspack.rs/zh/config/module-rules#condition)
+- **类型：** [Rspack.RuleSetCondition](https://rspack.rs/zh/config/module-rules#condition)`[]`
 - **默认值：** `[]`
 
 排除不需要被 [SWC](/guide/configuration/swc) 编译的 JavaScript 或 TypeScript 文件。

--- a/website/docs/zh/config/source/include.mdx
+++ b/website/docs/zh/config/source/include.mdx
@@ -4,7 +4,7 @@ description: '用于指定额外需要被 SWC 编译的 JavaScript 文件。'
 
 # source.include
 
-- **类型：** [Rspack.RuleSetCondition](https://rspack.rs/zh/config/module-rules#condition)
+- **类型：** [Rspack.RuleSetCondition](https://rspack.rs/zh/config/module-rules#condition)`[]`
 
 用于指定额外需要被 [SWC](/guide/configuration/swc) 编译的 JavaScript 文件。
 
@@ -19,7 +19,7 @@ description: '用于指定额外需要被 SWC 编译的 JavaScript 文件。'
 
 ```ts
 const defaultInclude = [
-  { not: /[\\/]node_modules[\\/]/ }
+  { not: /[\\/]node_modules[\\/]/ },
   /\.(?:ts|tsx|jsx|mts|cts)$/,
 ];
 ```


### PR DESCRIPTION
## Summary

This PR updates the `source.include` and `source.exclude` docs to clarify that `Rspack.RuleSetCondition` is accepted as an array in both English and Chinese pages. It also fixes minor punctuation in the related examples.