### PR TITLE
perf(CLI): remove process title update

### DIFF
--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -40,9 +40,6 @@ function setupLogLevel() {
 }
 
 export function runCLI(): void {
-  // make it easier to identify the process via activity monitor or other tools
-  process.title = 'rsbuild-node';
-
   initNodeEnv();
   setupLogLevel();
   showGreeting();


### PR DESCRIPTION
## Summary

This PR removes the Rsbuild CLI startup code that updates `process.title`. Updating the process title is a synchronous native operation and adds measurable overhead for short-lived CLI commands, while the title is not required for CLI correctness.

## Related Links

https://github.com/nodejs/node/issues/59678

## Performance

Benchmarked with `hyperfine` in `/Users/chenjiahan/Project/build-tools-performance/cases/react-1k`, clearing `./node_modules/.cache` before each run and timing `node ../../node_modules/@rsbuild/core/bin/rsbuild.js build >/dev/null`.

- 30 runs: `471.666 ms ± 8.618 ms` -> `453.165 ms ± 5.265 ms`, improving mean time by `18.501 ms` and median time by `18.743 ms`.
- 80 runs: `469.274 ms ± 10.337 ms` -> `459.256 ms ± 25.248 ms`, improving mean time by `10.018 ms` and median time by `13.419 ms`.
