### PR TITLE
perf(core): reduce CLI startup work

### DIFF
--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -4,12 +4,12 @@ import { setupCommands } from './commands';
 
 const { argv } = process;
 
-function initNodeEnv() {
+function initNodeEnv(command: string | undefined) {
   if (!process.env.NODE_ENV) {
-    const command = argv[2];
-    process.env.NODE_ENV = ['build', 'preview'].includes(command)
-      ? 'production'
-      : 'development';
+    process.env.NODE_ENV =
+      command === 'build' || command === 'preview'
+        ? 'production'
+        : 'development';
   }
 }
 
@@ -28,7 +28,11 @@ function showGreeting() {
 
 // ensure log level is set before any log is printed
 function setupLogLevel() {
-  const logLevelIndex = process.argv.findIndex(
+  if (argv.length <= 3) {
+    return;
+  }
+
+  const logLevelIndex = argv.findIndex(
     (item) => item === '--log-level' || item === '--logLevel',
   );
   if (logLevelIndex !== -1) {
@@ -40,7 +44,9 @@ function setupLogLevel() {
 }
 
 export function runCLI(): void {
-  initNodeEnv();
+  const command = argv[2];
+
+  initNodeEnv(command);
   setupLogLevel();
   showGreeting();
 

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -90,9 +90,11 @@ export async function init({
   }
 
   // Build multiple environments can be shortened to: --environment name1,name2
-  commonOpts.environment = commonOpts.environment?.flatMap((env) =>
-    env.split(','),
-  );
+  if (commonOpts.environment?.some((env) => env.includes(','))) {
+    commonOpts.environment = commonOpts.environment.flatMap((env) =>
+      env.split(','),
+    );
+  }
 
   let logger = defaultLogger;
 


### PR DESCRIPTION
## Summary

This PR trims a few small pieces of Rsbuild CLI startup overhead after removing the previous process title update. The CLI now reuses the parsed command for NODE_ENV initialization, skips log-level argument scanning when no extra CLI arguments are present, and avoids splitting the --environment option unless a comma-separated value is actually used.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/7657