### PR TITLE
perf(core): skip resource hints when disabled

### DIFF
--- a/packages/core/src/plugins/resourceHints.ts
+++ b/packages/core/src/plugins/resourceHints.ts
@@ -72,6 +72,11 @@ export const pluginResourceHints = (): RsbuildPlugin => ({
       const {
         performance: { preload, prefetch },
       } = config;
+
+      if (!preload && !prefetch) {
+        return;
+      }
+
       const HTMLCount = chain.entryPoints.values().length;
       const excludes = getInlineExcludes(config);
 


### PR DESCRIPTION
## Summary

This PR skips the resource hints plugin work when both `performance.preload` and `performance.prefetch` are disabled. This avoids unnecessary HTML/resource hint processing for builds that do not enable either feature.