### PR TITLE
docs: correct compiler and server references

### DIFF
--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -578,7 +578,7 @@ export type RsbuildPluginAPI = Readonly<{
    */
   onAfterBuild: PluginHook<OnAfterBuildFn>;
   /**
-   * A callback function that is triggered after the compiler instance has been
+   * A callback function that is triggered after the Rspack Compiler instance has been
    * created, but before the build process. This hook is called when you run
    * `rsbuild.startDevServer`, `rsbuild.build`, or `rsbuild.createCompiler`.
    */
@@ -614,7 +614,7 @@ export type RsbuildPluginAPI = Readonly<{
    */
   onBeforeDevCompile: PluginHook<OnBeforeDevCompileFn>;
   /**
-   * A callback function that is triggered after the Compiler instance has been
+   * A callback function that is triggered after the Rspack Compiler instance has been
    * created, but before the build process begins. This hook is called when you
    * run `rsbuild.startDevServer`, `rsbuild.build`, or `rsbuild.createCompiler`.
    */

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -614,8 +614,8 @@ export type RsbuildPluginAPI = Readonly<{
    */
   onBeforeDevCompile: PluginHook<OnBeforeDevCompileFn>;
   /**
-   * A callback function that is triggered after the Rspack Compiler instance has been
-   * created, but before the build process begins. This hook is called when you
+   * A callback function that is triggered before the Rspack Compiler instance is
+   * created. This hook is called when you
    * run `rsbuild.startDevServer`, `rsbuild.build`, or `rsbuild.createCompiler`.
    */
   onBeforeCreateCompiler: PluginHook<OnBeforeCreateCompilerFn>;

--- a/website/docs/en/config/server/https.mdx
+++ b/website/docs/en/config/server/https.mdx
@@ -37,9 +37,9 @@ When HTTPS is enabled, Rsbuild uses an HTTP/2 server by default.
 
 ## Set certificate
 
-You can manually pass in the certificate and the private key required in the `server.https` option. This parameter will be directly passed to the `createServer` method of the https module in Node.js.
+You can manually pass in the certificate and the private key required in the `server.https` option. This parameter will be directly passed to the `createSecureServer` method of the http2 module in Node.js.
 
-For details, please refer to [https.createServer](https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener).
+For details, see [http2.createSecureServer](https://nodejs.org/api/http2.html#http2createsecureserveroptions-onrequesthandler).
 
 ```ts
 import fs from 'node:fs';

--- a/website/docs/en/config/server/setup.mdx
+++ b/website/docs/en/config/server/setup.mdx
@@ -99,9 +99,9 @@ type ServerSetupContext =
 
 ## Middleware execution order
 
-When `server.setup` is called, the default middleware of Rsbuild are not registered yet, so the middleware you add will run before the default middleware.
+When `server.setup` is called, the default Rsbuild middlewares are not registered yet, so the middleware you add will run before the default middlewares.
 
-`server.setup` allows you to return a callback function, which will be called when the default middleware of Rsbuild are registered. The middleware you register in the callback function will run after the default middleware.
+`server.setup` allows you to return a callback function, which will be called when the default Rsbuild middlewares are registered. The middleware you register in the callback function will run after the default middlewares.
 
 ```ts title="rsbuild.config.ts"
 export default {

--- a/website/docs/en/shared/onAfterCreateCompiler.mdx
+++ b/website/docs/en/shared/onAfterCreateCompiler.mdx
@@ -1,4 +1,4 @@
-A callback function that is triggered after the Rspack compiler instance has been created, but before the build process. This hook is called when you run `rsbuild.startDevServer`, `rsbuild.build`, or `rsbuild.createCompiler`.
+A callback function that is triggered after the Rspack Compiler instance has been created, but before the build process. This hook is called when you run `rsbuild.startDevServer`, `rsbuild.build`, or `rsbuild.createCompiler`.
 
 You can access the [Compiler instance](https://rspack.rs/api/javascript-api/compiler) through the `compiler` parameter:
 

--- a/website/docs/en/shared/onAfterCreateCompiler.mdx
+++ b/website/docs/en/shared/onAfterCreateCompiler.mdx
@@ -1,4 +1,4 @@
-A callback function that is triggered after the compiler instance has been created, but before the build process. This hook is called when you run `rsbuild.startDevServer`, `rsbuild.build`, or `rsbuild.createCompiler`.
+A callback function that is triggered after the Rspack compiler instance has been created, but before the build process. This hook is called when you run `rsbuild.startDevServer`, `rsbuild.build`, or `rsbuild.createCompiler`.
 
 You can access the [Compiler instance](https://rspack.rs/api/javascript-api/compiler) through the `compiler` parameter:
 

--- a/website/docs/en/shared/onBeforeCreateCompiler.mdx
+++ b/website/docs/en/shared/onBeforeCreateCompiler.mdx
@@ -1,4 +1,4 @@
-A callback function that is triggered after the Compiler instance has been created, but before the build process begins. This hook is called when you run `rsbuild.startDevServer`, `rsbuild.build`, or `rsbuild.createCompiler`.
+A callback function that is triggered before the Rspack Compiler instance is created. This hook is called when you run `rsbuild.startDevServer`, `rsbuild.build`, or `rsbuild.createCompiler`.
 
 You can access the Rspack configuration array through the `bundlerConfigs` parameter. The array may contain one or more [Rspack configurations](https://rspack.rs/config/). It depends on whether multiple [environments](/config/environments) are configured.
 

--- a/website/docs/zh/config/server/https.mdx
+++ b/website/docs/zh/config/server/https.mdx
@@ -37,9 +37,9 @@ type Https = ServerOptions | SecureServerSessionOptions;
 
 ## 设置证书
 
-你可以在 `server.https` 选项中手动传入 HTTPS 服务器所需要的证书和对应的私钥，这个参数将直接传递给 Node.js 中 https 模块的 `createServer` 方法。
+你可以在 `server.https` 选项中手动传入 HTTPS 服务器所需要的证书和对应的私钥，这个参数将直接传递给 Node.js 中 http2 模块的 `createSecureServer` 方法。
 
-具体可以参考 [https.createServer](https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener)。
+具体可以参考 [http2.createSecureServer](https://nodejs.org/api/http2.html#http2createsecureserveroptions-onrequesthandler)。
 
 ```ts
 import fs from 'node:fs';

--- a/website/docs/zh/shared/onAfterCreateCompiler.mdx
+++ b/website/docs/zh/shared/onAfterCreateCompiler.mdx
@@ -1,4 +1,4 @@
-`onAfterCreateCompiler` 是在创建 Compiler 实例后、执行构建前触发的回调函数，当你执行 `rsbuild.startDevServer`、`rsbuild.build` 或 `rsbuild.createCompiler` 时，都会调用此钩子。
+`onAfterCreateCompiler` 是在创建 Rspack Compiler 实例后、执行构建前触发的回调函数，当你执行 `rsbuild.startDevServer`、`rsbuild.build` 或 `rsbuild.createCompiler` 时，都会调用此钩子。
 
 你可以通过 `compiler` 参数获取到 [Compiler 实例对象](https://rspack.rs/zh/api/javascript-api/compiler):
 

--- a/website/docs/zh/shared/onBeforeCreateCompiler.mdx
+++ b/website/docs/zh/shared/onBeforeCreateCompiler.mdx
@@ -1,4 +1,4 @@
-`onBeforeCreateCompiler` 是在创建底层 Compiler 实例前触发的回调函数，当你执行 `rsbuild.startDevServer`、`rsbuild.build` 或 `rsbuild.createCompiler` 时，都会调用此钩子。
+`onBeforeCreateCompiler` 是在创建 Rspack Compiler 实例前触发的回调函数，当你执行 `rsbuild.startDevServer`、`rsbuild.build` 或 `rsbuild.createCompiler` 时，都会调用此钩子。
 
 你可以通过 `bundlerConfigs` 参数获取到 Rspack 配置数组，数组中可能包含一份或多份 [Rspack 配置](https://rspack.rs/zh/config/)，这取决于是否配置了多个 [environments](/config/environments)。
 


### PR DESCRIPTION
## Summary

This PR corrects docs and API comments where compiler and server APIs were described imprecisely. It clarifies that compiler hooks use the Rspack Compiler instance, points `server.https` certificate options to Node.js `http2.createSecureServer`, and uses consistent middleware wording in the server setup docs.