### PR TITLE
docs: clarify JavaScript API behavior

### DIFF
--- a/packages/core/src/mergeConfig.ts
+++ b/packages/core/src/mergeConfig.ts
@@ -128,6 +128,12 @@ const normalizeConfigStructure = <T = RsbuildConfig>(config: T): T => {
   return normalizedConfig as T;
 };
 
+/**
+ * Deeply merges multiple Rsbuild configuration objects.
+ *
+ * This function returns a new merged configuration object and does not modify
+ * the input configuration objects.
+ */
 export const mergeRsbuildConfig = <T = RsbuildConfig>(
   ...originalConfigs: (T | undefined)[]
 ): T => {

--- a/website/docs/en/api/javascript-api/core.mdx
+++ b/website/docs/en/api/javascript-api/core.mdx
@@ -145,7 +145,8 @@ function loadConfig(params?: {
    * Specify the config loader, can be `auto`, `jiti` or `native`.
    * - 'auto': Use native Node.js loader first, fallback to jiti if failed
    * - 'jiti': Use jiti as loader, which supports TypeScript and ESM out of the box
-   * - 'native': Use native Node.js loader, requires TypeScript support in Node.js >= 22.6
+   * - 'native': Use native Node.js loader. TypeScript config files require
+   *   native TypeScript support, such as Node.js 22.6+.
    * @default 'auto'
    */
   loader?: 'auto' | 'jiti' | 'native';
@@ -333,7 +334,7 @@ loadEnv({ processEnv: { ...process.env } });
 
 Used to merge multiple Rsbuild configuration objects.
 
-The `mergeRsbuildConfig` function takes multiple configuration objects as parameters. It deep merges each configuration object, automatically combining multiple function values into an array of sequentially executed functions, and returns a merged configuration object.
+The `mergeRsbuildConfig` function takes multiple configuration objects as parameters. It deeply merges each configuration object, automatically combining multiple function values into an array of sequentially executed functions, and returns a new merged configuration object without modifying the input configuration objects.
 
 - **Type:**
 

--- a/website/docs/zh/api/javascript-api/core.mdx
+++ b/website/docs/zh/api/javascript-api/core.mdx
@@ -145,7 +145,8 @@ function loadConfig(params?: {
    * 指定配置文件加载器，可选值为 `auto`、`jiti` 或 `native`。
    * - `auto`：优先使用 Node.js 原生加载器，若加载失败则回退到 jiti
    * - `jiti`：使用 jiti 作为加载器，开箱即用地支持 TypeScript 和 ESM
-   * - `native`：使用 Node.js 原生加载器，要求 Node.js >= 22.6 且原生支持 TypeScript
+   * - `native`：使用 Node.js 原生加载器。TypeScript 配置文件要求运行时原生支持
+   *   TypeScript，例如 Node.js 22.6+
    * @default 'auto'
    */
   loader?: 'auto' | 'jiti' | 'native';
@@ -333,7 +334,7 @@ loadEnv({ processEnv: { ...process.env } });
 
 用于合并多份 Rsbuild 配置对象。
 
-`mergeRsbuildConfig` 函数接收多个配置对象作为参数，它会将每一个配置对象进行深层合并，自动将多个函数项合并为顺序执行的函数数组，返回一个合并后的配置对象。
+`mergeRsbuildConfig` 函数接收多个配置对象作为参数。它会对每个配置对象进行深层合并，自动将多个函数项合并为顺序执行的函数数组，并返回一个新的合并配置对象，不会修改传入的配置对象。
 
 - **类型：**
 


### PR DESCRIPTION
## Summary

This PR clarifies JavaScript API docs around `mergeRsbuildConfig` immutability and native TypeScript loader support. It also adds JSDoc to the exported `mergeRsbuildConfig` helper so its non-mutating behavior is visible from source-level API docs.