### PR TITLE
chore(deps): group rstest renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,6 +19,11 @@
       "matchPackageNames": ["/rspress/"]
     },
     {
+      "groupName": "Rstest",
+      "groupSlug": "rstest",
+      "matchPackageNames": ["/rstest/"]
+    },
+    {
       "groupName": "Sass",
       "groupSlug": "sass",
       "matchPackageNames": ["/sass/"]


### PR DESCRIPTION
## Summary

This PR adds a Renovate package rule for Rstest dependencies so related updates are grouped together.