### PR TITLE
docs: update environment config limitations

### DIFF
--- a/website/docs/en/blog/v0-3.mdx
+++ b/website/docs/en/blog/v0-3.mdx
@@ -30,7 +30,7 @@ Notable changes:
 
 The need to import TOML and YAML in JS is not common, so Rsbuild core will no longer support import TOML and YAML by default in v0.3.0.
 
-The TOML and YAML plugin will become a independent plugin:
+The TOML and YAML plugin will become an independent plugin:
 
 - TOML:
 

--- a/website/docs/en/config/environments.mdx
+++ b/website/docs/en/config/environments.mdx
@@ -24,6 +24,11 @@ type Environments = {
 
 Since multiple environments share the same server instance, the following options are currently not supported in `EnvironmentConfig`:
 
+- `root`
+- `mode`
+- `logLevel`
+- `customLogger`
+- `environments`
 - `server.*`
 - `dev.watchFiles`
 - `dev.cliShortcuts`

--- a/website/docs/zh/config/environments.mdx
+++ b/website/docs/zh/config/environments.mdx
@@ -24,6 +24,11 @@ type Environments = {
 
 由于多个 environment 共享同一个 server 实例，以下选项暂不支持在 `EnvironmentConfig` 中配置：
 
+- `root`
+- `mode`
+- `logLevel`
+- `customLogger`
+- `environments`
 - `server.*`
 - `dev.watchFiles`
 - `dev.cliShortcuts`


### PR DESCRIPTION
## Summary

This PR updates the environment configuration docs to list additional options that are not supported in `EnvironmentConfig` because multiple environments share the same server instance. It also fixes a minor article typo in the v0.3 blog post.