### PR TITLE
docs: update output hash examples

### DIFF
--- a/website/docs/en/config/output/asset-prefix.mdx
+++ b/website/docs/en/config/output/asset-prefix.mdx
@@ -32,7 +32,7 @@ After the build, the URL of the JS bundle in the HTML file will be:
 ```html
 <script
   defer
-  src="https://cdn.example.com/assets/static/js/index.ebc4ff4f.js"
+  src="https://cdn.example.com/assets/static/js/index.ebc4ff4fab.js"
 ></script>
 ```
 
@@ -49,7 +49,7 @@ export default {
 After the build, the URL of the JS bundle in the HTML file will be:
 
 ```html
-<script defer src="./static/js/index.ebc4ff4f.js"></script>
+<script defer src="./static/js/index.ebc4ff4fab.js"></script>
 ```
 
 ## Default value

--- a/website/docs/en/config/output/filename-hash.mdx
+++ b/website/docs/en/config/output/filename-hash.mdx
@@ -34,8 +34,8 @@ If [output.filename](/config/output/filename) is configured, it has a higher pri
 By default, output file names include a hash value:
 
 ```bash
-dist/static/css/index.7879e19d.css
-dist/static/js/index.18a568e5.js
+dist/static/css/index.7879e19dab.css
+dist/static/js/index.18a568e5ab.js
 ```
 
 You can set `output.filenameHash` to `false` to disable this behavior:

--- a/website/docs/en/config/output/filename.mdx
+++ b/website/docs/en/config/output/filename.mdx
@@ -136,7 +136,7 @@ Common filename placeholders include:
 When you import a module via dynamic import, the module will be bundled into a separate file using these default naming rules:
 
 - In development mode, the filename will be generated based on the module path, such as `dist/static/js/async/src_add_ts.js`.
-- In production mode, it will be a random numeric id, such as `dist/static/js/async/798.27e3083e.js`. This is to avoid leaking the source code path in production mode, and the number of characters is also less.
+- In production mode, it will be a random numeric id, such as `dist/static/js/async/798.27e3083eab.js`. This is to avoid leaking the source code path in production mode, and the number of characters is also less.
 
 ```js title="src/index.ts"
 const { add } = await import('./add.ts');
@@ -245,8 +245,8 @@ In this case, the filenames of JS and CSS will not include a hash, but the URLs 
 <!DOCTYPE html>
 <html>
   <head>
-    <script defer src="/static/js/index.js?v=b8565050"></script>
-    <link href="/static/css/index.css?v=02d157ca" rel="stylesheet" />
+    <script defer src="/static/js/index.js?v=b8565050ab"></script>
+    <link href="/static/css/index.css?v=02d157caab" rel="stylesheet" />
   </head>
 </html>
 ```

--- a/website/docs/en/config/output/inline-scripts.mdx
+++ b/website/docs/en/config/output/inline-scripts.mdx
@@ -101,14 +101,14 @@ export default {
 ```
 
 :::tip
-Production filenames include a hash value by default, such as `static/js/main.18a568e5.js`. In regular expressions, use `\w+` to match the hash.
+Production filenames include a hash value by default, such as `static/js/main.18a568e5ab.js`. In regular expressions, use `\w+` to match the hash.
 :::
 
 ### Using function
 
 You can also set `output.inlineScripts` to a function that accepts the following parameters:
 
-- `name`: The filename, such as `static/js/main.18a568e5.js`.
+- `name`: The filename, such as `static/js/main.18a568e5ab.js`.
 - `size`: The file size in bytes.
 
 For example, if we want to inline assets that are smaller than 10 kB, we can add the following configuration:

--- a/website/docs/en/config/output/inline-styles.mdx
+++ b/website/docs/en/config/output/inline-styles.mdx
@@ -85,14 +85,14 @@ export default {
 ```
 
 :::tip
-Production filenames include a hash value by default, such as `static/css/main.18a568e5.css`. In regular expressions, use `\w+` to match the hash.
+Production filenames include a hash value by default, such as `static/css/main.18a568e5ab.css`. In regular expressions, use `\w+` to match the hash.
 :::
 
 ### Using function
 
 Set `output.inlineStyles` to a function that accepts the following parameters:
 
-- `name`: The filename, such as `static/css/main.18a568e5.css`.
+- `name`: The filename, such as `static/css/main.18a568e5ab.css`.
 - `size`: The file size in bytes.
 
 To inline assets smaller than 10 kB, add the following configuration:

--- a/website/docs/en/config/performance/print-file-size.mdx
+++ b/website/docs/en/config/performance/print-file-size.mdx
@@ -28,13 +28,13 @@ Whether to print the file sizes after production build.
 The default output log is as follows:
 
 ```
-File (web)                              Size        Gzip
-dist/static/js/lib-react.b0714b60.js    140.4 kB    45.0 kB
-dist/static/js/index.f3fde9c7.js        1.9 kB      0.97 kB
-dist/index.html                         0.39 kB     0.25 kB
-dist/static/css/index.2960ac62.css      0.35 kB     0.26 kB
+File (web)                                Size        Gzip
+dist/static/js/lib-react.b0714b60ab.js    140.4 kB    45.0 kB
+dist/static/js/index.f3fde9c7ab.js        1.9 kB      0.97 kB
+dist/index.html                           0.39 kB     0.25 kB
+dist/static/css/index.2960ac62ab.css      0.35 kB     0.26 kB
 
-                               Total:   143.0 kB    46.3 kB
+                                 Total:   143.0 kB    46.3 kB
 ```
 
 ## Disable outputs
@@ -257,12 +257,12 @@ export default {
 On the second build, the output begins to include inline size deltas:
 
 ```
-File (web)                              Size                  Gzip
-dist/static/js/lib-react.b0714b60.js    140.4 kB (+2.1 kB)    45.0 kB (+0.5 kB)
-dist/static/js/index.f3fde9c7.js        1.9 kB (-0.3 kB)      0.97 kB (-0.1 kB)
-dist/static/css/index.2960ac62.css      0.35 kB (+0.35 kB)    0.26 kB (+0.26 kB)
+File (web)                                Size                  Gzip
+dist/static/js/lib-react.b0714b60ab.js    140.4 kB (+2.1 kB)    45.0 kB (+0.5 kB)
+dist/static/js/index.f3fde9c7ab.js        1.9 kB (-0.3 kB)      0.97 kB (-0.1 kB)
+dist/static/css/index.2960ac62ab.css      0.35 kB (+0.35 kB)    0.26 kB (+0.26 kB)
 
-                               Total:   143.0 kB (+2.15 kB)   46.3 kB (+0.66 kB)
+                                 Total:   143.0 kB (+2.15 kB)   46.3 kB (+0.66 kB)
 ```
 
 - Increases are highlighted in red with a `+` prefix

--- a/website/docs/en/plugins/list/plugin-svgr.mdx
+++ b/website/docs/en/plugins/list/plugin-svgr.mdx
@@ -52,7 +52,7 @@ If the imported path doesn't include the `?react` suffix, the SVG will be treate
 ```js
 import logoURL from './static/logo.svg';
 
-console.log(logoURL); // => "/static/logo.6c12aba3.png"
+console.log(logoURL); // => "/static/svg/logo.6c12aba3ab.svg" or a base64 URL
 ```
 
 ### Named import

--- a/website/docs/zh/config/output/asset-prefix.mdx
+++ b/website/docs/zh/config/output/asset-prefix.mdx
@@ -32,7 +32,7 @@ export default {
 ```html
 <script
   defer
-  src="https://cdn.example.com/assets/static/js/index.ebc4ff4f.js"
+  src="https://cdn.example.com/assets/static/js/index.ebc4ff4fab.js"
 ></script>
 ```
 
@@ -49,7 +49,7 @@ export default {
 构建后，HTML 产物中加载 JS bundle 的 URL 如下：
 
 ```html
-<script defer src="./static/js/index.ebc4ff4f.js"></script>
+<script defer src="./static/js/index.ebc4ff4fab.js"></script>
 ```
 
 ## 默认值

--- a/website/docs/zh/config/output/filename-hash.mdx
+++ b/website/docs/zh/config/output/filename-hash.mdx
@@ -34,8 +34,8 @@ type FilenameHash =
 默认情况下，构建后的产物名称会包含 hash 值：
 
 ```bash
-dist/static/css/index.7879e19d.css
-dist/static/js/index.18a568e5.js
+dist/static/css/index.7879e19dab.css
+dist/static/js/index.18a568e5ab.js
 ```
 
 你可以将 `output.filenameHash` 设置为 false 来禁用这个行为：

--- a/website/docs/zh/config/output/filename.mdx
+++ b/website/docs/zh/config/output/filename.mdx
@@ -136,7 +136,7 @@ export default {
 当你在代码中通过 dynamic import 的方式引入模块时，该模块会被单独打包成一个文件，它默认的命名规则如下：
 
 - 在开发模式下会基于模块路径生成名称，比如 `dist/static/js/async/src_add_ts.js`。
-- 在生产模式下会是一个随机的数字 id，比如 `dist/static/js/async/798.27e3083e.js`，这是为了避免在生产模式中泄露源代码的路径，同时字符数也更少。
+- 在生产模式下会是一个随机的数字 id，比如 `dist/static/js/async/798.27e3083eab.js`，这是为了避免在生产模式中泄露源代码的路径，同时字符数也更少。
 
 ```js title="src/index.ts"
 const { add } = await import('./add.ts');
@@ -245,8 +245,8 @@ export default {
 <!DOCTYPE html>
 <html>
   <head>
-    <script defer src="/static/js/index.js?v=b8565050"></script>
-    <link href="/static/css/index.css?v=02d157ca" rel="stylesheet" />
+    <script defer src="/static/js/index.js?v=b8565050ab"></script>
+    <link href="/static/css/index.css?v=02d157caab" rel="stylesheet" />
   </head>
 </html>
 ```

--- a/website/docs/zh/config/output/inline-scripts.mdx
+++ b/website/docs/zh/config/output/inline-scripts.mdx
@@ -101,14 +101,14 @@ export default {
 ```
 
 :::tip
-生产模式的文件名中默认包含了一个 hash 值，比如 `static/js/main.18a568e5.js`。因此，在正则表达式中需要通过 `\w+` 来匹配 hash。
+生产模式的文件名中默认包含了一个 hash 值，比如 `static/js/main.18a568e5ab.js`。因此，在正则表达式中需要通过 `\w+` 来匹配 hash。
 :::
 
 ### 通过函数匹配
 
 你也可以将 `output.inlineScripts` 设置为一个函数，函数接收以下参数：
 
-- `name`：文件名，比如 `static/js/main.18a568e5.js`。
+- `name`：文件名，比如 `static/js/main.18a568e5ab.js`。
 - `size`：文件大小，单位为 byte。
 
 比如，我们希望内联小于 10kB 的资源，可以添加如下配置：

--- a/website/docs/zh/config/output/inline-styles.mdx
+++ b/website/docs/zh/config/output/inline-styles.mdx
@@ -85,14 +85,14 @@ export default {
 ```
 
 :::tip
-生产模式的文件名中默认包含了一个 hash 值，比如 `static/css/main.18a568e5.css`。因此，在正则表达式中需要通过 `\w+` 来匹配 hash。
+生产模式的文件名中默认包含了一个 hash 值，比如 `static/css/main.18a568e5ab.css`。因此，在正则表达式中需要通过 `\w+` 来匹配 hash。
 :::
 
 ### 通过函数匹配
 
 你也可以将 `output.inlineStyles` 设置为一个函数，函数接收以下参数：
 
-- `name`：文件名，比如 `static/css/main.18a568e5.css`。
+- `name`：文件名，比如 `static/css/main.18a568e5ab.css`。
 - `size`：文件大小，单位为 byte。
 
 比如，我们希望内联小于 10kB 的资源，可以添加如下配置：

--- a/website/docs/zh/config/performance/print-file-size.mdx
+++ b/website/docs/zh/config/performance/print-file-size.mdx
@@ -15,6 +15,7 @@ type PrintFileSizeOptions =
       compressed?: boolean;
       include?: (asset: PrintFileSizeAsset) => boolean;
       exclude?: (asset: PrintFileSizeAsset) => boolean;
+      diff?: boolean;
     };
 ```
 
@@ -27,13 +28,13 @@ type PrintFileSizeOptions =
 默认输出的日志如下：
 
 ```
-File (web)                              Size        Gzip
-dist/static/js/lib-react.b0714b60.js    140.4 kB    45.0 kB
-dist/static/js/index.f3fde9c7.js        1.9 kB      0.97 kB
-dist/index.html                         0.39 kB     0.25 kB
-dist/static/css/index.2960ac62.css      0.35 kB     0.26 kB
+File (web)                                Size        Gzip
+dist/static/js/lib-react.b0714b60ab.js    140.4 kB    45.0 kB
+dist/static/js/index.f3fde9c7ab.js        1.9 kB      0.97 kB
+dist/index.html                           0.39 kB     0.25 kB
+dist/static/css/index.2960ac62ab.css      0.35 kB     0.26 kB
 
-                               Total:   143.0 kB    46.3 kB
+                                 Total:   143.0 kB    46.3 kB
 ```
 
 ## 禁用输出
@@ -256,12 +257,12 @@ export default {
 从第二次构建开始，输出中将显示体积变化信息：
 
 ```
-File (web)                              Size                  Gzip
-dist/static/js/lib-react.b0714b60.js    140.4 kB (+2.1 kB)    45.0 kB (+0.5 kB)
-dist/static/js/index.f3fde9c7.js        1.9 kB (-0.3 kB)      0.97 kB (-0.1 kB)
-dist/static/css/index.2960ac62.css      0.35 kB (+0.35 kB)    0.26 kB (+0.26 kB)
+File (web)                                Size                  Gzip
+dist/static/js/lib-react.b0714b60ab.js    140.4 kB (+2.1 kB)    45.0 kB (+0.5 kB)
+dist/static/js/index.f3fde9c7ab.js        1.9 kB (-0.3 kB)      0.97 kB (-0.1 kB)
+dist/static/css/index.2960ac62ab.css      0.35 kB (+0.35 kB)    0.26 kB (+0.26 kB)
 
-                               Total:   143.0 kB (+2.15 kB)   46.3 kB (+0.66 kB)
+                                 Total:   143.0 kB (+2.15 kB)   46.3 kB (+0.66 kB)
 ```
 
 - 文件体积增加会以红色并带有 `+` 前缀

--- a/website/docs/zh/plugins/list/plugin-svgr.mdx
+++ b/website/docs/zh/plugins/list/plugin-svgr.mdx
@@ -52,7 +52,7 @@ export const App = () => <Logo />;
 ```js
 import logoURL from './static/logo.svg';
 
-console.log(logoURL); // => "/static/logo.6c12aba3.png"
+console.log(logoURL); // => "/static/svg/logo.6c12aba3ab.svg" 或 base64 URL
 ```
 
 ### 具名导入


### PR DESCRIPTION
## Summary

This PR updates the English and Chinese docs to align filename hash examples, print-file-size sample output, and the SVGR asset URL example with the current output format.