### PR TITLE
fix(core): clone single merged config

### DIFF
--- a/packages/core/src/mergeConfig.ts
+++ b/packages/core/src/mergeConfig.ts
@@ -145,9 +145,6 @@ export const mergeRsbuildConfig = <T = RsbuildConfig>(
   if (configs.length === 2) {
     return merge(configs[0], configs[1]) as T;
   }
-  if (configs.length === 1) {
-    return configs[0];
-  }
   if (configs.length === 0) {
     return {} as T;
   }

--- a/packages/core/tests/mergeConfig.test.ts
+++ b/packages/core/tests/mergeConfig.test.ts
@@ -196,6 +196,35 @@ describe('mergeRsbuildConfig', () => {
     });
   });
 
+  it('should not modify the original object when a merged single config is modified', () => {
+    const obj: RsbuildConfig = {
+      source: {
+        entry: {
+          index: './src/index.ts',
+        },
+      },
+    };
+
+    const res = mergeRsbuildConfig(obj);
+
+    res.source!.entry!.index = './src/main.ts';
+
+    expect(res).toEqual({
+      source: {
+        entry: {
+          index: './src/main.ts',
+        },
+      },
+    });
+    expect(obj).toEqual({
+      source: {
+        entry: {
+          index: './src/index.ts',
+        },
+      },
+    });
+  });
+
   test('should merge server.open correctly', async () => {
     expect(
       mergeRsbuildConfig(


### PR DESCRIPTION
## Summary

This PR fixes `mergeRsbuildConfig` single-argument behavior so the result goes through the normal merge clone path instead of returning the normalized input directly. This prevents nested plain-object config fields from being shared with the original input when the returned config is modified.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/7668