### PR TITLE
feat(core): support worker query imports

### DIFF
--- a/e2e/cases/workers/worker-query-basic/index.test.ts
+++ b/e2e/cases/workers/worker-query-basic/index.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from '@e2e/helper';
+
+test('should support worker query imports', async ({ page, runBothServe }) => {
+  await runBothServe(async () => {
+    await expect(page.locator('#worker')).toHaveText('named-query-worker: 42');
+    await expect(page.locator('#mjs-worker')).toHaveText('mjs-worker: 42');
+  });
+});

--- a/e2e/cases/workers/worker-query-basic/src/index.ts
+++ b/e2e/cases/workers/worker-query-basic/src/index.ts
@@ -1,0 +1,36 @@
+import MjsWorker from './mjs-worker.mjs?worker';
+import QueryWorker from './query-worker?worker';
+
+document.body.innerHTML = `
+  <div id="worker"></div>
+  <div id="mjs-worker"></div>
+`;
+
+const setText = (selector: string, text: string) => {
+  const element = document.querySelector(selector);
+  if (element) {
+    element.textContent = text;
+  }
+};
+
+const runWorker = (
+  worker: Worker,
+  message: unknown,
+  selector: string,
+  format: (data: Record<string, string>) => string,
+) => {
+  worker.addEventListener('message', ({ data }) => {
+    setText(selector, format(data));
+    worker.terminate();
+  });
+  worker.postMessage(message);
+};
+
+runWorker(
+  new QueryWorker({ name: 'named-query-worker' }),
+  'ping',
+  '#worker',
+  (data) => data.text,
+);
+
+runWorker(new MjsWorker(), 'mjs-worker', '#mjs-worker', (data) => data.text);

--- a/e2e/cases/workers/worker-query-basic/src/message.ts
+++ b/e2e/cases/workers/worker-query-basic/src/message.ts
@@ -1,0 +1,3 @@
+export const answer = 42;
+
+export const formatMessage = (name: string): string => `${name}: ${answer}`;

--- a/e2e/cases/workers/worker-query-basic/src/mjs-worker.mjs
+++ b/e2e/cases/workers/worker-query-basic/src/mjs-worker.mjs
@@ -1,0 +1,7 @@
+import { formatMessage } from './message';
+
+self.onmessage = ({ data }) => {
+  self.postMessage({
+    text: formatMessage(data),
+  });
+};

--- a/e2e/cases/workers/worker-query-basic/src/query-worker.ts
+++ b/e2e/cases/workers/worker-query-basic/src/query-worker.ts
@@ -1,0 +1,7 @@
+import { formatMessage } from './message';
+
+self.onmessage = () => {
+  self.postMessage({
+    text: formatMessage(self.name || 'query-worker'),
+  });
+};

--- a/e2e/cases/workers/worker-query-dynamic-import/index.test.ts
+++ b/e2e/cases/workers/worker-query-dynamic-import/index.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from '@e2e/helper';
+
+test('should support dynamic imports inside worker query imports', async ({
+  page,
+  runBothServe,
+}) => {
+  await runBothServe(async () => {
+    await expect(page.locator('#dynamic-import-worker')).toHaveText(
+      'module-a:module-b',
+    );
+  });
+});

--- a/e2e/cases/workers/worker-query-dynamic-import/src/chunk-worker.ts
+++ b/e2e/cases/workers/worker-query-dynamic-import/src/chunk-worker.ts
@@ -1,0 +1,10 @@
+self.onmessage = async () => {
+  const [{ message }, { default: defaultMessage }] = await Promise.all([
+    import('./module-a'),
+    import('./module-b'),
+  ]);
+
+  self.postMessage({
+    text: `${message}:${defaultMessage}`,
+  });
+};

--- a/e2e/cases/workers/worker-query-dynamic-import/src/index.ts
+++ b/e2e/cases/workers/worker-query-dynamic-import/src/index.ts
@@ -1,0 +1,15 @@
+import ChunkWorker from './chunk-worker?worker';
+
+document.body.innerHTML = '<div id="dynamic-import-worker"></div>';
+
+const worker = new ChunkWorker();
+
+worker.addEventListener('message', ({ data }) => {
+  const element = document.querySelector('#dynamic-import-worker');
+  if (element) {
+    element.textContent = data.text;
+  }
+  worker.terminate();
+});
+
+worker.postMessage('ping');

--- a/e2e/cases/workers/worker-query-dynamic-import/src/module-a.ts
+++ b/e2e/cases/workers/worker-query-dynamic-import/src/module-a.ts
@@ -1,0 +1,1 @@
+export const message = 'module-a';

--- a/e2e/cases/workers/worker-query-dynamic-import/src/module-b.ts
+++ b/e2e/cases/workers/worker-query-dynamic-import/src/module-b.ts
@@ -1,0 +1,1 @@
+export default 'module-b';

--- a/e2e/cases/workers/worker-query-inline/index.test.ts
+++ b/e2e/cases/workers/worker-query-inline/index.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from '@e2e/helper';
+
+test('should support inline worker query imports', async ({
+  page,
+  runBothServe,
+}) => {
+  await runBothServe(async ({ mode, result }) => {
+    await expect(page.locator('#inline-worker')).toHaveText(
+      'named-inline-worker: 42 named-inline-worker rsbuild-inline-worker-marker',
+    );
+    await expect(page.locator('#inline-worker-reordered')).toHaveText(
+      'inline-worker-reordered: 42',
+    );
+    await expect(page.locator('#inline-worker-unicode')).toHaveText(
+      '\u2022pong\u2022',
+    );
+
+    if (mode === 'build') {
+      const files = result.getDistFiles();
+      const emittedInlineWorkerFiles = Object.keys(files).filter((filename) =>
+        /inline-worker\.[\w-]+\.js$/.test(filename),
+      );
+
+      expect(emittedInlineWorkerFiles).toEqual([]);
+      expect(Object.values(files).join('\n')).toContain(
+        'rsbuild-inline-worker-marker',
+      );
+    }
+  });
+});

--- a/e2e/cases/workers/worker-query-inline/src/index.ts
+++ b/e2e/cases/workers/worker-query-inline/src/index.ts
@@ -1,0 +1,49 @@
+import InlineWorker from './inline-worker?worker&inline';
+import InlineWorkerReordered from './inline-worker?inline&worker';
+
+document.body.innerHTML = `
+  <div id="inline-worker"></div>
+  <div id="inline-worker-reordered"></div>
+  <div id="inline-worker-unicode"></div>
+`;
+
+const setText = (selector: string, text: string) => {
+  const element = document.querySelector(selector);
+  if (element) {
+    element.textContent = text;
+  }
+};
+
+const runWorker = (
+  worker: Worker,
+  message: unknown,
+  selector: string,
+  format: (data: Record<string, string>) => string,
+) => {
+  worker.addEventListener('message', ({ data }) => {
+    setText(selector, format(data));
+    worker.terminate();
+  });
+  worker.postMessage(message);
+};
+
+runWorker(
+  new InlineWorker({ name: 'named-inline-worker' }),
+  'named-inline-worker',
+  '#inline-worker',
+  (data) => `${data.text} ${data.name} ${data.marker}`,
+);
+
+runWorker(
+  new InlineWorkerReordered(),
+  'inline-worker-reordered',
+  '#inline-worker-reordered',
+  (data) => data.text,
+);
+
+runWorker(
+  new InlineWorker(),
+  'unicode',
+  '#inline-worker-unicode',
+  (data) => data.text,
+);

--- a/e2e/cases/workers/worker-query-inline/src/inline-worker.ts
+++ b/e2e/cases/workers/worker-query-inline/src/inline-worker.ts
@@ -1,0 +1,11 @@
+import { formatMessage } from './message';
+
+const marker = 'rsbuild-inline-worker-marker';
+
+self.onmessage = ({ data }) => {
+  self.postMessage({
+    marker,
+    name: self.name,
+    text: data === 'unicode' ? '\u2022pong\u2022' : formatMessage(data),
+  });
+};

--- a/e2e/cases/workers/worker-query-inline/src/message.ts
+++ b/e2e/cases/workers/worker-query-inline/src/message.ts
@@ -1,0 +1,3 @@
+export const answer = 42;
+
+export const formatMessage = (name: string): string => `${name}: ${answer}`;

--- a/e2e/cases/workers/worker-query-module/index.test.ts
+++ b/e2e/cases/workers/worker-query-module/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
 test('should support worker query imports with output.module enabled', async ({
   page,
@@ -14,9 +14,7 @@ test('should support worker query imports with output.module enabled', async ({
 
     if (mode === 'build') {
       const files = result.getDistFiles();
-      const html = getFileContent(files, 'index.html');
 
-      expect(html).toContain('type="module"');
       expect(Object.values(files).join('\n')).toContain('type:"module"');
     }
   });

--- a/e2e/cases/workers/worker-query-module/index.test.ts
+++ b/e2e/cases/workers/worker-query-module/index.test.ts
@@ -1,0 +1,23 @@
+import { expect, getFileContent, test } from '@e2e/helper';
+
+test('should support worker query imports with output.module enabled', async ({
+  page,
+  runBothServe,
+}) => {
+  await runBothServe(async ({ mode, result }) => {
+    await expect(page.locator('#module-worker')).toHaveText(
+      'module-worker: module message',
+    );
+    await expect(page.locator('#module-inline-worker')).toHaveText(
+      'inline-module-worker: inline module message',
+    );
+
+    if (mode === 'build') {
+      const files = result.getDistFiles();
+      const html = getFileContent(files, 'index.html');
+
+      expect(html).toContain('type="module"');
+      expect(Object.values(files).join('\n')).toContain('type:"module"');
+    }
+  });
+});

--- a/e2e/cases/workers/worker-query-module/rsbuild.config.ts
+++ b/e2e/cases/workers/worker-query-module/rsbuild.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    module: true,
+  },
+});

--- a/e2e/cases/workers/worker-query-module/src/index.ts
+++ b/e2e/cases/workers/worker-query-module/src/index.ts
@@ -1,0 +1,32 @@
+import InlineModuleWorker from './inline-module-worker?worker&inline';
+import ModuleWorker from './module-worker?worker';
+
+document.body.innerHTML = `
+  <div id="module-worker"></div>
+  <div id="module-inline-worker"></div>
+`;
+
+const setText = (selector: string, text: string) => {
+  const element = document.querySelector(selector);
+  if (element) {
+    element.textContent = text;
+  }
+};
+
+const moduleWorker = new ModuleWorker({ name: 'module-worker' });
+
+moduleWorker.addEventListener('message', ({ data }) => {
+  setText('#module-worker', data.text);
+  moduleWorker.terminate();
+});
+moduleWorker.postMessage('module message');
+
+const inlineModuleWorker = new InlineModuleWorker({
+  name: 'inline-module-worker',
+});
+
+inlineModuleWorker.addEventListener('message', ({ data }) => {
+  setText('#module-inline-worker', data.text);
+  inlineModuleWorker.terminate();
+});
+inlineModuleWorker.postMessage('inline module message');

--- a/e2e/cases/workers/worker-query-module/src/inline-module-worker.ts
+++ b/e2e/cases/workers/worker-query-module/src/inline-module-worker.ts
@@ -1,0 +1,7 @@
+import { formatMessage } from './message';
+
+self.onmessage = ({ data }) => {
+  self.postMessage({
+    text: formatMessage(self.name, data),
+  });
+};

--- a/e2e/cases/workers/worker-query-module/src/message.ts
+++ b/e2e/cases/workers/worker-query-module/src/message.ts
@@ -1,0 +1,2 @@
+export const formatMessage = (name: string, message: string): string =>
+  `${name}: ${message}`;

--- a/e2e/cases/workers/worker-query-module/src/module-worker.ts
+++ b/e2e/cases/workers/worker-query-module/src/module-worker.ts
@@ -1,0 +1,7 @@
+import { formatMessage } from './message';
+
+self.onmessage = ({ data }) => {
+  self.postMessage({
+    text: formatMessage(self.name, data),
+  });
+};

--- a/e2e/cases/workers/worker-query-nested/index.test.ts
+++ b/e2e/cases/workers/worker-query-nested/index.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '@e2e/helper';
+
+test('should support worker query imports inside workers', async ({
+  page,
+  runBothServe,
+}) => {
+  await runBothServe(async () => {
+    await expect(page.locator('#nested-worker')).toHaveText(
+      /nested-worker http/,
+    );
+    await expect(page.locator('#nested-sub-worker')).toHaveText(
+      'sub-worker:nested-sub-worker',
+    );
+    await expect(page.locator('#nested-constructor-worker')).toHaveText(
+      'constructor-worker',
+    );
+  });
+});

--- a/e2e/cases/workers/worker-query-nested/src/index.ts
+++ b/e2e/cases/workers/worker-query-nested/src/index.ts
@@ -1,0 +1,28 @@
+import NestedWorker from './nested-worker?worker';
+
+document.body.innerHTML = `
+  <div id="nested-worker"></div>
+  <div id="nested-sub-worker"></div>
+  <div id="nested-constructor-worker"></div>
+`;
+
+const setText = (selector: string, text: string) => {
+  const element = document.querySelector(selector);
+  if (element) {
+    element.textContent = text;
+  }
+};
+
+const worker = new NestedWorker();
+
+worker.addEventListener('message', ({ data }) => {
+  if (data.type === 'nested-worker') {
+    setText('#nested-worker', `${data.text} ${data.href}`);
+  } else if (data.type === 'sub-worker') {
+    setText('#nested-sub-worker', data.text);
+  } else if (data.type === 'constructor-worker') {
+    setText('#nested-constructor-worker', data.text);
+  }
+});
+
+worker.postMessage('ping');

--- a/e2e/cases/workers/worker-query-nested/src/nested-worker.ts
+++ b/e2e/cases/workers/worker-query-nested/src/nested-worker.ts
@@ -1,0 +1,30 @@
+import SubWorker from './sub-worker?worker';
+
+const subWorker = new SubWorker({ name: 'nested-sub-worker' });
+const constructorWorker = new Worker(
+  new URL('./url-worker.ts', import.meta.url),
+  {
+    name: 'constructor-worker',
+    type: 'module',
+  },
+);
+
+self.postMessage({
+  href: self.location.href,
+  text: 'nested-worker',
+  type: 'nested-worker',
+});
+
+self.onmessage = ({ data }) => {
+  if (data === 'ping') {
+    subWorker.postMessage('ping');
+  }
+};
+
+subWorker.addEventListener('message', ({ data }) => {
+  self.postMessage(data);
+});
+
+constructorWorker.addEventListener('message', ({ data }) => {
+  self.postMessage(data);
+});

--- a/e2e/cases/workers/worker-query-nested/src/sub-worker.ts
+++ b/e2e/cases/workers/worker-query-nested/src/sub-worker.ts
@@ -1,0 +1,8 @@
+self.onmessage = ({ data }) => {
+  if (data === 'ping') {
+    self.postMessage({
+      text: `sub-worker:${self.name || 'anonymous'}`,
+      type: 'sub-worker',
+    });
+  }
+};

--- a/e2e/cases/workers/worker-query-nested/src/url-worker.ts
+++ b/e2e/cases/workers/worker-query-nested/src/url-worker.ts
@@ -1,0 +1,4 @@
+self.postMessage({
+  text: self.name || 'constructor-worker',
+  type: 'constructor-worker',
+});

--- a/e2e/cases/workers/worker-query-self-reference/index.test.ts
+++ b/e2e/cases/workers/worker-query-self-reference/index.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@e2e/helper';
+
+test('should support self reference worker query imports', async ({
+  page,
+  runBothServe,
+}) => {
+  await runBothServe(async () => {
+    await expect(page.locator('#self-reference-worker')).toContainText(
+      'pong: main',
+    );
+    await expect(page.locator('#self-reference-worker')).toContainText(
+      'pong: nested',
+    );
+  });
+});

--- a/e2e/cases/workers/worker-query-self-reference/src/index.ts
+++ b/e2e/cases/workers/worker-query-self-reference/src/index.ts
@@ -1,0 +1,14 @@
+import SelfReferenceWorker from './self-reference-worker?worker';
+
+document.body.innerHTML = '<div id="self-reference-worker"></div>';
+
+const worker = new SelfReferenceWorker();
+
+worker.addEventListener('message', ({ data }) => {
+  const element = document.querySelector('#self-reference-worker');
+  if (element) {
+    element.textContent += `${data}\n`;
+  }
+});
+
+worker.postMessage('main');

--- a/e2e/cases/workers/worker-query-self-reference/src/self-reference-worker.ts
+++ b/e2e/cases/workers/worker-query-self-reference/src/self-reference-worker.ts
@@ -1,0 +1,15 @@
+import SelfWorker from './self-reference-worker?worker';
+
+self.addEventListener('message', ({ data }) => {
+  if (data === 'main') {
+    const nestedWorker = new SelfWorker();
+
+    nestedWorker.addEventListener('message', (event) => {
+      self.postMessage(event.data);
+      nestedWorker.terminate();
+    });
+    nestedWorker.postMessage('nested');
+  }
+
+  self.postMessage(`pong: ${data}`);
+});

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -176,6 +176,7 @@ export default defineConfig({
           ignoreCssLoader: './src/loader/ignoreCssLoader.ts',
           transformLoader: './src/loader/transformLoader.ts',
           transformRawLoader: './src/loader/transformRawLoader.ts',
+          workerQueryLoader: './src/loader/workerQueryLoader.ts',
         },
       },
       dts: {

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -176,7 +176,7 @@ export default defineConfig({
           ignoreCssLoader: './src/loader/ignoreCssLoader.ts',
           transformLoader: './src/loader/transformLoader.ts',
           transformRawLoader: './src/loader/transformRawLoader.ts',
-          workerQueryLoader: './src/loader/workerQueryLoader.ts',
+          workerLoader: './src/loader/workerLoader.ts',
         },
       },
       dts: {

--- a/packages/core/src/configChain.ts
+++ b/packages/core/src/configChain.ts
@@ -66,6 +66,7 @@ export const CHAIN_ID = {
   ONE_OF: {
     /** JS oneOf rules */
     JS_MAIN: 'js',
+    JS_WORKER: 'js-worker',
     JS_RAW: 'js-raw',
     /** CSS oneOf rules */
     CSS_MAIN: 'css',
@@ -100,6 +101,8 @@ export const CHAIN_ID = {
     VUE: 'vue',
     /** swc-loader */
     SWC: 'swc',
+    /** worker query loader */
+    WORKER_QUERY: 'worker-query',
     /** svgr */
     SVGR: 'svgr',
     /** babel-loader */

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -69,6 +69,11 @@ export const INLINE_QUERY_REGEX: RegExp = /[?&]inline(?:&|=|$)/;
  * Matches patterns like: `?url`, `?url&other=value`, `?other=value&url`, `?url=value`
  */
 export const URL_QUERY_REGEX: RegExp = /[?&]url(?:&|=|$)/;
+/**
+ * Regular expression to match the 'worker' query parameter.
+ * Matches patterns like: `?worker`, `?worker&inline`, `?inline&worker`, `?worker=value`
+ */
+export const WORKER_QUERY_REGEX: RegExp = /[?&]worker(?:&|=|$)/;
 export const NODE_MODULES_REGEX: RegExp = /[\\/]node_modules[\\/]/;
 
 // Plugins

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -52,6 +52,7 @@ import { pluginSri } from './plugins/sri';
 import { pluginSwc } from './plugins/swc';
 import { pluginTarget } from './plugins/target';
 import { pluginWasm } from './plugins/wasm';
+import { pluginWorker } from './plugins/worker';
 import { createDevServer as baseCreateDevServer } from './server/devServer';
 import { startPreviewServer } from './server/previewServer';
 import type {
@@ -98,6 +99,7 @@ function applyDefaultPlugins(
     pluginCss(),
     pluginMinimize(),
     pluginProgress(),
+    pluginWorker(),
     pluginSwc(),
     pluginExternals(),
     pluginSplitChunks(),

--- a/packages/core/src/loader/workerLoader.ts
+++ b/packages/core/src/loader/workerLoader.ts
@@ -142,7 +142,7 @@ const compileInlineWorker = (
       workerChunkLoading: outputOptions.workerChunkLoading,
       wasmLoading: outputOptions.wasmLoading,
       workerWasmLoading: outputOptions.workerWasmLoading,
-    } as Compilation['outputOptions'],
+    },
     [],
   );
 

--- a/packages/core/src/loader/workerLoader.ts
+++ b/packages/core/src/loader/workerLoader.ts
@@ -123,10 +123,10 @@ const getCompilerPlugin = <T>(getPlugin: () => T): T => {
 const compileInlineWorker = (
   loaderContext: LoaderContext<WorkerLoaderOptions>,
 ): Promise<string> => {
-  const callbackCompiler = loaderContext._compiler;
+  const compiler = loaderContext._compiler;
   const compilation = loaderContext._compilation;
-  const rspack = callbackCompiler.webpack;
-  const outputOptions = compilation.outputOptions;
+  const { rspack } = compiler;
+  const { outputOptions } = compilation;
   const compilerName = `rsbuild-worker ${loaderContext.resourcePath}`;
 
   const childCompiler = compilation.createChildCompiler(

--- a/packages/core/src/loader/workerLoader.ts
+++ b/packages/core/src/loader/workerLoader.ts
@@ -12,7 +12,7 @@ const HASH_PLACEHOLDER_REGEX =
 const SOURCE_MAPPING_URL_REGEX =
   /(?:\/\*# sourceMappingURL=.*?\*\/|\/\/# sourceMappingURL=.*)$/gm;
 
-type WorkerQueryLoaderOptions = {
+type WorkerLoaderOptions = {
   name?: string;
 };
 
@@ -121,7 +121,7 @@ const getCompilerPlugin = <T>(getPlugin: () => T): T => {
 };
 
 const compileInlineWorker = (
-  loaderContext: LoaderContext<WorkerQueryLoaderOptions>,
+  loaderContext: LoaderContext<WorkerLoaderOptions>,
 ): Promise<string> => {
   const callbackCompiler = loaderContext._compiler;
   const compilation = loaderContext._compilation;
@@ -229,8 +229,8 @@ const compileInlineWorker = (
   });
 };
 
-const workerQueryLoader: LoaderDefinition<WorkerQueryLoaderOptions> =
-  async function workerQueryLoader(): Promise<void> {
+const workerLoader: LoaderDefinition<WorkerLoaderOptions> =
+  async function workerLoader(): Promise<void> {
     const callback = this.async();
     const isModule = Boolean(this._compilation.outputOptions.module);
 
@@ -250,4 +250,4 @@ const workerQueryLoader: LoaderDefinition<WorkerQueryLoaderOptions> =
     }
   };
 
-export default workerQueryLoader;
+export default workerLoader;

--- a/packages/core/src/loader/workerLoader.ts
+++ b/packages/core/src/loader/workerLoader.ts
@@ -121,13 +121,13 @@ const getCompilerPlugin = <T>(getPlugin: () => T): T => {
 };
 
 const compileInlineWorker = (
-  loaderContext: LoaderContext<WorkerLoaderOptions>,
+  context: LoaderContext<WorkerLoaderOptions>,
 ): Promise<string> => {
-  const compiler = loaderContext._compiler;
-  const compilation = loaderContext._compilation;
+  const compiler = context._compiler;
+  const compilation = context._compilation;
   const { rspack } = compiler;
   const { outputOptions } = compilation;
-  const compilerName = `rsbuild-worker ${loaderContext.resourcePath}`;
+  const compilerName = `rsbuild-worker ${context.resourcePath}`;
 
   const childCompiler = compilation.createChildCompiler(
     compilerName,
@@ -153,9 +153,9 @@ const compileInlineWorker = (
   new rspack.LoaderTargetPlugin('webworker').apply(childCompiler);
 
   new rspack.EntryPlugin(
-    loaderContext.context ?? path.dirname(loaderContext.resourcePath),
-    loaderContext.resourcePath,
-    path.parse(loaderContext.resourcePath).name,
+    context.context ?? path.dirname(context.resourcePath),
+    context.resourcePath,
+    path.parse(context.resourcePath).name,
   ).apply(childCompiler);
 
   return new Promise((resolve, reject) => {
@@ -169,7 +169,7 @@ const compileInlineWorker = (
       if (!entry || !childCompilation) {
         reject(
           new Error(
-            `[rsbuild:worker] Failed to compile inline worker "${loaderContext.resourcePath}".`,
+            `[rsbuild:worker] Failed to compile inline worker "${context.resourcePath}".`,
           ),
         );
         return;
@@ -182,7 +182,7 @@ const compileInlineWorker = (
       if (!workerFilename) {
         reject(
           new Error(
-            `[rsbuild:worker] Failed to find the inline worker output for "${loaderContext.resourcePath}".`,
+            `[rsbuild:worker] Failed to find the inline worker output for "${context.resourcePath}".`,
           ),
         );
         return;
@@ -195,7 +195,7 @@ const compileInlineWorker = (
       if (extraJsFiles.length > 0) {
         reject(
           new Error(
-            `[rsbuild:worker] Inline workers do not support code splitting yet. Use ?worker instead, or remove dynamic imports from "${loaderContext.resourcePath}".`,
+            `[rsbuild:worker] Inline workers do not support code splitting yet. Use ?worker instead, or remove dynamic imports from "${context.resourcePath}".`,
           ),
         );
         return;
@@ -215,13 +215,13 @@ const compileInlineWorker = (
       deleteAsset(compilation, `${workerFilename}.map`);
 
       for (const file of childCompilation.fileDependencies) {
-        loaderContext.addDependency(file);
+        context.addDependency(file);
       }
-      for (const context of childCompilation.contextDependencies) {
-        loaderContext.addContextDependency(context);
+      for (const dir of childCompilation.contextDependencies) {
+        context.addContextDependency(dir);
       }
       for (const missing of childCompilation.missingDependencies) {
-        loaderContext.addMissingDependency(missing);
+        context.addMissingDependency(missing);
       }
 
       resolve(asset.source.source().toString());

--- a/packages/core/src/loader/workerQueryLoader.ts
+++ b/packages/core/src/loader/workerQueryLoader.ts
@@ -1,0 +1,253 @@
+import path from 'node:path';
+import type {
+  Compilation,
+  LoaderContext,
+  LoaderDefinition,
+} from '@rspack/core';
+
+const INLINE_QUERY_REGEX = /[?&]inline(?:&|=|$)/;
+const JS_FILE_REGEX = /\.m?js(?:\?.*)?$/;
+const HASH_PLACEHOLDER_REGEX =
+  /\[(?:[^:\]]+:)?(?:chunkhash|contenthash|hash|fullhash)(?::[^\]]+)?]/i;
+const SOURCE_MAPPING_URL_REGEX =
+  /(?:\/\*# sourceMappingURL=.*?\*\/|\/\/# sourceMappingURL=.*)$/gm;
+
+type WorkerQueryLoaderOptions = {
+  name?: string;
+};
+
+const normalizePath = (value: string) => value.replace(/\\/g, '/');
+
+const toWorkerRequest = (resourcePath: string) =>
+  `./${normalizePath(path.basename(resourcePath))}`;
+
+const getWorkerOptionsCode = (isModule: boolean) => `{
+  ${isModule ? 'type: "module",' : ''}
+  name: options && options.name
+}`;
+
+const getWorkerWrapper = ({
+  resourcePath,
+  isModule,
+}: {
+  resourcePath: string;
+  isModule: boolean;
+}) => {
+  const workerRequest = toWorkerRequest(resourcePath);
+  const workerOptions = getWorkerOptionsCode(isModule);
+
+  return `export default function WorkerWrapper(options) {
+  return new Worker(new URL(${JSON.stringify(workerRequest)}, import.meta.url), ${workerOptions});
+}`;
+};
+
+const stripSourceMappingURL = (source: string) =>
+  source.replace(SOURCE_MAPPING_URL_REGEX, '');
+
+const getInlineWorkerWrapper = ({
+  source,
+  isModule,
+}: {
+  source: string;
+  isModule: boolean;
+}) => {
+  const workerOptions = getWorkerOptionsCode(isModule);
+  const revokeCode = isModule
+    ? 'URL.revokeObjectURL(import.meta.url);'
+    : '(self.URL || self.webkitURL).revokeObjectURL(self.location.href);';
+
+  return `const jsContent = ${JSON.stringify(stripSourceMappingURL(source))};
+const blob = typeof self !== "undefined" && self.Blob && new Blob([${JSON.stringify(
+    revokeCode,
+  )}, jsContent], { type: "text/javascript;charset=utf-8" });
+
+export default function WorkerWrapper(options) {
+  let objURL;
+  try {
+    objURL = blob && (self.URL || self.webkitURL).createObjectURL(blob);
+    if (!objURL) throw "";
+    const worker = new Worker(objURL, ${workerOptions});
+    worker.addEventListener("error", () => {
+      (self.URL || self.webkitURL).revokeObjectURL(objURL);
+    });
+    return worker;
+  } catch {
+    return new Worker(
+      "data:text/javascript;charset=utf-8," + encodeURIComponent(jsContent),
+      ${workerOptions}
+    );
+  }
+}`;
+};
+
+const getChildFilename = (
+  filename: Compilation['outputOptions']['filename'],
+): string => {
+  if (typeof filename !== 'string') {
+    return 'static/js/[name].worker.js';
+  }
+
+  return HASH_PLACEHOLDER_REGEX.test(filename)
+    ? filename
+    : filename.replace(/\.js(?:\?.*)?$/i, '.worker.js');
+};
+
+const getChildChunkFilename = (
+  chunkFilename: Compilation['outputOptions']['chunkFilename'],
+): string => {
+  if (typeof chunkFilename !== 'string') {
+    return 'static/js/async/[name].worker.js';
+  }
+
+  return HASH_PLACEHOLDER_REGEX.test(chunkFilename)
+    ? chunkFilename
+    : chunkFilename.replace(/\.js(?:\?.*)?$/i, '.worker.js');
+};
+
+const deleteAsset = (compilation: Compilation, filename: string) => {
+  if (compilation.getAsset(filename)) {
+    compilation.deleteAsset(filename);
+  }
+};
+
+const getCompilerPlugin = <T>(getPlugin: () => T): T => {
+  const plugin = getPlugin();
+  if (!plugin) {
+    throw new Error(
+      '[rsbuild:worker] The current Rspack version does not support inline worker compilation.',
+    );
+  }
+  return plugin;
+};
+
+const compileInlineWorker = (
+  loaderContext: LoaderContext<WorkerQueryLoaderOptions>,
+): Promise<string> => {
+  const callbackCompiler = loaderContext._compiler;
+  const compilation = loaderContext._compilation;
+  const rspack = callbackCompiler.webpack;
+  const outputOptions = compilation.outputOptions;
+  const compilerName = `rsbuild-worker ${loaderContext.resourcePath}`;
+
+  const childCompiler = compilation.createChildCompiler(
+    compilerName,
+    {
+      filename: getChildFilename(outputOptions.filename),
+      chunkFilename: getChildChunkFilename(outputOptions.chunkFilename),
+      publicPath: outputOptions.publicPath,
+      globalObject: 'self',
+      module: outputOptions.module,
+      chunkFormat: outputOptions.module ? 'module' : undefined,
+      chunkLoading: outputOptions.module ? 'import' : undefined,
+      workerChunkLoading: outputOptions.workerChunkLoading,
+      wasmLoading: outputOptions.wasmLoading,
+      workerWasmLoading: outputOptions.workerWasmLoading,
+    } as Compilation['outputOptions'],
+    [],
+  );
+
+  new (getCompilerPlugin(
+    () => rspack.webworker.WebWorkerTemplatePlugin,
+  ))().apply(childCompiler);
+
+  new rspack.LoaderTargetPlugin('webworker').apply(childCompiler);
+
+  new rspack.EntryPlugin(
+    loaderContext.context ?? path.dirname(loaderContext.resourcePath),
+    loaderContext.resourcePath,
+    path.parse(loaderContext.resourcePath).name,
+  ).apply(childCompiler);
+
+  return new Promise((resolve, reject) => {
+    childCompiler.runAsChild((error, entries, childCompilation) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      const entry = entries?.[0];
+      if (!entry || !childCompilation) {
+        reject(
+          new Error(
+            `[rsbuild:worker] Failed to compile inline worker "${loaderContext.resourcePath}".`,
+          ),
+        );
+        return;
+      }
+
+      const files = [...entry.files];
+      const jsFiles = files.filter((file) => JS_FILE_REGEX.test(file));
+      const workerFilename = jsFiles[0];
+
+      if (!workerFilename) {
+        reject(
+          new Error(
+            `[rsbuild:worker] Failed to find the inline worker output for "${loaderContext.resourcePath}".`,
+          ),
+        );
+        return;
+      }
+
+      const extraJsFiles = childCompilation
+        .getAssets()
+        .map((asset) => asset.name)
+        .filter((file) => file !== workerFilename && JS_FILE_REGEX.test(file));
+      if (extraJsFiles.length > 0) {
+        reject(
+          new Error(
+            `[rsbuild:worker] Inline workers do not support code splitting yet. Use ?worker instead, or remove dynamic imports from "${loaderContext.resourcePath}".`,
+          ),
+        );
+        return;
+      }
+
+      const asset = childCompilation.getAsset(workerFilename);
+      if (!asset) {
+        reject(
+          new Error(
+            `[rsbuild:worker] Failed to read the inline worker output "${workerFilename}".`,
+          ),
+        );
+        return;
+      }
+
+      deleteAsset(compilation, workerFilename);
+      deleteAsset(compilation, `${workerFilename}.map`);
+
+      for (const file of childCompilation.fileDependencies) {
+        loaderContext.addDependency(file);
+      }
+      for (const context of childCompilation.contextDependencies) {
+        loaderContext.addContextDependency(context);
+      }
+      for (const missing of childCompilation.missingDependencies) {
+        loaderContext.addMissingDependency(missing);
+      }
+
+      resolve(asset.source.source().toString());
+    });
+  });
+};
+
+const workerQueryLoader: LoaderDefinition<WorkerQueryLoaderOptions> =
+  async function workerQueryLoader(): Promise<void> {
+    const callback = this.async();
+    const isModule = Boolean(this._compilation.outputOptions.module);
+
+    try {
+      if (!INLINE_QUERY_REGEX.test(this.resourceQuery)) {
+        callback(
+          null,
+          getWorkerWrapper({ resourcePath: this.resourcePath, isModule }),
+        );
+        return;
+      }
+
+      const source = await compileInlineWorker(this);
+      callback(null, getInlineWorkerWrapper({ source, isModule }));
+    } catch (error) {
+      callback(error instanceof Error ? error : new Error(String(error)));
+    }
+  };
+
+export default workerQueryLoader;

--- a/packages/core/src/plugins/worker.ts
+++ b/packages/core/src/plugins/worker.ts
@@ -19,7 +19,7 @@ export const pluginWorker = (): RsbuildPlugin => ({
           .resourceQuery(WORKER_QUERY_REGEX)
           .type('javascript/auto')
           .use(CHAIN_ID.USE.WORKER_QUERY)
-          .loader(path.join(LOADER_PATH, 'workerQueryLoader.mjs'));
+          .loader(path.join(LOADER_PATH, 'workerLoader.mjs'));
       },
     });
   },

--- a/packages/core/src/plugins/worker.ts
+++ b/packages/core/src/plugins/worker.ts
@@ -1,0 +1,26 @@
+import path from 'node:path';
+import { LOADER_PATH, WORKER_QUERY_REGEX } from '../constants';
+import type { RsbuildPlugin } from '../types';
+
+export const pluginWorker = (): RsbuildPlugin => ({
+  name: 'rsbuild:worker',
+
+  setup(api) {
+    api.modifyBundlerChain({
+      order: 'pre',
+      handler: (chain, { CHAIN_ID, isServer }) => {
+        if (isServer) {
+          return;
+        }
+
+        chain.module
+          .rule(CHAIN_ID.RULE.JS)
+          .oneOf(CHAIN_ID.ONE_OF.JS_WORKER)
+          .resourceQuery(WORKER_QUERY_REGEX)
+          .type('javascript/auto')
+          .use(CHAIN_ID.USE.WORKER_QUERY)
+          .loader(path.join(LOADER_PATH, 'workerQueryLoader.mjs'));
+      },
+    });
+  },
+});

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -164,6 +164,15 @@ exports[`default bundler > should use Rspack by default 1`] = `
         ],
         "oneOf": [
           {
+            "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+            "type": "javascript/auto",
+            "use": [
+              {
+                "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+              },
+            ],
+          },
+          {
             "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/source",
           },

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -168,7 +168,7 @@ exports[`default bundler > should use Rspack by default 1`] = `
             "type": "javascript/auto",
             "use": [
               {
-                "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+                "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
               },
             ],
           },

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -191,7 +191,7 @@ exports[`should apply default plugins correctly 1`] = `
             "type": "javascript/auto",
             "use": [
               {
-                "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+                "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
               },
             ],
           },
@@ -675,7 +675,7 @@ exports[`should apply default plugins correctly in production 1`] = `
             "type": "javascript/auto",
             "use": [
               {
-                "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+                "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
               },
             ],
           },
@@ -1649,7 +1649,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "type": "javascript/auto",
             "use": [
               {
-                "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+                "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
               },
             ],
           },

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -187,6 +187,15 @@ exports[`should apply default plugins correctly 1`] = `
         ],
         "oneOf": [
           {
+            "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+            "type": "javascript/auto",
+            "use": [
+              {
+                "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+              },
+            ],
+          },
+          {
             "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/source",
           },
@@ -661,6 +670,15 @@ exports[`should apply default plugins correctly in production 1`] = `
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         ],
         "oneOf": [
+          {
+            "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+            "type": "javascript/auto",
+            "use": [
+              {
+                "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+              },
+            ],
+          },
           {
             "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/source",
@@ -1626,6 +1644,15 @@ exports[`tools.rspack > should match snapshot 1`] = `
           /\\[\\\\\\\\/\\]@rsbuild\\[\\\\\\\\/\\]core\\[\\\\\\\\/\\]dist\\[\\\\\\\\/\\]/,
         ],
         "oneOf": [
+          {
+            "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+            "type": "javascript/auto",
+            "use": [
+              {
+                "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+              },
+            ],
+          },
           {
             "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/source",

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -160,6 +160,15 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
           ],
           "oneOf": [
             {
+              "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+              "type": "javascript/auto",
+              "use": [
+                {
+                  "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+                },
+              ],
+            },
+            {
               "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
               "type": "asset/source",
             },

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -164,7 +164,7 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
               "type": "javascript/auto",
               "use": [
                 {
-                  "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+                  "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
                 },
               ],
             },

--- a/packages/core/tests/__snapshots__/swc.test.ts.snap
+++ b/packages/core/tests/__snapshots__/swc.test.ts.snap
@@ -20,6 +20,15 @@ exports[`plugin-swc > should allow \`tools.swc\` to be a function 1`] = `
     ],
     "oneOf": [
       {
+        "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+        "type": "javascript/auto",
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+          },
+        ],
+      },
+      {
         "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
         "type": "asset/source",
       },
@@ -61,6 +70,15 @@ exports[`plugin-swc > should allow using \`tools.swc\` to configure swc-loader o
       /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
     ],
     "oneOf": [
+      {
+        "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+        "type": "javascript/auto",
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+          },
+        ],
+      },
       {
         "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
         "type": "asset/source",
@@ -132,6 +150,15 @@ exports[`plugin-swc > should apply decorators version 2023-11 1`] = `
         /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
       ],
       "oneOf": [
+        {
+          "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+          "type": "javascript/auto",
+          "use": [
+            {
+              "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+            },
+          ],
+        },
         {
           "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
           "type": "asset/source",
@@ -206,6 +233,15 @@ exports[`plugin-swc > should apply environment config correctly 1`] = `
       /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
     ],
     "oneOf": [
+      {
+        "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+        "type": "javascript/auto",
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+          },
+        ],
+      },
       {
         "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
         "type": "asset/source",
@@ -366,6 +402,15 @@ exports[`plugin-swc > should apply overrideBrowserslist 1`] = `
       ],
       "oneOf": [
         {
+          "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+          "type": "javascript/auto",
+          "use": [
+            {
+              "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+            },
+          ],
+        },
+        {
           "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
           "type": "asset/source",
         },
@@ -434,6 +479,15 @@ exports[`plugin-swc > should apply pluginImport 1`] = `
         /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
       ],
       "oneOf": [
+        {
+          "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+          "type": "javascript/auto",
+          "use": [
+            {
+              "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+            },
+          ],
+        },
         {
           "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
           "type": "asset/source",
@@ -511,6 +565,15 @@ exports[`plugin-swc > should apply pluginImport correctly with ConfigChain 1`] =
         /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
       ],
       "oneOf": [
+        {
+          "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+          "type": "javascript/auto",
+          "use": [
+            {
+              "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+            },
+          ],
+        },
         {
           "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
           "type": "asset/source",
@@ -591,6 +654,15 @@ exports[`plugin-swc > should disable pluginImport when it returns undefined 1`] 
         /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
       ],
       "oneOf": [
+        {
+          "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+          "type": "javascript/auto",
+          "use": [
+            {
+              "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+            },
+          ],
+        },
         {
           "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
           "type": "asset/source",
@@ -733,6 +805,15 @@ exports[`plugin-swc > should disable preset-env mode 1`] = `
       ],
       "oneOf": [
         {
+          "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+          "type": "javascript/auto",
+          "use": [
+            {
+              "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+            },
+          ],
+        },
+        {
           "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
           "type": "asset/source",
         },
@@ -804,6 +885,15 @@ exports[`plugin-swc > should enable preset-env in entry mode 1`] = `
         /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
       ],
       "oneOf": [
+        {
+          "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+          "type": "javascript/auto",
+          "use": [
+            {
+              "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+            },
+          ],
+        },
         {
           "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
           "type": "asset/source",
@@ -884,6 +974,15 @@ exports[`plugin-swc > should enable preset-env in usage mode 1`] = `
       ],
       "oneOf": [
         {
+          "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+          "type": "javascript/auto",
+          "use": [
+            {
+              "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+            },
+          ],
+        },
+        {
           "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
           "type": "asset/source",
         },
@@ -963,6 +1062,15 @@ exports[`plugin-swc > should use the correct core-js version 1`] = `
         /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
       ],
       "oneOf": [
+        {
+          "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+          "type": "javascript/auto",
+          "use": [
+            {
+              "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+            },
+          ],
+        },
         {
           "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
           "type": "asset/source",

--- a/packages/core/tests/__snapshots__/swc.test.ts.snap
+++ b/packages/core/tests/__snapshots__/swc.test.ts.snap
@@ -24,7 +24,7 @@ exports[`plugin-swc > should allow \`tools.swc\` to be a function 1`] = `
         "type": "javascript/auto",
         "use": [
           {
-            "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+            "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
           },
         ],
       },
@@ -75,7 +75,7 @@ exports[`plugin-swc > should allow using \`tools.swc\` to configure swc-loader o
         "type": "javascript/auto",
         "use": [
           {
-            "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+            "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
           },
         ],
       },
@@ -155,7 +155,7 @@ exports[`plugin-swc > should apply decorators version 2023-11 1`] = `
           "type": "javascript/auto",
           "use": [
             {
-              "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+              "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
             },
           ],
         },
@@ -238,7 +238,7 @@ exports[`plugin-swc > should apply environment config correctly 1`] = `
         "type": "javascript/auto",
         "use": [
           {
-            "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+            "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
           },
         ],
       },
@@ -406,7 +406,7 @@ exports[`plugin-swc > should apply overrideBrowserslist 1`] = `
           "type": "javascript/auto",
           "use": [
             {
-              "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+              "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
             },
           ],
         },
@@ -484,7 +484,7 @@ exports[`plugin-swc > should apply pluginImport 1`] = `
           "type": "javascript/auto",
           "use": [
             {
-              "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+              "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
             },
           ],
         },
@@ -570,7 +570,7 @@ exports[`plugin-swc > should apply pluginImport correctly with ConfigChain 1`] =
           "type": "javascript/auto",
           "use": [
             {
-              "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+              "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
             },
           ],
         },
@@ -659,7 +659,7 @@ exports[`plugin-swc > should disable pluginImport when it returns undefined 1`] 
           "type": "javascript/auto",
           "use": [
             {
-              "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+              "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
             },
           ],
         },
@@ -809,7 +809,7 @@ exports[`plugin-swc > should disable preset-env mode 1`] = `
           "type": "javascript/auto",
           "use": [
             {
-              "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+              "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
             },
           ],
         },
@@ -890,7 +890,7 @@ exports[`plugin-swc > should enable preset-env in entry mode 1`] = `
           "type": "javascript/auto",
           "use": [
             {
-              "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+              "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
             },
           ],
         },
@@ -978,7 +978,7 @@ exports[`plugin-swc > should enable preset-env in usage mode 1`] = `
           "type": "javascript/auto",
           "use": [
             {
-              "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+              "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
             },
           ],
         },
@@ -1067,7 +1067,7 @@ exports[`plugin-swc > should use the correct core-js version 1`] = `
           "type": "javascript/auto",
           "use": [
             {
-              "loader": "<ROOT>/packages/core/src/workerQueryLoader.mjs",
+              "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
             },
           ],
         },

--- a/packages/core/types.d.ts
+++ b/packages/core/types.d.ts
@@ -253,6 +253,39 @@ declare module '*?url' {
 }
 
 /**
+ * Imports the file as a Web Worker constructor.
+ * @example
+ * import MyWorker from './worker.ts?worker';
+ * const worker = new MyWorker();
+ */
+declare module '*?worker' {
+  const WorkerConstructor: {
+    new (options?: { name?: string }): Worker;
+  };
+  export default WorkerConstructor;
+}
+
+/**
+ * Imports the file as an inline Web Worker constructor.
+ * @example
+ * import MyWorker from './worker.ts?worker&inline';
+ * const worker = new MyWorker();
+ */
+declare module '*?worker&inline' {
+  const WorkerConstructor: {
+    new (options?: { name?: string }): Worker;
+  };
+  export default WorkerConstructor;
+}
+
+declare module '*?inline&worker' {
+  const WorkerConstructor: {
+    new (options?: { name?: string }): Worker;
+  };
+  export default WorkerConstructor;
+}
+
+/**
  * Imports the file content as a base64 encoded string.
  * @note Only works for static assets and CSS files by default.
  * @example

--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -21,7 +21,7 @@ exports[`plugins/babel > babel-loader should works with builtin:swc-loader 1`] =
       "type": "javascript/auto",
       "use": [
         {
-          "loader": "<ROOT>/packages/core/dist/workerQueryLoader.mjs",
+          "loader": "<ROOT>/packages/core/dist/workerLoader.mjs",
         },
       ],
     },
@@ -210,7 +210,7 @@ exports[`plugins/babel > should apply decorators version 2023-11 correctly 1`] =
       "type": "javascript/auto",
       "use": [
         {
-          "loader": "<ROOT>/packages/core/dist/workerQueryLoader.mjs",
+          "loader": "<ROOT>/packages/core/dist/workerLoader.mjs",
         },
       ],
     },
@@ -312,7 +312,7 @@ exports[`plugins/babel > should apply environment config correctly 1`] = `
       "type": "javascript/auto",
       "use": [
         {
-          "loader": "<ROOT>/packages/core/dist/workerQueryLoader.mjs",
+          "loader": "<ROOT>/packages/core/dist/workerLoader.mjs",
         },
       ],
     },
@@ -503,7 +503,7 @@ exports[`plugins/babel > should set babel-loader 1`] = `
       "type": "javascript/auto",
       "use": [
         {
-          "loader": "<ROOT>/packages/core/dist/workerQueryLoader.mjs",
+          "loader": "<ROOT>/packages/core/dist/workerLoader.mjs",
         },
       ],
     },
@@ -602,7 +602,7 @@ exports[`plugins/babel > should set babel-loader when config is add 1`] = `
       "type": "javascript/auto",
       "use": [
         {
-          "loader": "<ROOT>/packages/core/dist/workerQueryLoader.mjs",
+          "loader": "<ROOT>/packages/core/dist/workerLoader.mjs",
         },
       ],
     },

--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -17,6 +17,15 @@ exports[`plugins/babel > babel-loader should works with builtin:swc-loader 1`] =
   ],
   "oneOf": [
     {
+      "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "<ROOT>/packages/core/dist/workerQueryLoader.mjs",
+        },
+      ],
+    },
+    {
       "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
       "type": "asset/source",
     },
@@ -197,6 +206,15 @@ exports[`plugins/babel > should apply decorators version 2023-11 correctly 1`] =
   ],
   "oneOf": [
     {
+      "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "<ROOT>/packages/core/dist/workerQueryLoader.mjs",
+        },
+      ],
+    },
+    {
       "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
       "type": "asset/source",
     },
@@ -289,6 +307,15 @@ exports[`plugins/babel > should apply environment config correctly 1`] = `
     /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
   ],
   "oneOf": [
+    {
+      "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "<ROOT>/packages/core/dist/workerQueryLoader.mjs",
+        },
+      ],
+    },
     {
       "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
       "type": "asset/source",
@@ -472,6 +499,15 @@ exports[`plugins/babel > should set babel-loader 1`] = `
   ],
   "oneOf": [
     {
+      "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "<ROOT>/packages/core/dist/workerQueryLoader.mjs",
+        },
+      ],
+    },
+    {
       "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
       "type": "asset/source",
     },
@@ -561,6 +597,15 @@ exports[`plugins/babel > should set babel-loader when config is add 1`] = `
     /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
   ],
   "oneOf": [
+    {
+      "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "<ROOT>/packages/core/dist/workerQueryLoader.mjs",
+        },
+      ],
+    },
     {
       "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
       "type": "asset/source",

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -25,7 +25,7 @@ exports[`plugins/react > should configuring \`tools.swc\` to override react runt
         "type": "javascript/auto",
         "use": [
           {
-            "loader": "<ROOT>/packages/core/dist/workerQueryLoader.mjs",
+            "loader": "<ROOT>/packages/core/dist/workerLoader.mjs",
           },
         ],
       },
@@ -160,7 +160,7 @@ exports[`plugins/react > should work with swc-loader 1`] = `
         "type": "javascript/auto",
         "use": [
           {
-            "loader": "<ROOT>/packages/core/dist/workerQueryLoader.mjs",
+            "loader": "<ROOT>/packages/core/dist/workerLoader.mjs",
           },
         ],
       },

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -21,6 +21,15 @@ exports[`plugins/react > should configuring \`tools.swc\` to override react runt
     ],
     "oneOf": [
       {
+        "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+        "type": "javascript/auto",
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/dist/workerQueryLoader.mjs",
+          },
+        ],
+      },
+      {
         "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
         "type": "asset/source",
       },
@@ -146,6 +155,15 @@ exports[`plugins/react > should work with swc-loader 1`] = `
       /\\[\\\\\\\\/\\]@rsbuild\\[\\\\\\\\/\\]core\\[\\\\\\\\/\\]dist\\[\\\\\\\\/\\]/,
     ],
     "oneOf": [
+      {
+        "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+        "type": "javascript/auto",
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/dist/workerQueryLoader.mjs",
+          },
+        ],
+      },
       {
         "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
         "type": "asset/source",

--- a/packages/plugin-solid/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-solid/tests/__snapshots__/index.test.ts.snap
@@ -13,6 +13,15 @@ exports[`plugin-solid > should allow deprecated solidPresetOptions alias 1`] = `
   ],
   "oneOf": [
     {
+      "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "<ROOT>/packages/core/dist/workerQueryLoader.mjs",
+        },
+      ],
+    },
+    {
       "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
       "type": "asset/source",
     },
@@ -202,6 +211,15 @@ exports[`plugin-solid > should allow to configure solid options 1`] = `
   ],
   "oneOf": [
     {
+      "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "<ROOT>/packages/core/dist/workerQueryLoader.mjs",
+        },
+      ],
+    },
+    {
       "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
       "type": "asset/source",
     },
@@ -301,6 +319,15 @@ exports[`plugin-solid > should apply solid preset correctly 1`] = `
   ],
   "oneOf": [
     {
+      "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "<ROOT>/packages/core/dist/workerQueryLoader.mjs",
+        },
+      ],
+    },
+    {
       "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
       "type": "asset/source",
     },
@@ -396,6 +423,15 @@ exports[`plugin-solid > should use hydratable dom output for ssr option on web t
     /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
   ],
   "oneOf": [
+    {
+      "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "<ROOT>/packages/core/dist/workerQueryLoader.mjs",
+        },
+      ],
+    },
     {
       "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
       "type": "asset/source",

--- a/packages/plugin-solid/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-solid/tests/__snapshots__/index.test.ts.snap
@@ -17,7 +17,7 @@ exports[`plugin-solid > should allow deprecated solidPresetOptions alias 1`] = `
       "type": "javascript/auto",
       "use": [
         {
-          "loader": "<ROOT>/packages/core/dist/workerQueryLoader.mjs",
+          "loader": "<ROOT>/packages/core/dist/workerLoader.mjs",
         },
       ],
     },
@@ -215,7 +215,7 @@ exports[`plugin-solid > should allow to configure solid options 1`] = `
       "type": "javascript/auto",
       "use": [
         {
-          "loader": "<ROOT>/packages/core/dist/workerQueryLoader.mjs",
+          "loader": "<ROOT>/packages/core/dist/workerLoader.mjs",
         },
       ],
     },
@@ -323,7 +323,7 @@ exports[`plugin-solid > should apply solid preset correctly 1`] = `
       "type": "javascript/auto",
       "use": [
         {
-          "loader": "<ROOT>/packages/core/dist/workerQueryLoader.mjs",
+          "loader": "<ROOT>/packages/core/dist/workerLoader.mjs",
         },
       ],
     },
@@ -428,7 +428,7 @@ exports[`plugin-solid > should use hydratable dom output for ssr option on web t
       "type": "javascript/auto",
       "use": [
         {
-          "loader": "<ROOT>/packages/core/dist/workerQueryLoader.mjs",
+          "loader": "<ROOT>/packages/core/dist/workerLoader.mjs",
         },
       ],
     },

--- a/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
@@ -28,7 +28,7 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
         "type": "javascript/auto",
         "use": [
           {
-            "loader": "<ROOT>/packages/core/dist/workerQueryLoader.mjs",
+            "loader": "<ROOT>/packages/core/dist/workerLoader.mjs",
           },
         ],
       },
@@ -161,7 +161,7 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
         "type": "javascript/auto",
         "use": [
           {
-            "loader": "<ROOT>/packages/core/dist/workerQueryLoader.mjs",
+            "loader": "<ROOT>/packages/core/dist/workerLoader.mjs",
           },
         ],
       },

--- a/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
@@ -24,6 +24,15 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
     ],
     "oneOf": [
       {
+        "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+        "type": "javascript/auto",
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/dist/workerQueryLoader.mjs",
+          },
+        ],
+      },
+      {
         "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
         "type": "asset/source",
       },
@@ -147,6 +156,15 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
       /node_modules\\[\\\\\\\\/\\]svelte\\[\\\\\\\\/\\]/,
     ],
     "oneOf": [
+      {
+        "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+        "type": "javascript/auto",
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/dist/workerQueryLoader.mjs",
+          },
+        ],
+      },
       {
         "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
         "type": "asset/source",


### PR DESCRIPTION
## Summary

This PR adds Vite-compatible `?worker` and `?worker&inline` imports in Rsbuild so worker scripts can be imported as Worker constructors without external loaders. It adds a built-in worker plugin and loader, type declarations for worker query imports, and focused e2e coverage for basic, inline, nested, self-reference, and dynamic import worker scenarios.