### PR TITLE
refactor(core): simplify worker template plugin usage

### DIFF
--- a/packages/core/src/loader/workerLoader.ts
+++ b/packages/core/src/loader/workerLoader.ts
@@ -110,16 +110,6 @@ const deleteAsset = (compilation: Compilation, filename: string) => {
   }
 };
 
-const getCompilerPlugin = <T>(getPlugin: () => T): T => {
-  const plugin = getPlugin();
-  if (!plugin) {
-    throw new Error(
-      '[rsbuild:worker] The current Rspack version does not support inline worker compilation.',
-    );
-  }
-  return plugin;
-};
-
 const compileInlineWorker = (
   context: LoaderContext<WorkerLoaderOptions>,
 ): Promise<string> => {
@@ -146,9 +136,7 @@ const compileInlineWorker = (
     [],
   );
 
-  new (getCompilerPlugin(
-    () => rspack.webworker.WebWorkerTemplatePlugin,
-  ))().apply(childCompiler);
+  new rspack.webworker.WebWorkerTemplatePlugin().apply(childCompiler);
 
   new rspack.LoaderTargetPlugin('webworker').apply(childCompiler);
 


### PR DESCRIPTION
## Summary

This PR removes the worker loader's `getCompilerPlugin` wrapper and directly applies `rspack.webworker.WebWorkerTemplatePlugin`. The plugin is exposed by the supported `@rspack/core` version, so the extra generic accessor only adds indirection without a useful compatibility fallback.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/7675