### PR TITLE
fix(core): inline dynamic imports in inline workers

### DIFF
--- a/e2e/cases/workers/worker-query-basic/index.test.ts
+++ b/e2e/cases/workers/worker-query-basic/index.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@e2e/helper';
 
 test('should support worker query imports', async ({ page, runBothServe }) => {
   await runBothServe(async () => {
-    await expect(page.locator('#worker')).toHaveText('named-query-worker: 42');
-    await expect(page.locator('#mjs-worker')).toHaveText('mjs-worker: 42');
+    await expect(page.locator('#worker')).toHaveText('named: 42');
+    await expect(page.locator('#mjs')).toHaveText('mjs: 42');
   });
 });

--- a/e2e/cases/workers/worker-query-basic/src/index.ts
+++ b/e2e/cases/workers/worker-query-basic/src/index.ts
@@ -3,7 +3,7 @@ import QueryWorker from './query-worker?worker';
 
 document.body.innerHTML = `
   <div id="worker"></div>
-  <div id="mjs-worker"></div>
+  <div id="mjs"></div>
 `;
 
 const setText = (selector: string, text: string) => {
@@ -27,10 +27,10 @@ const runWorker = (
 };
 
 runWorker(
-  new QueryWorker({ name: 'named-query-worker' }),
+  new QueryWorker({ name: 'named' }),
   'ping',
   '#worker',
   (data) => data.text,
 );
 
-runWorker(new MjsWorker(), 'mjs-worker', '#mjs-worker', (data) => data.text);
+runWorker(new MjsWorker(), 'mjs', '#mjs', (data) => data.text);

--- a/e2e/cases/workers/worker-query-basic/src/query-worker.ts
+++ b/e2e/cases/workers/worker-query-basic/src/query-worker.ts
@@ -2,6 +2,6 @@ import { formatMessage } from './message';
 
 self.onmessage = () => {
   self.postMessage({
-    text: formatMessage(self.name || 'query-worker'),
+    text: formatMessage(self.name || 'worker'),
   });
 };

--- a/e2e/cases/workers/worker-query-dynamic-import/index.test.ts
+++ b/e2e/cases/workers/worker-query-dynamic-import/index.test.ts
@@ -5,8 +5,6 @@ test('should support dynamic imports inside worker query imports', async ({
   runBothServe,
 }) => {
   await runBothServe(async () => {
-    await expect(page.locator('#dynamic-import-worker')).toHaveText(
-      'module-a:module-b',
-    );
+    await expect(page.locator('#worker')).toHaveText('a:b');
   });
 });

--- a/e2e/cases/workers/worker-query-dynamic-import/src/index.ts
+++ b/e2e/cases/workers/worker-query-dynamic-import/src/index.ts
@@ -1,11 +1,11 @@
 import ChunkWorker from './chunk-worker?worker';
 
-document.body.innerHTML = '<div id="dynamic-import-worker"></div>';
+document.body.innerHTML = '<div id="worker"></div>';
 
 const worker = new ChunkWorker();
 
 worker.addEventListener('message', ({ data }) => {
-  const element = document.querySelector('#dynamic-import-worker');
+  const element = document.querySelector('#worker');
   if (element) {
     element.textContent = data.text;
   }

--- a/e2e/cases/workers/worker-query-dynamic-import/src/module-a.ts
+++ b/e2e/cases/workers/worker-query-dynamic-import/src/module-a.ts
@@ -1,1 +1,1 @@
-export const message = 'module-a';
+export const message = 'a';

--- a/e2e/cases/workers/worker-query-dynamic-import/src/module-b.ts
+++ b/e2e/cases/workers/worker-query-dynamic-import/src/module-b.ts
@@ -1,1 +1,1 @@
-export default 'module-b';
+export default 'b';

--- a/e2e/cases/workers/worker-query-inline-dynamic-import/index.test.ts
+++ b/e2e/cases/workers/worker-query-inline-dynamic-import/index.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@e2e/helper';
+
+test('should inline dynamic imports in inline worker query imports', async ({
+  page,
+  runBothServe,
+}) => {
+  await runBothServe(async ({ mode, result }) => {
+    await expect(page.locator('#result')).toHaveText(
+      'inline: dynamic inline-dynamic-marker',
+    );
+
+    if (mode === 'build') {
+      const files = result.getDistFiles();
+      const jsFiles = Object.entries(files).filter(([filename]) =>
+        filename.endsWith('.js'),
+      );
+
+      expect(jsFiles).toHaveLength(1);
+      expect(jsFiles[0][1]).toContain('inline-dynamic-marker');
+      expect(jsFiles[0][1]).toContain(': dynamic');
+    }
+  });
+});

--- a/e2e/cases/workers/worker-query-inline-dynamic-import/src/index.ts
+++ b/e2e/cases/workers/worker-query-inline-dynamic-import/src/index.ts
@@ -1,0 +1,15 @@
+import InlineWorker from './worker?worker&inline';
+
+document.body.innerHTML = '<div id="result"></div>';
+
+const worker = new InlineWorker();
+
+worker.addEventListener('message', ({ data }) => {
+  const element = document.querySelector('#result');
+  if (element) {
+    element.textContent = `${data.text} ${data.marker}`;
+  }
+  worker.terminate();
+});
+
+worker.postMessage('inline');

--- a/e2e/cases/workers/worker-query-inline-dynamic-import/src/message.ts
+++ b/e2e/cases/workers/worker-query-inline-dynamic-import/src/message.ts
@@ -1,0 +1,1 @@
+export const getMessage = (name: string): string => `${name}: dynamic`;

--- a/e2e/cases/workers/worker-query-inline-dynamic-import/src/worker.ts
+++ b/e2e/cases/workers/worker-query-inline-dynamic-import/src/worker.ts
@@ -1,0 +1,10 @@
+const marker = 'inline-dynamic-marker';
+
+self.onmessage = async ({ data }) => {
+  const { getMessage } = await import('./message');
+
+  self.postMessage({
+    marker,
+    text: getMessage(data),
+  });
+};

--- a/e2e/cases/workers/worker-query-inline/index.test.ts
+++ b/e2e/cases/workers/worker-query-inline/index.test.ts
@@ -5,15 +5,11 @@ test('should support inline worker query imports', async ({
   runBothServe,
 }) => {
   await runBothServe(async ({ mode, result }) => {
-    await expect(page.locator('#inline-worker')).toHaveText(
-      'named-inline-worker: 42 named-inline-worker rsbuild-inline-worker-marker',
+    await expect(page.locator('#worker')).toHaveText(
+      'named: 42 named inline-marker',
     );
-    await expect(page.locator('#inline-worker-reordered')).toHaveText(
-      'inline-worker-reordered: 42',
-    );
-    await expect(page.locator('#inline-worker-unicode')).toHaveText(
-      '\u2022pong\u2022',
-    );
+    await expect(page.locator('#reordered')).toHaveText('reordered: 42');
+    await expect(page.locator('#unicode')).toHaveText('\u2022pong\u2022');
 
     if (mode === 'build') {
       const files = result.getDistFiles();
@@ -22,9 +18,7 @@ test('should support inline worker query imports', async ({
       );
 
       expect(emittedInlineWorkerFiles).toEqual([]);
-      expect(Object.values(files).join('\n')).toContain(
-        'rsbuild-inline-worker-marker',
-      );
+      expect(Object.values(files).join('\n')).toContain('inline-marker');
     }
   });
 });

--- a/e2e/cases/workers/worker-query-inline/src/index.ts
+++ b/e2e/cases/workers/worker-query-inline/src/index.ts
@@ -2,9 +2,9 @@ import InlineWorker from './inline-worker?worker&inline';
 import InlineWorkerReordered from './inline-worker?inline&worker';
 
 document.body.innerHTML = `
-  <div id="inline-worker"></div>
-  <div id="inline-worker-reordered"></div>
-  <div id="inline-worker-unicode"></div>
+  <div id="worker"></div>
+  <div id="reordered"></div>
+  <div id="unicode"></div>
 `;
 
 const setText = (selector: string, text: string) => {
@@ -28,22 +28,17 @@ const runWorker = (
 };
 
 runWorker(
-  new InlineWorker({ name: 'named-inline-worker' }),
-  'named-inline-worker',
-  '#inline-worker',
+  new InlineWorker({ name: 'named' }),
+  'named',
+  '#worker',
   (data) => `${data.text} ${data.name} ${data.marker}`,
 );
 
 runWorker(
   new InlineWorkerReordered(),
-  'inline-worker-reordered',
-  '#inline-worker-reordered',
+  'reordered',
+  '#reordered',
   (data) => data.text,
 );
 
-runWorker(
-  new InlineWorker(),
-  'unicode',
-  '#inline-worker-unicode',
-  (data) => data.text,
-);
+runWorker(new InlineWorker(), 'unicode', '#unicode', (data) => data.text);

--- a/e2e/cases/workers/worker-query-inline/src/inline-worker.ts
+++ b/e2e/cases/workers/worker-query-inline/src/inline-worker.ts
@@ -1,6 +1,6 @@
 import { formatMessage } from './message';
 
-const marker = 'rsbuild-inline-worker-marker';
+const marker = 'inline-marker';
 
 self.onmessage = ({ data }) => {
   self.postMessage({

--- a/e2e/cases/workers/worker-query-module/index.test.ts
+++ b/e2e/cases/workers/worker-query-module/index.test.ts
@@ -5,12 +5,8 @@ test('should support worker query imports with output.module enabled', async ({
   runBothServe,
 }) => {
   await runBothServe(async ({ mode, result }) => {
-    await expect(page.locator('#module-worker')).toHaveText(
-      'module-worker: module message',
-    );
-    await expect(page.locator('#module-inline-worker')).toHaveText(
-      'inline-module-worker: inline module message',
-    );
+    await expect(page.locator('#worker')).toHaveText('worker: msg');
+    await expect(page.locator('#inline')).toHaveText('inline: msg');
 
     if (mode === 'build') {
       const files = result.getDistFiles();

--- a/e2e/cases/workers/worker-query-module/src/index.ts
+++ b/e2e/cases/workers/worker-query-module/src/index.ts
@@ -2,8 +2,8 @@ import InlineModuleWorker from './inline-module-worker?worker&inline';
 import ModuleWorker from './module-worker?worker';
 
 document.body.innerHTML = `
-  <div id="module-worker"></div>
-  <div id="module-inline-worker"></div>
+  <div id="worker"></div>
+  <div id="inline"></div>
 `;
 
 const setText = (selector: string, text: string) => {
@@ -13,20 +13,20 @@ const setText = (selector: string, text: string) => {
   }
 };
 
-const moduleWorker = new ModuleWorker({ name: 'module-worker' });
+const moduleWorker = new ModuleWorker({ name: 'worker' });
 
 moduleWorker.addEventListener('message', ({ data }) => {
-  setText('#module-worker', data.text);
+  setText('#worker', data.text);
   moduleWorker.terminate();
 });
-moduleWorker.postMessage('module message');
+moduleWorker.postMessage('msg');
 
 const inlineModuleWorker = new InlineModuleWorker({
-  name: 'inline-module-worker',
+  name: 'inline',
 });
 
 inlineModuleWorker.addEventListener('message', ({ data }) => {
-  setText('#module-inline-worker', data.text);
+  setText('#inline', data.text);
   inlineModuleWorker.terminate();
 });
-inlineModuleWorker.postMessage('inline module message');
+inlineModuleWorker.postMessage('msg');

--- a/e2e/cases/workers/worker-query-nested/index.test.ts
+++ b/e2e/cases/workers/worker-query-nested/index.test.ts
@@ -5,14 +5,8 @@ test('should support worker query imports inside workers', async ({
   runBothServe,
 }) => {
   await runBothServe(async () => {
-    await expect(page.locator('#nested-worker')).toHaveText(
-      /nested-worker http/,
-    );
-    await expect(page.locator('#nested-sub-worker')).toHaveText(
-      'sub-worker:nested-sub-worker',
-    );
-    await expect(page.locator('#nested-constructor-worker')).toHaveText(
-      'constructor-worker',
-    );
+    await expect(page.locator('#worker')).toHaveText(/main http/);
+    await expect(page.locator('#sub')).toHaveText('sub:sub');
+    await expect(page.locator('#ctor')).toHaveText('ctor');
   });
 });

--- a/e2e/cases/workers/worker-query-nested/src/index.ts
+++ b/e2e/cases/workers/worker-query-nested/src/index.ts
@@ -1,9 +1,9 @@
 import NestedWorker from './nested-worker?worker';
 
 document.body.innerHTML = `
-  <div id="nested-worker"></div>
-  <div id="nested-sub-worker"></div>
-  <div id="nested-constructor-worker"></div>
+  <div id="worker"></div>
+  <div id="sub"></div>
+  <div id="ctor"></div>
 `;
 
 const setText = (selector: string, text: string) => {
@@ -16,12 +16,12 @@ const setText = (selector: string, text: string) => {
 const worker = new NestedWorker();
 
 worker.addEventListener('message', ({ data }) => {
-  if (data.type === 'nested-worker') {
-    setText('#nested-worker', `${data.text} ${data.href}`);
-  } else if (data.type === 'sub-worker') {
-    setText('#nested-sub-worker', data.text);
-  } else if (data.type === 'constructor-worker') {
-    setText('#nested-constructor-worker', data.text);
+  if (data.type === 'main') {
+    setText('#worker', `${data.text} ${data.href}`);
+  } else if (data.type === 'sub') {
+    setText('#sub', data.text);
+  } else if (data.type === 'ctor') {
+    setText('#ctor', data.text);
   }
 });
 

--- a/e2e/cases/workers/worker-query-nested/src/nested-worker.ts
+++ b/e2e/cases/workers/worker-query-nested/src/nested-worker.ts
@@ -1,18 +1,18 @@
 import SubWorker from './sub-worker?worker';
 
-const subWorker = new SubWorker({ name: 'nested-sub-worker' });
+const subWorker = new SubWorker({ name: 'sub' });
 const constructorWorker = new Worker(
   new URL('./url-worker.ts', import.meta.url),
   {
-    name: 'constructor-worker',
+    name: 'ctor',
     type: 'module',
   },
 );
 
 self.postMessage({
   href: self.location.href,
-  text: 'nested-worker',
-  type: 'nested-worker',
+  text: 'main',
+  type: 'main',
 });
 
 self.onmessage = ({ data }) => {

--- a/e2e/cases/workers/worker-query-nested/src/sub-worker.ts
+++ b/e2e/cases/workers/worker-query-nested/src/sub-worker.ts
@@ -1,8 +1,8 @@
 self.onmessage = ({ data }) => {
   if (data === 'ping') {
     self.postMessage({
-      text: `sub-worker:${self.name || 'anonymous'}`,
-      type: 'sub-worker',
+      text: `sub:${self.name || 'anonymous'}`,
+      type: 'sub',
     });
   }
 };

--- a/e2e/cases/workers/worker-query-nested/src/url-worker.ts
+++ b/e2e/cases/workers/worker-query-nested/src/url-worker.ts
@@ -1,4 +1,4 @@
 self.postMessage({
-  text: self.name || 'constructor-worker',
-  type: 'constructor-worker',
+  text: self.name || 'ctor',
+  type: 'ctor',
 });

--- a/e2e/cases/workers/worker-query-self-reference/index.test.ts
+++ b/e2e/cases/workers/worker-query-self-reference/index.test.ts
@@ -5,11 +5,7 @@ test('should support self reference worker query imports', async ({
   runBothServe,
 }) => {
   await runBothServe(async () => {
-    await expect(page.locator('#self-reference-worker')).toContainText(
-      'pong: main',
-    );
-    await expect(page.locator('#self-reference-worker')).toContainText(
-      'pong: nested',
-    );
+    await expect(page.locator('#worker')).toContainText('pong: main');
+    await expect(page.locator('#worker')).toContainText('pong: nested');
   });
 });

--- a/e2e/cases/workers/worker-query-self-reference/src/index.ts
+++ b/e2e/cases/workers/worker-query-self-reference/src/index.ts
@@ -1,11 +1,11 @@
 import SelfReferenceWorker from './self-reference-worker?worker';
 
-document.body.innerHTML = '<div id="self-reference-worker"></div>';
+document.body.innerHTML = '<div id="worker"></div>';
 
 const worker = new SelfReferenceWorker();
 
 worker.addEventListener('message', ({ data }) => {
-  const element = document.querySelector('#self-reference-worker');
+  const element = document.querySelector('#worker');
   if (element) {
     element.textContent += `${data}\n`;
   }

--- a/packages/core/src/loader/workerLoader.ts
+++ b/packages/core/src/loader/workerLoader.ts
@@ -138,6 +138,11 @@ const compileInlineWorker = (
 
   new rspack.webworker.WebWorkerTemplatePlugin().apply(childCompiler);
 
+  // Inline workers run from Blob/data URLs, so dynamic import chunks cannot be
+  // loaded by relative URLs. Use eager imports to keep the worker in one file.
+  childCompiler.options.module.parser.javascript ??= {};
+  childCompiler.options.module.parser.javascript.dynamicImportMode = 'eager';
+
   new rspack.LoaderTargetPlugin('webworker').apply(childCompiler);
 
   new rspack.EntryPlugin(

--- a/packages/core/src/loader/workerLoader.ts
+++ b/packages/core/src/loader/workerLoader.ts
@@ -138,10 +138,21 @@ const compileInlineWorker = (
 
   new rspack.webworker.WebWorkerTemplatePlugin().apply(childCompiler);
 
+  const moduleOptions = childCompiler.options.module;
+  const parserOptions = moduleOptions.parser ?? {};
+
   // Inline workers run from Blob/data URLs, so dynamic import chunks cannot be
   // loaded by relative URLs. Use eager imports to keep the worker in one file.
-  childCompiler.options.module.parser.javascript ??= {};
-  childCompiler.options.module.parser.javascript.dynamicImportMode = 'eager';
+  childCompiler.options.module = {
+    ...moduleOptions,
+    parser: {
+      ...parserOptions,
+      javascript: {
+        ...parserOptions.javascript,
+        dynamicImportMode: 'eager',
+      },
+    },
+  };
 
   new rspack.LoaderTargetPlugin('webworker').apply(childCompiler);
 


### PR DESCRIPTION
## Summary

This PR keeps `?worker&inline` output single-file when the worker uses dynamic `import()`. Inline workers run from Blob URLs, so the worker child compiler now uses eager dynamic imports to avoid emitting relative chunks that cannot be loaded reliably.

It also adds a dedicated E2E case for inline worker dynamic imports and shortens the worker-query fixture strings.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/7675