### PR TITLE
fix(core): respect worker output filenames

### DIFF
--- a/e2e/cases/workers/worker-query-filename/index.test.ts
+++ b/e2e/cases/workers/worker-query-filename/index.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from '@e2e/helper';
+
+test('should respect custom JS output filename for worker query imports', async ({
+  build,
+}) => {
+  const result = await build();
+
+  const files = result.getDistFiles();
+  const jsFiles = Object.keys(files)
+    .filter((filename) => filename.endsWith('.js'))
+    .sort();
+
+  expect(jsFiles).toHaveLength(2);
+  expect(jsFiles[0]).toMatch(/\/assets\/async\/.+\.bundle\.js$/);
+  expect(jsFiles[1]).toMatch(/\/assets\/js\/index\.bundle\.js$/);
+  expect(files[jsFiles[0]]).toContain('worker-filename-marker');
+});

--- a/e2e/cases/workers/worker-query-filename/rsbuild.config.ts
+++ b/e2e/cases/workers/worker-query-filename/rsbuild.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    filenameHash: false,
+    distPath: {
+      js: 'assets/js',
+      jsAsync: 'assets/async',
+    },
+    filename: {
+      js(pathData) {
+        const name = pathData.chunk?.name;
+        return `${name || 'chunk'}.bundle.js`;
+      },
+    },
+  },
+});

--- a/e2e/cases/workers/worker-query-filename/src/index.ts
+++ b/e2e/cases/workers/worker-query-filename/src/index.ts
@@ -1,0 +1,10 @@
+import QueryWorker from './worker?worker';
+
+const worker = new QueryWorker();
+
+worker.addEventListener('message', ({ data }) => {
+  document.body.textContent = data;
+  worker.terminate();
+});
+
+worker.postMessage('filename');

--- a/e2e/cases/workers/worker-query-filename/src/worker.ts
+++ b/e2e/cases/workers/worker-query-filename/src/worker.ts
@@ -1,0 +1,3 @@
+self.onmessage = ({ data }) => {
+  self.postMessage(`${data}: worker-filename-marker`);
+};

--- a/e2e/cases/workers/worker-query-inline/index.test.ts
+++ b/e2e/cases/workers/worker-query-inline/index.test.ts
@@ -13,12 +13,16 @@ test('should support inline worker query imports', async ({
 
     if (mode === 'build') {
       const files = result.getDistFiles();
+      const jsFiles = Object.keys(files).filter((filename) =>
+        filename.endsWith('.js'),
+      );
       const emittedInlineWorkerFiles = Object.keys(files).filter((filename) =>
         /inline-worker\.[\w-]+\.js$/.test(filename),
       );
 
+      expect(jsFiles).toHaveLength(1);
       expect(emittedInlineWorkerFiles).toEqual([]);
-      expect(Object.values(files).join('\n')).toContain('inline-marker');
+      expect(files[jsFiles[0]]).toContain('inline-marker');
     }
   });
 });

--- a/e2e/cases/workers/worker-query-module/index.test.ts
+++ b/e2e/cases/workers/worker-query-module/index.test.ts
@@ -10,8 +10,12 @@ test('should support worker query imports with output.module enabled', async ({
 
     if (mode === 'build') {
       const files = result.getDistFiles();
+      const indexFile = Object.keys(files).find((filename) =>
+        /\/static\/js\/index\.[\w-]+\.js$/.test(filename),
+      );
 
-      expect(Object.values(files).join('\n')).toContain('type:"module"');
+      expect(indexFile).toBeDefined();
+      expect(files[indexFile!]).toContain('type:"module"');
     }
   });
 });

--- a/packages/core/src/loader/workerLoader.ts
+++ b/packages/core/src/loader/workerLoader.ts
@@ -7,8 +7,6 @@ import type {
 
 const INLINE_QUERY_REGEX = /[?&]inline(?:&|=|$)/;
 const JS_FILE_REGEX = /\.m?js(?:\?.*)?$/;
-const HASH_PLACEHOLDER_REGEX =
-  /\[(?:[^:\]]+:)?(?:chunkhash|contenthash|hash|fullhash)(?::[^\]]+)?]/i;
 const SOURCE_MAPPING_URL_REGEX =
   /(?:\/\*# sourceMappingURL=.*?\*\/|\/\/# sourceMappingURL=.*)$/gm;
 
@@ -80,30 +78,6 @@ export default function WorkerWrapper(options) {
 }`;
 };
 
-const getChildFilename = (
-  filename: Compilation['outputOptions']['filename'],
-): string => {
-  if (typeof filename !== 'string') {
-    return 'static/js/[name].worker.js';
-  }
-
-  return HASH_PLACEHOLDER_REGEX.test(filename)
-    ? filename
-    : filename.replace(/\.js(?:\?.*)?$/i, '.worker.js');
-};
-
-const getChildChunkFilename = (
-  chunkFilename: Compilation['outputOptions']['chunkFilename'],
-): string => {
-  if (typeof chunkFilename !== 'string') {
-    return 'static/js/async/[name].worker.js';
-  }
-
-  return HASH_PLACEHOLDER_REGEX.test(chunkFilename)
-    ? chunkFilename
-    : chunkFilename.replace(/\.js(?:\?.*)?$/i, '.worker.js');
-};
-
 const deleteAsset = (compilation: Compilation, filename: string) => {
   if (compilation.getAsset(filename)) {
     compilation.deleteAsset(filename);
@@ -122,8 +96,6 @@ const compileInlineWorker = (
   const childCompiler = compilation.createChildCompiler(
     compilerName,
     {
-      filename: getChildFilename(outputOptions.filename),
-      chunkFilename: getChildChunkFilename(outputOptions.chunkFilename),
       publicPath: outputOptions.publicPath,
       globalObject: 'self',
       module: outputOptions.module,


### PR DESCRIPTION
## Summary

This PR lets worker query output use the parent JS output filename configuration instead of overriding child worker compilation with hardcoded `static/js` paths. It removes the inline worker child filename overrides and adds E2E coverage for non-inline `?worker` bundles with custom `output.filename.js` and `output.distPath.jsAsync`.

It also updates worker-query E2E assertions to check specific output files instead of searching across all emitted files.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/7677