### PR TITLE
chore(skills): update e2e case skill guidance

### DIFF
--- a/.agents/skills/write-e2e-cases/SKILL.md
+++ b/.agents/skills/write-e2e-cases/SKILL.md
@@ -22,8 +22,7 @@ description: Use when adding or updating Rsbuild end-to-end tests in `e2e/cases`
 ## Case Structure
 
 - Include a `src` directory in every case (required).
-- Prefer putting static Rsbuild configurations in rsbuild.config.ts to enable
-  easier debugging via npx rsbuild.
+- Prefer putting static Rsbuild configurations in `rsbuild.config.ts` to enable easier debugging via `npx rsbuild`.
 - Use inline config for dynamic values or minor per-test variations.
 - Split into multiple case directories when cases need different `src` code or different Rsbuild configs.
 

--- a/.agents/skills/write-e2e-cases/SKILL.md
+++ b/.agents/skills/write-e2e-cases/SKILL.md
@@ -15,14 +15,17 @@ description: Use when adding or updating Rsbuild end-to-end tests in `e2e/cases`
 
 4. Add Playwright cases under `e2e/cases`, following existing directory patterns.
 
-5. Keep assertions focused and readable; avoid redundant setup and checks.
+5. Use short, direct, and stable assertions. Avoid redundant setup and checks.
 
 6. Run `pnpm e2e` to validate.
 
 ## Case Structure
 
 - Include a `src` directory in every case (required).
-- Add `rsbuild.config.ts` only when needed.
+- If a test file uses one non-dynamic, fixed Rsbuild config, prefer putting it
+  in `rsbuild.config.ts` instead of passing it inline to `build` or `dev`.
+- Add inline config only when the test needs dynamic values, per-test variants,
+  or multiple config shapes in the same file.
 - Split into multiple case directories when cases need different `src` code or different Rsbuild configs.
 
 ## Constraints

--- a/.agents/skills/write-e2e-cases/SKILL.md
+++ b/.agents/skills/write-e2e-cases/SKILL.md
@@ -22,10 +22,9 @@ description: Use when adding or updating Rsbuild end-to-end tests in `e2e/cases`
 ## Case Structure
 
 - Include a `src` directory in every case (required).
-- If a test file uses one non-dynamic, fixed Rsbuild config, prefer putting it
-  in `rsbuild.config.ts` instead of passing it inline to `build` or `dev`.
-- Add inline config only when the test needs dynamic values, per-test variants,
-  or multiple config shapes in the same file.
+- Prefer putting static Rsbuild configurations in rsbuild.config.ts to enable
+  easier debugging via npx rsbuild.
+- Use inline config for dynamic values or minor per-test variations.
 - Split into multiple case directories when cases need different `src` code or different Rsbuild configs.
 
 ## Constraints


### PR DESCRIPTION
## Summary

This PR updates the e2e case writing skill to clarify when fixed Rsbuild config should live in `rsbuild.config.ts`, and tightens assertion guidance toward short, stable checks.