### PR TITLE
fix(core): support worker query in SSR builds

### DIFF
--- a/e2e/cases/workers/worker-query-ssr/index.test.ts
+++ b/e2e/cases/workers/worker-query-ssr/index.test.ts
@@ -1,0 +1,25 @@
+import { pathToFileURL } from 'node:url';
+import { expect, test } from '@e2e/helper';
+
+test('should support worker query imports in SSR builds', async ({ build }) => {
+  const result = await build();
+  const files = result.getDistFiles();
+  const entryFile = Object.keys(files).find((file) =>
+    file.endsWith('/index.js'),
+  );
+  expect(entryFile).toBeDefined();
+
+  const entry = files[entryFile!];
+  const queryWorker = Object.entries(files).find(([, content]) =>
+    content.includes('query-ssr-worker'),
+  );
+  const bundle = await import(
+    `${pathToFileURL(entryFile!).href}?t=${Date.now()}`
+  );
+
+  expect(entry).toContain('inline-ssr-worker');
+  expect(entry).toContain('new Worker');
+  expect(bundle.workerTypes).toBe('function:function');
+  expect(queryWorker?.[0]).not.toBe(entryFile);
+  expect(queryWorker?.[1]).toContain('query-ssr-worker');
+});

--- a/e2e/cases/workers/worker-query-ssr/rsbuild.config.ts
+++ b/e2e/cases/workers/worker-query-ssr/rsbuild.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  environments: {
+    node: {
+      output: {
+        target: 'node',
+      },
+      source: {
+        entry: {
+          index: './src/index.ts',
+        },
+      },
+    },
+  },
+});

--- a/e2e/cases/workers/worker-query-ssr/src/index.ts
+++ b/e2e/cases/workers/worker-query-ssr/src/index.ts
@@ -1,0 +1,9 @@
+import InlineWorker from './inline-worker?worker&inline';
+import QueryWorker from './query-worker?worker';
+
+export const workerTypes = `${typeof QueryWorker}:${typeof InlineWorker}`;
+
+export const workerSources = {
+  inline: String(InlineWorker),
+  query: String(QueryWorker),
+};

--- a/e2e/cases/workers/worker-query-ssr/src/inline-worker.ts
+++ b/e2e/cases/workers/worker-query-ssr/src/inline-worker.ts
@@ -1,0 +1,3 @@
+const marker = 'inline-ssr-worker';
+
+self.postMessage(marker);

--- a/e2e/cases/workers/worker-query-ssr/src/query-worker.ts
+++ b/e2e/cases/workers/worker-query-ssr/src/query-worker.ts
@@ -1,0 +1,3 @@
+const marker = 'query-ssr-worker';
+
+self.postMessage(marker);

--- a/packages/core/src/plugins/worker.ts
+++ b/packages/core/src/plugins/worker.ts
@@ -8,11 +8,7 @@ export const pluginWorker = (): RsbuildPlugin => ({
   setup(api) {
     api.modifyBundlerChain({
       order: 'pre',
-      handler: (chain, { CHAIN_ID, isServer }) => {
-        if (isServer) {
-          return;
-        }
-
+      handler: (chain, { CHAIN_ID }) => {
         chain.module
           .rule(CHAIN_ID.RULE.JS)
           .oneOf(CHAIN_ID.ONE_OF.JS_WORKER)

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -1162,6 +1162,15 @@ exports[`should apply default plugins correctly when target is node 1`] = `
         ],
         "oneOf": [
           {
+            "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+            "type": "javascript/auto",
+            "use": [
+              {
+                "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
+              },
+            ],
+          },
+          {
             "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/source",
           },

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -625,6 +625,15 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
           ],
           "oneOf": [
             {
+              "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+              "type": "javascript/auto",
+              "use": [
+                {
+                  "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
+                },
+              ],
+            },
+            {
               "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
               "type": "asset/source",
             },

--- a/packages/core/tests/__snapshots__/swc.test.ts.snap
+++ b/packages/core/tests/__snapshots__/swc.test.ts.snap
@@ -329,6 +329,15 @@ exports[`plugin-swc > should apply environment config correctly 2`] = `
     ],
     "oneOf": [
       {
+        "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+        "type": "javascript/auto",
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
+          },
+        ],
+      },
+      {
         "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
         "type": "asset/source",
       },
@@ -735,6 +744,15 @@ exports[`plugin-swc > should disable preset-env for non-web targets 1`] = `
         /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
       ],
       "oneOf": [
+        {
+          "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+          "type": "javascript/auto",
+          "use": [
+            {
+              "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
+            },
+          ],
+        },
         {
           "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
           "type": "asset/source",
@@ -1150,6 +1168,15 @@ exports[`plugin-swc > should use the correct core-js version 2`] = `
         /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
       ],
       "oneOf": [
+        {
+          "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+          "type": "javascript/auto",
+          "use": [
+            {
+              "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
+            },
+          ],
+        },
         {
           "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
           "type": "asset/source",

--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -410,6 +410,15 @@ exports[`plugins/babel > should apply environment config correctly 2`] = `
   ],
   "oneOf": [
     {
+      "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "<ROOT>/packages/core/dist/workerLoader.mjs",
+        },
+      ],
+    },
+    {
       "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
       "type": "asset/source",
     },

--- a/packages/plugin-solid/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-solid/tests/__snapshots__/index.test.ts.snap
@@ -121,6 +121,15 @@ exports[`plugin-solid > should allow solid options to override ssr defaults 1`] 
   ],
   "oneOf": [
     {
+      "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "<ROOT>/packages/core/dist/workerLoader.mjs",
+        },
+      ],
+    },
+    {
       "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
       "type": "asset/source",
     },
@@ -531,6 +540,15 @@ exports[`plugin-solid > should use ssr output for ssr option on node target 1`] 
     /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
   ],
   "oneOf": [
+    {
+      "resourceQuery": /\\[\\?&\\]worker\\(\\?:&\\|=\\|\\$\\)/,
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "<ROOT>/packages/core/dist/workerLoader.mjs",
+        },
+      ],
+    },
     {
       "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
       "type": "asset/source",


### PR DESCRIPTION
## Summary

This PR aligns Rsbuild worker query imports with Vite's SSR build behavior. It lets node/SSR builds process `?worker` and `?worker&inline` through the worker loader instead of falling through to normal module handling, so shared modules can import worker constructors during SSR while actual worker instantiation remains client-only. It also adds an SSR e2e case covering regular and inline worker query imports.