### PR TITLE
docs: update Babel exclude example

### DIFF
--- a/website/docs/en/plugins/list/plugin-babel.mdx
+++ b/website/docs/en/plugins/list/plugin-babel.mdx
@@ -244,21 +244,13 @@ Used to specify the files that need to be compiled by Babel.
 
 Due to the performance overhead of Babel compilation, matching only certain files through `include` can reduce the number of modules compiled by Babel, thereby improving build performance.
 
-For example, to only compile `.custom.js` files and ignore files under `node_modules`:
+For example, to only compile `.custom.js` files:
 
 ```js
 pluginBabel({
   include: /\.custom\.js$/,
-  // recommended to exclude the node_modules to improve build performance
-  exclude: /[\\/]node_modules[\\/]/,
 });
 ```
-
-:::tip
-When you configure the `include` or `exclude` options, Rsbuild will create a separate Rspack rule to apply babel-loader and swc-loader.
-
-This separate rule is completely independent of the SWC rule built into Rsbuild and is not affected by [source.include](/config/source/include) and [source.exclude](/config/source/exclude).
-:::
 
 ### exclude
 
@@ -268,6 +260,22 @@ This separate rule is completely independent of the SWC rule built into Rsbuild 
 Used to specify the files that do not need to be compiled by Babel.
 
 Due to the performance overhead of Babel compilation, excluding certain files through `exclude` can reduce the number of modules compiled by Babel, thereby improving build performance.
+
+For example, to ignore `.js` files under `node_modules`:
+
+```js
+pluginBabel({
+  include: /\.custom\.js$/,
+  // Exclude .js files under node_modules to improve build performance
+  exclude: /[\\/]node_modules[\\/].*\.js$/,
+});
+```
+
+:::tip
+When you configure the `include` or `exclude` options, Rsbuild will create a separate Rspack rule to apply babel-loader and swc-loader.
+
+This separate rule is completely independent of the SWC rule built into Rsbuild and is not affected by [source.include](/config/source/include) and [source.exclude](/config/source/exclude).
+:::
 
 ## Execution order
 

--- a/website/docs/en/plugins/list/plugin-babel.mdx
+++ b/website/docs/en/plugins/list/plugin-babel.mdx
@@ -265,7 +265,6 @@ For example, to ignore `.js` files under `node_modules`:
 
 ```js
 pluginBabel({
-  include: /\.custom\.js$/,
   // Exclude .js files under node_modules to improve build performance
   exclude: /[\\/]node_modules[\\/].*\.js$/,
 });

--- a/website/docs/zh/plugins/list/plugin-babel.mdx
+++ b/website/docs/zh/plugins/list/plugin-babel.mdx
@@ -264,7 +264,6 @@ pluginBabel({
 
 ```js
 pluginBabel({
-  include: /\.custom\.js$/,
   // 排除 node_modules 下的 .js 文件以提升构建性能
   exclude: /[\\/]node_modules[\\/].*\.js$/,
 });

--- a/website/docs/zh/plugins/list/plugin-babel.mdx
+++ b/website/docs/zh/plugins/list/plugin-babel.mdx
@@ -243,21 +243,13 @@ pluginBabel({
 
 由于 Babel 编译存在性能开销，通过 `include` 来匹配部分文件可以减少 Babel 编译的模块数量，从而提升构建性能。
 
-比如，只对 `.custom.js` 文件进行编译，并忽略 `node_modules` 下的文件：
+比如，只对 `.custom.js` 文件进行编译：
 
 ```js
 pluginBabel({
   include: /\.custom\.js$/,
-  // 建议 exclude node_modules 目录以提升构建性能
-  exclude: /[\\/]node_modules[\\/]/,
 });
 ```
-
-:::tip
-当你配置 `include` 或 `exclude` 选项时，Rsbuild 会创建一条单独的 Rspack rule 来应用 babel-loader 和 swc-loader。
-
-这条单独的 rule 与 Rsbuild 内置的 SWC rule 是完全独立的，并且不会受到 [source.include](/config/source/include) 和 [source.exclude](/config/source/exclude) 的作用。
-:::
 
 ### exclude
 
@@ -267,6 +259,22 @@ pluginBabel({
 用于指定不需要 Babel 编译的文件。
 
 由于 Babel 编译存在性能开销，通过 `exclude` 来排除部分文件可以减少 Babel 编译的模块数量，从而提升构建性能。
+
+比如，忽略 `node_modules` 下的 `.js` 文件：
+
+```js
+pluginBabel({
+  include: /\.custom\.js$/,
+  // 排除 node_modules 下的 .js 文件以提升构建性能
+  exclude: /[\\/]node_modules[\\/].*\.js$/,
+});
+```
+
+:::tip
+当你配置 `include` 或 `exclude` 选项时，Rsbuild 会创建一条单独的 Rspack rule 来应用 babel-loader 和 swc-loader。
+
+这条单独的 rule 与 Rsbuild 内置的 SWC rule 是完全独立的，并且不会受到 [source.include](/config/source/include) 和 [source.exclude](/config/source/exclude) 的作用。
+:::
 
 ## 执行顺序
 


### PR DESCRIPTION
## Summary

This PR updates the Babel plugin docs to avoid recommending a broad `node_modules` exclusion. The `include` example now focuses only on selecting files, and the `exclude` example is moved under the `exclude` option while only excluding `.js` files under `node_modules`, so dependency `.jsx` / `.tsx` sources can still be processed when needed.

## Related Links

https://github.com/web-infra-dev/rsbuild/discussions/7680