### PR TITLE
chore(security): avoid stale PR label updates

### DIFF
--- a/.github/workflows/issue-close-require.yml
+++ b/.github/workflows/issue-close-require.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           days-before-stale: -1
           days-before-pr-close: -1
+          remove-pr-stale-when-updated: false
           days-before-issue-close: 5
           stale-issue-label: 'need reproduction'
           close-issue-message: |


### PR DESCRIPTION
## Summary

Follow up on #7683 by disabling PR-specific stale label removal in the inactive issue workflow. `actions/stale` scans pull requests through the issues API, so this keeps the workflow limited to issue mutations while preserving the default behavior that removes `need reproduction` from issues after new activity.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/7683
- https://docs.github.com/en/actions/tutorials/manage-your-work/close-inactive-issues