### PR TITLE
chore(security): scope GitHub Actions permissions by job

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -11,15 +11,14 @@ on:
         required: true
         default: 'main'
 
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   changes:
     runs-on: ubuntu-latest
     if: github.repository == 'web-infra-dev/rsbuild' && github.event_name != 'workflow_dispatch'
+    permissions:
+      contents: read
     outputs:
       changed: ${{ steps.changes.outputs.changed }}
     steps:
@@ -37,10 +36,15 @@ jobs:
               - "!**/*.mdx"
               - "!**/_meta.json"
               - "!**/dictionary.txt"
+
   ecosystem_ci_dispatch:
     name: Dispatch ecosystem CI
     runs-on: ubuntu-latest
     if: github.repository == 'web-infra-dev/rsbuild' && github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
     steps:
       - name: Trigger Ecosystem CI
         uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@1345990b3128d94ee37afbb7607f9ddc9feadb49 # v0.3.0
@@ -51,11 +55,14 @@ jobs:
           workflow-file: rsbuild-ecosystem-ci-selected.yml
           client-payload: '{"ref":"${{ github.event.inputs.branch }}","repo":"web-infra-dev/rsbuild","suite":"-","suiteRefType":"precoded","suiteRef":"precoded"}'
           branch: ${{ github.event.inputs.branch }}
+
   ecosystem_ci_per_commit:
     name: Run ecosystem CI per commit
     needs: changes
     runs-on: ubuntu-latest
     if: github.repository == 'web-infra-dev/rsbuild' && github.event_name != 'workflow_dispatch' && needs.changes.outputs.changed == 'true'
+    permissions:
+      contents: read
     steps:
       - name: Trigger Ecosystem CI
         uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_per_commit@1345990b3128d94ee37afbb7607f9ddc9feadb49 # v0.3.0

--- a/.github/workflows/issue-close-require.yml
+++ b/.github/workflows/issue-close-require.yml
@@ -4,13 +4,14 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
-permissions:
-  issues: write
+permissions: {}
 
 jobs:
   issue-close-require:
     runs-on: ubuntu-latest
     if: github.repository == 'web-infra-dev/rsbuild'
+    permissions:
+      issues: write
     steps:
       - name: Close inactive need reproduction issues
         uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -4,14 +4,15 @@ on:
   issues:
     types: [labeled]
 
-permissions:
-  issues: write
+permissions: {}
 
 jobs:
   reply-labeled:
     name: Reply need reproduction
     runs-on: ubuntu-latest
     if: github.repository == 'web-infra-dev/rsbuild'
+    permissions:
+      issues: write
     steps:
       - name: need reproduction
         if: github.event.label.name == 'need reproduction'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,12 +9,13 @@ on:
 
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -11,13 +11,14 @@ on:
         required: true
         default: 'main'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   preview:
     if: github.repository == 'web-infra-dev/rsbuild'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,7 @@ on:
         required: true
         default: 'main'
 
-permissions:
-  # Provenance generation in GitHub Actions requires "write" access to the "id-token"
-  id-token: write
+permissions: {}
 
 jobs:
   release:
@@ -29,6 +27,9 @@ jobs:
     if: github.repository == 'web-infra-dev/rsbuild' && github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: npm
+    permissions:
+      # Provenance generation in GitHub Actions requires "write" access to the "id-token"
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,7 @@ on:
 
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 env:
   # Configure Node.js memory limit to 6GB (default GitHub Actions limit is 7GB)
@@ -21,6 +20,8 @@ jobs:
   ut:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
+    permissions:
+      contents: read
     strategy:
       matrix:
         # run ut on macOS, as SWC cases will fail on Ubuntu CI
@@ -67,6 +68,8 @@ jobs:
   e2e:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]


### PR DESCRIPTION
## Summary

Move GitHub Actions token permissions to job level and add top-level `permissions: {}` defaults so future jobs start without implicit token access. Existing workflow permissions are made explicit per job, and `ecosystem-ci.yml` is narrowed to the permissions required by its checkout, PR lookup, issue comment, and commit comment paths.