### PR TITLE
docs: update Web Workers query docs

### DIFF
--- a/website/docs/en/guide/basic/web-workers.mdx
+++ b/website/docs/en/guide/basic/web-workers.mdx
@@ -67,9 +67,7 @@ Supported in Rsbuild v2.0.7 and later.
 
 #### Importing package workers
 
-JavaScript files in `node_modules` are not compiled by Rsbuild by default. The `?worker` query is applied to the resolved worker file, so this can affect package workers whether the import is written in your app code or inside the package itself.
-
-If a `?worker` request resolves to a JavaScript file in `node_modules` and the worker is not handled as expected, add the package that contains the worker file to [source.include](/config/source/include):
+JavaScript files in `node_modules` are not compiled by Rsbuild by default. If a `?worker` request resolves to a JavaScript file in `node_modules` and the worker is not handled as expected, add the package that contains the worker file to [source.include](/config/source/include):
 
 ```ts title="rsbuild.config.ts"
 export default {

--- a/website/docs/en/guide/basic/web-workers.mdx
+++ b/website/docs/en/guide/basic/web-workers.mdx
@@ -39,45 +39,45 @@ worker.postMessage(10);
 
 Rspack supports multiple Worker syntaxes by default. See [Rspack - Web Workers](https://rspack.rs/guide/features/web-workers) for more information.
 
-### Using worker-loader
+### Import with query suffixes
 
-If your project already uses `worker-loader`, or you want to use the `inline` and other features provided by `worker-loader`, you can use [worker-rspack-loader](https://github.com/rstackjs/worker-rspack-loader) as an alternative to `worker-loader` in Rsbuild projects.
+You can also import a Web Worker script by appending `?worker` to the import request. The default export is a custom Worker constructor.
+
+```js title="index.js"
+import MyWorker from './worker.js?worker';
+
+const worker = new MyWorker();
+
+worker.postMessage(10);
+```
+
+By default, the worker script is emitted as a separate chunk in the production build. If you want to inline the worker script, add the `inline` query:
+
+```js title="index.js"
+import InlineWorker from './worker.js?worker&inline';
+
+const worker = new InlineWorker();
+
+worker.postMessage(10);
+```
+
+:::tip
+Supported in Rsbuild v2.0.7 and later.
+:::
+
+#### Importing package workers
+
+JavaScript files in `node_modules` are not compiled by Rsbuild by default. The `?worker` query is applied to the resolved worker file, so this can affect package workers whether the import is written in your app code or inside the package itself.
+
+If a `?worker` request resolves to a JavaScript file in `node_modules` and the worker is not handled as expected, add the package that contains the worker file to [source.include](/config/source/include):
 
 ```ts title="rsbuild.config.ts"
 export default {
-  tools: {
-    rspack: {
-      resolveLoader: {
-        alias: {
-          // Modify the resolution of worker-loader in the inline loader
-          // such as `worker-loader!pdfjs-dist/es5/build/pdf.worker.js`
-          'worker-loader': require.resolve('worker-rspack-loader'),
-        },
-      },
-      module: {
-        rules: [
-          {
-            test: /\.worker\.js$/,
-            loader: 'worker-rspack-loader',
-          },
-        ],
-      },
-    },
+  source: {
+    include: [/node_modules[\\/]some-package[\\/]/],
   },
 };
 ```
-
-When using `worker-rspack-loader`, load the Web Worker file with `import` instead of `new Worker('/path/to/worker.js')`.
-
-```js
-import Worker from './file.worker.js';
-
-const worker = new Worker();
-
-worker.postMessage({ a: 1 });
-```
-
-> `worker-loader` is no longer maintained. If you don't need to inline Web Workers, we recommend using the `new Worker()` syntax.
 
 ### Loading scripts from remote URLs
 

--- a/website/docs/en/guide/basic/web-workers.mdx
+++ b/website/docs/en/guide/basic/web-workers.mdx
@@ -67,7 +67,7 @@ Supported in Rsbuild v2.0.7 and later.
 
 #### Importing package workers
 
-JavaScript files in `node_modules` are not compiled by Rsbuild by default. If a `?worker` request resolves to a JavaScript file in `node_modules` and the worker is not handled as expected, add the package that contains the worker file to [source.include](/config/source/include):
+JavaScript files in `node_modules` are not compiled by Rsbuild's JavaScript rule by default. Since the `?worker` query is handled by this rule, it will not take effect when the request resolves to a worker file in `node_modules`, whether the import is written in your application code or inside a package. To make the query take effect, add the package that contains the worker file to [source.include](/config/source/include):
 
 ```ts title="rsbuild.config.ts"
 export default {

--- a/website/docs/zh/guide/basic/web-workers.mdx
+++ b/website/docs/zh/guide/basic/web-workers.mdx
@@ -67,7 +67,7 @@ Rsbuild v2.0.7 及以上版本支持。
 
 #### 导入 npm 包中的 worker
 
-默认情况下，Rsbuild 不会编译 `node_modules` 中的 JavaScript 文件。如果 `?worker` 请求解析到 `node_modules` 中的 JavaScript 文件，并且该 worker 未按预期处理，可以将包含该 worker 文件的包加入 [source.include](/config/source/include)：
+默认情况下，Rsbuild 的 JavaScript 编译规则不会处理 `node_modules` 中的 JavaScript 文件。由于 `?worker` query 是在这条规则中处理的，因此当请求解析到 `node_modules` 中的 worker 文件时，无论导入语句写在应用代码中还是 npm 包内部，query 都不会生效。要让该 query 生效，可以将包含 worker 文件的包加入 [source.include](/config/source/include)：
 
 ```ts title="rsbuild.config.ts"
 export default {

--- a/website/docs/zh/guide/basic/web-workers.mdx
+++ b/website/docs/zh/guide/basic/web-workers.mdx
@@ -39,45 +39,45 @@ worker.postMessage(10);
 
 Rspack 默认支持多种 Worker 语法，查看 [Rspack - Web Workers](https://rspack.rs/zh/guide/features/web-workers) 了解更多。
 
-### 使用 worker-loader
+### 使用 query 后缀导入
 
-如果你的项目已经在使用 `worker-loader`，或者希望使用 `worker-loader` 的 `inline` 等能力，在 Rsbuild 项目中可以使用 `worker-loader` 的替代方案 [worker-rspack-loader](https://github.com/rstackjs/worker-rspack-loader)。
+你也可以通过在导入请求后添加 `?worker` 来导入 Web Worker 脚本。默认导出是一个自定义的 Worker 构造器。
+
+```js title="index.js"
+import MyWorker from './worker.js?worker';
+
+const worker = new MyWorker();
+
+worker.postMessage(10);
+```
+
+默认情况下，生产环境构建会将 worker 脚本输出成一个独立的 chunk。如果你希望内联 worker 脚本，可以添加 `inline` query：
+
+```js title="index.js"
+import InlineWorker from './worker.js?worker&inline';
+
+const worker = new InlineWorker();
+
+worker.postMessage(10);
+```
+
+:::tip
+Rsbuild v2.0.7 及以上版本支持。
+:::
+
+#### 导入 npm 包中的 worker
+
+默认情况下，Rsbuild 不会编译 `node_modules` 中的 JavaScript 文件。`?worker` query 是基于解析后的 worker 文件进行处理的，因此无论导入语句写在应用代码中，还是写在 npm 包内部，只要最终解析到 npm 包中的 worker 文件，都可能受到这个限制。
+
+如果 `?worker` 请求解析到 `node_modules` 中的 JavaScript 文件，并且该 worker 未按预期处理，可以将包含该 worker 文件的包加入 [source.include](/config/source/include)：
 
 ```ts title="rsbuild.config.ts"
 export default {
-  tools: {
-    rspack: {
-      resolveLoader: {
-        alias: {
-          // 修改内联 loader 中 worker-loader 的指向
-          // 如 `worker-loader!pdfjs-dist/es5/build/pdf.worker.js`
-          'worker-loader': require.resolve('worker-rspack-loader'),
-        },
-      },
-      module: {
-        rules: [
-          {
-            test: /\.worker\.js$/,
-            loader: 'worker-rspack-loader',
-          },
-        ],
-      },
-    },
+  source: {
+    include: [/node_modules[\\/]some-package[\\/]/],
   },
 };
 ```
-
-使用 `worker-rspack-loader` 时，需要使用 `import` 来引入 Web Worker 文件，而不是 `new Worker('/path/to/worker.js')`。
-
-```js
-import Worker from './file.worker.js';
-
-const worker = new Worker();
-
-worker.postMessage({ a: 1 });
-```
-
-> `worker-loader` 已不再维护，如果你没有内联 Web Workers 的需求，推荐使用 `new Worker()` 语法。
 
 ### 从远程 URL 加载脚本
 

--- a/website/docs/zh/guide/basic/web-workers.mdx
+++ b/website/docs/zh/guide/basic/web-workers.mdx
@@ -67,9 +67,7 @@ Rsbuild v2.0.7 及以上版本支持。
 
 #### 导入 npm 包中的 worker
 
-默认情况下，Rsbuild 不会编译 `node_modules` 中的 JavaScript 文件。`?worker` query 是基于解析后的 worker 文件进行处理的，因此无论导入语句写在应用代码中，还是写在 npm 包内部，只要最终解析到 npm 包中的 worker 文件，都可能受到这个限制。
-
-如果 `?worker` 请求解析到 `node_modules` 中的 JavaScript 文件，并且该 worker 未按预期处理，可以将包含该 worker 文件的包加入 [source.include](/config/source/include)：
+默认情况下，Rsbuild 不会编译 `node_modules` 中的 JavaScript 文件。如果 `?worker` 请求解析到 `node_modules` 中的 JavaScript 文件，并且该 worker 未按预期处理，可以将包含该 worker 文件的包加入 [source.include](/config/source/include)：
 
 ```ts title="rsbuild.config.ts"
 export default {


### PR DESCRIPTION
## Summary

This PR updates the Web Workers docs to replace the legacy worker-loader guidance with the new `?worker` query suffix usage. It also documents the supported Rsbuild version and clarifies how package worker files resolved from `node_modules` can be handled with `source.include` when needed.