### PR TITLE
chore(deps): bump rstack ecosystem ci action

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -47,7 +47,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Trigger Ecosystem CI
-        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@1345990b3128d94ee37afbb7607f9ddc9feadb49 # v0.3.0
+        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@ca8d345a115158ea5ab3807378357f2162be7467 # main
         with:
           github-token: ${{ secrets.REPO_RSBUILD_ECO_CI_GITHUB_TOKEN_NEXT }}
           ecosystem-owner: web-infra-dev
@@ -65,7 +65,7 @@ jobs:
       contents: read
     steps:
       - name: Trigger Ecosystem CI
-        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_per_commit@1345990b3128d94ee37afbb7607f9ddc9feadb49 # v0.3.0
+        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_per_commit@ca8d345a115158ea5ab3807378357f2162be7467 # main
         with:
           github-token: ${{ secrets.REPO_RSBUILD_ECO_CI_GITHUB_TOKEN_NEXT }}
           ecosystem-owner: web-infra-dev


### PR DESCRIPTION
## Summary

This PR updates the two `rstackjs/rstack-ecosystem-ci` composite action pins used by Rsbuild's Ecosystem CI workflow to `ca8d345a115158ea5ab3807378357f2162be7467`. The new commit includes upstream pinning fixes for transitive actions, aligning with the org policy that GitHub Actions must be pinned to full-length SHAs.

## Related Links

- https://github.com/web-infra-dev/rstest/pull/1283
- https://github.com/rstackjs/rstack-ecosystem-ci/pull/41
- https://github.com/rstackjs/rstack-ecosystem-ci/commit/ca8d345a115158ea5ab3807378357f2162be7467