### PR TITLE
docs: document worker constructor options

### DIFF
--- a/e2e/cases/workers/new-worker-options/index.test.ts
+++ b/e2e/cases/workers/new-worker-options/index.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from '@e2e/helper';
+
+test('should support options in the new Worker syntax', async ({
+  page,
+  runBothServe,
+}) => {
+  await runBothServe(async () => {
+    await expect(page.locator('#root')).toHaveText('worker:include');
+  });
+});

--- a/e2e/cases/workers/new-worker-options/src/index.ts
+++ b/e2e/cases/workers/new-worker-options/src/index.ts
@@ -1,0 +1,22 @@
+document.body.innerHTML = '<div id="root"></div>';
+
+let credentials = '';
+
+const worker = new Worker(new URL('./worker.ts', import.meta.url), {
+  get credentials(): RequestCredentials {
+    credentials = 'include';
+    return 'include';
+  },
+  name: 'worker',
+  type: 'module',
+});
+
+worker.addEventListener('message', ({ data }) => {
+  const element = document.getElementById('root');
+  if (element) {
+    element.textContent = [data.name, credentials].join(':');
+  }
+  worker.terminate();
+});
+
+worker.postMessage('ping');

--- a/e2e/cases/workers/new-worker-options/src/worker.ts
+++ b/e2e/cases/workers/new-worker-options/src/worker.ts
@@ -1,0 +1,5 @@
+self.onmessage = () => {
+  self.postMessage({
+    name: self.name,
+  });
+};

--- a/website/docs/en/guide/basic/web-workers.mdx
+++ b/website/docs/en/guide/basic/web-workers.mdx
@@ -37,6 +37,15 @@ worker.onmessage = (event) => {
 worker.postMessage(10);
 ```
 
+You can also pass standard [`WorkerOptions`](https://developer.mozilla.org/en-US/docs/Web/API/Worker/Worker#options) as the second argument. Rsbuild preserves runtime options such as `name` and `credentials`, and uses `type` to determine whether the worker should be handled as a module worker or a classic worker.
+
+```js title="index.js"
+const worker = new Worker(new URL('./worker.js', import.meta.url), {
+  credentials: 'include',
+  type: 'module',
+});
+```
+
 Rspack supports multiple Worker syntaxes by default. See [Rspack - Web Workers](https://rspack.rs/guide/features/web-workers) for more information.
 
 ### Using worker-loader

--- a/website/docs/zh/guide/basic/web-workers.mdx
+++ b/website/docs/zh/guide/basic/web-workers.mdx
@@ -37,6 +37,15 @@ worker.onmessage = (event) => {
 worker.postMessage(10);
 ```
 
+你也可以将标准的 [`WorkerOptions`](https://developer.mozilla.org/zh-CN/docs/Web/API/Worker/Worker#options) 作为第二个参数传入。Rsbuild 会保留 `name`、`credentials` 等运行时选项，并根据 `type` 判断应该将 worker 作为 module worker 还是 classic worker 来处理。
+
+```js title="index.js"
+const worker = new Worker(new URL('./worker.js', import.meta.url), {
+  credentials: 'include',
+  type: 'module',
+});
+```
+
 Rspack 默认支持多种 Worker 语法，查看 [Rspack - Web Workers](https://rspack.rs/zh/guide/features/web-workers) 了解更多。
 
 ### 使用 worker-loader


### PR DESCRIPTION
## Summary

This PR documents the standard `new Worker(new URL(...), options)` usage for Web Workers, including runtime options such as `credentials` and `type`. It also adds a minimal E2E case to verify Rsbuild preserves constructor options for the native `new Worker` syntax while keeping `?worker` imports aligned with Vite's constructor behavior.