### PR TITLE
fix(core): downlevel inline worker wrapper syntax

### DIFF
--- a/packages/core/src/loader/workerLoader.ts
+++ b/packages/core/src/loader/workerLoader.ts
@@ -54,6 +54,7 @@ const getInlineWorkerWrapper = ({
     ? 'URL.revokeObjectURL(import.meta.url);'
     : '(self.URL || self.webkitURL).revokeObjectURL(self.location.href);';
 
+  // Keep the generated wrapper code ES6-compatible since it will not go through transforms.
   return `const jsContent = ${JSON.stringify(stripSourceMappingURL(source))};
 const blob = typeof self !== "undefined" && self.Blob && new Blob([${JSON.stringify(
     revokeCode,
@@ -69,7 +70,7 @@ export default function WorkerWrapper(options) {
       (self.URL || self.webkitURL).revokeObjectURL(objURL);
     });
     return worker;
-  } catch {
+  } catch (e) {
     return new Worker(
       "data:text/javascript;charset=utf-8," + encodeURIComponent(jsContent),
       ${workerOptions}


### PR DESCRIPTION
## Summary

This PR keeps the generated inline worker wrapper syntax at ES6 level because the wrapper string returned by the loader does not go through transforms. It replaces optional catch binding with an explicit catch parameter and documents the generated-code constraint.