### PR TITLE
ci: align preview workflow setup-node config

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -2,8 +2,6 @@
 name: Preview Release
 
 on:
-  # push:
-  #   branches: [main]
   workflow_dispatch:
     inputs:
       branch:
@@ -36,7 +34,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.15.0
-          cache: 'pnpm'
+          package-manager-cache: false
 
       - name: Install Dependencies
         run: pnpm install


### PR DESCRIPTION
## Summary

This PR aligns the Preview Release workflow with the other GitHub Actions by disabling setup-node's package manager cache via `package-manager-cache: false`. It also removes the stale commented push trigger from the workflow.