### PR TITLE
docs: update GitHub Pages action versions

### DIFF
--- a/website/docs/en/guide/basic/static-deploy.mdx
+++ b/website/docs/en/guide/basic/static-deploy.mdx
@@ -155,12 +155,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
+          package-manager-cache: false
 
       # If you use other package managers like yarn or pnpm,
       # you will need to install them first
@@ -171,16 +172,16 @@ jobs:
         run: npm run build
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: './dist'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 ```
 
 5. Commit and wait for GitHub Actions to execute. Once complete, you can visit `https://<USERNAME>.github.io/<REPO_NAME>/` to view the deployed page.

--- a/website/docs/zh/guide/basic/static-deploy.mdx
+++ b/website/docs/zh/guide/basic/static-deploy.mdx
@@ -155,12 +155,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
+          package-manager-cache: false
 
       # 如果你使用其他的包管理器，如 yarn 或 pnpm，
       # 你需要先安装它们
@@ -171,16 +172,16 @@ jobs:
         run: npm run build
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: './dist'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 ```
 
 5. 提交，等待 GitHub Actions 执行，执行完成后，你可以访问 `https://<USERNAME>.github.io/<REPO_NAME>/` 来查看部署后的页面。


### PR DESCRIPTION
## Summary

This PR updates the GitHub Pages deployment examples in the English and Chinese docs to use the latest stable major GitHub Actions versions and Node.js 24 LTS. It also includes `package-manager-cache: false` in the setup-node example for consistency with the repository workflows.