### PR TITLE
ci: allow ecosystem CI commit comments

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'web-infra-dev/rsbuild' && github.event_name != 'workflow_dispatch' && needs.changes.outputs.changed == 'true'
     permissions:
-      contents: read
+      contents: write
     steps:
       - name: Trigger Ecosystem CI
         uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_per_commit@ca8d345a115158ea5ab3807378357f2162be7467 # main


### PR DESCRIPTION
## Summary

Restore the `contents: write` permission for the per-commit ecosystem CI job so the failure-reporting path can create commit comments after downstream ecosystem CI failures. The other narrowed permissions remain unchanged.

- https://github.com/web-infra-dev/rsbuild/pull/7685
- https://github.com/web-infra-dev/rsbuild/actions/runs/26089792786/job/76712586221
