### PR TITLE
docs: clarify proxy changeOrigin default

### DIFF
--- a/website/docs/en/config/server/proxy.mdx
+++ b/website/docs/en/config/server/proxy.mdx
@@ -18,7 +18,11 @@ type ProxyConfig = ProxyOptions[] | Record<string, string | ProxyOptions>;
 
 Configure proxy rules for the dev server or preview server, and forward requests to the specified service.
 
+## Proxy options
+
 This feature is powered by [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware). You can use [all options](https://github.com/chimurai/http-proxy-middleware#options) provided by `http-proxy-middleware`, plus the extra [bypass](#bypass) option from Rsbuild.
+
+Rsbuild sets [`changeOrigin`](https://github.com/chimurai/http-proxy-middleware#httpxy-options) to `true` by default for every proxy rule. Other proxy options follow the defaults of `http-proxy-middleware`. Set `changeOrigin: false` to override it.
 
 ## Example
 

--- a/website/docs/en/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/en/guide/upgrade/v1-to-v2.mdx
@@ -434,6 +434,22 @@ export default {
 };
 ```
 
+- Rsbuild now applies default proxy options to all config styles. In array-style proxy config, [`changeOrigin`](https://github.com/chimurai/http-proxy-middleware#httpxy-options) now defaults to `true`, matching the record-style config. If you relied on the previous `false` default, set it explicitly:
+
+```diff title="rsbuild.config.ts"
+export default {
+  server: {
+    proxy: [
+      {
+        pathFilter: '/api',
+        target: 'https://example.com',
++       changeOrigin: false,
+      },
+    ],
+  },
+};
+```
+
 - Proxy events are now configured in a unified way using the `on` option:
 
 ```diff title="rsbuild.config.ts"

--- a/website/docs/zh/config/server/proxy.mdx
+++ b/website/docs/zh/config/server/proxy.mdx
@@ -18,7 +18,11 @@ type ProxyConfig = ProxyOptions[] | Record<string, string | ProxyOptions>;
 
 为开发服务器或预览服务器配置代理规则，把请求转发到指定服务。
 
+## 代理选项
+
 该功能基于 [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware) 实现。你可以使用 `http-proxy-middleware` 提供的 [全部选项](https://github.com/chimurai/http-proxy-middleware#options)，以及 Rsbuild 额外扩展的 [bypass](#bypass) 选项。
+
+Rsbuild 会默认将每条代理规则的 [`changeOrigin`](https://github.com/chimurai/http-proxy-middleware#httpxy-options) 设置为 `true`。其他代理选项遵循 `http-proxy-middleware` 的默认行为。设置 `changeOrigin: false` 可覆盖该默认值。
 
 ## 示例
 

--- a/website/docs/zh/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/zh/guide/upgrade/v1-to-v2.mdx
@@ -434,6 +434,22 @@ export default {
 };
 ```
 
+- Rsbuild 现在会对所有代理配置写法应用默认代理选项。在数组写法中，[`changeOrigin`](https://github.com/chimurai/http-proxy-middleware#httpxy-options) 现在默认值为 `true`，与对象写法保持一致。如果你依赖之前的 `false` 默认值，请显式设置：
+
+```diff title="rsbuild.config.ts"
+export default {
+  server: {
+    proxy: [
+      {
+        pathFilter: '/api',
+        target: 'https://example.com',
++       changeOrigin: false,
+      },
+    ],
+  },
+};
+```
+
 - 事件改为使用 `on` 统一配置：
 
 ```diff title="rsbuild.config.ts"


### PR DESCRIPTION
## Summary

Clarify that Rsbuild sets `changeOrigin` to `true` by default for every `server.proxy` rule, and document the migration impact for array-style proxy config from Rsbuild 1 to 2. Users can set `changeOrigin: false` to preserve the previous behavior.

## Related Links

- https://github.com/web-infra-dev/rsbuild/issues/7696