### PR TITLE
docs: add import.meta.env.SSR

### DIFF
--- a/website/docs/en/guide/advanced/env-vars.mdx
+++ b/website/docs/en/guide/advanced/env-vars.mdx
@@ -17,6 +17,7 @@ By default, Rsbuild uses [source.define](#using-define) to inject environment va
 - [import.meta.env.MODE](#importmetaenvmode)
 - [import.meta.env.DEV](#importmetaenvdev)
 - [import.meta.env.PROD](#importmetaenvprod)
+- [import.meta.env.SSR](#importmetaenvssr)
 - [import.meta.env.BASE_URL](#importmetaenvbase_url)
 - [import.meta.env.ASSET_PREFIX](#importmetaenvasset_prefix)
 
@@ -80,6 +81,19 @@ If [mode](/config/mode) is `'production'`, the value is `true`; otherwise, it is
 ```ts
 if (import.meta.env.PROD) {
   console.log('this is production mode');
+}
+```
+
+### import.meta.env.SSR
+
+- **Type:** `boolean`
+- **Scope:** Available in source code, replaced at build time via [define](/guide/advanced/env-vars#using-define)
+
+If [output.target](/config/output/target) is `'node'`, the value is `true`; otherwise, it is `false`.
+
+```ts
+if (import.meta.env.SSR) {
+  console.log('this is the SSR build');
 }
 ```
 

--- a/website/docs/en/guide/migration/vite.mdx
+++ b/website/docs/en/guide/migration/vite.mdx
@@ -191,32 +191,9 @@ Rsbuild injects the following [environment variables](/guide/advanced/env-vars) 
 - `import.meta.env.BASE_URL`
 - `import.meta.env.PROD`
 - `import.meta.env.DEV`
+- `import.meta.env.SSR`
 
-For `import.meta.env.SSR`, you can set it through the [environments](/config/environments) and [source.define](/config/source/define) configuration options:
-
-```ts title="rsbuild.config.ts"
-export default defineConfig({
-  environments: {
-    web: {
-      source: {
-        define: {
-          'import.meta.env.SSR': JSON.stringify(false),
-        },
-      },
-    },
-    node: {
-      source: {
-        define: {
-          'import.meta.env.SSR': JSON.stringify(true),
-        },
-      },
-      output: {
-        target: 'node',
-      },
-    },
-  },
-});
-```
+`import.meta.env.SSR` is `true` when [output.target](/config/output/target) is `'node'`, and `false` otherwise.
 
 ## Preset types
 

--- a/website/docs/en/guide/migration/vite.mdx
+++ b/website/docs/en/guide/migration/vite.mdx
@@ -193,8 +193,6 @@ Rsbuild injects the following [environment variables](/guide/advanced/env-vars) 
 - `import.meta.env.DEV`
 - `import.meta.env.SSR`
 
-`import.meta.env.SSR` is `true` when [output.target](/config/output/target) is `'node'`, and `false` otherwise.
-
 ## Preset types
 
 Vite provides some preset type definitions through the `vite-env.d.ts` file. When migrating to Rsbuild, you can use the [preset types](/guide/basic/typescript#preset-types) provided by `@rsbuild/core`:

--- a/website/docs/zh/guide/advanced/env-vars.mdx
+++ b/website/docs/zh/guide/advanced/env-vars.mdx
@@ -17,6 +17,7 @@ Rsbuild 默认通过 [source.define](#使用-define) 向代码中注入以下环
 - [import.meta.env.MODE](#importmetaenvmode)
 - [import.meta.env.DEV](#importmetaenvdev)
 - [import.meta.env.PROD](#importmetaenvprod)
+- [import.meta.env.SSR](#importmetaenvssr)
 - [import.meta.env.BASE_URL](#importmetaenvbase_url)
 - [import.meta.env.ASSET_PREFIX](#importmetaenvasset_prefix)
 
@@ -80,6 +81,19 @@ if (import.meta.env.DEV) {
 ```ts
 if (import.meta.env.PROD) {
   console.log('this is production mode');
+}
+```
+
+### import.meta.env.SSR
+
+- **类型：** `boolean`
+- **使用范围：** 源代码中可用，构建时通过 [define](/guide/advanced/env-vars#使用-define) 替换
+
+当 [output.target](/config/output/target) 为 `'node'` 时，值为 `true`，否则为 `false`。
+
+```ts
+if (import.meta.env.SSR) {
+  console.log('this is the SSR build');
 }
 ```
 

--- a/website/docs/zh/guide/migration/vite.mdx
+++ b/website/docs/zh/guide/migration/vite.mdx
@@ -191,32 +191,9 @@ Rsbuild 默认注入了以下 [环境变量](/guide/advanced/env-vars)：
 - `import.meta.env.BASE_URL`
 - `import.meta.env.PROD`
 - `import.meta.env.DEV`
+- `import.meta.env.SSR`
 
-对于 `import.meta.env.SSR`，你可以通过 [environments](/config/environments) 和 [source.define](/config/source/define) 配置项来设置：
-
-```ts title="rsbuild.config.ts"
-export default defineConfig({
-  environments: {
-    web: {
-      source: {
-        define: {
-          'import.meta.env.SSR': JSON.stringify(false),
-        },
-      },
-    },
-    node: {
-      source: {
-        define: {
-          'import.meta.env.SSR': JSON.stringify(true),
-        },
-      },
-      output: {
-        target: 'node',
-      },
-    },
-  },
-});
-```
+当 [output.target](/config/output/target) 为 `'node'` 时，`import.meta.env.SSR` 为 `true`，否则为 `false`。
 
 ## 预设类型
 

--- a/website/docs/zh/guide/migration/vite.mdx
+++ b/website/docs/zh/guide/migration/vite.mdx
@@ -193,8 +193,6 @@ Rsbuild 默认注入了以下 [环境变量](/guide/advanced/env-vars)：
 - `import.meta.env.DEV`
 - `import.meta.env.SSR`
 
-当 [output.target](/config/output/target) 为 `'node'` 时，`import.meta.env.SSR` 为 `true`，否则为 `false`。
-
 ## 预设类型
 
 Vite 通过 `vite-env.d.ts` 文件提供了一些预设的类型定义，迁移到 Rsbuild 时，你可以使用 `@rsbuild/core` 提供的 [预设类型](/guide/basic/typescript#预设类型)：


### PR DESCRIPTION
## Summary

This PR documents the built-in `import.meta.env.SSR` value and updates the Vite migration guide to remove the manual `source.define` workaround once Rsbuild provides the value by default.

## Related Links

- #7700