### PR TITLE
test: add public manifest html case

### DIFF
--- a/e2e/cases/html/app-icon-public-manifest/index.test.ts
+++ b/e2e/cases/html/app-icon-public-manifest/index.test.ts
@@ -1,0 +1,23 @@
+import { expect, getDistFiles, getFileContent, test } from '@e2e/helper';
+
+test('should use public manifest for additional manifest fields', async ({
+  build,
+}) => {
+  const rsbuild = await build();
+  const files = await getDistFiles(rsbuild.distPath);
+  const html = getFileContent(files, 'index.html');
+  const manifest = getFileContent(files, 'manifest.webmanifest');
+
+  expect(html).toContain('<link rel="manifest" href="/manifest.webmanifest">');
+  expect(JSON.parse(manifest)).toEqual({
+    name: 'My Website',
+    short_name: 'Website',
+    icons: [
+      {
+        src: '/icon-192.png',
+        sizes: '192x192',
+        type: 'image/png',
+      },
+    ],
+  });
+});

--- a/e2e/cases/html/app-icon-public-manifest/public/manifest.webmanifest
+++ b/e2e/cases/html/app-icon-public-manifest/public/manifest.webmanifest
@@ -1,0 +1,11 @@
+{
+  "name": "My Website",
+  "short_name": "Website",
+  "icons": [
+    {
+      "src": "/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    }
+  ]
+}

--- a/e2e/cases/html/app-icon-public-manifest/rsbuild.config.ts
+++ b/e2e/cases/html/app-icon-public-manifest/rsbuild.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  html: {
+    tags: [
+      {
+        tag: 'link',
+        attrs: {
+          rel: 'manifest',
+          href: '/manifest.webmanifest',
+        },
+      },
+    ],
+  },
+});

--- a/e2e/cases/html/app-icon-public-manifest/src/index.js
+++ b/e2e/cases/html/app-icon-public-manifest/src/index.js
@@ -1,0 +1,1 @@
+console.log('1');


### PR DESCRIPTION
## Summary

Add an e2e case that validates using `public/manifest.webmanifest` with `html.tags` to reference a Web App Manifest containing fields beyond what `html.appIcon` generates.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/4933