### PR TITLE
docs: add autoExternal version history

### DIFF
--- a/website/docs/en/config/output/auto-external.mdx
+++ b/website/docs/en/config/output/auto-external.mdx
@@ -134,3 +134,9 @@ For more complex `output.externals` configurations, such as arrays, functions, o
 If [output.target](/config/output/target) is `web-worker`, Rsbuild removes the `externals` configuration, so `output.autoExternal` will not take effect. This is because a Web Worker runs in an isolated global scope and cannot access global variables injected into `window` by CDN scripts or the host page.
 
 :::
+
+## Version history
+
+| Version | Changes           |
+| ------- | ----------------- |
+| v2.0.7  | Added this option |

--- a/website/docs/zh/config/output/auto-external.mdx
+++ b/website/docs/zh/config/output/auto-external.mdx
@@ -134,3 +134,9 @@ export default {
 当 [output.target](/config/output/target) 为 `web-worker` 时，Rsbuild 会移除 `externals` 配置，因此 `output.autoExternal` 不会生效。这是因为 Web Worker 运行在独立的全局作用域中，无法访问主页面通过 CDN 脚本或宿主环境注入到 `window` 上的全局变量。
 
 :::
+
+## 版本历史
+
+| 版本   | 变更内容   |
+| ------ | ---------- |
+| v2.0.7 | 新增该选项 |


### PR DESCRIPTION
## Summary

This PR adds version history entries to the English and Chinese `output.autoExternal` docs so readers can see that the option was introduced in Rsbuild v2.0.7.

https://github.com/web-infra-dev/rsbuild/pull/7638