### PR TITLE
fix(core): remove redundant autoExternal rules

### DIFF
--- a/e2e/cases/output/auto-external/fixtures/auto-external-dev-pkg/package.json
+++ b/e2e/cases/output/auto-external/fixtures/auto-external-dev-pkg/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "auto-external-dev-pkg",
+  "name": "@e2e/auto-external-dev-pkg",
   "version": "1.0.0",
   "type": "module",
   "main": "index.js"

--- a/e2e/cases/output/auto-external/fixtures/auto-external-peer-pkg/package.json
+++ b/e2e/cases/output/auto-external/fixtures/auto-external-peer-pkg/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "auto-external-peer-pkg",
+  "name": "@e2e/auto-external-peer-pkg",
   "version": "1.0.0",
   "type": "module",
   "main": "index.js"

--- a/e2e/cases/output/auto-external/fixtures/auto-external-pkg/package.json
+++ b/e2e/cases/output/auto-external/fixtures/auto-external-pkg/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "auto-external-pkg",
+  "name": "@e2e/auto-external-pkg",
   "version": "1.0.0",
   "type": "module",
   "main": "index.js"

--- a/e2e/cases/output/auto-external/index.test.ts
+++ b/e2e/cases/output/auto-external/index.test.ts
@@ -22,9 +22,9 @@ test('should not auto externalize package.json dependencies by default', async (
   expect(content).toContain('subpath');
   expect(content).toContain('dev');
   expect(content).toContain('peer');
-  expect(content).not.toContain('external "auto-external-pkg"');
-  expect(content).not.toContain('external "auto-external-pkg/subpath"');
-  expect(content).not.toContain('external "auto-external-peer-pkg"');
+  expect(content).not.toContain('external "@e2e/auto-external-pkg"');
+  expect(content).not.toContain('external "@e2e/auto-external-pkg/subpath"');
+  expect(content).not.toContain('external "@e2e/auto-external-peer-pkg"');
 });
 
 test('should auto externalize dependencies and subpath imports', async ({
@@ -46,10 +46,10 @@ test('should auto externalize dependencies and subpath imports', async ({
   const files = rsbuild.getDistFiles();
   const content = getFileContent(files, '.js');
 
-  expect(content).toContain('external "auto-external-pkg"');
-  expect(content).toContain('external "auto-external-pkg/subpath"');
-  expect(content).toContain('external "auto-external-peer-pkg"');
-  expect(content).not.toContain('external "auto-external-dev-pkg"');
+  expect(content).toContain('external "@e2e/auto-external-pkg"');
+  expect(content).toContain('external "@e2e/auto-external-pkg/subpath"');
+  expect(content).toContain('external "@e2e/auto-external-peer-pkg"');
+  expect(content).not.toContain('external "@e2e/auto-external-dev-pkg"');
   expect(content).toContain('dev');
 });
 
@@ -74,5 +74,5 @@ test('should auto externalize devDependencies when enabled', async ({
   const files = rsbuild.getDistFiles();
   const content = getFileContent(files, '.js');
 
-  expect(content).toContain('external "auto-external-dev-pkg"');
+  expect(content).toContain('external "@e2e/auto-external-dev-pkg"');
 });

--- a/e2e/cases/output/auto-external/package.json
+++ b/e2e/cases/output/auto-external/package.json
@@ -3,13 +3,13 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "auto-external-pkg": "link:./fixtures/auto-external-pkg"
+    "@e2e/auto-external-pkg": "link:./fixtures/auto-external-pkg"
   },
   "peerDependencies": {
-    "auto-external-peer-pkg": "1.0.0"
+    "@e2e/auto-external-peer-pkg": "1.0.0"
   },
   "devDependencies": {
-    "auto-external-dev-pkg": "link:./fixtures/auto-external-dev-pkg",
-    "auto-external-peer-pkg": "link:./fixtures/auto-external-peer-pkg"
+    "@e2e/auto-external-dev-pkg": "link:./fixtures/auto-external-dev-pkg",
+    "@e2e/auto-external-peer-pkg": "link:./fixtures/auto-external-peer-pkg"
   }
 }

--- a/e2e/cases/output/auto-external/src/index.js
+++ b/e2e/cases/output/auto-external/src/index.js
@@ -1,6 +1,6 @@
-import { dep } from 'auto-external-pkg';
-import { subpath } from 'auto-external-pkg/subpath';
-import { dev } from 'auto-external-dev-pkg';
-import { peer } from 'auto-external-peer-pkg';
+import { dep } from '@e2e/auto-external-pkg';
+import { subpath } from '@e2e/auto-external-pkg/subpath';
+import { dev } from '@e2e/auto-external-dev-pkg';
+import { peer } from '@e2e/auto-external-peer-pkg';
 
 export { dep, dev, peer, subpath };

--- a/packages/core/src/plugins/externals.ts
+++ b/packages/core/src/plugins/externals.ts
@@ -47,7 +47,7 @@ export const composeAutoExternalRules = (options: {
   autoExternal?: AutoExternal;
   pkgJson?: PackageJson;
   userExternals?: Externals;
-}): (string | RegExp)[] | undefined => {
+}): RegExp[] | undefined => {
   const { autoExternal, pkgJson, userExternals } = options;
   const externalOptions = resolveAutoExternalOptions(autoExternal);
 
@@ -73,20 +73,17 @@ export const composeAutoExternalRules = (options: {
 
   const uniqueExternals = Array.from(new Set(externals));
 
+  // Exclude dependencies and subpath imports, e.g. `react`, `react/jsx-runtime`.
   return uniqueExternals.length
-    ? [
-        // Exclude dependencies and subpath imports, e.g. `react`, `react/jsx-runtime`.
-        ...uniqueExternals.map(
-          (dep) => new RegExp(`^${escapeRegExp(dep)}($|\/|\\\\)`),
-        ),
-        ...uniqueExternals,
-      ]
+    ? uniqueExternals.map(
+        (dep) => new RegExp(`^${escapeRegExp(dep)}(?:$|[/\\\\])`),
+      )
     : undefined;
 };
 
 const mergeExternals = (
   userExternals: Externals | undefined,
-  autoExternalRules: (string | RegExp)[] | undefined,
+  autoExternalRules: RegExp[] | undefined,
 ): Externals | undefined => {
   if (!autoExternalRules?.length) {
     return userExternals;

--- a/packages/core/tests/externals.test.ts
+++ b/packages/core/tests/externals.test.ts
@@ -55,14 +55,10 @@ describe('plugin-externals', () => {
     });
 
     expect(result).toEqual([
-      /^foo($|\/|\\)/,
-      /^foo\.bar($|\/|\\)/,
-      /^baz($|\/|\\)/,
-      /^@scope\/pkg($|\/|\\)/,
-      'foo',
-      'foo.bar',
-      'baz',
-      '@scope/pkg',
+      /^foo(?:$|[/\\])/,
+      /^foo\.bar(?:$|[/\\])/,
+      /^baz(?:$|[/\\])/,
+      /^@scope\/pkg(?:$|[/\\])/,
     ]);
   });
 
@@ -85,7 +81,7 @@ describe('plugin-externals', () => {
       },
     });
 
-    expect(result).toEqual([/^baz($|\/|\\)/, /^bar($|\/|\\)/, 'baz', 'bar']);
+    expect(result).toEqual([/^baz(?:$|[/\\])/, /^bar(?:$|[/\\])/]);
   });
 
   it('should not compose rules when autoExternal is disabled', () => {
@@ -115,7 +111,7 @@ describe('plugin-externals', () => {
       },
     });
 
-    expect(result).toEqual([/^bar($|\/|\\)/, 'bar']);
+    expect(result).toEqual([/^bar(?:$|[/\\])/]);
   });
 
   it('should apply autoExternal to Rspack externals', async () => {
@@ -146,12 +142,7 @@ describe('plugin-externals', () => {
 
     const [config] = await rsbuild.initConfigs();
 
-    expect(config.externals).toEqual([
-      /^foo($|\/|\\)/,
-      /^bar($|\/|\\)/,
-      'foo',
-      'bar',
-    ]);
+    expect(config.externals).toEqual([/^foo(?:$|[/\\])/, /^bar(?:$|[/\\])/]);
   });
 
   it('should keep user externals before autoExternal rules', async () => {
@@ -181,7 +172,7 @@ describe('plugin-externals', () => {
 
     const [config] = await rsbuild.initConfigs();
 
-    expect(config.externals).toEqual([userExternals, /^bar($|\/|\\)/, 'bar']);
+    expect(config.externals).toEqual([userExternals, /^bar(?:$|[/\\])/]);
   });
 
   it('should apply autoExternal before creating compiler for web worker target', async () => {
@@ -209,6 +200,6 @@ describe('plugin-externals', () => {
 
     // The final web worker externals are removed in the onBeforeCreateCompiler hook.
     // initConfigs only verifies the generated Rspack config before that hook runs.
-    expect(config.externals).toEqual([/^foo($|\/|\\)/, 'foo']);
+    expect(config.externals).toEqual([/^foo(?:$|[/\\])/]);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,14 +217,14 @@ importers:
 
   e2e/cases/output/auto-external:
     dependencies:
-      auto-external-pkg:
+      '@e2e/auto-external-pkg':
         specifier: link:./fixtures/auto-external-pkg
         version: link:fixtures/auto-external-pkg
     devDependencies:
-      auto-external-dev-pkg:
+      '@e2e/auto-external-dev-pkg':
         specifier: link:./fixtures/auto-external-dev-pkg
         version: link:fixtures/auto-external-dev-pkg
-      auto-external-peer-pkg:
+      '@e2e/auto-external-peer-pkg':
         specifier: link:./fixtures/auto-external-peer-pkg
         version: link:fixtures/auto-external-peer-pkg
 


### PR DESCRIPTION
## Summary

This PR removes redundant string entries from the generated `output.autoExternal` externals rules because the package RegExp already covers both exact dependency imports and subpath imports. It also updates the auto-external e2e fixture package names to use the `@e2e/` namespace and adjusts the related assertions.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/7638