### PR TITLE
chore: restore Renovate workspace scanning

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,7 @@
     "helpers:pinGitHubActionDigests",
     "github>rstackjs/renovate:security"
   ],
+  "ignorePaths": ["**/node_modules/**"],
   "rangeStrategy": "bump",
   "packageRules": [
     {


### PR DESCRIPTION
## Summary

Restore the explicit Renovate ignore path override so `config:recommended` no longer ignores workspace package files under example and test-like directories. This keeps Renovate dependency updates aligned with the package scopes declared in `pnpm-workspace.yaml` while still ignoring `node_modules/**`.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/7528
https://github.com/web-infra-dev/rslib/pull/1662