### PR TITLE
test: cover SSR autoExternal

### DIFF
--- a/e2e/cases/server/ssr/index.test.ts
+++ b/e2e/cases/server/ssr/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 test('support SSR', async ({ page, devOnly }) => {
   const rsbuild = await devOnly();
@@ -14,13 +14,14 @@ test('support SSR', async ({ page, devOnly }) => {
   expect(rsbuild.logs.filter((log) => log.includes('load SSR')).length).toBe(1);
 });
 
-test('support SSR with external', async ({ page, devOnly }) => {
+test('support SSR with autoExternal', async ({ page, devOnly }) => {
   const rsbuild = await devOnly({
     config: {
-      output: {
-        externals: {
-          react: 'react',
-          'react-dom': 'react-dom',
+      environments: {
+        node: {
+          output: {
+            autoExternal: true,
+          },
         },
       },
     },
@@ -31,6 +32,11 @@ test('support SSR with external', async ({ page, devOnly }) => {
   await page.goto(url.href);
   await expect(page.locator('body')).toContainText('Rsbuild with React');
 
+  const files = rsbuild.getDistFiles();
+  const content = getFileContent(files, 'dist/index.js');
+  expect(content).toContain('module.exports = require("react")');
+  expect(content).toContain('module.exports = require("react-dom/server")');
+
   await page.goto(url.href);
 
   // bundle result should cacheable and only load once.
@@ -38,7 +44,7 @@ test('support SSR with external', async ({ page, devOnly }) => {
 });
 
 test('support SSR with esm target', async ({ page, devOnly }) => {
-  process.env.TEST_ESM_LIBRARY = '1';
+  process.env.TEST_ESM_LIBRARY = 'true';
 
   const rsbuild = await devOnly();
 
@@ -50,15 +56,19 @@ test('support SSR with esm target', async ({ page, devOnly }) => {
   delete process.env.TEST_ESM_LIBRARY;
 });
 
-test('support SSR with esm target & external', async ({ page, devOnly }) => {
-  process.env.TEST_ESM_LIBRARY = '1';
+test('support SSR with esm target and autoExternal', async ({
+  page,
+  devOnly,
+}) => {
+  process.env.TEST_ESM_LIBRARY = 'true';
 
   const rsbuild = await devOnly({
     config: {
-      output: {
-        externals: {
-          react: 'react',
-          'react-dom': 'react-dom',
+      environments: {
+        node: {
+          output: {
+            autoExternal: true,
+          },
         },
       },
     },
@@ -68,6 +78,11 @@ test('support SSR with esm target & external', async ({ page, devOnly }) => {
 
   await page.goto(url1.href);
   await expect(page.locator('body')).toContainText('Rsbuild with React');
+
+  const files = rsbuild.getDistFiles();
+  const content = getFileContent(files, 'dist/index.mjs');
+  expect(content).toContain('import * as __rspack_external_react');
+  expect(content).toContain('from "react-dom/server"');
 
   delete process.env.TEST_ESM_LIBRARY;
 });

--- a/e2e/cases/server/ssr/package.json
+++ b/e2e/cases/server/ssr/package.json
@@ -7,6 +7,10 @@
     "dev": "rsbuild",
     "dev:esm": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" TEST_ESM_LIBRARY=true rsbuild"
   },
+  "dependencies": {
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6"
+  },
   "devDependencies": {
     "@rsbuild/core": "workspace:*"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,6 +273,13 @@ importers:
   e2e/cases/server/custom-server: {}
 
   e2e/cases/server/ssr:
+    dependencies:
+      react:
+        specifier: ^19.2.6
+        version: 19.2.6
+      react-dom:
+        specifier: ^19.2.6
+        version: 19.2.6(react@19.2.6)
     devDependencies:
       '@rsbuild/core':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

This PR moves the SSR `output.autoExternal` coverage into a dedicated test change. It updates the SSR e2e case to use `autoExternal` for the node environment, verifies both CommonJS and ESM external output in the server bundle, and declares the React runtime dependencies needed by auto externalization.