### PR TITLE
docs: update Vite ssr.external migration

### DIFF
--- a/website/docs/en/guide/migration/vite.mdx
+++ b/website/docs/en/guide/migration/vite.mdx
@@ -111,57 +111,58 @@ You can refer to [Plugin List](/plugins/list/index) to learn more about availabl
 
 Here is the corresponding Rsbuild configuration for each Vite option:
 
-| Vite                                  | Rsbuild                                                           |
-| ------------------------------------- | ----------------------------------------------------------------- |
-| root                                  | [root](/config/root)                                              |
-| mode                                  | [mode](/config/mode)                                              |
-| base                                  | [server.base](/config/server/base)                                |
-| define                                | [source.define](/config/source/define)                            |
-| plugins                               | [plugins](/config/plugins)                                        |
-| appType                               | [server.historyApiFallback](/config/server/history-api-fallback)  |
-| envDir                                | [Env directory](/guide/advanced/env-vars#env-directory)           |
-| logLevel                              | [logLevel](/config/log-level)                                     |
-| cacheDir                              | [buildCache](/config/performance/build-cache)                     |
-| publicDir                             | [server.publicDir](/config/server/public-dir)                     |
-| customLogger                          | [customLogger](/config/custom-logger)                             |
-| assetsInclude                         | [source.assetsInclude](/config/source/assets-include)             |
-| resolve.alias                         | [resolve.alias](/config/resolve/alias)                            |
-| resolve.dedupe                        | [resolve.dedupe](/config/resolve/dedupe)                          |
-| resolve.extensions                    | [resolve.extensions](/config/resolve/extensions)                  |
-| resolve.conditions                    | [resolve.conditionNames](/config/resolve/condition-names)         |
-| resolve.mainFields                    | [resolve.mainFields](/config/resolve/main-fields)                 |
-| resolve.preserveSymlinks              | [tools.rspack.resolve.symlinks](/config/tools/rspack)             |
-| html.cspNonce                         | [security.nonce](/config/security/nonce)                          |
-| css.modules                           | [output.cssModules](/config/output/css-modules)                   |
-| css.postcss                           | [tools.postcss](/config/tools/postcss)                            |
-| css.preprocessorOptions.sass          | [pluginSass](/plugins/list/plugin-sass)                           |
-| css.preprocessorOptions.less          | [pluginLess](/plugins/list/plugin-less)                           |
-| css.preprocessorOptions.stylus        | [pluginStylus](https://github.com/rstackjs/rsbuild-plugin-stylus) |
-| css.devSourcemap                      | [output.sourceMap](/config/output/source-map)                     |
-| css.lightningcss                      | [tools.lightningcssLoader](/config/tools/lightningcss-loader)     |
-| server.host, preview.host             | [server.host](/config/server/host)                                |
-| server.port, preview.port             | [server.port](/config/server/port)                                |
-| server.cors, preview.cors             | [server.cors](/config/server/cors)                                |
-| server.strictPort, preview.strictPort | [server.strictPort](/config/server/strict-port)                   |
-| server.https, preview.https           | [server.https](/config/server/https)                              |
-| server.open, preview.open             | [server.open](/config/server/open)                                |
-| server.proxy, preview.proxy           | [server.proxy](/config/server/proxy)                              |
-| server.headers, preview.headers       | [server.headers](/config/server/headers)                          |
-| server.hmr                            | [dev.hmr](/config/dev/hmr), [dev.client](/config/dev/client)      |
-| server.middlewareMode                 | [server.middlewareMode](/config/server/middleware-mode)           |
-| build.target, build.cssTarget         | [Browserslist](/guide/advanced/browserslist)                      |
-| build.outDir, build.assetsDir         | [output.distPath](/config/output/dist-path)                       |
-| build.assetsInlineLimit               | [output.dataUriLimit](/config/output/data-uri-limit)              |
-| build.cssMinify                       | [output.minify](/config/output/minify)                            |
-| build.sourcemap                       | [output.sourceMap](/config/output/source-map)                     |
-| build.lib                             | Use [Rslib](https://github.com/web-infra-dev/rslib)               |
-| build.manifest                        | [output.manifest](/config/output/manifest)                        |
-| build.ssrEmitAssets                   | [output.emitAssets](/config/output/emit-assets)                   |
-| build.minify, build.terserOptions     | [output.minify](/config/output/minify)                            |
-| build.emptyOutDir                     | [output.cleanDistPath](/config/output/clean-dist-path)            |
-| build.copyPublicDir                   | [server.publicDir](/config/server/public-dir)                     |
-| build.reportCompressedSize            | [performance.printFileSize](/config/performance/print-file-size)  |
-| ssr, worker                           | [environments](/config/environments)                              |
+| Vite                                  | Rsbuild                                                                                           |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| root                                  | [root](/config/root)                                                                              |
+| mode                                  | [mode](/config/mode)                                                                              |
+| base                                  | [server.base](/config/server/base)                                                                |
+| define                                | [source.define](/config/source/define)                                                            |
+| plugins                               | [plugins](/config/plugins)                                                                        |
+| appType                               | [server.historyApiFallback](/config/server/history-api-fallback)                                  |
+| envDir                                | [Env directory](/guide/advanced/env-vars#env-directory)                                           |
+| logLevel                              | [logLevel](/config/log-level)                                                                     |
+| cacheDir                              | [buildCache](/config/performance/build-cache)                                                     |
+| publicDir                             | [server.publicDir](/config/server/public-dir)                                                     |
+| customLogger                          | [customLogger](/config/custom-logger)                                                             |
+| assetsInclude                         | [source.assetsInclude](/config/source/assets-include)                                             |
+| resolve.alias                         | [resolve.alias](/config/resolve/alias)                                                            |
+| resolve.dedupe                        | [resolve.dedupe](/config/resolve/dedupe)                                                          |
+| resolve.extensions                    | [resolve.extensions](/config/resolve/extensions)                                                  |
+| resolve.conditions                    | [resolve.conditionNames](/config/resolve/condition-names)                                         |
+| resolve.mainFields                    | [resolve.mainFields](/config/resolve/main-fields)                                                 |
+| resolve.preserveSymlinks              | [tools.rspack.resolve.symlinks](/config/tools/rspack)                                             |
+| html.cspNonce                         | [security.nonce](/config/security/nonce)                                                          |
+| css.modules                           | [output.cssModules](/config/output/css-modules)                                                   |
+| css.postcss                           | [tools.postcss](/config/tools/postcss)                                                            |
+| css.preprocessorOptions.sass          | [pluginSass](/plugins/list/plugin-sass)                                                           |
+| css.preprocessorOptions.less          | [pluginLess](/plugins/list/plugin-less)                                                           |
+| css.preprocessorOptions.stylus        | [pluginStylus](https://github.com/rstackjs/rsbuild-plugin-stylus)                                 |
+| css.devSourcemap                      | [output.sourceMap](/config/output/source-map)                                                     |
+| css.lightningcss                      | [tools.lightningcssLoader](/config/tools/lightningcss-loader)                                     |
+| server.host, preview.host             | [server.host](/config/server/host)                                                                |
+| server.port, preview.port             | [server.port](/config/server/port)                                                                |
+| server.cors, preview.cors             | [server.cors](/config/server/cors)                                                                |
+| server.strictPort, preview.strictPort | [server.strictPort](/config/server/strict-port)                                                   |
+| server.https, preview.https           | [server.https](/config/server/https)                                                              |
+| server.open, preview.open             | [server.open](/config/server/open)                                                                |
+| server.proxy, preview.proxy           | [server.proxy](/config/server/proxy)                                                              |
+| server.headers, preview.headers       | [server.headers](/config/server/headers)                                                          |
+| server.hmr                            | [dev.hmr](/config/dev/hmr), [dev.client](/config/dev/client)                                      |
+| server.middlewareMode                 | [server.middlewareMode](/config/server/middleware-mode)                                           |
+| build.target, build.cssTarget         | [Browserslist](/guide/advanced/browserslist)                                                      |
+| build.outDir, build.assetsDir         | [output.distPath](/config/output/dist-path)                                                       |
+| build.assetsInlineLimit               | [output.dataUriLimit](/config/output/data-uri-limit)                                              |
+| build.cssMinify                       | [output.minify](/config/output/minify)                                                            |
+| build.sourcemap                       | [output.sourceMap](/config/output/source-map)                                                     |
+| build.lib                             | Use [Rslib](https://github.com/web-infra-dev/rslib)                                               |
+| build.manifest                        | [output.manifest](/config/output/manifest)                                                        |
+| build.ssrEmitAssets                   | [output.emitAssets](/config/output/emit-assets)                                                   |
+| build.minify, build.terserOptions     | [output.minify](/config/output/minify)                                                            |
+| build.emptyOutDir                     | [output.cleanDistPath](/config/output/clean-dist-path)                                            |
+| build.copyPublicDir                   | [server.publicDir](/config/server/public-dir)                                                     |
+| build.reportCompressedSize            | [performance.printFileSize](/config/performance/print-file-size)                                  |
+| ssr.external                          | [output.autoExternal](/config/output/auto-external), [output.externals](/config/output/externals) |
+| ssr, worker                           | [environments](/config/environments)                                                              |
 
 Notes:
 

--- a/website/docs/zh/guide/migration/vite.mdx
+++ b/website/docs/zh/guide/migration/vite.mdx
@@ -111,57 +111,58 @@ Rsbuild 会在构建时自动注入 `<script>` 标签到生成的 HTML 文件中
 
 以下是 Vite 配置对应的 Rsbuild 配置：
 
-| Vite                                  | Rsbuild                                                           |
-| ------------------------------------- | ----------------------------------------------------------------- |
-| root                                  | [root](/config/root)                                              |
-| mode                                  | [mode](/config/mode)                                              |
-| base                                  | [server.base](/config/server/base)                                |
-| define                                | [source.define](/config/source/define)                            |
-| appType                               | [server.historyApiFallback](/config/server/history-api-fallback)  |
-| plugins                               | [plugins](/config/plugins)                                        |
-| envDir                                | [Env Directory](/guide/advanced/env-vars#env-directory)           |
-| logLevel                              | [logLevel](/config/log-level)                                     |
-| cacheDir                              | [buildCache](/config/performance/build-cache)                     |
-| publicDir                             | [server.publicDir](/config/server/public-dir)                     |
-| customLogger                          | [customLogger](/config/custom-logger)                             |
-| assetsInclude                         | [source.assetsInclude](/config/source/assets-include)             |
-| resolve.alias                         | [resolve.alias](/config/resolve/alias)                            |
-| resolve.dedupe                        | [resolve.dedupe](/config/resolve/dedupe)                          |
-| resolve.extensions                    | [resolve.extensions](/config/resolve/extensions)                  |
-| resolve.conditions                    | [resolve.conditionNames](/config/resolve/condition-names)         |
-| resolve.mainFields                    | [resolve.mainFields](/config/resolve/main-fields)                 |
-| resolve.preserveSymlinks              | [tools.rspack.resolve.symlinks](/config/tools/rspack)             |
-| html.cspNonce                         | [security.nonce](/config/security/nonce)                          |
-| css.modules                           | [output.cssModules](/config/output/css-modules)                   |
-| css.postcss                           | [tools.postcss](/config/tools/postcss)                            |
-| css.preprocessorOptions.sass          | [pluginSass](/plugins/list/plugin-sass)                           |
-| css.preprocessorOptions.less          | [pluginLess](/plugins/list/plugin-less)                           |
-| css.preprocessorOptions.stylus        | [pluginStylus](https://github.com/rstackjs/rsbuild-plugin-stylus) |
-| css.devSourcemap                      | [output.sourceMap](/config/output/source-map)                     |
-| css.lightningcss                      | [tools.lightningcssLoader](/config/tools/lightningcss-loader)     |
-| server.host, preview.host             | [server.host](/config/server/host)                                |
-| server.port, preview.port             | [server.port](/config/server/port)                                |
-| server.cors, preview.cors             | [server.cors](/config/server/cors)                                |
-| server.strictPort, preview.strictPort | [server.strictPort](/config/server/strict-port)                   |
-| server.https, preview.https           | [server.https](/config/server/https)                              |
-| server.open, preview.open             | [server.open](/config/server/open)                                |
-| server.proxy, preview.proxy           | [server.proxy](/config/server/proxy)                              |
-| server.headers, preview.headers       | [server.headers](/config/server/headers)                          |
-| server.hmr                            | [dev.hmr](/config/dev/hmr), [dev.client](/config/dev/client)      |
-| server.middlewareMode                 | [server.middlewareMode](/config/server/middleware-mode)           |
-| build.target, build.cssTarget         | [Browserslist](/guide/advanced/browserslist)                      |
-| build.outDir, build.assetsDir         | [output.distPath](/config/output/dist-path)                       |
-| build.assetsInlineLimit               | [output.dataUriLimit](/config/output/data-uri-limit)              |
-| build.cssMinify                       | [output.minify](/config/output/minify)                            |
-| build.sourcemap                       | [output.sourceMap](/config/output/source-map)                     |
-| build.lib                             | Use [Rslib](https://github.com/web-infra-dev/rslib)               |
-| build.manifest                        | [output.manifest](/config/output/manifest)                        |
-| build.ssrEmitAssets                   | [output.emitAssets](/config/output/emit-assets)                   |
-| build.minify, build.terserOptions     | [output.minify](/config/output/minify)                            |
-| build.emptyOutDir                     | [output.cleanDistPath](/config/output/clean-dist-path)            |
-| build.copyPublicDir                   | [server.publicDir](/config/server/public-dir)                     |
-| build.reportCompressedSize            | [performance.printFileSize](/config/performance/print-file-size)  |
-| ssr, worker                           | [environments](/config/environments)                              |
+| Vite                                  | Rsbuild                                                                                           |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| root                                  | [root](/config/root)                                                                              |
+| mode                                  | [mode](/config/mode)                                                                              |
+| base                                  | [server.base](/config/server/base)                                                                |
+| define                                | [source.define](/config/source/define)                                                            |
+| appType                               | [server.historyApiFallback](/config/server/history-api-fallback)                                  |
+| plugins                               | [plugins](/config/plugins)                                                                        |
+| envDir                                | [Env Directory](/guide/advanced/env-vars#env-directory)                                           |
+| logLevel                              | [logLevel](/config/log-level)                                                                     |
+| cacheDir                              | [buildCache](/config/performance/build-cache)                                                     |
+| publicDir                             | [server.publicDir](/config/server/public-dir)                                                     |
+| customLogger                          | [customLogger](/config/custom-logger)                                                             |
+| assetsInclude                         | [source.assetsInclude](/config/source/assets-include)                                             |
+| resolve.alias                         | [resolve.alias](/config/resolve/alias)                                                            |
+| resolve.dedupe                        | [resolve.dedupe](/config/resolve/dedupe)                                                          |
+| resolve.extensions                    | [resolve.extensions](/config/resolve/extensions)                                                  |
+| resolve.conditions                    | [resolve.conditionNames](/config/resolve/condition-names)                                         |
+| resolve.mainFields                    | [resolve.mainFields](/config/resolve/main-fields)                                                 |
+| resolve.preserveSymlinks              | [tools.rspack.resolve.symlinks](/config/tools/rspack)                                             |
+| html.cspNonce                         | [security.nonce](/config/security/nonce)                                                          |
+| css.modules                           | [output.cssModules](/config/output/css-modules)                                                   |
+| css.postcss                           | [tools.postcss](/config/tools/postcss)                                                            |
+| css.preprocessorOptions.sass          | [pluginSass](/plugins/list/plugin-sass)                                                           |
+| css.preprocessorOptions.less          | [pluginLess](/plugins/list/plugin-less)                                                           |
+| css.preprocessorOptions.stylus        | [pluginStylus](https://github.com/rstackjs/rsbuild-plugin-stylus)                                 |
+| css.devSourcemap                      | [output.sourceMap](/config/output/source-map)                                                     |
+| css.lightningcss                      | [tools.lightningcssLoader](/config/tools/lightningcss-loader)                                     |
+| server.host, preview.host             | [server.host](/config/server/host)                                                                |
+| server.port, preview.port             | [server.port](/config/server/port)                                                                |
+| server.cors, preview.cors             | [server.cors](/config/server/cors)                                                                |
+| server.strictPort, preview.strictPort | [server.strictPort](/config/server/strict-port)                                                   |
+| server.https, preview.https           | [server.https](/config/server/https)                                                              |
+| server.open, preview.open             | [server.open](/config/server/open)                                                                |
+| server.proxy, preview.proxy           | [server.proxy](/config/server/proxy)                                                              |
+| server.headers, preview.headers       | [server.headers](/config/server/headers)                                                          |
+| server.hmr                            | [dev.hmr](/config/dev/hmr), [dev.client](/config/dev/client)                                      |
+| server.middlewareMode                 | [server.middlewareMode](/config/server/middleware-mode)                                           |
+| build.target, build.cssTarget         | [Browserslist](/guide/advanced/browserslist)                                                      |
+| build.outDir, build.assetsDir         | [output.distPath](/config/output/dist-path)                                                       |
+| build.assetsInlineLimit               | [output.dataUriLimit](/config/output/data-uri-limit)                                              |
+| build.cssMinify                       | [output.minify](/config/output/minify)                                                            |
+| build.sourcemap                       | [output.sourceMap](/config/output/source-map)                                                     |
+| build.lib                             | Use [Rslib](https://github.com/web-infra-dev/rslib)                                               |
+| build.manifest                        | [output.manifest](/config/output/manifest)                                                        |
+| build.ssrEmitAssets                   | [output.emitAssets](/config/output/emit-assets)                                                   |
+| build.minify, build.terserOptions     | [output.minify](/config/output/minify)                                                            |
+| build.emptyOutDir                     | [output.cleanDistPath](/config/output/clean-dist-path)                                            |
+| build.copyPublicDir                   | [server.publicDir](/config/server/public-dir)                                                     |
+| build.reportCompressedSize            | [performance.printFileSize](/config/performance/print-file-size)                                  |
+| ssr.external                          | [output.autoExternal](/config/output/auto-external), [output.externals](/config/output/externals) |
+| ssr, worker                           | [environments](/config/environments)                                                              |
 
 说明：
 

--- a/website/docs/zh/guide/migration/vite.mdx
+++ b/website/docs/zh/guide/migration/vite.mdx
@@ -154,7 +154,7 @@ Rsbuild 会在构建时自动注入 `<script>` 标签到生成的 HTML 文件中
 | build.assetsInlineLimit               | [output.dataUriLimit](/config/output/data-uri-limit)                                              |
 | build.cssMinify                       | [output.minify](/config/output/minify)                                                            |
 | build.sourcemap                       | [output.sourceMap](/config/output/source-map)                                                     |
-| build.lib                             | Use [Rslib](https://github.com/web-infra-dev/rslib)                                               |
+| build.lib                             | 使用 [Rslib](https://github.com/web-infra-dev/rslib)                                               |
 | build.manifest                        | [output.manifest](/config/output/manifest)                                                        |
 | build.ssrEmitAssets                   | [output.emitAssets](/config/output/emit-assets)                                                   |
 | build.minify, build.terserOptions     | [output.minify](/config/output/minify)                                                            |

--- a/website/docs/zh/guide/migration/vite.mdx
+++ b/website/docs/zh/guide/migration/vite.mdx
@@ -119,7 +119,7 @@ Rsbuild 会在构建时自动注入 `<script>` 标签到生成的 HTML 文件中
 | define                                | [source.define](/config/source/define)                                                            |
 | appType                               | [server.historyApiFallback](/config/server/history-api-fallback)                                  |
 | plugins                               | [plugins](/config/plugins)                                                                        |
-| envDir                                | [Env Directory](/guide/advanced/env-vars#env-directory)                                           |
+| envDir                                | [Env 目录](/guide/advanced/env-vars#env-directory)                                                |
 | logLevel                              | [logLevel](/config/log-level)                                                                     |
 | cacheDir                              | [buildCache](/config/performance/build-cache)                                                     |
 | publicDir                             | [server.publicDir](/config/server/public-dir)                                                     |


### PR DESCRIPTION
## Summary

This PR updates the Vite migration guide to document how `ssr.external` maps to Rsbuild's `output.autoExternal` and `output.externals` options. It adds the mapping in both English and Chinese docs.