### PR TITLE
docs: update autoExternal docs

### DIFF
--- a/website/docs/en/config/output/auto-external.mdx
+++ b/website/docs/en/config/output/auto-external.mdx
@@ -70,6 +70,8 @@ import { jsx } from 'react/jsx-runtime';
 
 ### Enable auto externalization
 
+Set `autoExternal` to `true` to externalize the default dependency types from `package.json`.
+
 ```ts title="rsbuild.config.ts"
 export default {
   output: {
@@ -80,6 +82,8 @@ export default {
 ```
 
 ### Customize dependency types
+
+Use object syntax to decide which dependency fields should be externalized.
 
 ```ts title="rsbuild.config.ts"
 export default {
@@ -97,6 +101,8 @@ export default {
 
 ### Disable a dependency type
 
+Set a dependency field to `false` to keep packages from that field bundled.
+
 ```ts title="rsbuild.config.ts"
 export default {
   output: {
@@ -109,6 +115,44 @@ export default {
 ```
 
 ## Options
+
+When `output.autoExternal` is configured as an object, omitted options use the same defaults as `autoExternal: true`.
+
+### dependencies
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+Whether to automatically externalize packages declared in the `dependencies` field of the root `package.json`.
+
+When this option is `true`, Rsbuild converts each package name in `dependencies` into an externalization rule. Subpath imports of these packages are also externalized.
+
+### optionalDependencies
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+Whether to automatically externalize packages declared in the `optionalDependencies` field of the root `package.json`.
+
+This is useful when optional dependencies are installed and loaded by the runtime environment instead of being bundled into the output.
+
+### devDependencies
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Whether to automatically externalize packages declared in the `devDependencies` field of the root `package.json`.
+
+`devDependencies` are not externalized by default because they are usually only needed during local development, testing, or build-time tooling. Enable this option only when the build output needs to load packages from `devDependencies` at runtime.
+
+### peerDependencies
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+Whether to automatically externalize packages declared in the `peerDependencies` field of the root `package.json`.
+
+This is useful for library-like or framework-integrated bundles where peer dependencies are expected to be provided by the host application or runtime.
 
 ### exclude
 

--- a/website/docs/en/guide/migration/vite.mdx
+++ b/website/docs/en/guide/migration/vite.mdx
@@ -162,6 +162,7 @@ Here is the corresponding Rsbuild configuration for each Vite option:
 | build.copyPublicDir                   | [server.publicDir](/config/server/public-dir)                                                     |
 | build.reportCompressedSize            | [performance.printFileSize](/config/performance/print-file-size)                                  |
 | ssr.external                          | [output.autoExternal](/config/output/auto-external), [output.externals](/config/output/externals) |
+| ssr.noExternal                        | [output.autoExternal.exclude](/config/output/auto-external#exclude)                               |
 | ssr, worker                           | [environments](/config/environments)                                                              |
 
 Notes:

--- a/website/docs/zh/config/output/auto-external.mdx
+++ b/website/docs/zh/config/output/auto-external.mdx
@@ -70,6 +70,8 @@ import { jsx } from 'react/jsx-runtime';
 
 ### 开启自动 external
 
+将 `autoExternal` 设置为 `true`，即可 external `package.json` 中默认的依赖类型。
+
 ```ts title="rsbuild.config.ts"
 export default {
   output: {
@@ -80,6 +82,8 @@ export default {
 ```
 
 ### 自定义依赖类型
+
+使用对象写法可以控制哪些依赖字段会被 external。
 
 ```ts title="rsbuild.config.ts"
 export default {
@@ -97,6 +101,8 @@ export default {
 
 ### 关闭某类依赖
 
+将某个依赖字段设置为 `false`，可以让该字段中的包继续被打进 bundle。
+
 ```ts title="rsbuild.config.ts"
 export default {
   output: {
@@ -109,6 +115,44 @@ export default {
 ```
 
 ## 选项
+
+当 `output.autoExternal` 配置为对象时，未配置的选项会使用与 `autoExternal: true` 相同的默认值。
+
+### dependencies
+
+- **类型：** `boolean`
+- **默认值：** `true`
+
+是否自动 external 根目录 `package.json` 的 `dependencies` 字段中声明的包。
+
+当该选项为 `true` 时，Rsbuild 会将 `dependencies` 中的每个包名转换为 external 规则。这些包的子路径导入也会被 external。
+
+### optionalDependencies
+
+- **类型：** `boolean`
+- **默认值：** `true`
+
+是否自动 external 根目录 `package.json` 的 `optionalDependencies` 字段中声明的包。
+
+这个选项适用于可选依赖由运行时环境安装和加载，而不是被打进产物的场景。
+
+### devDependencies
+
+- **类型：** `boolean`
+- **默认值：** `false`
+
+是否自动 external 根目录 `package.json` 的 `devDependencies` 字段中声明的包。
+
+`devDependencies` 默认不会被 external，因为它们通常只在本地开发、测试或构建工具链中使用。仅当构建产物需要在运行时加载 `devDependencies` 中的包时，才需要开启该选项。
+
+### peerDependencies
+
+- **类型：** `boolean`
+- **默认值：** `true`
+
+是否自动 external 根目录 `package.json` 的 `peerDependencies` 字段中声明的包。
+
+这个选项适用于类库或框架集成场景，peer dependencies 通常应由宿主应用或运行时提供。
 
 ### exclude
 

--- a/website/docs/zh/guide/migration/vite.mdx
+++ b/website/docs/zh/guide/migration/vite.mdx
@@ -154,7 +154,7 @@ Rsbuild 会在构建时自动注入 `<script>` 标签到生成的 HTML 文件中
 | build.assetsInlineLimit               | [output.dataUriLimit](/config/output/data-uri-limit)                                              |
 | build.cssMinify                       | [output.minify](/config/output/minify)                                                            |
 | build.sourcemap                       | [output.sourceMap](/config/output/source-map)                                                     |
-| build.lib                             | 使用 [Rslib](https://github.com/web-infra-dev/rslib)                                               |
+| build.lib                             | 使用 [Rslib](https://github.com/web-infra-dev/rslib)                                              |
 | build.manifest                        | [output.manifest](/config/output/manifest)                                                        |
 | build.ssrEmitAssets                   | [output.emitAssets](/config/output/emit-assets)                                                   |
 | build.minify, build.terserOptions     | [output.minify](/config/output/minify)                                                            |
@@ -162,6 +162,7 @@ Rsbuild 会在构建时自动注入 `<script>` 标签到生成的 HTML 文件中
 | build.copyPublicDir                   | [server.publicDir](/config/server/public-dir)                                                     |
 | build.reportCompressedSize            | [performance.printFileSize](/config/performance/print-file-size)                                  |
 | ssr.external                          | [output.autoExternal](/config/output/auto-external), [output.externals](/config/output/externals) |
+| ssr.noExternal                        | [output.autoExternal.exclude](/config/output/auto-external#exclude)                               |
 | ssr, worker                           | [environments](/config/environments)                                                              |
 
 说明：


### PR DESCRIPTION
## Summary

This PR updates the `output.autoExternal` documentation to explain each object option, adds concise descriptions for the examples, and maps Vite's `ssr.noExternal` option to `output.autoExternal.exclude` in the migration guide.