### PR TITLE
test: cover externals overriding autoExternal

### DIFF
--- a/e2e/cases/output/auto-external/index.test.ts
+++ b/e2e/cases/output/auto-external/index.test.ts
@@ -64,6 +64,34 @@ test('should auto externalize dependencies and subpath imports', async ({
   expectBundledExport(content, 'dev');
 });
 
+test('should allow output.externals to override autoExternal rules', async ({
+  build,
+}) => {
+  const rsbuild = await build({
+    config: {
+      source: {
+        entry: {
+          index: './src/index.js',
+        },
+      },
+      output: {
+        target: 'node',
+        autoExternal: true,
+        externals: {
+          '@e2e/auto-external-pkg': '@e2e/auto-external-overridden-pkg',
+        },
+      },
+    },
+  });
+  const files = rsbuild.getDistFiles();
+  const content = getFileContent(files, '.js');
+
+  expect(content).toContain('external "@e2e/auto-external-overridden-pkg"');
+  expect(content).not.toContain('external "@e2e/auto-external-pkg"');
+  expectBundledSubpath(content);
+  expect(content).toContain('external "@e2e/auto-external-peer-pkg"');
+});
+
 test('should auto externalize devDependencies when enabled', async ({
   build,
 }) => {


### PR DESCRIPTION
## Summary

This PR adds e2e coverage for the priority between `output.autoExternal` and `output.externals`. It verifies that an explicit `output.externals` entry overrides the generated autoExternal rule for the same package while autoExternal still applies to other eligible dependencies.