### PR TITLE
docs: clarify module federation output module limit

### DIFF
--- a/website/docs/en/guide/advanced/module-federation.mdx
+++ b/website/docs/en/guide/advanced/module-federation.mdx
@@ -78,3 +78,9 @@ Rsbuild provides Module Federation example projects you can explore:
 
 - [Module Federation v2.0 Example](https://github.com/rstackjs/rstack-examples/tree/main/rsbuild/module-federation-enhanced)
 - [Module Federation v1.5 Example](https://github.com/rstackjs/rstack-examples/tree/main/rsbuild/module-federation)
+
+## Limitations
+
+Module Federation is currently incompatible with [output.module](/config/output/module).
+
+The Module Federation runtime does not yet support ESM output. Avoid setting `output.module: true` in a Module Federation application; otherwise, loading may fail at runtime.

--- a/website/docs/zh/guide/advanced/module-federation.mdx
+++ b/website/docs/zh/guide/advanced/module-federation.mdx
@@ -78,3 +78,9 @@ Rsbuild 提供了一些 Module Federation 的示例项目，你可以参考：
 
 - [Module Federation v2.0 示例](https://github.com/rstackjs/rstack-examples/tree/main/rsbuild/module-federation-enhanced)
 - [Module Federation v1.5 示例](https://github.com/rstackjs/rstack-examples/tree/main/rsbuild/module-federation)
+
+## 使用限制
+
+模块联邦目前不兼容 [output.module](/config/output/module)。
+
+这是因为模块联邦的运行时目前还不支持 ESM 产物。请避免在模块联邦应用中设置 `output.module: true`，否则可能会在运行时加载失败。


### PR DESCRIPTION
## Summary

Document that Module Federation is currently incompatible with `output.module` because its runtime does not yet support ESM output, and update both the English and Chinese guides to avoid enabling `output.module: true` in Module Federation applications.