### PR TITLE
feat(core): support autoExternal packageJson option

### DIFF
--- a/e2e/cases/output/auto-external/fixtures/_node_modules/package-json-dep/package.json
+++ b/e2e/cases/output/auto-external/fixtures/_node_modules/package-json-dep/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@e2e/auto-external-pkg": "1.0.0"
+  }
+}

--- a/e2e/cases/output/auto-external/fixtures/_node_modules/package-json-dev/package.json
+++ b/e2e/cases/output/auto-external/fixtures/_node_modules/package-json-dev/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@e2e/auto-external-dev-pkg": "1.0.0"
+  }
+}

--- a/e2e/cases/output/auto-external/fixtures/_node_modules/package-json-peer/package.json
+++ b/e2e/cases/output/auto-external/fixtures/_node_modules/package-json-peer/package.json
@@ -1,0 +1,5 @@
+{
+  "peerDependencies": {
+    "@e2e/auto-external-peer-pkg": "1.0.0"
+  }
+}

--- a/e2e/cases/output/auto-external/index.test.ts
+++ b/e2e/cases/output/auto-external/index.test.ts
@@ -116,6 +116,67 @@ test('should auto externalize devDependencies when enabled', async ({
   expect(content).toContain('external "@e2e/auto-external-dev-pkg"');
 });
 
+test('should auto externalize dependencies from custom packageJson path', async ({
+  build,
+}) => {
+  const rsbuild = await build({
+    config: {
+      source: {
+        entry: {
+          index: './src/index.js',
+        },
+      },
+      output: {
+        target: 'node',
+        autoExternal: {
+          packageJson: './fixtures/_node_modules/package-json-dev/package.json',
+        },
+      },
+    },
+  });
+  const files = rsbuild.getDistFiles();
+  const content = getFileContent(files, '.js');
+
+  expect(content).toContain('external "@e2e/auto-external-dev-pkg"');
+  expect(content).not.toContain('external "@e2e/auto-external-pkg"');
+  expect(content).not.toContain('external "@e2e/auto-external-pkg/subpath"');
+  expect(content).not.toContain('external "@e2e/auto-external-peer-pkg"');
+  expectBundledExport(content, 'dep');
+  expectBundledSubpath(content);
+  expectBundledExport(content, 'peer');
+});
+
+test('should auto externalize dependencies from multiple packageJson paths', async ({
+  build,
+}) => {
+  const rsbuild = await build({
+    config: {
+      source: {
+        entry: {
+          index: './src/index.js',
+        },
+      },
+      output: {
+        target: 'node',
+        autoExternal: {
+          packageJson: [
+            './fixtures/_node_modules/package-json-dep/package.json',
+            './fixtures/_node_modules/package-json-peer/package.json',
+          ],
+        },
+      },
+    },
+  });
+  const files = rsbuild.getDistFiles();
+  const content = getFileContent(files, '.js');
+
+  expect(content).toContain('external "@e2e/auto-external-pkg"');
+  expect(content).toContain('external "@e2e/auto-external-pkg/subpath"');
+  expect(content).toContain('external "@e2e/auto-external-peer-pkg"');
+  expect(content).not.toContain('external "@e2e/auto-external-dev-pkg"');
+  expectBundledExport(content, 'dev');
+});
+
 test('should not auto externalize packages matched by string exclude', async ({
   build,
 }) => {

--- a/packages/core/src/helpers/packageJson.ts
+++ b/packages/core/src/helpers/packageJson.ts
@@ -1,5 +1,4 @@
 import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
 import { isFileExists } from './fs';
 
 export type PackageJson = Partial<{
@@ -11,11 +10,9 @@ export type PackageJson = Partial<{
   devDependencies: Record<string, string>;
 }>;
 
-export const readPackageJson = async (
-  rootPath: string,
+export const readPackageJsonByPath = async (
+  pkgJsonPath: string,
 ): Promise<PackageJson | undefined> => {
-  const pkgJsonPath = join(rootPath, 'package.json');
-
   if (!(await isFileExists(pkgJsonPath))) {
     return undefined;
   }

--- a/packages/core/src/plugins/externals.ts
+++ b/packages/core/src/plugins/externals.ts
@@ -1,6 +1,10 @@
+import { resolve } from 'node:path';
 import type { Externals } from '@rspack/core';
 import { castArray, isPlainObject } from '../helpers';
-import { readPackageJson, type PackageJson } from '../helpers/packageJson';
+import {
+  readPackageJsonByPath,
+  type PackageJson,
+} from '../helpers/packageJson';
 import type { AutoExternal, RsbuildPlugin } from '../types';
 
 type DependencyType =
@@ -42,6 +46,59 @@ const resolveAutoExternalOptions = (autoExternal?: AutoExternal) => {
 
 const escapeRegExp = (str: string): string =>
   str.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&');
+
+const resolvePackageJsonPaths = (
+  rootPath: string,
+  packageJson?: string | string[],
+): string[] => {
+  return castArray(packageJson ?? 'package.json').map((path) =>
+    resolve(rootPath, path),
+  );
+};
+
+const mergePackageJsonList = (
+  packageJsonList: PackageJson[],
+): PackageJson | undefined => {
+  if (!packageJsonList.length) {
+    return undefined;
+  }
+
+  return dependencyTypes.reduce<PackageJson>((merged, type) => {
+    for (const pkgJson of packageJsonList) {
+      const deps = pkgJson[type];
+
+      if (isPlainObject(deps)) {
+        merged[type] = {
+          ...merged[type],
+          ...deps,
+        };
+      }
+    }
+
+    return merged;
+  }, {});
+};
+
+const readPackageJsonList = async (
+  paths: string[],
+  cache: Map<string, PackageJson | undefined>,
+): Promise<PackageJson | undefined> => {
+  const packageJsonList = await Promise.all(
+    paths.map(async (path) => {
+      if (!cache.has(path)) {
+        cache.set(path, await readPackageJsonByPath(path));
+      }
+
+      return cache.get(path);
+    }),
+  );
+
+  return mergePackageJsonList(
+    packageJsonList.filter((pkgJson): pkgJson is PackageJson =>
+      Boolean(pkgJson),
+    ),
+  );
+};
 
 const matchAutoExternalExclude = (
   packageName: string,
@@ -132,17 +189,23 @@ export function pluginExternals(): RsbuildPlugin {
   return {
     name: 'rsbuild:externals',
     setup(api) {
-      let pkgJson: PackageJson | undefined;
-      let hasReadPackageJson = false;
+      const packageJsonCache = new Map<string, PackageJson | undefined>();
       let hasWarnedReadPackageJsonFailed = false;
 
       api.modifyBundlerChain(async (chain, { environment }) => {
         const { autoExternal, externals } = environment.config.output;
         const externalOptions = resolveAutoExternalOptions(autoExternal);
+        let pkgJson: PackageJson | undefined;
 
-        if (externalOptions && !hasReadPackageJson) {
-          pkgJson = await readPackageJson(api.context.rootPath);
-          hasReadPackageJson = true;
+        if (externalOptions) {
+          const packageJsonPaths = resolvePackageJsonPaths(
+            api.context.rootPath,
+            externalOptions.packageJson,
+          );
+          pkgJson = await readPackageJsonList(
+            packageJsonPaths,
+            packageJsonCache,
+          );
         }
 
         if (externalOptions && !pkgJson && !hasWarnedReadPackageJsonFailed) {

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1343,6 +1343,12 @@ export type AutoExternal =
        */
       devDependencies?: boolean;
       /**
+       * Specify the package.json file path(s) used to collect dependencies.
+       * Relative paths are resolved from the Rsbuild root directory.
+       * @default '<root>/package.json'
+       */
+      packageJson?: string | string[];
+      /**
        * Prevent matched packages from being automatically externalized.
        * Strings match package names exactly, and regular expressions test package names.
        * @default undefined

--- a/packages/core/tests/helpers.test.ts
+++ b/packages/core/tests/helpers.test.ts
@@ -3,16 +3,17 @@ import { tmpdir } from 'node:os';
 import { join, sep } from 'node:path';
 import { isPlainObject, isWebTarget, pick, prettyTime } from '../src/helpers';
 import { dedupeNestedPaths, getCommonParentPath } from '../src/helpers/path';
-import { readPackageJson } from '../src/helpers/packageJson';
+import { readPackageJsonByPath } from '../src/helpers/packageJson';
 import { ensureAssetPrefix } from '../src/helpers/url';
 import { getRoutes, normalizeUrl } from '../src/server/helper';
 import type { InternalContext, RsbuildTarget } from '../src/types';
 
-describe('readPackageJson', () => {
-  it('should read package.json from root path', async () => {
+describe('readPackageJsonByPath', () => {
+  it('should read package.json from specified path', async () => {
     const root = mkdtempSync(join(tmpdir(), 'rsbuild-package-json-'));
+    const packageJsonPath = join(root, 'package.json');
     writeFileSync(
-      join(root, 'package.json'),
+      packageJsonPath,
       JSON.stringify({
         name: 'test-package',
         dependencies: {
@@ -21,7 +22,7 @@ describe('readPackageJson', () => {
       }),
     );
 
-    await expect(readPackageJson(root)).resolves.toEqual({
+    await expect(readPackageJsonByPath(packageJsonPath)).resolves.toEqual({
       name: 'test-package',
       dependencies: {
         foo: '1.0.0',
@@ -30,12 +31,16 @@ describe('readPackageJson', () => {
   });
 
   it('should return undefined when package.json does not exist or is invalid', async () => {
-    const missingRoot = mkdtempSync(join(tmpdir(), 'rsbuild-package-json-'));
-    await expect(readPackageJson(missingRoot)).resolves.toBeUndefined();
+    const missingPath = join(
+      mkdtempSync(join(tmpdir(), 'rsbuild-package-json-')),
+      'package.json',
+    );
+    await expect(readPackageJsonByPath(missingPath)).resolves.toBeUndefined();
 
     const invalidRoot = mkdtempSync(join(tmpdir(), 'rsbuild-package-json-'));
-    writeFileSync(join(invalidRoot, 'package.json'), '{ invalid json');
-    await expect(readPackageJson(invalidRoot)).resolves.toBeUndefined();
+    const invalidPath = join(invalidRoot, 'package.json');
+    writeFileSync(invalidPath, '{ invalid json');
+    await expect(readPackageJsonByPath(invalidPath)).resolves.toBeUndefined();
   });
 });
 

--- a/website/docs/en/config/output/auto-external.mdx
+++ b/website/docs/en/config/output/auto-external.mdx
@@ -14,13 +14,14 @@ type AutoExternal =
       optionalDependencies?: boolean;
       devDependencies?: boolean;
       peerDependencies?: boolean;
+      packageJson?: string | string[];
       exclude?: string | RegExp | (string | RegExp)[];
     };
 ```
 
 - **Default:** `false`
 
-Automatically externalize dependencies declared in the root `package.json`. When enabled, Rsbuild reads the dependency fields from `<root>/package.json` and converts the matched package names into [output.externals](/config/output/externals) rules.
+Automatically externalize dependencies declared in `package.json`. When enabled, Rsbuild reads the dependency fields from `<root>/package.json` by default and converts the matched package names into [output.externals](/config/output/externals) rules.
 
 This is useful for Node.js or SSR bundles where some dependencies should be loaded by the runtime instead of being bundled, such as observability SDKs, native addons, or dependencies that rely on runtime instrumentation.
 
@@ -123,7 +124,7 @@ When `output.autoExternal` is configured as an object, omitted options use the s
 - **Type:** `boolean`
 - **Default:** `true`
 
-Whether to automatically externalize packages declared in the `dependencies` field of the root `package.json`.
+Whether to automatically externalize packages declared in the `dependencies` field of the configured `package.json` file(s).
 
 When this option is `true`, Rsbuild converts each package name in `dependencies` into an externalization rule. Subpath imports of these packages are also externalized.
 
@@ -132,7 +133,7 @@ When this option is `true`, Rsbuild converts each package name in `dependencies`
 - **Type:** `boolean`
 - **Default:** `true`
 
-Whether to automatically externalize packages declared in the `optionalDependencies` field of the root `package.json`.
+Whether to automatically externalize packages declared in the `optionalDependencies` field of the configured `package.json` file(s).
 
 This is useful when optional dependencies are installed and loaded by the runtime environment instead of being bundled into the output.
 
@@ -141,7 +142,7 @@ This is useful when optional dependencies are installed and loaded by the runtim
 - **Type:** `boolean`
 - **Default:** `false`
 
-Whether to automatically externalize packages declared in the `devDependencies` field of the root `package.json`.
+Whether to automatically externalize packages declared in the `devDependencies` field of the configured `package.json` file(s).
 
 `devDependencies` are not externalized by default because they are usually only needed during local development, testing, or build-time tooling. Enable this option only when the build output needs to load packages from `devDependencies` at runtime.
 
@@ -150,9 +151,34 @@ Whether to automatically externalize packages declared in the `devDependencies` 
 - **Type:** `boolean`
 - **Default:** `true`
 
-Whether to automatically externalize packages declared in the `peerDependencies` field of the root `package.json`.
+Whether to automatically externalize packages declared in the `peerDependencies` field of the configured `package.json` file(s).
 
 This is useful for library-like or framework-integrated bundles where peer dependencies are expected to be provided by the host application or runtime.
+
+### packageJson
+
+- **Type:**
+
+```ts
+type PackageJson = string | string[];
+```
+
+- **Default:** `'<root>/package.json'`
+
+Specify the `package.json` file path(s) used to collect dependencies. Relative paths are resolved from the Rsbuild root directory.
+
+When multiple files are specified, Rsbuild merges their dependency fields and de-duplicates package names.
+
+```ts title="rsbuild.config.ts"
+export default {
+  output: {
+    target: 'node',
+    autoExternal: {
+      packageJson: ['./package.json', './apps/server/package.json'],
+    },
+  },
+};
+```
 
 ### exclude
 
@@ -209,7 +235,7 @@ If [output.target](/config/output/target) is `web-worker`, Rsbuild removes the `
 
 ## Version history
 
-| Version | Changes                            |
-| ------- | ---------------------------------- |
-| v2.0.7  | Added `output.autoExternal` option |
-| v2.0.8  | Added `exclude` option             |
+| Version | Changes                                   |
+| ------- | ----------------------------------------- |
+| v2.0.7  | Added `output.autoExternal` option        |
+| v2.0.8  | Added `exclude` and `packageJson` options |

--- a/website/docs/zh/config/output/auto-external.mdx
+++ b/website/docs/zh/config/output/auto-external.mdx
@@ -14,13 +14,14 @@ type AutoExternal =
       optionalDependencies?: boolean;
       devDependencies?: boolean;
       peerDependencies?: boolean;
+      packageJson?: string | string[];
       exclude?: string | RegExp | (string | RegExp)[];
     };
 ```
 
 - **默认值：** `false`
 
-用于自动 external 根目录 `package.json` 中声明的依赖。开启后，Rsbuild 会读取 `<root>/package.json` 中的依赖字段，并将匹配到的包名转换为 [output.externals](/config/output/externals) 规则。
+用于自动 external `package.json` 中声明的依赖。开启后，Rsbuild 默认会读取 `<root>/package.json` 中的依赖字段，并将匹配到的包名转换为 [output.externals](/config/output/externals) 规则。
 
 这个能力适用于 Node.js 或 SSR bundle 场景。例如，一些依赖需要由运行时加载，而不是被打进 bundle，包括观测 SDK、原生插件，或依赖运行时 instrumentation 的包。
 
@@ -123,7 +124,7 @@ export default {
 - **类型：** `boolean`
 - **默认值：** `true`
 
-是否自动 external 根目录 `package.json` 的 `dependencies` 字段中声明的包。
+是否自动 external 配置的 `package.json` 文件中 `dependencies` 字段声明的包。
 
 当该选项为 `true` 时，Rsbuild 会将 `dependencies` 中的每个包名转换为 external 规则。这些包的子路径导入也会被 external。
 
@@ -132,7 +133,7 @@ export default {
 - **类型：** `boolean`
 - **默认值：** `true`
 
-是否自动 external 根目录 `package.json` 的 `optionalDependencies` 字段中声明的包。
+是否自动 external 配置的 `package.json` 文件中 `optionalDependencies` 字段声明的包。
 
 这个选项适用于可选依赖由运行时环境安装和加载，而不是被打进产物的场景。
 
@@ -141,7 +142,7 @@ export default {
 - **类型：** `boolean`
 - **默认值：** `false`
 
-是否自动 external 根目录 `package.json` 的 `devDependencies` 字段中声明的包。
+是否自动 external 配置的 `package.json` 文件中 `devDependencies` 字段声明的包。
 
 `devDependencies` 默认不会被 external，因为它们通常只在本地开发、测试或构建工具链中使用。仅当构建产物需要在运行时加载 `devDependencies` 中的包时，才需要开启该选项。
 
@@ -150,9 +151,34 @@ export default {
 - **类型：** `boolean`
 - **默认值：** `true`
 
-是否自动 external 根目录 `package.json` 的 `peerDependencies` 字段中声明的包。
+是否自动 external 配置的 `package.json` 文件中 `peerDependencies` 字段声明的包。
 
 这个选项适用于类库或框架集成场景，peer dependencies 通常应由宿主应用或运行时提供。
+
+### packageJson
+
+- **类型：**
+
+```ts
+type PackageJson = string | string[];
+```
+
+- **默认值：** `'<root>/package.json'`
+
+指定用于收集依赖的 `package.json` 文件路径。相对路径会基于 Rsbuild 根目录解析。
+
+当指定多个文件时，Rsbuild 会合并它们的依赖字段，并对包名去重。
+
+```ts title="rsbuild.config.ts"
+export default {
+  output: {
+    target: 'node',
+    autoExternal: {
+      packageJson: ['./package.json', './apps/server/package.json'],
+    },
+  },
+};
+```
 
 ### exclude
 
@@ -209,7 +235,7 @@ export default {
 
 ## 版本历史
 
-| 版本   | 变更内容                        |
-| ------ | ------------------------------- |
-| v2.0.7 | 新增 `output.autoExternal` 选项 |
-| v2.0.8 | 新增 `exclude`                  |
+| 版本   | 变更内容                             |
+| ------ | ------------------------------------ |
+| v2.0.7 | 新增 `output.autoExternal` 选项      |
+| v2.0.8 | 新增 `exclude` 和 `packageJson` 选项 |


### PR DESCRIPTION
## Summary

Add `output.autoExternal.packageJson` so projects can collect auto external dependencies from custom package.json files, including multiple files in monorepos.

The option supports `string` or `string[]` paths resolved from the Rsbuild root and merges dependency fields before generating autoExternal rules.
