### PR TITLE
chore: externalize supports-color in core build

### DIFF
--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -33,6 +33,8 @@ const externals: Rspack.Configuration['externals'] = [
   'tsx/cjs/api',
   // allow to `require('events')`
   { events: 'node-commonjs node:events' },
+  // allow `debug` to require its optional peer dependency
+  { 'supports-color': 'node-commonjs supports-color' },
   // externalize pre-bundled dependencies
   ({ request }, callback) => {
     const entries = Object.entries(regexpMap);


### PR DESCRIPTION
## Summary

Fix the build warning:

```bash
File: ../../node_modules/.pnpm/debug@4.4.3/node_modules/debug/src/node.js:32:32-48
  ⚠ Module not found: Can't resolve 'supports-color' in '/Users/chenjiahan/Project/rsbuild/node_modules/.pnpm/debug@4.4.3/node_modules/debug/src'
    ╭─[32:26]
 30 │     // Optional dependency (as in, doesn't need to be installed, NOT like optionalDependencies in package.json)
 31 │     // eslint-disable-next-line import/no-extraneous-dependencies
 32 │     const supportsColor = require('supports-color');
    ·                           ─────────────────────────
 33 │
 34 │     if (supportsColor && (supportsColor.stderr || supportsColor).level >= 2) {
    ╰────
```
