### PR TITLE
test: cover autoExternal web CommonJS output

### DIFF
--- a/e2e/cases/output/auto-external-web/index.test.ts
+++ b/e2e/cases/output/auto-external-web/index.test.ts
@@ -1,5 +1,34 @@
 import { expect, getFileContent, test } from '@e2e/helper';
 
+test('should auto externalize dependencies for web CommonJS library output', async ({
+  build,
+}) => {
+  const rsbuild = await build({
+    config: {
+      output: {
+        target: 'web',
+        autoExternal: true,
+      },
+      tools: {
+        rspack: {
+          output: {
+            library: {
+              type: 'commonjs2',
+            },
+          },
+        },
+      },
+    },
+  });
+  const files = rsbuild.getDistFiles();
+  const content = getFileContent(files, '.js');
+
+  expect(content).toContain('require("@e2e/auto-external-pkg")');
+  expect(content).toContain('require("@e2e/auto-external-pkg/subpath")');
+  expect(content).toContain('require("@e2e/auto-external-peer-pkg")');
+  expect(content).not.toContain('require("@e2e/auto-external-dev-pkg")');
+});
+
 test('should auto externalize dependencies for web ESM output', async ({
   build,
 }) => {


### PR DESCRIPTION
## Summary

This PR adds e2e coverage for using output.autoExternal with a web target that emits a CommonJS library. The case verifies that package and subpath dependencies remain externalized as require() calls when the final Rspack output library type is commonjs2.