### PR TITLE
docs: clarify autoExternal usage

### DIFF
--- a/website/docs/en/config/output/auto-external.mdx
+++ b/website/docs/en/config/output/auto-external.mdx
@@ -25,12 +25,6 @@ Automatically externalize dependencies declared in `package.json`. When enabled,
 
 This is useful for Node.js or SSR bundles where some dependencies should be loaded by the runtime instead of being bundled, such as observability SDKs, native addons, or dependencies that rely on runtime instrumentation.
 
-:::tip
-
-`output.autoExternal` is disabled by default. In normal web app builds, dependencies are usually bundled so that the browser can run the output directly. If you enable `output.autoExternal` for a web target, make sure the externalized dependencies are available at runtime, for example through a CDN, import map, or host environment.
-
-:::
-
 ## When to use
 
 Use `output.autoExternal` when the build output can load external dependencies directly at runtime:

--- a/website/docs/en/config/output/auto-external.mdx
+++ b/website/docs/en/config/output/auto-external.mdx
@@ -35,7 +35,7 @@ This is useful for Node.js or SSR bundles where some dependencies should be load
 
 Use `output.autoExternal` when the build output can load external dependencies directly at runtime:
 
-- Use it for ESM output, such as `output.module: true`. Externalized dependencies stay as `import` statements, so they can be provided by import maps or the host environment.
+- Use it for ESM output, such as `output.module: true`. Externalized dependencies stay as `import` statements, so they can be provided by the host environment.
 - Use it for CommonJS output. Externalized dependencies become `require()` calls, so they can be loaded by Node.js or a CommonJS library runtime.
 - Avoid using it for the default web output. Rsbuild emits an IIFE bundle by default, and IIFE externals need explicit browser global variable names. `output.autoExternal` only reads package names from `package.json`, so it cannot infer those globals reliably.
 

--- a/website/docs/en/config/output/auto-external.mdx
+++ b/website/docs/en/config/output/auto-external.mdx
@@ -31,6 +31,16 @@ This is useful for Node.js or SSR bundles where some dependencies should be load
 
 :::
 
+## When to use
+
+Use `output.autoExternal` when the build output can load external dependencies directly at runtime:
+
+- Use it for ESM output, such as `output.module: true`. Externalized dependencies stay as `import` statements, so they can be provided by import maps or the host environment.
+- Use it for CommonJS output. Externalized dependencies become `require()` calls, so they can be loaded by Node.js or a CommonJS library runtime.
+- Avoid using it for the default web output. Rsbuild emits an IIFE bundle by default, and IIFE externals need explicit browser global variable names. `output.autoExternal` only reads package names from `package.json`, so it cannot infer those globals reliably.
+
+For web apps that use the default IIFE output, configure [output.externals](/config/output/externals) manually so you can set the browser global name explicitly. This is especially important for scoped packages and subpath imports such as `@scope/pkg/button` or `react-dom/client`.
+
 ## Default behavior
 
 When `output.autoExternal` is `true`, the following dependency types are externalized by default:
@@ -60,7 +70,7 @@ export default {
 
 ## Subpath imports
 
-Rsbuild also externalizes subpath imports of matched dependencies. For example, if `react` is declared in `dependencies`, both of the following imports will be externalized:
+When `output.autoExternal` is applied, Rsbuild also externalizes subpath imports of matched dependencies. For example, if `react` is declared in `dependencies`, both of the following imports will be externalized:
 
 ```ts
 import React from 'react';

--- a/website/docs/zh/config/output/auto-external.mdx
+++ b/website/docs/zh/config/output/auto-external.mdx
@@ -31,6 +31,16 @@ type AutoExternal =
 
 :::
 
+## 何时使用
+
+当构建产物可以在运行时直接加载外部依赖时，适合使用 `output.autoExternal`：
+
+- 适合用于 ESM 产物，例如 `output.module: true`。external 的依赖会保留为 `import` 语句，可以由 import maps 或宿主环境提供。
+- 适合用于 CommonJS 产物。external 的依赖会输出为 `require()` 调用，可以由 Node.js 或 CommonJS 类库运行时加载。
+- 避免用于默认的 Web 产物。Rsbuild 默认输出 IIFE bundle，而 IIFE externals 需要明确的浏览器全局变量名。`output.autoExternal` 只能从 `package.json` 中读取包名，无法可靠推导这些全局变量名。
+
+对于使用默认 IIFE 产物的 Web 应用，建议手动配置 [output.externals](/config/output/externals)，这样可以显式设置浏览器全局变量名。对于 `@scope/pkg/button` 或 `react-dom/client` 这类 scoped package 和子路径导入，这一点尤其重要。
+
 ## 默认行为
 
 当 `output.autoExternal` 为 `true` 时，以下依赖类型默认会被 external：
@@ -60,7 +70,7 @@ export default {
 
 ## 子路径导入
 
-Rsbuild 也会 external 匹配依赖的子路径导入。例如，如果 `react` 声明在 `dependencies` 中，下面两个导入都会被 external：
+当 `output.autoExternal` 生效时，Rsbuild 也会 external 匹配依赖的子路径导入。例如，如果 `react` 声明在 `dependencies` 中，下面两个导入都会被 external：
 
 ```ts
 import React from 'react';

--- a/website/docs/zh/config/output/auto-external.mdx
+++ b/website/docs/zh/config/output/auto-external.mdx
@@ -25,12 +25,6 @@ type AutoExternal =
 
 这个能力适用于 Node.js 或 SSR bundle 场景。例如，一些依赖需要由运行时加载，而不是被打进 bundle，包括观测 SDK、原生插件，或依赖运行时 instrumentation 的包。
 
-:::tip
-
-`output.autoExternal` 默认关闭。在普通 Web 应用构建中，依赖通常需要被打进 bundle，浏览器才能直接运行产物。如果你在 Web target 中开启 `output.autoExternal`，需要确保被 external 的依赖能在运行时被提供，例如通过 CDN、import map 或宿主环境注入。
-
-:::
-
 ## 何时使用
 
 当构建产物可以在运行时直接加载外部依赖时，适合使用 `output.autoExternal`：

--- a/website/docs/zh/config/output/auto-external.mdx
+++ b/website/docs/zh/config/output/auto-external.mdx
@@ -35,7 +35,7 @@ type AutoExternal =
 
 当构建产物可以在运行时直接加载外部依赖时，适合使用 `output.autoExternal`：
 
-- 适合用于 ESM 产物，例如 `output.module: true`。external 的依赖会保留为 `import` 语句，可以由 import maps 或宿主环境提供。
+- 适合用于 ESM 产物，例如 `output.module: true`。external 的依赖会保留为 `import` 语句，可以由宿主环境提供。
 - 适合用于 CommonJS 产物。external 的依赖会输出为 `require()` 调用，可以由 Node.js 或 CommonJS 类库运行时加载。
 - 避免用于默认的 Web 产物。Rsbuild 默认输出 IIFE bundle，而 IIFE externals 需要明确的浏览器全局变量名。`output.autoExternal` 只能从 `package.json` 中读取包名，无法可靠推导这些全局变量名。
 


### PR DESCRIPTION
## Summary

This PR updates the output.autoExternal docs to explain when the option is appropriate. It calls out ESM and CommonJS outputs as suitable cases, and clarifies why default web IIFE output should use explicit output.externals configuration for browser global names instead.