### PR TITLE
feat(plugin-tailwindcss): support inline imports

### DIFF
--- a/e2e/cases/tailwindcss/plugin-inline-query/index.test.ts
+++ b/e2e/cases/tailwindcss/plugin-inline-query/index.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from '@e2e/helper';
+
+test('should return transformed Tailwind CSS with `?inline`', async ({
+  page,
+  runBothServe,
+}) => {
+  await runBothServe(async () => {
+    const inlineCss = await page.evaluate<string>('window.tailwindInlineCss');
+
+    expect(inlineCss).toContain('.underline');
+  });
+});

--- a/e2e/cases/tailwindcss/plugin-inline-query/rsbuild.config.ts
+++ b/e2e/cases/tailwindcss/plugin-inline-query/rsbuild.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginTailwindcss } from '@rsbuild/plugin-tailwindcss';
+
+export default defineConfig({
+  html: {
+    template: './src/index.html',
+  },
+  plugins: [pluginTailwindcss()],
+});

--- a/e2e/cases/tailwindcss/plugin-inline-query/src/index.css
+++ b/e2e/cases/tailwindcss/plugin-inline-query/src/index.css
@@ -1,0 +1,1 @@
+@import 'tailwindcss';

--- a/e2e/cases/tailwindcss/plugin-inline-query/src/index.html
+++ b/e2e/cases/tailwindcss/plugin-inline-query/src/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+  <head></head>
+  <body>
+    <h1 class="underline">Hello world!</h1>
+  </body>
+</html>

--- a/e2e/cases/tailwindcss/plugin-inline-query/src/index.js
+++ b/e2e/cases/tailwindcss/plugin-inline-query/src/index.js
@@ -1,0 +1,3 @@
+import inlineCss from './index.css?inline';
+
+window.tailwindInlineCss = inlineCss;

--- a/packages/plugin-tailwindcss/src/index.ts
+++ b/packages/plugin-tailwindcss/src/index.ts
@@ -5,8 +5,6 @@ const require = createRequire(import.meta.url);
 
 export const PLUGIN_TAILWINDCSS_NAME = 'rsbuild:tailwindcss';
 
-const TAILWINDCSS_LOADER = 'tailwindcss';
-
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === 'object' && !Array.isArray(value);
 
@@ -37,18 +35,24 @@ export const pluginTailwindcss = (): RsbuildPlugin => ({
 
   setup(api) {
     api.modifyBundlerChain((chain, { CHAIN_ID }) => {
-      const cssMainRule = chain.module
-        .rule(CHAIN_ID.RULE.CSS)
-        .oneOf(CHAIN_ID.ONE_OF.CSS_MAIN);
+      if (!chain.module.rules.has(CHAIN_ID.RULE.CSS)) {
+        return;
+      }
 
-      incrementCssImportLoaders(cssMainRule, CHAIN_ID.USE.CSS);
+      const addTailwindLoader = (rule: RspackChain.Rule<unknown>) => {
+        incrementCssImportLoaders(rule, CHAIN_ID.USE.CSS);
 
-      cssMainRule
-        .use(TAILWINDCSS_LOADER)
-        .loader(require.resolve('@tailwindcss/webpack'))
-        .options({
-          base: api.context.rootPath,
-        });
+        rule
+          .use('tailwindcss')
+          .loader(require.resolve('@tailwindcss/webpack'))
+          .options({
+            base: api.context.rootPath,
+          });
+      };
+
+      const cssRule = chain.module.rule(CHAIN_ID.RULE.CSS);
+      addTailwindLoader(cssRule.oneOf(CHAIN_ID.ONE_OF.CSS_MAIN));
+      addTailwindLoader(cssRule.oneOf(CHAIN_ID.ONE_OF.CSS_INLINE));
     });
   },
 });

--- a/packages/plugin-tailwindcss/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-tailwindcss/tests/__snapshots__/index.test.ts.snap
@@ -60,7 +60,7 @@ exports[`plugin-tailwindcss > should add tailwindcss loader to CSS rule 1`] = `
             "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
             "options": {
               "exportType": "string",
-              "importLoaders": 1,
+              "importLoaders": 2,
               "modules": false,
               "sourceMap": false,
             },
@@ -75,6 +75,12 @@ exports[`plugin-tailwindcss > should add tailwindcss loader to CSS rule 1`] = `
                 "firefox >= 104",
                 "safari >= 16",
               ],
+            },
+          },
+          {
+            "loader": "<PNPM_INNER>/@tailwindcss/webpack/dist/index.js",
+            "options": {
+              "base": "<ROOT>",
             },
           },
         ],


### PR DESCRIPTION
## Summary

This PR extends the official `@rsbuild/plugin-tailwindcss` package to process CSS imported with `?inline`. The plugin now wires `@tailwindcss/webpack` into both the CSS main and inline rule branches, keeps `css-loader.importLoaders` aligned for inline imports, and adds an e2e case under the plugin-prefixed Tailwind CSS test suite.

## Related Links

Follow-up to https://github.com/web-infra-dev/rsbuild/pull/7745