### PR TITLE
fix(plugin-tailwindcss): skip main rule when css is not emitted

### DIFF
--- a/e2e/cases/tailwindcss/plugin-emit-css/index.test.ts
+++ b/e2e/cases/tailwindcss/plugin-emit-css/index.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from '@e2e/helper';
+
+test('should skip Tailwind main-rule transform when CSS is not emitted', async ({
+  build,
+}) => {
+  const rsbuild = await build({
+    config: {
+      output: {
+        target: 'node',
+      },
+    },
+  });
+
+  const files = rsbuild.getDistFiles();
+  expect(Object.keys(files).some((file) => file.endsWith('.css'))).toBe(false);
+});
+
+test('should run Tailwind main-rule transform when emitCss is enabled', async ({
+  build,
+}) => {
+  const rsbuild = await build({
+    catchBuildError: true,
+    config: {
+      output: {
+        emitCss: true,
+        target: 'node',
+      },
+    },
+  });
+
+  expect(rsbuild.buildError?.message).toBe('Rspack build failed.');
+  await rsbuild.expectLog('missing-tailwind-plugin');
+});

--- a/e2e/cases/tailwindcss/plugin-emit-css/rsbuild.config.ts
+++ b/e2e/cases/tailwindcss/plugin-emit-css/rsbuild.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginTailwindcss } from '@rsbuild/plugin-tailwindcss';
+
+export default defineConfig({
+  plugins: [pluginTailwindcss()],
+});

--- a/e2e/cases/tailwindcss/plugin-emit-css/src/index.css
+++ b/e2e/cases/tailwindcss/plugin-emit-css/src/index.css
@@ -1,0 +1,6 @@
+/* This missing plugin is a probe: the build fails only if Tailwind runs. */
+@plugin './missing-tailwind-plugin.js';
+
+.unused {
+  color: red;
+}

--- a/e2e/cases/tailwindcss/plugin-emit-css/src/index.js
+++ b/e2e/cases/tailwindcss/plugin-emit-css/src/index.js
@@ -1,0 +1,3 @@
+import './index.css';
+
+export const test = 'tailwindcss';

--- a/packages/plugin-tailwindcss/src/index.ts
+++ b/packages/plugin-tailwindcss/src/index.ts
@@ -34,10 +34,12 @@ export const pluginTailwindcss = (): RsbuildPlugin => ({
   name: PLUGIN_TAILWINDCSS_NAME,
 
   setup(api) {
-    api.modifyBundlerChain((chain, { CHAIN_ID }) => {
+    api.modifyBundlerChain((chain, { CHAIN_ID, environment, target }) => {
       if (!chain.module.rules.has(CHAIN_ID.RULE.CSS)) {
         return;
       }
+
+      const emitCss = environment.config.output.emitCss ?? target === 'web';
 
       const addTailwindLoader = (rule: RspackChain.Rule<unknown>) => {
         incrementCssImportLoaders(rule, CHAIN_ID.USE.CSS);
@@ -52,7 +54,9 @@ export const pluginTailwindcss = (): RsbuildPlugin => ({
 
       const cssRule = chain.module.rule(CHAIN_ID.RULE.CSS);
       addTailwindLoader(cssRule.oneOf(CHAIN_ID.ONE_OF.CSS_URL));
-      addTailwindLoader(cssRule.oneOf(CHAIN_ID.ONE_OF.CSS_MAIN));
+      if (emitCss) {
+        addTailwindLoader(cssRule.oneOf(CHAIN_ID.ONE_OF.CSS_MAIN));
+      }
       addTailwindLoader(cssRule.oneOf(CHAIN_ID.ONE_OF.CSS_INLINE));
     });
   },


### PR DESCRIPTION
## Summary

This PR avoids running `@tailwindcss/webpack` on the CSS main rule when CSS output is not emitted. The plugin now follows Rsbuild core's `output.emitCss ?? target === 'web'` behavior for `CHAIN_ID.ONE_OF.CSS_MAIN`, while still processing `?inline` and `?url` CSS imports because those branches are transformed even when CSS emission is disabled.

## Related Links

Follow-up to https://github.com/web-infra-dev/rsbuild/pull/7747
Related to https://github.com/web-infra-dev/rsbuild/issues/7660