### PR TITLE
test(plugin-tailwindcss): add injectStyles e2e

### DIFF
--- a/e2e/cases/tailwindcss/plugin-inject-styles/index.test.ts
+++ b/e2e/cases/tailwindcss/plugin-inject-styles/index.test.ts
@@ -1,0 +1,19 @@
+import { expect, getFileContent, test } from '@e2e/helper';
+
+test('should inject transformed Tailwind CSS when injectStyles is enabled', async ({
+  page,
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview();
+
+  const files = rsbuild.getDistFiles();
+  const cssFiles = Object.keys(files).filter((file) => file.endsWith('.css'));
+  expect(cssFiles).toHaveLength(0);
+
+  const indexJs = getFileContent(files, 'index.js');
+  expect(indexJs).toMatch(/\.underline\{text-decoration-line:underline\}/);
+
+  const title = page.locator('#title');
+  await expect(title).toHaveCSS('font-weight', '700');
+  await expect(title).toHaveCSS('text-decoration-line', 'underline');
+});

--- a/e2e/cases/tailwindcss/plugin-inject-styles/rsbuild.config.ts
+++ b/e2e/cases/tailwindcss/plugin-inject-styles/rsbuild.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginTailwindcss } from '@rsbuild/plugin-tailwindcss';
+
+export default defineConfig({
+  html: {
+    template: './src/index.html',
+  },
+  output: {
+    injectStyles: true,
+  },
+  plugins: [pluginTailwindcss()],
+});

--- a/e2e/cases/tailwindcss/plugin-inject-styles/src/index.css
+++ b/e2e/cases/tailwindcss/plugin-inject-styles/src/index.css
@@ -1,0 +1,1 @@
+@import 'tailwindcss';

--- a/e2e/cases/tailwindcss/plugin-inject-styles/src/index.html
+++ b/e2e/cases/tailwindcss/plugin-inject-styles/src/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+  <head></head>
+  <body>
+    <h1 id="title" class="text-3xl font-bold underline">Hello world!</h1>
+  </body>
+</html>

--- a/e2e/cases/tailwindcss/plugin-inject-styles/src/index.js
+++ b/e2e/cases/tailwindcss/plugin-inject-styles/src/index.js
@@ -1,0 +1,1 @@
+import './index.css';


### PR DESCRIPTION
## Summary

This PR adds an e2e case for using `@rsbuild/plugin-tailwindcss` together with `output.injectStyles`. The test verifies that Tailwind utilities are transformed into the injected JS style payload without emitting a standalone CSS file, and that the injected styles take effect in preview.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/7660