### PR TITLE
feat(plugin-tailwindcss): add optimize option

### DIFF
--- a/e2e/cases/tailwindcss/plugin-optimize/index.test.ts
+++ b/e2e/cases/tailwindcss/plugin-optimize/index.test.ts
@@ -1,19 +1,23 @@
 import { expect, getFileContent, test } from '@e2e/helper';
 import { pluginTailwindcss } from '@rsbuild/plugin-tailwindcss';
 
+const commonConfig = {
+  html: {
+    template: './src/index.html',
+  },
+  output: {
+    minify: false,
+  },
+  tools: {
+    lightningcssLoader: false,
+  },
+};
+
 test('should disable Tailwind optimization by default', async ({ build }) => {
   const rsbuild = await build({
     config: {
-      html: {
-        template: './src/index.html',
-      },
-      output: {
-        minify: false,
-      },
+      ...commonConfig,
       plugins: [pluginTailwindcss()],
-      tools: {
-        lightningcssLoader: false,
-      },
     },
   });
 
@@ -26,16 +30,8 @@ test('should enable Tailwind minify when optimize is true', async ({
 }) => {
   const rsbuild = await build({
     config: {
-      html: {
-        template: './src/index.html',
-      },
-      output: {
-        minify: false,
-      },
+      ...commonConfig,
       plugins: [pluginTailwindcss({ optimize: true })],
-      tools: {
-        lightningcssLoader: false,
-      },
     },
   });
 
@@ -49,16 +45,8 @@ test('should keep Tailwind minify disabled when optimize minify is omitted', asy
 }) => {
   const rsbuild = await build({
     config: {
-      html: {
-        template: './src/index.html',
-      },
-      output: {
-        minify: false,
-      },
+      ...commonConfig,
       plugins: [pluginTailwindcss({ optimize: {} })],
-      tools: {
-        lightningcssLoader: false,
-      },
     },
   });
 
@@ -75,16 +63,8 @@ test('should enable Tailwind minify when optimize minify is true', async ({
 }) => {
   const rsbuild = await build({
     config: {
-      html: {
-        template: './src/index.html',
-      },
-      output: {
-        minify: false,
-      },
+      ...commonConfig,
       plugins: [pluginTailwindcss({ optimize: { minify: true } })],
-      tools: {
-        lightningcssLoader: false,
-      },
     },
   });
 

--- a/e2e/cases/tailwindcss/plugin-optimize/index.test.ts
+++ b/e2e/cases/tailwindcss/plugin-optimize/index.test.ts
@@ -4,6 +4,9 @@ import { pluginTailwindcss } from '@rsbuild/plugin-tailwindcss';
 test('should disable Tailwind optimization by default', async ({ build }) => {
   const rsbuild = await build({
     config: {
+      html: {
+        template: './src/index.html',
+      },
       output: {
         minify: false,
       },
@@ -23,6 +26,9 @@ test('should enable Tailwind minify when optimize is true', async ({
 }) => {
   const rsbuild = await build({
     config: {
+      html: {
+        template: './src/index.html',
+      },
       output: {
         minify: false,
       },
@@ -43,6 +49,9 @@ test('should keep Tailwind minify disabled when optimize minify is omitted', asy
 }) => {
   const rsbuild = await build({
     config: {
+      html: {
+        template: './src/index.html',
+      },
       output: {
         minify: false,
       },
@@ -66,6 +75,9 @@ test('should enable Tailwind minify when optimize minify is true', async ({
 }) => {
   const rsbuild = await build({
     config: {
+      html: {
+        template: './src/index.html',
+      },
       output: {
         minify: false,
       },

--- a/e2e/cases/tailwindcss/plugin-optimize/index.test.ts
+++ b/e2e/cases/tailwindcss/plugin-optimize/index.test.ts
@@ -1,0 +1,82 @@
+import { expect, getFileContent, test } from '@e2e/helper';
+import { pluginTailwindcss } from '@rsbuild/plugin-tailwindcss';
+
+test('should disable Tailwind optimization by default', async ({ build }) => {
+  const rsbuild = await build({
+    config: {
+      output: {
+        minify: false,
+      },
+      plugins: [pluginTailwindcss()],
+      tools: {
+        lightningcssLoader: false,
+      },
+    },
+  });
+
+  const css = getFileContent(rsbuild.getDistFiles(), 'index.css');
+  expect(css).toContain('& .title');
+});
+
+test('should enable Tailwind minify when optimize is true', async ({
+  build,
+}) => {
+  const rsbuild = await build({
+    config: {
+      output: {
+        minify: false,
+      },
+      plugins: [pluginTailwindcss({ optimize: true })],
+      tools: {
+        lightningcssLoader: false,
+      },
+    },
+  });
+
+  const css = getFileContent(rsbuild.getDistFiles(), 'index.css');
+  expect(css).toContain('.card .title');
+  expect(css).toContain('.underline{text-decoration-line:underline}');
+});
+
+test('should keep Tailwind minify disabled when optimize minify is omitted', async ({
+  build,
+}) => {
+  const rsbuild = await build({
+    config: {
+      output: {
+        minify: false,
+      },
+      plugins: [pluginTailwindcss({ optimize: {} })],
+      tools: {
+        lightningcssLoader: false,
+      },
+    },
+  });
+
+  const css = getFileContent(rsbuild.getDistFiles(), 'index.css');
+  expect(css).toContain('.card .title');
+  expect(css).toMatch(
+    /\.underline \{\n\s+text-decoration-line: underline;\n\s+\}/,
+  );
+  expect(css).not.toContain('.underline{text-decoration-line:underline}');
+});
+
+test('should enable Tailwind minify when optimize minify is true', async ({
+  build,
+}) => {
+  const rsbuild = await build({
+    config: {
+      output: {
+        minify: false,
+      },
+      plugins: [pluginTailwindcss({ optimize: { minify: true } })],
+      tools: {
+        lightningcssLoader: false,
+      },
+    },
+  });
+
+  const css = getFileContent(rsbuild.getDistFiles(), 'index.css');
+  expect(css).toContain('.card .title');
+  expect(css).toContain('.underline{text-decoration-line:underline}');
+});

--- a/e2e/cases/tailwindcss/plugin-optimize/src/index.css
+++ b/e2e/cases/tailwindcss/plugin-optimize/src/index.css
@@ -1,0 +1,7 @@
+@import 'tailwindcss';
+
+.card {
+  & .title {
+    color: blue;
+  }
+}

--- a/e2e/cases/tailwindcss/plugin-optimize/src/index.html
+++ b/e2e/cases/tailwindcss/plugin-optimize/src/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+  <head></head>
+  <body>
+    <h1 class="underline">Hello world!</h1>
+  </body>
+</html>

--- a/e2e/cases/tailwindcss/plugin-optimize/src/index.js
+++ b/e2e/cases/tailwindcss/plugin-optimize/src/index.js
@@ -1,0 +1,1 @@
+import './index.css';

--- a/packages/plugin-tailwindcss/src/index.ts
+++ b/packages/plugin-tailwindcss/src/index.ts
@@ -5,6 +5,27 @@ const require = createRequire(import.meta.url);
 
 export const PLUGIN_TAILWINDCSS_NAME = 'rsbuild:tailwindcss';
 
+export type PluginTailwindcssOptions = {
+  /**
+   * Enable Tailwind CSS's built-in Lightning CSS optimization.
+   *
+   * This overlaps with Rsbuild's built-in Lightning CSS optimization. It is
+   * recommended to enable this option only when Rsbuild's built-in Lightning
+   * CSS optimization is disabled.
+   *
+   * @default false
+   */
+  optimize?:
+    | boolean
+    | {
+        /**
+         * Enable minification in Tailwind CSS's built-in Lightning CSS optimization.
+         * @default false
+         */
+        minify?: boolean;
+      };
+};
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === 'object' && !Array.isArray(value);
 
@@ -30,7 +51,9 @@ const incrementCssImportLoaders = (
   });
 };
 
-export const pluginTailwindcss = (): RsbuildPlugin => ({
+export const pluginTailwindcss = (
+  options: PluginTailwindcssOptions = {},
+): RsbuildPlugin => ({
   name: PLUGIN_TAILWINDCSS_NAME,
 
   setup(api) {
@@ -39,7 +62,12 @@ export const pluginTailwindcss = (): RsbuildPlugin => ({
         return;
       }
 
-      const emitCss = environment.config.output.emitCss ?? target === 'web';
+      const { output } = environment.config;
+      const tailwindOptions = {
+        base: api.context.rootPath,
+        optimize: options.optimize ?? false,
+      };
+      const emitCss = output.emitCss ?? target === 'web';
 
       const addTailwindLoader = (rule: RspackChain.Rule<unknown>) => {
         incrementCssImportLoaders(rule, CHAIN_ID.USE.CSS);
@@ -47,9 +75,7 @@ export const pluginTailwindcss = (): RsbuildPlugin => ({
         rule
           .use('tailwindcss')
           .loader(require.resolve('@tailwindcss/webpack'))
-          .options({
-            base: api.context.rootPath,
-          });
+          .options(tailwindOptions);
       };
 
       const cssRule = chain.module.rule(CHAIN_ID.RULE.CSS);

--- a/packages/plugin-tailwindcss/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-tailwindcss/tests/__snapshots__/index.test.ts.snap
@@ -51,6 +51,7 @@ exports[`plugin-tailwindcss > should add tailwindcss loader to CSS rule 1`] = `
             "loader": "<PNPM_INNER>/@tailwindcss/webpack/dist/index.js",
             "options": {
               "base": "<ROOT>",
+              "optimize": false,
             },
           },
         ],
@@ -87,6 +88,7 @@ exports[`plugin-tailwindcss > should add tailwindcss loader to CSS rule 1`] = `
             "loader": "<PNPM_INNER>/@tailwindcss/webpack/dist/index.js",
             "options": {
               "base": "<ROOT>",
+              "optimize": false,
             },
           },
         ],
@@ -134,6 +136,7 @@ exports[`plugin-tailwindcss > should add tailwindcss loader to CSS rule 1`] = `
             "loader": "<PNPM_INNER>/@tailwindcss/webpack/dist/index.js",
             "options": {
               "base": "<ROOT>",
+              "optimize": false,
             },
           },
         ],


### PR DESCRIPTION
## Summary

This PR adds an `optimize` option to `@rsbuild/plugin-tailwindcss` so users can opt into Tailwind CSS's built-in Lightning CSS optimization when needed, such as when Rsbuild's built-in Lightning CSS optimization is disabled. 

The option defaults to `false` and is passed through to `@tailwindcss/webpack`.