### PR TITLE
release: @rsbuild/plugin-tailwindcss v2.0.0

### DIFF
--- a/packages/plugin-tailwindcss/package.json
+++ b/packages/plugin-tailwindcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-tailwindcss",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Tailwind CSS plugin for Rsbuild",
   "homepage": "https://rsbuild.rs",
   "repository": {


### PR DESCRIPTION
## Summary

This PR releases `@rsbuild/plugin-tailwindcss` v2.0.0 as the first published version of the official Tailwind CSS plugin.

The plugin only supports Rsbuild v2, so its package version starts from 2.0.0 instead of 1.x.