### PR TITLE
docs: update Tailwind CSS v4 guide

### DIFF
--- a/website/docs/en/guide/styling/tailwindcss-v3.mdx
+++ b/website/docs/en/guide/styling/tailwindcss-v3.mdx
@@ -18,7 +18,7 @@ import { PackageManagerTabs } from '@theme';
 
 ## Configuring PostCSS
 
-You can register the `tailwindcss` PostCSS plugin through [postcss.config.cjs](https://npmjs.com/package/postcss-loader#config) or [tools.postcss](/config/tools/postcss).
+You can register the `tailwindcss` PostCSS plugin through a [PostCSS configuration file](https://npmjs.com/package/postcss-loader#config) or [tools.postcss](/config/tools/postcss).
 
 ```js title="postcss.config.cjs"
 module.exports = {
@@ -65,7 +65,7 @@ module.exports = {
 
 ### Other configuration methods
 
-- You can directly pass the Tailwind CSS configuration to `postcss.config.cjs`:
+- You can directly pass the Tailwind CSS configuration to the PostCSS configuration file:
 
 ```js title="postcss.config.cjs"
 module.exports = {

--- a/website/docs/en/guide/styling/tailwindcss.mdx
+++ b/website/docs/en/guide/styling/tailwindcss.mdx
@@ -46,7 +46,7 @@ Rsbuild has built-in support for PostCSS, so projects that already have a PostCS
 
 <PackageManagerTabs command="add tailwindcss @tailwindcss/postcss -D" />
 
-You can register the Tailwind CSS PostCSS plugin through [postcss.config.cjs](https://npmjs.com/package/postcss-loader#config) or [tools.postcss](/config/tools/postcss).
+You can register the Tailwind CSS PostCSS plugin through a [PostCSS configuration file](https://npmjs.com/package/postcss-loader#config) or [tools.postcss](/config/tools/postcss).
 
 ```js title="postcss.config.mjs"
 export default {

--- a/website/docs/en/guide/styling/tailwindcss.mdx
+++ b/website/docs/en/guide/styling/tailwindcss.mdx
@@ -1,12 +1,12 @@
 ---
-description: 'Tailwind CSS v4 guide covering key concepts, configuration, and practical usage in Rsbuild.'
+description: 'Use Tailwind CSS v4 in Rsbuild with the recommended @rsbuild/plugin-tailwindcss integration or the @tailwindcss/postcss plugin.'
 ---
 
 # Tailwind CSS v4
 
-[Tailwind CSS](https://tailwindcss.com/) is a CSS framework and design system based on utility classes, which can quickly add common styles to components and supports flexible extension of theme styles.
+import { PackageManagerTabs } from '@theme';
 
-You can integrate Tailwind CSS in Rsbuild via PostCSS plugins.
+[Tailwind CSS](https://tailwindcss.com/) is a CSS framework and design system based on utility classes, which can quickly add common styles to components and supports flexible extension of theme styles.
 
 ## Choosing Tailwind CSS version
 
@@ -16,15 +16,35 @@ Please note that Tailwind CSS v4 uses many modern CSS features, such as [Cascade
 
 More information can be found in [Tailwind CSS - Compatibility](https://tailwindcss.com/docs/compatibility).
 
-## Installing Tailwind CSS
+## Integrating Tailwind CSS
 
-Rsbuild has built-in support for PostCSS, you can install `tailwindcss` and `@tailwindcss/postcss` packages to integrate Tailwind CSS:
+### Using the Rsbuild plugin
 
-import { PackageManagerTabs } from '@theme';
+We recommend using the [@rsbuild/plugin-tailwindcss](/plugins/list/plugin-tailwindcss) plugin to integrate Tailwind CSS in Rsbuild.
+
+The plugin is based on [@tailwindcss/webpack](https://www.npmjs.com/package/@tailwindcss/webpack) and does not need to run Tailwind CSS transforms through [@tailwindcss/postcss](https://www.npmjs.com/package/@tailwindcss/postcss), providing better build performance.
+
+Install `@rsbuild/plugin-tailwindcss` and `tailwindcss`:
+
+<PackageManagerTabs command="add @rsbuild/plugin-tailwindcss tailwindcss -D" />
+
+Register the plugin in the `rsbuild.config.ts` file:
+
+```ts title="rsbuild.config.ts"
+import { pluginTailwindcss } from '@rsbuild/plugin-tailwindcss';
+
+export default {
+  plugins: [pluginTailwindcss()],
+};
+```
+
+> See [Tailwind CSS plugin documentation](/plugins/list/plugin-tailwindcss) for more details.
+
+### Using the PostCSS plugin
+
+Rsbuild has built-in support for PostCSS, so projects that already have a PostCSS setup can install `tailwindcss` and [@tailwindcss/postcss](https://www.npmjs.com/package/@tailwindcss/postcss) to integrate Tailwind CSS:
 
 <PackageManagerTabs command="add tailwindcss @tailwindcss/postcss -D" />
-
-## Configuring PostCSS
 
 You can register the Tailwind CSS PostCSS plugin through [postcss.config.cjs](https://npmjs.com/package/postcss-loader#config) or [tools.postcss](/config/tools/postcss).
 

--- a/website/docs/zh/guide/styling/tailwindcss-v3.mdx
+++ b/website/docs/zh/guide/styling/tailwindcss-v3.mdx
@@ -18,7 +18,7 @@ import { PackageManagerTabs } from '@theme';
 
 ## 配置 PostCSS
 
-你可以通过 [postcss.config.cjs](https://npmjs.com/package/postcss-loader#config) 或 [tools.postcss](/config/tools/postcss) 来注册 `tailwindcss` 的 PostCSS 插件。
+你可以通过 [PostCSS 配置文件](https://npmjs.com/package/postcss-loader#config) 或 [tools.postcss](/config/tools/postcss) 来注册 `tailwindcss` 的 PostCSS 插件。
 
 ```js title="postcss.config.cjs"
 module.exports = {
@@ -65,7 +65,7 @@ module.exports = {
 
 ### 其他配置方式
 
-- 你可以在 `postcss.config.cjs` 中直接传入 Tailwind CSS 的配置：
+- 你可以在 PostCSS 配置文件中直接传入 Tailwind CSS 的配置：
 
 ```js title="postcss.config.cjs"
 module.exports = {

--- a/website/docs/zh/guide/styling/tailwindcss.mdx
+++ b/website/docs/zh/guide/styling/tailwindcss.mdx
@@ -1,12 +1,12 @@
 ---
-description: 'Tailwind CSS 是一个以 Utility Class 为基础的 CSS 框架和设计系统，可以快速地为组件添加常用样式，同时支持主题样式的灵活扩展。'
+description: '在 Rsbuild 中通过推荐的 @rsbuild/plugin-tailwindcss 集成 Tailwind CSS v4，也可以继续使用 @tailwindcss/postcss 插件。'
 ---
 
 # Tailwind CSS v4
 
-[Tailwind CSS](https://tailwindcss.com/) 是一个以 Utility Class 为基础的 CSS 框架和设计系统，可以快速地为组件添加常用样式，同时支持主题样式的灵活扩展。
+import { PackageManagerTabs } from '@theme';
 
-你可以通过 PostCSS 插件来在 Rsbuild 中接入 Tailwind CSS。
+[Tailwind CSS](https://tailwindcss.com/) 是一个以 Utility Class 为基础的 CSS 框架和设计系统，可以快速地为组件添加常用样式，同时支持主题样式的灵活扩展。
 
 ## 选择 Tailwind CSS 版本
 
@@ -16,15 +16,35 @@ description: 'Tailwind CSS 是一个以 Utility Class 为基础的 CSS 框架和
 
 更多信息请参考 [Tailwind CSS - Compatibility](https://tailwindcss.com/docs/compatibility)。
 
-## 安装 Tailwind CSS
+## 集成 Tailwind CSS
 
-Rsbuild 内置支持 PostCSS，你可以安装 `tailwindcss` 和 `@tailwindcss/postcss` 包来接入 Tailwind CSS：
+### 通过 Rsbuild 插件
 
-import { PackageManagerTabs } from '@theme';
+推荐使用 [@rsbuild/plugin-tailwindcss](/plugins/list/plugin-tailwindcss) 插件在 Rsbuild 中集成 Tailwind CSS。
+
+该插件基于 [@tailwindcss/webpack](https://www.npmjs.com/package/@tailwindcss/webpack) 实现，无需通过 [@tailwindcss/postcss](https://www.npmjs.com/package/@tailwindcss/postcss) 执行 Tailwind CSS 转换，因此提供了更好的构建性能。
+
+安装 `@rsbuild/plugin-tailwindcss` 和 `tailwindcss`：
+
+<PackageManagerTabs command="add @rsbuild/plugin-tailwindcss tailwindcss -D" />
+
+在 `rsbuild.config.ts` 文件中注册插件：
+
+```ts title="rsbuild.config.ts"
+import { pluginTailwindcss } from '@rsbuild/plugin-tailwindcss';
+
+export default {
+  plugins: [pluginTailwindcss()],
+};
+```
+
+> 详见 [Tailwind CSS 插件文档](/plugins/list/plugin-tailwindcss)。
+
+### 通过 PostCSS 插件
+
+Rsbuild 内置支持 PostCSS，已有 PostCSS 配置的项目也可以安装 `tailwindcss` 和 [@tailwindcss/postcss](https://www.npmjs.com/package/@tailwindcss/postcss) 来接入 Tailwind CSS：
 
 <PackageManagerTabs command="add tailwindcss @tailwindcss/postcss -D" />
-
-## 配置 PostCSS
 
 你可以通过 [postcss.config.cjs](https://npmjs.com/package/postcss-loader#config) 或 [tools.postcss](/config/tools/postcss) 来注册 Tailwind CSS 的 PostCSS 插件。
 

--- a/website/docs/zh/guide/styling/tailwindcss.mdx
+++ b/website/docs/zh/guide/styling/tailwindcss.mdx
@@ -46,7 +46,7 @@ Rsbuild 内置支持 PostCSS，已有 PostCSS 配置的项目也可以安装 `ta
 
 <PackageManagerTabs command="add tailwindcss @tailwindcss/postcss -D" />
 
-你可以通过 [postcss.config.cjs](https://npmjs.com/package/postcss-loader#config) 或 [tools.postcss](/config/tools/postcss) 来注册 Tailwind CSS 的 PostCSS 插件。
+你可以通过 [PostCSS 配置文件](https://npmjs.com/package/postcss-loader#config) 或 [tools.postcss](/config/tools/postcss) 来注册 Tailwind CSS 的 PostCSS 插件。
 
 ```js title="postcss.config.mjs"
 export default {


### PR DESCRIPTION
## Summary

This PR updates the Tailwind CSS v4 guide to recommend `@rsbuild/plugin-tailwindcss` as the primary integration path, while keeping `@tailwindcss/postcss` as the PostCSS-based alternative for projects with an existing PostCSS setup. It also syncs the English and Chinese docs.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/7752