### PR TITLE
test(plugin-tailwindcss): add React HMR e2e case

### DIFF
--- a/e2e/cases/tailwindcss/plugin-react-hmr/index.test.ts
+++ b/e2e/cases/tailwindcss/plugin-react-hmr/index.test.ts
@@ -1,0 +1,35 @@
+import { join } from 'node:path';
+import { expect, test } from '@e2e/helper';
+
+test('should support Tailwind CSS HMR in React components', async ({
+  page,
+  dev,
+  editFile,
+  copySrcDir,
+}) => {
+  const tempSrc = await copySrcDir();
+
+  await dev({
+    config: {
+      source: {
+        entry: {
+          index: join(tempSrc, 'index.tsx'),
+        },
+      },
+    },
+  });
+
+  const button = page.locator('#button');
+  await expect(button).toHaveText('count: 0');
+  await expect(button).toHaveCSS('background-color', 'rgb(18, 52, 86)');
+
+  await button.click();
+  await expect(button).toHaveText('count: 1');
+
+  await editFile(join(tempSrc, 'App.tsx'), (code) =>
+    code.replace('bg-[#123456]', 'bg-[#654321]'),
+  );
+
+  await expect(button).toHaveText('count: 1');
+  await expect(button).toHaveCSS('background-color', 'rgb(101, 67, 33)');
+});

--- a/e2e/cases/tailwindcss/plugin-react-hmr/rsbuild.config.ts
+++ b/e2e/cases/tailwindcss/plugin-react-hmr/rsbuild.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+import { pluginTailwindcss } from '@rsbuild/plugin-tailwindcss';
+
+export default defineConfig({
+  plugins: [pluginReact(), pluginTailwindcss()],
+});

--- a/e2e/cases/tailwindcss/plugin-react-hmr/src/App.tsx
+++ b/e2e/cases/tailwindcss/plugin-react-hmr/src/App.tsx
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+
+const App = () => {
+  const [count, setCount] = useState(0);
+
+  return (
+    <button
+      id="button"
+      className="bg-[#123456] px-4 py-2 text-white"
+      type="button"
+      onClick={() => setCount(count + 1)}
+    >
+      count: {count}
+    </button>
+  );
+};
+
+export default App;

--- a/e2e/cases/tailwindcss/plugin-react-hmr/src/index.css
+++ b/e2e/cases/tailwindcss/plugin-react-hmr/src/index.css
@@ -1,0 +1,1 @@
+@import 'tailwindcss';

--- a/e2e/cases/tailwindcss/plugin-react-hmr/src/index.tsx
+++ b/e2e/cases/tailwindcss/plugin-react-hmr/src/index.tsx
@@ -1,0 +1,9 @@
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+const container = document.getElementById('root');
+if (container) {
+  const root = createRoot(container);
+  root.render(<App />);
+}


### PR DESCRIPTION
## Summary

This PR adds an e2e case for `@rsbuild/plugin-tailwindcss` with React Fast Refresh. The case updates a Tailwind class inside a React component, verifies that the component state is preserved, and checks that the newly generated Tailwind CSS is applied after HMR.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/7660