### PR TITLE
test: add Tailwind CSS source scope cases

### DIFF
--- a/e2e/cases/plugin-tailwindcss/source-directive/fixtures/page.html
+++ b/e2e/cases/plugin-tailwindcss/source-directive/fixtures/page.html
@@ -1,0 +1,1 @@
+<div class="font-bold">Tailwind source directive</div>

--- a/e2e/cases/plugin-tailwindcss/source-directive/index.test.ts
+++ b/e2e/cases/plugin-tailwindcss/source-directive/index.test.ts
@@ -1,0 +1,11 @@
+import { expect, getFileContent, test } from '@e2e/helper';
+
+test('should generate Tailwind utilities from @source files', async ({
+  runBoth,
+}) => {
+  await runBoth(async ({ result }) => {
+    const indexCss = getFileContent(result.getDistFiles(), 'index.css');
+    expect(indexCss).toContain('.font-bold');
+    expect(indexCss).not.toContain('.underline{');
+  });
+});

--- a/e2e/cases/plugin-tailwindcss/source-directive/rsbuild.config.ts
+++ b/e2e/cases/plugin-tailwindcss/source-directive/rsbuild.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginTailwindcss } from '@rsbuild/plugin-tailwindcss';
+
+export default defineConfig({
+  html: {
+    template: './src/index.html',
+  },
+  plugins: [pluginTailwindcss()],
+});

--- a/e2e/cases/plugin-tailwindcss/source-directive/src/index.css
+++ b/e2e/cases/plugin-tailwindcss/source-directive/src/index.css
@@ -1,0 +1,3 @@
+@import 'tailwindcss' source(none);
+
+@source '../fixtures/**/*.html';

--- a/e2e/cases/plugin-tailwindcss/source-directive/src/index.html
+++ b/e2e/cases/plugin-tailwindcss/source-directive/src/index.html
@@ -1,0 +1,1 @@
+<div id="root" class="underline"></div>

--- a/e2e/cases/plugin-tailwindcss/source-directive/src/index.js
+++ b/e2e/cases/plugin-tailwindcss/source-directive/src/index.js
@@ -1,0 +1,1 @@
+import './index.css';

--- a/e2e/cases/plugin-tailwindcss/source-function/fixtures/page.html
+++ b/e2e/cases/plugin-tailwindcss/source-function/fixtures/page.html
@@ -1,0 +1,1 @@
+<div class="font-bold">Tailwind source function</div>

--- a/e2e/cases/plugin-tailwindcss/source-function/index.test.ts
+++ b/e2e/cases/plugin-tailwindcss/source-function/index.test.ts
@@ -1,0 +1,11 @@
+import { expect, getFileContent, test } from '@e2e/helper';
+
+test('should generate Tailwind utilities from source() files', async ({
+  runBoth,
+}) => {
+  await runBoth(async ({ result }) => {
+    const indexCss = getFileContent(result.getDistFiles(), 'index.css');
+    expect(indexCss).toContain('.font-bold');
+    expect(indexCss).not.toContain('.underline{');
+  });
+});

--- a/e2e/cases/plugin-tailwindcss/source-function/rsbuild.config.ts
+++ b/e2e/cases/plugin-tailwindcss/source-function/rsbuild.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginTailwindcss } from '@rsbuild/plugin-tailwindcss';
+
+export default defineConfig({
+  html: {
+    template: './src/index.html',
+  },
+  plugins: [pluginTailwindcss()],
+});

--- a/e2e/cases/plugin-tailwindcss/source-function/src/index.css
+++ b/e2e/cases/plugin-tailwindcss/source-function/src/index.css
@@ -1,0 +1,1 @@
+@import 'tailwindcss' source('../fixtures');

--- a/e2e/cases/plugin-tailwindcss/source-function/src/index.html
+++ b/e2e/cases/plugin-tailwindcss/source-function/src/index.html
@@ -1,0 +1,1 @@
+<div id="root" class="underline"></div>

--- a/e2e/cases/plugin-tailwindcss/source-function/src/index.js
+++ b/e2e/cases/plugin-tailwindcss/source-function/src/index.js
@@ -1,0 +1,1 @@
+import './index.css';


### PR DESCRIPTION
## Summary

This PR adds `@rsbuild/plugin-tailwindcss` e2e coverage for Tailwind CSS scan scope controls. It verifies both `source(...)` and `@source` generate utilities from explicitly registered fixture files while excluding classes from the default HTML entry.