### PR TITLE
fix(core): correct base middleware path matching

### DIFF
--- a/e2e/cases/module-federation/v1-basic/host/rsbuild.config.ts
+++ b/e2e/cases/module-federation/v1-basic/host/rsbuild.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     options: {
       name: 'host',
       remotes: {
-        remote: `remote@http://localhost:${process.env.REMOTE_PORT || 3002}/remoteEntry.js`,
+        remote: `remote@http://localhost:${process.env.REMOTE_PORT || 3002}${process.env.REMOTE_BASE || ''}/remoteEntry.js`,
       },
       shared: {
         react: {

--- a/e2e/cases/module-federation/v1-basic/index.test.ts
+++ b/e2e/cases/module-federation/v1-basic/index.test.ts
@@ -81,6 +81,7 @@ test('should run module federation in dev with server.base', async ({
   const remotePort = await getRandomPort();
 
   process.env.REMOTE_PORT = remotePort.toString();
+  process.env.REMOTE_BASE = '/remote';
 
   const remoteApp = await devOnly({
     cwd: remote,
@@ -98,6 +99,7 @@ test('should run module federation in dev with server.base', async ({
       },
     },
   });
+  delete process.env.REMOTE_BASE;
 
   await gotoPage(page, remoteApp);
   await expect(page.locator('#title')).toHaveText('Remote');

--- a/e2e/cases/server/base-url/index.test.ts
+++ b/e2e/cases/server/base-url/index.test.ts
@@ -34,6 +34,13 @@ test('should apply server.base in dev', async ({ page, dev }) => {
     'The server is configured with a base URL of /base',
   );
 
+  // should not treat paths that only share the base prefix as based URLs
+  const similarPrefixRes = await page.goto(
+    `http://localhost:${rsbuild.port}/baseball`,
+  );
+  expect(similarPrefixRes?.status()).toBe(404);
+  expect(await page.content()).toContain('href="/base/baseball"');
+
   // should visit public dir correctly with base prefix
   await page.goto(`http://localhost:${rsbuild.port}/base/aaa.txt`);
 

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -36,10 +36,10 @@ import {
   getRoutes,
   getServerTerminator,
   printServerURLs,
+  removeBasePath,
   type RsbuildServerBase,
   resolvePort,
   type StartDevServerResult,
-  stripBase,
 } from './helper';
 import { createHttpServer } from './httpServer';
 import { notFoundMiddleware, optionsFallbackMiddleware } from './middlewares';
@@ -173,7 +173,7 @@ export async function createDevServer<
     context.publicPathnames = publicPaths
       .map(getPathnameFromUrl)
       .map((prefix) =>
-        base && base !== '/' ? stripBase(prefix, base) : prefix,
+        base && base !== '/' ? removeBasePath(prefix, base) : prefix,
       );
 
     compiler?.hooks.watchRun.tap('rsbuild:watchRun', () => {

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -6,7 +6,11 @@ import { posix, relative, sep } from 'node:path';
 import { ALL_INTERFACES_IPV4, LOCALHOST } from '../constants';
 import { color, isFunction } from '../helpers';
 import { getCommonParentPath } from '../helpers/path';
-import { addTrailingSlash, removeLeadingSlash } from '../helpers/url';
+import {
+  addTrailingSlash,
+  removeLeadingSlash,
+  removeTailingSlash,
+} from '../helpers/url';
 import type { Logger } from '../logger';
 import type {
   Connect,
@@ -73,23 +77,38 @@ const formatPrefix = (input: string | undefined) => {
 };
 
 // /a + /b => /a/b
-export const joinUrlSegments = (s1: string, s2: string): string => {
-  if (!s1 || !s2) {
-    return s1 || s2 || '';
+export const joinUrlPath = (basePath: string, pathname: string): string => {
+  if (basePath === '') {
+    return pathname;
   }
 
-  return addTrailingSlash(s1) + removeLeadingSlash(s2);
+  if (pathname === '') {
+    return basePath;
+  }
+
+  return addTrailingSlash(basePath) + removeLeadingSlash(pathname);
 };
 
-export const stripBase = (path: string, base: string): string => {
-  if (path === base) {
+export const isUrlPathUnderBase = (pathname: string, base: string): boolean => {
+  const basePath = removeTailingSlash(base);
+  return (
+    basePath === '' ||
+    pathname === basePath ||
+    pathname.startsWith(`${basePath}/`)
+  );
+};
+
+export const removeBasePath = (url: string, base: string): string => {
+  const basePath = removeTailingSlash(base);
+  if (basePath === '') {
+    return url;
+  }
+
+  if (url === basePath) {
     return '/';
   }
-  const trailingSlashBase = addTrailingSlash(base);
 
-  return path.startsWith(trailingSlashBase)
-    ? path.slice(trailingSlashBase.length - 1)
-    : path;
+  return url.startsWith(`${basePath}/`) ? url.slice(basePath.length) : url;
 };
 
 export const getRoutes = (context: InternalContext): Routes => {
@@ -127,7 +146,7 @@ export const formatRoutes = (
   distPathPrefix: string | undefined,
   outputStructure: OutputStructure | undefined,
 ): Routes => {
-  const prefix = joinUrlSegments(base, formatPrefix(distPathPrefix));
+  const prefix = joinUrlPath(base, formatPrefix(distPathPrefix));
 
   return (
     Object.keys(entry)

--- a/packages/core/src/server/middlewares.ts
+++ b/packages/core/src/server/middlewares.ts
@@ -6,7 +6,12 @@ import { addTrailingSlash } from '../helpers/url';
 import { isVerbose, type Logger } from '../logger';
 import type { Connect, EnvironmentAPI, RequestHandler, Rspack } from '../types';
 import type { BuildManager } from './buildManager';
-import { HttpCode, joinUrlSegments, stripBase } from './helper';
+import {
+  HttpCode,
+  isUrlPathUnderBase,
+  joinUrlPath,
+  removeBasePath,
+} from './helper';
 
 export const faviconFallbackMiddleware: RequestHandler = (req, res, next) => {
   if (req.url === '/favicon.ico') {
@@ -177,14 +182,14 @@ export const getBaseUrlMiddleware: (params: {
     const url = req.url!;
     const pathname = getUrlPathname(url);
 
-    if (pathname.startsWith(base)) {
-      req.url = stripBase(url, base);
+    if (isUrlPathUnderBase(pathname, base)) {
+      req.url = removeBasePath(url, base);
       next();
       return;
     }
 
     const redirectPath =
-      addTrailingSlash(url) !== base ? joinUrlSegments(base, url) : base;
+      addTrailingSlash(url) !== base ? joinUrlPath(base, url) : base;
 
     if (pathname === '/' || pathname === '/index.html') {
       // redirect root visit to based url with search and hash

--- a/packages/core/tests/server.test.ts
+++ b/packages/core/tests/server.test.ts
@@ -1,7 +1,13 @@
 import { rspack } from '@rspack/core';
 import { defaultAllowedOrigins } from '../src/defaultConfig';
 import { isClientCompiler } from '../src/server/assets-middleware';
-import { formatRoutes, printServerURLs } from '../src/server/helper';
+import {
+  formatRoutes,
+  isUrlPathUnderBase,
+  joinUrlPath,
+  printServerURLs,
+  removeBasePath,
+} from '../src/server/helper';
 import { createHttpServer } from '../src/server/httpServer';
 import type { Connect } from '../src/types';
 import { logger } from '../src';
@@ -163,6 +169,24 @@ test('should format routes correctly', () => {
       pathname: '/html/index',
     },
   ]);
+});
+
+test('should handle URL path helpers correctly', () => {
+  expect(joinUrlPath('', '')).toBe('');
+  expect(joinUrlPath('', '/main')).toBe('/main');
+  expect(joinUrlPath('/base', '')).toBe('/base');
+  expect(joinUrlPath('/base', '/')).toBe('/base/');
+  expect(joinUrlPath('/base', '/main')).toBe('/base/main');
+  expect(joinUrlPath('/base/', '/main')).toBe('/base/main');
+
+  expect(removeBasePath('/base', '/base')).toBe('/');
+  expect(removeBasePath('/base/', '/base')).toBe('/');
+  expect(removeBasePath('/base/foo', '/base')).toBe('/foo');
+  expect(removeBasePath('/baseball', '/base')).toBe('/baseball');
+
+  expect(isUrlPathUnderBase('/base', '/base')).toBe(true);
+  expect(isUrlPathUnderBase('/base/foo', '/base')).toBe(true);
+  expect(isUrlPathUnderBase('/baseball', '/base')).toBe(false);
 });
 
 test('should print server URLs correctly', () => {


### PR DESCRIPTION
## Summary

This PR fixes a base middleware bug where paths that only share the configured base prefix, such as `/baseball` with `server.base` set to `/base`, were incorrectly treated as based URLs and passed through. The middleware now only matches the exact base path or slash-delimited child paths, with e2e coverage for the regression.