### PR TITLE
test(plugin-tailwindcss): add Vue and Svelte e2e cases

### DIFF
--- a/e2e/cases/plugin-tailwindcss/svelte/index.test.ts
+++ b/e2e/cases/plugin-tailwindcss/svelte/index.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@e2e/helper';
+
+test('should generate Tailwind CSS utilities from Svelte components', async ({
+  page,
+  runBothServe,
+}) => {
+  await runBothServe(async () => {
+    const title = page.locator('#title');
+
+    await expect(title).toHaveText('Tailwind Svelte');
+    await expect(title).toHaveCSS('background-color', 'rgb(101, 67, 33)');
+    await expect(title).toHaveCSS('color', 'rgb(255, 255, 255)');
+  });
+});

--- a/e2e/cases/plugin-tailwindcss/svelte/rsbuild.config.ts
+++ b/e2e/cases/plugin-tailwindcss/svelte/rsbuild.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginSvelte } from '@rsbuild/plugin-svelte';
+import { pluginTailwindcss } from '@rsbuild/plugin-tailwindcss';
+
+export default defineConfig({
+  plugins: [pluginSvelte(), pluginTailwindcss()],
+});

--- a/e2e/cases/plugin-tailwindcss/svelte/src/App.svelte
+++ b/e2e/cases/plugin-tailwindcss/svelte/src/App.svelte
@@ -1,0 +1,9 @@
+<script>
+  let { name = 'Svelte' } = $props();
+</script>
+
+<main>
+  <h1 id="title" class="bg-[#654321] px-4 py-2 text-white">
+    Tailwind {name}
+  </h1>
+</main>

--- a/e2e/cases/plugin-tailwindcss/svelte/src/index.css
+++ b/e2e/cases/plugin-tailwindcss/svelte/src/index.css
@@ -1,0 +1,1 @@
+@import 'tailwindcss';

--- a/e2e/cases/plugin-tailwindcss/svelte/src/index.js
+++ b/e2e/cases/plugin-tailwindcss/svelte/src/index.js
@@ -1,0 +1,12 @@
+import { mount } from 'svelte';
+import App from './App.svelte';
+import './index.css';
+
+const app = mount(App, {
+  target: document.body,
+  props: {
+    name: 'Svelte',
+  },
+});
+
+export default app;

--- a/e2e/cases/plugin-tailwindcss/vue/index.test.ts
+++ b/e2e/cases/plugin-tailwindcss/vue/index.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@e2e/helper';
+
+test('should generate Tailwind CSS utilities from Vue components', async ({
+  page,
+  runBothServe,
+}) => {
+  await runBothServe(async () => {
+    const title = page.locator('#title');
+
+    await expect(title).toHaveText('Tailwind Vue');
+    await expect(title).toHaveCSS('background-color', 'rgb(18, 52, 86)');
+    await expect(title).toHaveCSS('color', 'rgb(255, 255, 255)');
+  });
+});

--- a/e2e/cases/plugin-tailwindcss/vue/rsbuild.config.ts
+++ b/e2e/cases/plugin-tailwindcss/vue/rsbuild.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginTailwindcss } from '@rsbuild/plugin-tailwindcss';
+import { pluginVue } from '@rsbuild/plugin-vue';
+
+export default defineConfig({
+  plugins: [pluginVue(), pluginTailwindcss()],
+});

--- a/e2e/cases/plugin-tailwindcss/vue/src/App.vue
+++ b/e2e/cases/plugin-tailwindcss/vue/src/App.vue
@@ -1,0 +1,5 @@
+<template>
+  <main>
+    <h1 id="title" class="bg-[#123456] px-4 py-2 text-white">Tailwind Vue</h1>
+  </main>
+</template>

--- a/e2e/cases/plugin-tailwindcss/vue/src/index.css
+++ b/e2e/cases/plugin-tailwindcss/vue/src/index.css
@@ -1,0 +1,1 @@
+@import 'tailwindcss';

--- a/e2e/cases/plugin-tailwindcss/vue/src/index.js
+++ b/e2e/cases/plugin-tailwindcss/vue/src/index.js
@@ -1,0 +1,5 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+import './index.css';
+
+createApp(App).mount('#root');

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -14,6 +14,7 @@
     "react": "catalog:",
     "react-dom": "catalog:",
     "solid-js": "catalog:",
+    "svelte": "catalog:",
     "vue": "catalog:"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -465,6 +465,9 @@ importers:
       solid-js:
         specifier: 'catalog:'
         version: 1.9.13
+      svelte:
+        specifier: 'catalog:'
+        version: 5.55.9
       vue:
         specifier: 'catalog:'
         version: 3.5.34(typescript@6.0.3)


### PR DESCRIPTION
## Summary

This PR adds Vue and Svelte e2e coverage for `@rsbuild/plugin-tailwindcss`. The new cases put Tailwind class names directly in Vue and Svelte components using each framework's standard component syntax, then verify that the generated utilities are applied in both dev and build-preview flows. It also adds `svelte` to the `@rsbuild/e2e` dependencies for the new Svelte case.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/7660