### PR TITLE
fix(plugin-babel): restrict Babel rule ID matching

### DIFF
--- a/packages/plugin-babel/src/helper.ts
+++ b/packages/plugin-babel/src/helper.ts
@@ -13,6 +13,7 @@ import type {
 } from './types.js';
 
 export const BABEL_JS_RULE = 'babel-js';
+const BABEL_JS_RULE_REGEXP = /^babel-js(?:-\d+)?$/;
 
 export const getBabelRuleId = (chain: RspackChain): string => {
   let id = BABEL_JS_RULE;
@@ -23,8 +24,7 @@ export const getBabelRuleId = (chain: RspackChain): string => {
   return id;
 };
 
-const isBabelRuleId = (id: string) =>
-  id === BABEL_JS_RULE || id.startsWith(`${BABEL_JS_RULE}-`);
+const isBabelRuleId = (id: string) => BABEL_JS_RULE_REGEXP.test(id);
 
 const getBabelRules = (chain: RspackChain) => {
   const ruleIds = Object.keys(chain.module.rules.entries()).filter(

--- a/website/docs/en/plugins/list/plugin-babel.mdx
+++ b/website/docs/en/plugins/list/plugin-babel.mdx
@@ -276,9 +276,9 @@ When you configure the `include` or `exclude` options, Rsbuild will create a sep
 This separate rule is completely independent of the SWC rule built into Rsbuild and is not affected by [source.include](/config/source/include) and [source.exclude](/config/source/exclude).
 :::
 
-### Configure multiple Babel plugins
+### Configure multiple Babel rules
 
-By using the `include` and `exclude` options, you can register multiple Babel plugins and specify different Babel transformations for different files.
+By using the `include` and `exclude` options, you can register multiple `@rsbuild/plugin-babel` instances and create separate Babel rules for different files.
 
 For example:
 

--- a/website/docs/zh/plugins/list/plugin-babel.mdx
+++ b/website/docs/zh/plugins/list/plugin-babel.mdx
@@ -275,9 +275,9 @@ pluginBabel({
 这条单独的 rule 与 Rsbuild 内置的 SWC rule 是完全独立的，并且不会受到 [source.include](/config/source/include) 和 [source.exclude](/config/source/exclude) 的作用。
 :::
 
-### 配置多个 Babel 插件
+### 配置多个 Babel 规则
 
-通过使用 `include` 和 `exclude` 选项，你可以同时注册多个 Babel 插件，并为不同文件指定不同的 Babel 转换规则。
+通过使用 `include` 和 `exclude` 选项，你可以注册多个 `@rsbuild/plugin-babel` 实例，并为不同文件创建独立的 Babel 规则。
 
 例如：
 


### PR DESCRIPTION
## Summary

This PR follows up on #7764 by tightening the generated Babel rule ID matching to only include `babel-js` and `babel-js-<number>` rules. It also updates the Babel plugin docs to describe multiple Babel rules while still clarifying that users register multiple `@rsbuild/plugin-babel` instances.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/7764