### PR TITLE
chore(deps): upgrade pnpm to 11.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
     "simple-git-hooks": "catalog:",
     "typescript": "catalog:"
   },
-  "packageManager": "pnpm@10.33.4",
+  "packageManager": "pnpm@11.3.0",
   "engines": {
     "node": ">=22.18.0",
-    "pnpm": ">=10.33.4"
+    "pnpm": ">=11.3.0"
   }
 }

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -17,7 +17,7 @@
     "create-rsbuild": "./bin.js"
   },
   "files": [
-    "template-*",
+    "template-*/**",
     "dist",
     "bin.js"
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -391,12 +391,8 @@ catalogs:
       version: 2.0.4
 
 patchedDependencies:
-  css-loader@7.1.4:
-    hash: b504d70330b6625a20bc0cb1428c9787350fe6413c2947f42bd88ff22123a019
-    path: patches/css-loader@7.1.4.patch
-  postcss-loader@8.2.1:
-    hash: 4829849d58d8366cd82cbdab1947d15f9e6d33e70f1e3d5310daffff152dff14
-    path: patches/postcss-loader@8.2.1.patch
+  css-loader@7.1.4: b504d70330b6625a20bc0cb1428c9787350fe6413c2947f42bd88ff22123a019
+  postcss-loader@8.2.1: 4829849d58d8366cd82cbdab1947d15f9e6d33e70f1e3d5310daffff152dff14
 
 importers:
 


### PR DESCRIPTION
## Summary

This PR upgrades the repo to pnpm 11.3.0 and adjusts the `create-rsbuild` package `files` list to use `template-*/**`, avoiding the pnpm 11 publish/pack behavior that otherwise omits the template directories from the published package.

## Related Links

https://github.com/pnpm/pnpm/releases/tag/v11.3.0