### PR TITLE
fix(deps): update @swc/helpers to v0.5.23

### DIFF
--- a/e2e/cases/syntax-es/decorator-2022-03/index.test.ts
+++ b/e2e/cases/syntax-es/decorator-2022-03/index.test.ts
@@ -27,6 +27,23 @@ test('should run stage 3 decorators correctly with babel-plugin', async ({
   expect(await page.evaluate('window.field')).toBe('message');
 });
 
+test('should return correct initializers in 2022-03 decorator helper', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview({
+    config: {
+      source: {
+        entry: {
+          index: './src/initializer-order.js',
+        },
+      },
+    },
+  });
+
+  expect(await page.evaluate('window.message')).toEqual(123);
+});
+
 test.fail(
   'stage 3 decorators do not support decoratorBeforeExport',
   async ({ page, buildPreview }) => {

--- a/e2e/cases/syntax-es/decorator-2022-03/src/initializer-order.js
+++ b/e2e/cases/syntax-es/decorator-2022-03/src/initializer-order.js
@@ -1,0 +1,11 @@
+const dec = () => {};
+class Foo {
+  @dec
+  a;
+
+  @dec
+  b = 123;
+}
+
+const instance = new Foo();
+window.message = instance.b;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,8 +113,8 @@ catalogs:
       specifier: 8.1.0
       version: 8.1.0
     '@swc/helpers':
-      specifier: ^0.5.22
-      version: 0.5.22
+      specifier: ^0.5.23
+      version: 0.5.23
     '@swc/plugin-prefresh':
       specifier: ^12.10.0
       version: 12.10.0
@@ -909,10 +909,10 @@ importers:
     dependencies:
       '@rspack/core':
         specifier: 'catalog:'
-        version: 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.22)
+        version: 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@swc/helpers':
         specifier: 'catalog:'
-        version: 0.5.22
+        version: 0.5.23
     devDependencies:
       '@jridgewell/remapping':
         specifier: 'catalog:'
@@ -2962,11 +2962,8 @@ packages:
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
-  '@swc/helpers@0.5.21':
-    resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==}
-
-  '@swc/helpers@0.5.22':
-    resolution: {integrity: sha512-/e2Ly3Docn9kYByap6TV4oquJ3wQuz3c+kC74riqtkwU9CwTMeuj6t2rW+bRr4pyOx/CYQM4wr0RgaKQwGEz0A==}
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
   '@swc/plugin-prefresh@12.10.0':
     resolution: {integrity: sha512-QGxS9IVAggBEB+6fXJcsHYXDRPg2762J9HqhHVAryoPxT4hObWAX1nyOhp0/kWLN77SGu665DY/xlFdLWiVCDw==}
@@ -6449,7 +6446,7 @@ snapshots:
       '@module-federation/manifest': 2.5.0(node-fetch@2.7.0)(typescript@6.0.3)
       '@module-federation/runtime-tools': 2.5.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
-      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.22)
+      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -6695,16 +6692,16 @@ snapshots:
 
   '@rsbuild/core@1.7.5':
     dependencies:
-      '@rspack/core': 1.7.11(@swc/helpers@0.5.21)
+      '@rspack/core': 1.7.11(@swc/helpers@0.5.23)
       '@rspack/lite-tapable': 1.1.0
-      '@swc/helpers': 0.5.21
+      '@swc/helpers': 0.5.23
       core-js: 3.47.0
       jiti: 2.7.0
 
   '@rsbuild/core@2.0.7(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)':
     dependencies:
-      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.22)
-      '@swc/helpers': 0.5.22
+      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@swc/helpers': 0.5.23
     optionalDependencies:
       core-js: 3.49.0
     transitivePeerDependencies:
@@ -6980,20 +6977,20 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 2.0.4
       '@rspack/binding-win32-x64-msvc': 2.0.4
 
-  '@rspack/core@1.7.11(@swc/helpers@0.5.21)':
+  '@rspack/core@1.7.11(@swc/helpers@0.5.23)':
     dependencies:
       '@module-federation/runtime-tools': 0.22.0
       '@rspack/binding': 1.7.11
       '@rspack/lite-tapable': 1.1.0
     optionalDependencies:
-      '@swc/helpers': 0.5.21
+      '@swc/helpers': 0.5.23
 
-  '@rspack/core@2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.22)':
+  '@rspack/core@2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)':
     dependencies:
       '@rspack/binding': 2.0.4
     optionalDependencies:
       '@module-federation/runtime-tools': 2.5.0(node-fetch@2.7.0)
-      '@swc/helpers': 0.5.22
+      '@swc/helpers': 0.5.23
 
   '@rspack/lite-tapable@1.1.0': {}
 
@@ -7006,7 +7003,7 @@ snapshots:
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.22)
+      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
 
   '@rspack/resolver-binding-darwin-arm64@0.2.8':
     optional: true
@@ -7323,11 +7320,7 @@ snapshots:
 
   '@swc/counter@0.1.3': {}
 
-  '@swc/helpers@0.5.21':
-    dependencies:
-      tslib: 2.8.1
-
-  '@swc/helpers@0.5.22':
+  '@swc/helpers@0.5.23':
     dependencies:
       tslib: 2.8.1
 
@@ -7727,7 +7720,7 @@ snapshots:
       '@babel/core': 7.29.0
       find-up: 5.0.0
     optionalDependencies:
-      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.22)
+      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
 
   babel-plugin-jsx-dom-expressions@0.40.6(@babel/core@7.29.0):
     dependencies:
@@ -7940,7 +7933,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.4
     optionalDependencies:
-      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.22)
+      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
 
   css-select@5.2.2:
     dependencies:
@@ -8402,7 +8395,7 @@ snapshots:
     dependencies:
       '@rspack/lite-tapable': 1.1.0
     optionalDependencies:
-      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.22)
+      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
 
   html-void-elements@3.0.0: {}
 
@@ -8547,7 +8540,7 @@ snapshots:
     dependencies:
       less: 4.6.4
     optionalDependencies:
-      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.22)
+      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
 
   less@4.6.4:
     dependencies:
@@ -9334,7 +9327,7 @@ snapshots:
       postcss: 8.5.15
       semver: 7.7.4
     optionalDependencies:
-      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.22)
+      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
     transitivePeerDependencies:
       - typescript
 
@@ -9671,13 +9664,13 @@ snapshots:
 
   rspack-chain@2.0.1(@rspack/core@2.0.4):
     optionalDependencies:
-      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.22)
+      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
 
   rspack-manifest-plugin@5.2.1(@rspack/core@2.0.4):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
     optionalDependencies:
-      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.22)
+      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
 
   rspack-merge@0.1.1: {}
 
@@ -9686,7 +9679,7 @@ snapshots:
       '@rspack/lite-tapable': 1.1.0
       chalk: 4.1.2
     optionalDependencies:
-      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.22)
+      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       vue: 3.5.34(typescript@6.0.3)
 
   rspress-plugin-font-open-sans@1.0.3(@rspress/core@2.0.12):
@@ -9796,7 +9789,7 @@ snapshots:
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
-      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.22)
+      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       sass: 1.100.0
       sass-embedded: 1.100.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -51,7 +51,7 @@ catalog:
   '@svgr/core': '8.1.0'
   '@svgr/plugin-jsx': '8.1.0'
   '@svgr/plugin-svgo': '8.1.0'
-  '@swc/helpers': '^0.5.22'
+  '@swc/helpers': '^0.5.23'
   '@swc/plugin-prefresh': '^12.10.0'
   '@swc/plugin-remove-console': '^12.10.0'
   '@tailwindcss/postcss': '^4.3.0'


### PR DESCRIPTION
## Summary

`@swc/helpers@0.5.22` contains a decorator helper regression in `_apply_decs_2203_r`. The fixed helper version has been released as `0.5.23`.

I also add a e2e test that will fail with old swc_core (which current rspack depends on) and newer `@swc/helpers`

## Related Links

related: https://github.com/web-infra-dev/rspack/pull/14176

