### PR TITLE
fix(types): allow webpack-compatible rspack plugins

### DIFF
--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -31,7 +31,7 @@ import type {
 } from './hooks';
 import type { RsbuildPlugins } from './plugin';
 import type { RsbuildEntry, RsbuildMode, RsbuildTarget } from './rsbuild';
-import type { Rspack, RspackRule } from './rspack';
+import type { Rspack, RspackPlugin, RspackRule } from './rspack';
 import type {
   Connect,
   CSSExtractOptions,
@@ -100,12 +100,8 @@ export type RspackMerge = (
 export type ModifyRspackConfigUtils = ModifyChainUtils & {
   addRules: (rules: RspackRule | RspackRule[]) => void;
   appendRules: (rules: RspackRule | RspackRule[]) => void;
-  prependPlugins: (
-    plugins: Rspack.RspackPluginInstance | Rspack.RspackPluginInstance[],
-  ) => void;
-  appendPlugins: (
-    plugins: Rspack.RspackPluginInstance | Rspack.RspackPluginInstance[],
-  ) => void;
+  prependPlugins: (plugins: OneOrMany<RspackPlugin>) => void;
+  appendPlugins: (plugins: OneOrMany<RspackPlugin>) => void;
   removePlugin: (pluginName: string) => void;
   mergeConfig: RspackMerge;
 };

--- a/packages/core/src/types/rspack.ts
+++ b/packages/core/src/types/rspack.ts
@@ -11,3 +11,4 @@ declare module '@rspack/core' {
 }
 
 export type RspackRule = Rspack.RuleSetRules[number];
+export type RspackPlugin = NonNullable<Rspack.Configuration['plugins']>[number];

--- a/website/docs/en/config/tools/rspack.mdx
+++ b/website/docs/en/config/tools/rspack.mdx
@@ -345,9 +345,7 @@ export default {
 - **Type:** `
 
 ```ts
-function prependPlugins(
-  plugins: Rspack.RspackPluginInstance | Rspack.RspackPluginInstance[],
-): void;
+function prependPlugins(plugins: Rspack.Plugin | Rspack.Plugin[]): void;
 ```
 
 Add additional plugins to the head of the internal Rspack plugins array, and the plugin will be executed first.
@@ -371,9 +369,7 @@ export default {
 - **Type:**
 
 ```ts
-function appendPlugins(
-  plugins: Rspack.RspackPluginInstance | Rspack.RspackPluginInstance[],
-): void;
+function appendPlugins(plugins: Rspack.Plugin | Rspack.Plugin[]): void;
 ```
 
 Add additional plugins at the end of the internal Rspack plugins array, the plugin will be executed last.
@@ -383,7 +379,7 @@ export default {
   tools: {
     rspack: (config, { appendPlugins }) => {
       // add a single plugin
-      appendPlugins([new PluginA()]);
+      appendPlugins(new PluginA());
 
       // Add multiple plugins
       appendPlugins([new PluginA(), new PluginB()]);

--- a/website/docs/zh/config/tools/rspack.mdx
+++ b/website/docs/zh/config/tools/rspack.mdx
@@ -345,9 +345,7 @@ export default {
 - **类型：**
 
 ```ts
-function prependPlugins(
-  plugins: Rspack.RspackPluginInstance | Rspack.RspackPluginInstance[],
-): void;
+function prependPlugins(plugins: Rspack.Plugin | Rspack.Plugin[]): void;
 ```
 
 在内部 Rspack 插件数组头部添加额外的插件，数组头部的插件会优先执行。
@@ -371,9 +369,7 @@ export default {
 - **类型：**
 
 ```ts
-function appendPlugins(
-  plugins: Rspack.RspackPluginInstance | Rspack.RspackPluginInstance[],
-): void;
+function appendPlugins(plugins: Rspack.Plugin | Rspack.Plugin[]): void;
 ```
 
 在内部 Rspack 插件数组尾部添加额外的插件，数组尾部的插件会在最后执行。
@@ -383,7 +379,7 @@ export default {
   tools: {
     rspack: (config, { appendPlugins }) => {
       // 添加单个插件
-      appendPlugins([new PluginA()]);
+      appendPlugins(new PluginA());
 
       // 以数组形式添加多个插件
       appendPlugins([new PluginA(), new PluginB()]);


### PR DESCRIPTION
## Summary

This PR fixes the `tools.rspack` plugin helper types so `appendPlugins` and `prependPlugins` accept the same plugin item type as Rspack's `configuration.plugins`, including webpack-compatible plugin instances. It adds a `RspackPlugin` alias derived from `Rspack.Configuration['plugins']` and uses it for both helpers.