### PR TITLE
fix(types): update rspack plugin types

### DIFF
--- a/packages/core/src/plugins/rsdoctor.ts
+++ b/packages/core/src/plugins/rsdoctor.ts
@@ -1,5 +1,4 @@
 import { pathToFileURL } from 'node:url';
-import type { Configuration } from '@rspack/core';
 import { isWindows } from '../constants';
 import { color, require } from '../helpers';
 import type { RsbuildPlugin, Rspack } from '../types';
@@ -8,7 +7,7 @@ type RsdoctorExports = {
   RsdoctorRspackPlugin: { new (): Rspack.RspackPluginInstance };
 };
 
-type MaybeRsdoctorPlugin = Configuration['plugins'] & {
+type MaybeRsdoctorPlugin = Rspack.RspackPluginInstance & {
   isRsdoctorPlugin?: boolean;
 };
 

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -31,7 +31,7 @@ import type {
 } from './hooks';
 import type { RsbuildPlugins } from './plugin';
 import type { RsbuildEntry, RsbuildMode, RsbuildTarget } from './rsbuild';
-import type { Rspack, RspackPlugin, RspackRule } from './rspack';
+import type { Rspack, RspackRule } from './rspack';
 import type {
   Connect,
   CSSExtractOptions,
@@ -98,10 +98,10 @@ export type RspackMerge = (
 ) => Rspack.Configuration;
 
 export type ModifyRspackConfigUtils = ModifyChainUtils & {
-  addRules: (rules: RspackRule | RspackRule[]) => void;
-  appendRules: (rules: RspackRule | RspackRule[]) => void;
-  prependPlugins: (plugins: OneOrMany<RspackPlugin>) => void;
-  appendPlugins: (plugins: OneOrMany<RspackPlugin>) => void;
+  addRules: (rules: OneOrMany<RspackRule>) => void;
+  appendRules: (rules: OneOrMany<RspackRule>) => void;
+  prependPlugins: (plugins: OneOrMany<Rspack.Plugin>) => void;
+  appendPlugins: (plugins: OneOrMany<Rspack.Plugin>) => void;
   removePlugin: (pluginName: string) => void;
   mergeConfig: RspackMerge;
 };
@@ -141,7 +141,7 @@ export type NarrowedRspackConfig = Omit<
   /**
    * Plugins to use during compilation.
    */
-  plugins: NonNullable<Rspack.Configuration['plugins']>;
+  plugins: Rspack.Plugin[];
   /**
    * Options for module configuration.
    */

--- a/packages/core/src/types/rspack.ts
+++ b/packages/core/src/types/rspack.ts
@@ -11,4 +11,3 @@ declare module '@rspack/core' {
 }
 
 export type RspackRule = Rspack.RuleSetRules[number];
-export type RspackPlugin = NonNullable<Rspack.Configuration['plugins']>[number];


### PR DESCRIPTION
## Summary

This PR updates Rsbuild's rspack plugin helper types to use `Rspack.Plugin` directly, keeping `modifyRspackConfig` utilities and normalized plugin config aligned with the current rspack type surface. It also narrows the Rsdoctor plugin marker type to a plugin instance instead of deriving it from the configuration plugins array.
