### PR TITLE
docs: update html template parameters docs

### DIFF
--- a/website/docs/en/config/html/template-parameters.mdx
+++ b/website/docs/en/config/html/template-parameters.mdx
@@ -69,15 +69,17 @@ The compiled HTML code will be:
 - **Type:**
 
 ```ts
+type MaybePromise<T> = T | Promise<T>;
+
 type TemplateParametersFunction = (
   defaultValue: Record<string, unknown>,
   utils: { entryName: string },
-) => Record<string, unknown> | void;
+) => MaybePromise<Record<string, unknown> | void>;
 ```
 
 When `html.templateParameters` is of type Function, the function receives two parameters:
 
-- `value`: Default `templateParameters` configuration of Rsbuild.
+- `defaultValue`: Default `templateParameters` configuration of Rsbuild.
 - `utils`: An object containing the `entryName` field, corresponding to the name of the current entry.
 
 In the context of a multi-page application (MPA), you can set different `templateParameters` based on the entry name:
@@ -102,3 +104,28 @@ export default {
   },
 };
 ```
+
+You can also use an async function to load template parameters:
+
+```ts title="rsbuild.config.ts"
+import fs from 'node:fs/promises';
+
+export default {
+  html: {
+    async templateParameters(defaultValue) {
+      const version = await fs.readFile('./VERSION', 'utf-8');
+
+      return {
+        ...defaultValue,
+        version: version.trim(),
+      };
+    },
+  },
+};
+```
+
+## Version history
+
+| Version | Changes                                                        |
+| ------- | -------------------------------------------------------------- |
+| v2.0.8  | Added support for async functions in `html.templateParameters` |

--- a/website/docs/zh/config/html/template-parameters.mdx
+++ b/website/docs/zh/config/html/template-parameters.mdx
@@ -69,16 +69,18 @@ export default {
 - **类型：**
 
 ```ts
+type MaybePromise<T> = T | Promise<T>;
+
 type TemplateParametersFunction = (
   defaultValue: Record<string, unknown>,
   utils: { entryName: string },
-) => Record<string, unknown> | void;
+) => MaybePromise<Record<string, unknown> | void>;
 ```
 
 当 `html.templateParameters` 为 Function 类型时，函数接收两个参数：
 
-- `value`：Rsbuild 的默认 templateParameters 配置。
-- `utils`: 一个对象，其中包含了 `entryName` 字段，对应当前入口的名称。
+- `defaultValue`：Rsbuild 的默认 templateParameters 配置。
+- `utils`：一个对象，其中包含了 `entryName` 字段，对应当前入口的名称。
 
 在 MPA（多页面应用）场景下，你可以基于入口名称设置不同的 `templateParameters` 参数：
 
@@ -102,3 +104,28 @@ export default {
   },
 };
 ```
+
+你也可以使用异步函数加载模板参数：
+
+```ts title="rsbuild.config.ts"
+import fs from 'node:fs/promises';
+
+export default {
+  html: {
+    async templateParameters(defaultValue) {
+      const version = await fs.readFile('./VERSION', 'utf-8');
+
+      return {
+        ...defaultValue,
+        version: version.trim(),
+      };
+    },
+  },
+};
+```
+
+## 版本历史
+
+| 版本   | 变更内容                                        |
+| ------ | ----------------------------------------------- |
+| v2.0.8 | 新增对 `html.templateParameters` 异步函数的支持 |


### PR DESCRIPTION
## Summary

Updates the `html.templateParameters` docs to reflect async template parameter functions added in #7773. The API docs now use `MaybePromise` in the function type, fix the parameter name from `value` to `defaultValue`, add async examples, and include version history entries in English and Chinese.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/7773