### PR TITLE
chore(core): upgrade reduce-configs to v2

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -83,7 +83,7 @@
     "postcss-loader": "catalog:",
     "prebundle": "catalog:",
     "range-parser": "catalog:",
-    "reduce-configs": "catalog:",
+    "reduce-configs": "^2.0.0",
     "rslog": "catalog:",
     "rspack-chain": "catalog:",
     "rspack-manifest-plugin": "catalog:",

--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -36,11 +36,11 @@ const getCSSModulesLocalIdentName = (
     ? '[local]-[hash:base64:6]'
     : '[path][name]__[local]-[hash:base64:6]');
 
-export function getLightningCSSLoaderOptions(
+export async function getLightningCSSLoaderOptions(
   config: NormalizedEnvironmentConfig,
   targets: string[],
   minify: boolean,
-): Rspack.LightningcssLoaderOptions {
+): Promise<Rspack.LightningcssLoaderOptions> {
   const userOptions =
     typeof config.tools.lightningcssLoader === 'object'
       ? config.tools.lightningcssLoader
@@ -172,7 +172,7 @@ const getPostcssLoaderOptions = async ({
     sourceMap: getCSSSourceMap(config),
   };
 
-  const finalOptions = reduceConfigsWithContext({
+  const finalOptions = await reduceConfigsWithContext({
     initial: defaultOptions,
     config: config.tools.postcss,
     ctx: context,
@@ -233,7 +233,7 @@ const getPostcssLoaderOptions = async ({
   return finalOptions;
 };
 
-const getCSSLoaderOptions = ({
+const getCSSLoaderOptions = async ({
   config,
   localIdentName,
   emitCss,
@@ -252,7 +252,7 @@ const getCSSLoaderOptions = ({
     sourceMap: getCSSSourceMap(config),
   };
 
-  const mergedCssLoaderOptions = reduceConfigs({
+  const mergedCssLoaderOptions = await reduceConfigs({
     initial: defaultOptions,
     config: config.tools.cssLoader,
     mergeFn: deepmerge,
@@ -317,7 +317,7 @@ export const pluginCss = (): RsbuildPlugin => ({
         if (emitCss) {
           // use style-loader
           if (config.output.injectStyles) {
-            const styleLoaderOptions = reduceConfigs({
+            const styleLoaderOptions = await reduceConfigs({
               initial: {},
               config: config.tools.styleLoader,
             });
@@ -346,22 +346,22 @@ export const pluginCss = (): RsbuildPlugin => ({
         };
 
         // Update CSS rules that share the CSS transform pipeline.
-        const updateRules = (
+        const updateRules = async (
           callback: (
             rule: RspackChain.Rule<RspackChain.Rule>,
             type: 'main' | 'inline' | 'url',
-          ) => void,
+          ) => void | Promise<void>,
           options: { skipMain?: boolean } = {},
         ) => {
           if (!options.skipMain) {
-            callback(mainRule, 'main');
+            await callback(mainRule, 'main');
           }
-          callback(inlineRule, 'inline');
-          callback(urlRule, 'url');
+          await callback(inlineRule, 'inline');
+          await callback(urlRule, 'url');
         };
 
         const cssLoaderPath = getCompiledPath('css-loader');
-        updateRules((rule) => {
+        await updateRules((rule) => {
           rule.use(CHAIN_ID.USE.CSS).loader(cssLoaderPath);
         });
 
@@ -386,8 +386,8 @@ export const pluginCss = (): RsbuildPlugin => ({
             }
           }
 
-          updateRules(
-            (rule, type) => {
+          await updateRules(
+            async (rule, type) => {
               // Inline styles are not processed by Rspack's minimizers,
               // so we need to minify them via `builtin:lightningcss-loader`
               const inlineStyle =
@@ -396,7 +396,7 @@ export const pluginCss = (): RsbuildPlugin => ({
                 config.output.injectStyles;
               const minify = inlineStyle && minifyCss;
 
-              const lightningcssOptions = getLightningCSSLoaderOptions(
+              const lightningcssOptions = await getLightningCSSLoaderOptions(
                 config,
                 browserslist,
                 minify,
@@ -430,7 +430,7 @@ export const pluginCss = (): RsbuildPlugin => ({
 
           const postcssLoaderPath = getCompiledPath('postcss-loader');
 
-          updateRules(
+          await updateRules(
             (rule) => {
               rule
                 .use(CHAIN_ID.USE.POSTCSS)
@@ -443,13 +443,13 @@ export const pluginCss = (): RsbuildPlugin => ({
         }
 
         const localIdentName = getCSSModulesLocalIdentName(config, isProd);
-        const cssLoaderOptions = getCSSLoaderOptions({
+        const cssLoaderOptions = await getCSSLoaderOptions({
           config,
           localIdentName,
           emitCss,
         });
 
-        updateRules((rule, type) => {
+        await updateRules((rule, type) => {
           let finalOptions = cssLoaderOptions;
 
           if (type === 'inline' || type === 'url') {

--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -2,8 +2,7 @@ import fs from 'node:fs';
 import path, { isAbsolute } from 'node:path';
 import type { EntryDescription } from '@rspack/core';
 import {
-  reduceConfigsAsyncWithContext,
-  reduceConfigsMergeContext,
+  reduceConfigsWithMergedContext,
   reduceConfigsWithContext,
 } from 'reduce-configs';
 import { castArray, color, isPlainObject } from '../helpers';
@@ -24,7 +23,7 @@ import type {
 } from '../types';
 
 function getTitle(entryName: string, config: NormalizedEnvironmentConfig) {
-  return reduceConfigsMergeContext({
+  return reduceConfigsWithMergedContext({
     initial: '',
     config: config.html.title,
     ctx: { entryName },
@@ -32,7 +31,7 @@ function getTitle(entryName: string, config: NormalizedEnvironmentConfig) {
 }
 
 function getInject(entryName: string, config: NormalizedEnvironmentConfig) {
-  return reduceConfigsMergeContext({
+  return reduceConfigsWithMergedContext({
     initial: 'head',
     config: config.html.inject,
     ctx: { entryName },
@@ -52,7 +51,7 @@ export async function getTemplate(
   | { templatePath: string; templateContent?: string }
   | { templatePath: undefined; templateContent: string }
 > {
-  const templatePath = reduceConfigsMergeContext({
+  const templatePath = await reduceConfigsWithMergedContext({
     initial: '',
     config: config.html.template,
     ctx: { entryName },
@@ -95,19 +94,19 @@ function getFavicon(
     html: HtmlConfig;
   },
 ) {
-  return reduceConfigsMergeContext({
+  return reduceConfigsWithMergedContext({
     initial: '',
     config: config.html.favicon,
     ctx: { entryName },
   });
 }
 
-function getMetaTags(
+async function getMetaTags(
   entryName: string,
   config: { html: HtmlConfig },
   templateContent?: string,
 ) {
-  const metaTags = reduceConfigsMergeContext({
+  const metaTags = await reduceConfigsWithMergedContext({
     initial: {},
     config: config.html.meta,
     ctx: { entryName },
@@ -148,7 +147,7 @@ function getTemplateParameters(
       rspackConfig,
     };
 
-    return reduceConfigsAsyncWithContext({
+    return reduceConfigsWithContext({
       initial: defaultOptions,
       config: templateParameters,
       ctx: { entryName },
@@ -248,7 +247,7 @@ export const pluginHtml = (context: InternalContext): RsbuildPlugin => ({
           entryNames.map(async (entryName) => {
             const entryValue = entries[entryName].values();
             const chunks = getChunks(entryName, entryValue);
-            const inject = getInject(entryName, config);
+            const inject = await getInject(entryName, config);
             const filename = htmlPaths[entryName];
             const { templatePath, templateContent } = await getTemplate(
               entryName,
@@ -261,7 +260,11 @@ export const pluginHtml = (context: InternalContext): RsbuildPlugin => ({
               assetPrefix,
             );
 
-            const metaTags = getMetaTags(entryName, config, templateContent);
+            const metaTags = await getMetaTags(
+              entryName,
+              config,
+              templateContent,
+            );
 
             const pluginOptions: HtmlRspackPlugin.Options = {
               meta: metaTags,
@@ -302,15 +305,15 @@ export const pluginHtml = (context: InternalContext): RsbuildPlugin => ({
               extraData.tagConfig = tagConfig;
             }
 
-            pluginOptions.title = getTitle(entryName, config);
+            pluginOptions.title = await getTitle(entryName, config);
 
             const favicon =
-              getFavicon(entryName, config) || resolveDefaultFavicon();
+              (await getFavicon(entryName, config)) || resolveDefaultFavicon();
             if (favicon) {
               extraData.favicon = favicon;
             }
 
-            const finalOptions = reduceConfigsWithContext({
+            const finalOptions = await reduceConfigsWithContext({
               initial: pluginOptions,
               config:
                 typeof config.tools.htmlPlugin === 'boolean'

--- a/packages/core/src/plugins/minimize.ts
+++ b/packages/core/src/plugins/minimize.ts
@@ -114,7 +114,7 @@ export const pluginMinimize = (): RsbuildPlugin => ({
   name: 'rsbuild:minimize',
 
   setup(api) {
-    api.modifyBundlerChain((chain, { environment, CHAIN_ID, rspack }) => {
+    api.modifyBundlerChain(async (chain, { environment, CHAIN_ID, rspack }) => {
       const { config } = environment;
       const { minifyJs, minifyCss, jsOptions, cssOptions } =
         parseMinifyOptions(config);
@@ -131,7 +131,7 @@ export const pluginMinimize = (): RsbuildPlugin => ({
       }
 
       if (minifyCss) {
-        const loaderOptions = getLightningCSSLoaderOptions(
+        const loaderOptions = await getLightningCSSLoaderOptions(
           config,
           environment.browserslist,
           true,

--- a/packages/core/src/plugins/resolve.ts
+++ b/packages/core/src/plugins/resolve.ts
@@ -9,7 +9,7 @@ import type {
   RspackChain,
 } from '../types';
 
-function applyAlias({
+async function applyAlias({
   chain,
   config,
   rootPath,
@@ -20,7 +20,7 @@ function applyAlias({
   rootPath: string;
   logger: Logger;
 }) {
-  const mergedAlias = reduceConfigs({
+  const mergedAlias = await reduceConfigs({
     initial: {},
     config: config.resolve.alias,
   });
@@ -110,7 +110,7 @@ export const pluginResolve = (): RsbuildPlugin => ({
   setup(api) {
     api.modifyBundlerChain({
       order: 'pre',
-      handler: (chain, { environment, CHAIN_ID }) => {
+      handler: async (chain, { environment, CHAIN_ID }) => {
         const { config, tsconfigPath } = environment;
         const { extensions, conditionNames, mainFields } = config.resolve;
 
@@ -133,7 +133,7 @@ export const pluginResolve = (): RsbuildPlugin => ({
             .set('.jsx', ['.jsx', '.tsx']);
         }
 
-        applyAlias({
+        await applyAlias({
           chain,
           config,
           rootPath: api.context.rootPath,

--- a/packages/core/src/plugins/swc.ts
+++ b/packages/core/src/plugins/swc.ts
@@ -111,7 +111,10 @@ export const pluginSwc = (): RsbuildPlugin => ({
   setup(api) {
     api.modifyBundlerChain({
       order: 'pre',
-      handler: (chain, { CHAIN_ID, isDev, isProd, target, environment }) => {
+      handler: async (
+        chain,
+        { CHAIN_ID, isDev, isProd, target, environment },
+      ) => {
         const { config, browserslist } = environment;
         const cacheRoot = path.join(api.context.cachePath, '.swc');
 
@@ -176,7 +179,7 @@ export const pluginSwc = (): RsbuildPlugin => ({
           }
         }
 
-        const mergedConfig = reduceConfigs({
+        const mergedConfig = await reduceConfigs({
           initial: swcConfig,
           config: config.tools.swc,
           mergeFn: deepmerge,

--- a/packages/core/src/rspackConfig.ts
+++ b/packages/core/src/rspackConfig.ts
@@ -1,14 +1,12 @@
 import { rspack } from '@rspack/core';
-import {
-  type ConfigChainAsyncWithContext,
-  reduceConfigsAsyncWithContext,
-} from 'reduce-configs';
+import { reduceConfigsWithContext } from 'reduce-configs';
 import { merge } from 'rspack-merge';
 import { CHAIN_ID, modifyBundlerChain } from './configChain';
 import { castArray, color, getNodeEnv } from './helpers';
 import type { Logger } from './logger';
 import { getHTMLPlugin } from './pluginHelper';
 import type {
+  ConfigChainAsyncWithContext,
   EnvironmentContext,
   InternalContext,
   ModifyChainUtils,
@@ -44,7 +42,7 @@ async function modifyRspackConfig(
       ModifyRspackConfigUtils
     >;
 
-    currentConfig = await reduceConfigsAsyncWithContext({
+    currentConfig = await reduceConfigsWithContext({
       initial: currentConfig as NarrowedRspackConfig,
       config: toolsRspackConfig,
       ctx: utils,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1005,8 +1005,8 @@ importers:
         specifier: 'catalog:'
         version: 1.2.1
       reduce-configs:
-        specifier: 'catalog:'
-        version: 1.1.2
+        specifier: ^2.0.0
+        version: 2.0.0
       rslog:
         specifier: 'catalog:'
         version: 2.1.1
@@ -4885,6 +4885,9 @@ packages:
 
   reduce-configs@1.1.2:
     resolution: {integrity: sha512-AgBP55V8FC7NaqoOP2RCbTpu6LE+YuX3LUZkNAoitcfyS3/PIC8Obg/TJrBzTkJ+lDvZv0TTAeDpLkzjTtYlbw==}
+
+  reduce-configs@2.0.0:
+    resolution: {integrity: sha512-oKMHUDY3TBSsyv4AzzQBpB3lRgmCIcNb3Ax3cAmJWCyRkHLYh3BcwP2Ari3aVsw8N6hoft1qW9hxvnKBnSlqNw==}
 
   regex-parser@2.3.1:
     resolution: {integrity: sha512-yXLRqatcCuKtVHsWrNg0JL3l1zGfdXeEvDa0bdu4tCDQw0RpMDZsqbkyRTUnKMR0tXF627V2oEWjBEaEdqTwtQ==}
@@ -9470,6 +9473,8 @@ snapshots:
       vfile: 6.0.3
 
   reduce-configs@1.1.2: {}
+
+  reduce-configs@2.0.0: {}
 
   regex-parser@2.3.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -178,6 +178,7 @@ minimumReleaseAgeExclude:
   - '@rstest/*'
   - '@rsdoctor/*'
   - '@rslint/*'
+  - 'reduce-configs'
   - '@rstack-dev/doc-ui'
   - 'rsbuild-plugin-*'
   - '@swc/*'


### PR DESCRIPTION
## Summary

This PR upgrades `@rsbuild/core` to `reduce-configs` v2 and updates internal reducer usage for the new async-only API. The core config pipeline now awaits `reduceConfigs`, `reduceConfigsWithContext`, and `reduceConfigsWithMergedContext`, and replaces removed v1 exports such as `reduceConfigsAsyncWithContext` and `reduceConfigsMergeContext`.

It keeps the v2 dependency scoped to `@rsbuild/core` instead of changing the workspace catalog, so other packages that still use `catalog:` are not upgraded in this PR.

## Related Links

- https://github.com/rstackjs/reduce-configs/releases/tag/v2.0.0