### PR TITLE
docs: update Vite migration for import.meta.glob

### DIFF
--- a/website/docs/en/guide/migration/vite.mdx
+++ b/website/docs/en/guide/migration/vite.mdx
@@ -236,19 +236,7 @@ The constructor syntax also lets you pass standard `WorkerOptions` or `SharedWor
 
 ## Glob import
 
-Vite provides `import.meta.glob()` for importing multiple modules.
-
-Rsbuild >= 2.0.8 is compatible with [import.meta.glob()](https://rspack.rs/api/runtime-api/module-variables#importmetaglob), so in most cases you can keep the Vite code unchanged when migrating to Rsbuild:
-
-```js
-const modules = import.meta.glob('./dir/*.js');
-
-for (const path in modules) {
-  modules[path]().then((mod) => {
-    console.log(path, mod);
-  });
-}
-```
+Rsbuild >= 2.0.8 is compatible with [import.meta.glob()](https://rspack.rs/api/runtime-api/module-variables#importmetaglob), so you can keep the Vite code unchanged when migrating to Rsbuild.
 
 ## vite-tsconfig-paths
 

--- a/website/docs/en/guide/migration/vite.mdx
+++ b/website/docs/en/guide/migration/vite.mdx
@@ -238,9 +238,7 @@ The constructor syntax also lets you pass standard `WorkerOptions` or `SharedWor
 
 Vite provides `import.meta.glob()` for importing multiple modules.
 
-When migrating to Rsbuild, you can use the [import.meta.webpackContext()](https://rspack.rs/api/runtime-api/module-variables#importmetawebpackcontext) function of Rspack instead:
-
-- Vite:
+Rsbuild >= 2.0.8 is compatible with [import.meta.glob()](https://rspack.rs/api/runtime-api/module-variables#importmetaglob), so in most cases you can keep the Vite code unchanged when migrating to Rsbuild:
 
 ```js
 const modules = import.meta.glob('./dir/*.js');
@@ -249,21 +247,6 @@ for (const path in modules) {
   modules[path]().then((mod) => {
     console.log(path, mod);
   });
-}
-```
-
-- Rsbuild:
-
-```js
-const context = import.meta.webpackContext('./dir', {
-  // Whether to search subdirectories
-  recursive: false,
-  regExp: /\.js$/,
-});
-
-for (const path of context.keys()) {
-  const mod = context(path);
-  console.log(path, mod);
 }
 ```
 

--- a/website/docs/zh/guide/migration/vite.mdx
+++ b/website/docs/zh/guide/migration/vite.mdx
@@ -238,9 +238,7 @@ const sharedWorker = new SharedWorker(new URL('./worker.ts', import.meta.url), {
 
 Vite 提供了 `import.meta.glob()` 来批量导入模块。
 
-迁移到 Rsbuild 时，你可以使用 Rspack 的 [import.meta.webpackContext](https://rspack.rs/zh/api/runtime-api/module-variables#importmetawebpackcontext) 函数代替：
-
-- Vite:
+Rsbuild >= 2.0.8 已兼容 [import.meta.glob()](https://rspack.rs/zh/api/runtime-api/module-variables#importmetaglob)，因此在大多数情况下，从 Vite 迁移到 Rsbuild 时可以保留原有代码：
 
 ```js
 const modules = import.meta.glob('./dir/*.js');
@@ -249,21 +247,6 @@ for (const path in modules) {
   modules[path]().then((mod) => {
     console.log(path, mod);
   });
-}
-```
-
-- Rsbuild:
-
-```js
-const context = import.meta.webpackContext('./dir', {
-  // 是否搜索子目录
-  recursive: false,
-  regExp: /\.js$/,
-});
-
-for (const path of context.keys()) {
-  const mod = context(path);
-  console.log(path, mod);
 }
 ```
 

--- a/website/docs/zh/guide/migration/vite.mdx
+++ b/website/docs/zh/guide/migration/vite.mdx
@@ -236,19 +236,7 @@ const sharedWorker = new SharedWorker(new URL('./worker.ts', import.meta.url), {
 
 ## Glob import
 
-Vite 提供了 `import.meta.glob()` 来批量导入模块。
-
-Rsbuild >= 2.0.8 已兼容 [import.meta.glob()](https://rspack.rs/zh/api/runtime-api/module-variables#importmetaglob)，因此在大多数情况下，从 Vite 迁移到 Rsbuild 时可以保留原有代码：
-
-```js
-const modules = import.meta.glob('./dir/*.js');
-
-for (const path in modules) {
-  modules[path]().then((mod) => {
-    console.log(path, mod);
-  });
-}
-```
+Rsbuild >= 2.0.8 已兼容 [import.meta.glob()](https://rspack.rs/zh/api/runtime-api/module-variables#importmetaglob)，因此从 Vite 迁移到 Rsbuild 时可以保留原有代码。
 
 ## vite-tsconfig-paths
 


### PR DESCRIPTION
## Summary

This PR updates the Vite migration guide to reflect that Rsbuild >= 2.0.8 supports `import.meta.glob()` directly, so users can usually keep their Vite glob import code unchanged when migrating to Rsbuild. It removes the old guidance that recommended replacing `import.meta.glob()` with `import.meta.webpackContext()`.

## Related Links

https://rspack.rs/api/runtime-api/module-variables#importmetaglob