### PR TITLE
chore(build): enable Rslib isolated declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@rstest/core": "catalog:",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:",
     "cross-env": "catalog:",
     "cspell-ban-words": "catalog:",
     "heading-case": "catalog:",

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -182,8 +182,7 @@ export default defineConfig({
         },
       },
       dts: {
-        build: true,
-        tsgo: true,
+        isolated: true,
         alias: {
           // alias to pre-bundled types as they are public API
           cors: './compiled/cors',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,9 +160,6 @@ catalogs:
     '@types/ws':
       specifier: ^8.18.1
       version: 8.18.1
-    '@typescript/native-preview':
-      specifier: 7.0.0-dev.20260524.1
-      version: 7.0.0-dev.20260524.1
     babel-loader:
       specifier: 10.1.1
       version: 10.1.1
@@ -416,9 +413,6 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.4
-      '@typescript/native-preview':
-        specifier: 'catalog:'
-        version: 7.0.0-dev.20260524.1
       cross-env:
         specifier: 'catalog:'
         version: 10.1.0
@@ -922,7 +916,7 @@ importers:
         version: 0.3.31
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
+        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@6.0.3)
       '@types/cors':
         specifier: 'catalog:'
         version: 2.8.19
@@ -1067,7 +1061,7 @@ importers:
         version: link:../plugin-vue
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
+        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@6.0.3)
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.4
@@ -1104,7 +1098,7 @@ importers:
         version: '@rsbuild/core@1.7.5'
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
+        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@6.0.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1144,7 +1138,7 @@ importers:
         version: '@rsbuild/core@1.7.5'
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
+        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@6.0.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1178,7 +1172,7 @@ importers:
         version: link:../core
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
+        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@6.0.3)
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.4
@@ -1206,7 +1200,7 @@ importers:
         version: '@rsbuild/core@1.7.5'
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
+        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@6.0.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1243,7 +1237,7 @@ importers:
         version: '@rsbuild/core@1.7.5'
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
+        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@6.0.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1283,7 +1277,7 @@ importers:
         version: link:../core
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
+        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@6.0.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1311,7 +1305,7 @@ importers:
         version: '@rsbuild/core@1.7.5'
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
+        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@6.0.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1354,7 +1348,7 @@ importers:
         version: '@rsbuild/core@1.7.5'
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
+        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@6.0.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1379,7 +1373,7 @@ importers:
         version: link:../core
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
+        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@6.0.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1404,7 +1398,7 @@ importers:
         version: '@rsbuild/core@1.7.5'
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
+        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@6.0.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1422,7 +1416,7 @@ importers:
     devDependencies:
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
+        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@6.0.3)
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.4
@@ -3267,53 +3261,6 @@ packages:
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
-
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260524.1':
-    resolution: {integrity: sha512-dIaYmijy9/tdrxHTxlnfwzP+AC6iAycUYGChOowLR3bVSbKhz4DUJZGMaodzGCtBEWSRUwx0MK1Sa1zBpFbM5g==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260524.1':
-    resolution: {integrity: sha512-HjfPFOSQCymn5Iu07xoySqfK5lwXthEWN1vltO5SDaFYVRasK6P3DBRe4QL0AiSGr8tRfA3x7BdRPjPVu94Epg==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260524.1':
-    resolution: {integrity: sha512-dH+zYjBs2ajcIRMmb8YkapY7TXzU/yX6HITrXhuoDov+mun7nCNfiRRmRBeqbGxl5JM8mUugBl/yyyhFWjIWdQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260524.1':
-    resolution: {integrity: sha512-gXzD1BNpPUSAv12a9UvxLTX/+WdoC34skLw6hDLk1kv3VYbd5LecQzEIb7u+WHCsNuXVXffk79+BZP7IQNS1aw==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm]
-    os: [linux]
-
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260524.1':
-    resolution: {integrity: sha512-Fr0A8RPBMXco9IIXel598hC25LE1A5wpB33mBhwimlIQe58MMCAeW+wDHXsmLmF2NiFVT1vr1tjMGmEMMdYdsg==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [linux]
-
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260524.1':
-    resolution: {integrity: sha512-AhFD6bct2RWeZxONLEvaKPlu+c+/TNejj7ntztHWREaq+lrjz8Qg3tXryah2K66EEmYY0TooapfWUWXWe8i+VQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260524.1':
-    resolution: {integrity: sha512-3VE5kBH2y7vYpj83X9iqGbNR8gwnlQlTjzLKJBzuyfTJPZ9R/vM4txvpuTDRJo18JGzEq4FUjKg7yqpf9ajb2g==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [win32]
-
-  '@typescript/native-preview@7.0.0-dev.20260524.1':
-    resolution: {integrity: sha512-L4YviXl4FVYt4V9vkUKRCZW1DcsUbLRaKC4gxsYmBJQqB262mtUo8eqjKqElgZNIpKwYEAAYsBDrVmNhy6ze2w==}
-    engines: {node: '>=16.20.0'}
-    hasBin: true
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -6933,10 +6880,10 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rslib/core@0.22.0(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)':
+  '@rslib/core@0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@6.0.3)':
     dependencies:
       '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
-      rsbuild-plugin-dts: 0.22.0(@rsbuild/core@2.0.8)(@typescript/native-preview@7.0.0-dev.20260524.1)(typescript@6.0.3)
+      rsbuild-plugin-dts: 0.22.0(@rsbuild/core@2.0.8)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -7291,7 +7238,7 @@ snapshots:
 
   '@rstest/adapter-rslib@0.10.2(@rslib/core@0.22.0)(@rstest/core@0.10.2)(typescript@6.0.3)':
     dependencies:
-      '@rslib/core': 0.22.0(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
+      '@rslib/core': 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@6.0.3)
       '@rstest/core': 0.10.2(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
     optionalDependencies:
       typescript: 6.0.3
@@ -7699,37 +7646,6 @@ snapshots:
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 24.12.4
-
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260524.1':
-    optional: true
-
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260524.1':
-    optional: true
-
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260524.1':
-    optional: true
-
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260524.1':
-    optional: true
-
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260524.1':
-    optional: true
-
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260524.1':
-    optional: true
-
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260524.1':
-    optional: true
-
-  '@typescript/native-preview@7.0.0-dev.20260524.1':
-    optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260524.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260524.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260524.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260524.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260524.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260524.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260524.1
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -9788,12 +9704,11 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
 
-  rsbuild-plugin-dts@0.22.0(@rsbuild/core@2.0.8)(@typescript/native-preview@7.0.0-dev.20260524.1)(typescript@6.0.3):
+  rsbuild-plugin-dts@0.22.0(@rsbuild/core@2.0.8)(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
     optionalDependencies:
-      '@typescript/native-preview': 7.0.0-dev.20260524.1
       typescript: 6.0.3
 
   rsbuild-plugin-google-analytics@1.0.5(@rsbuild/core@packages+core):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,8 +62,8 @@ catalogs:
       specifier: 1.5.11
       version: 1.5.11
     '@rslib/core':
-      specifier: 0.21.5
-      version: 0.21.5
+      specifier: 0.22.0
+      version: 0.22.0
     '@rslint/core':
       specifier: ^0.5.3
       version: 0.5.3
@@ -403,7 +403,7 @@ importers:
         version: 0.5.3(jiti@2.7.0)
       '@rstest/adapter-rslib':
         specifier: 'catalog:'
-        version: 0.10.2(@rslib/core@0.21.5)(@rstest/core@0.10.2)(typescript@6.0.3)
+        version: 0.10.2(@rslib/core@0.22.0)(@rstest/core@0.10.2)(typescript@6.0.3)
       '@rstest/core':
         specifier: 'catalog:'
         version: 0.10.2(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
@@ -922,7 +922,7 @@ importers:
         version: 0.3.31
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.21.5(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
+        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
       '@types/cors':
         specifier: 'catalog:'
         version: 2.8.19
@@ -1067,7 +1067,7 @@ importers:
         version: link:../plugin-vue
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.21.5(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
+        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.4
@@ -1104,7 +1104,7 @@ importers:
         version: '@rsbuild/core@1.7.5'
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.21.5(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
+        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1144,7 +1144,7 @@ importers:
         version: '@rsbuild/core@1.7.5'
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.21.5(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
+        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1178,7 +1178,7 @@ importers:
         version: link:../core
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.21.5(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
+        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.4
@@ -1206,7 +1206,7 @@ importers:
         version: '@rsbuild/core@1.7.5'
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.21.5(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
+        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1243,7 +1243,7 @@ importers:
         version: '@rsbuild/core@1.7.5'
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.21.5(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
+        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1283,7 +1283,7 @@ importers:
         version: link:../core
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.21.5(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
+        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1311,7 +1311,7 @@ importers:
         version: '@rsbuild/core@1.7.5'
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.21.5(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
+        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1354,7 +1354,7 @@ importers:
         version: '@rsbuild/core@1.7.5'
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.21.5(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
+        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1379,7 +1379,7 @@ importers:
         version: link:../core
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.21.5(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
+        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1404,7 +1404,7 @@ importers:
         version: '@rsbuild/core@1.7.5'
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.21.5(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
+        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1422,13 +1422,13 @@ importers:
     devDependencies:
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.21.5(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
+        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.4
       rsbuild-plugin-arethetypeswrong:
         specifier: 'catalog:'
-        version: 0.3.1(@rsbuild/core@2.0.7)(typescript@6.0.3)
+        version: 0.3.1(@rsbuild/core@2.0.8)(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -2437,6 +2437,16 @@ packages:
       core-js:
         optional: true
 
+  '@rsbuild/core@2.0.8':
+    resolution: {integrity: sha512-V5Bhn3zqljsaB5grw9oMkSk6XZFvMkr6UpIYPZnDmOWsRAT1fNQ6XF6cn8fVUKv/KILblBrKLUZf0DpvDt3exw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      core-js: '>= 3.0.0'
+    peerDependenciesMeta:
+      core-js:
+        optional: true
+
   '@rsbuild/plugin-check-syntax@1.6.1':
     resolution: {integrity: sha512-26xtEYN0QjZYoyt0lWnvIztBWjEZJvcfw7MN4f5B4SpNggmnF7F7aNPrgkY3EccXVFx1VGQBhnCkBV//OoS07Q==}
     peerDependencies:
@@ -2503,8 +2513,8 @@ packages:
   '@rsdoctor/utils@1.5.11':
     resolution: {integrity: sha512-+dKVriL1//G1JiG3iPzqX1C0Up6S2CfnqfTDTH4SeMgfJ10aKI/XWpvtyqdAS7jEJuZXGSrOzDv8Ph6wAoRwLQ==}
 
-  '@rslib/core@0.21.5':
-    resolution: {integrity: sha512-KPWR8gcodSIw8txfJ+KbgF5NoL7CxX0AljHiJk1VWDiClrN94jYmF5iGCFgaDraOBV9jJhpIIwPOfu09ild8eA==}
+  '@rslib/core@0.22.0':
+    resolution: {integrity: sha512-DGTMBDTSdILac0SmeBWvdYf/ZDn09vXgbJQ3/N1J7i6vBpFGWCCKjARoz1R5jYqr1Z9tLJ1OfOVZktbNY/XXuA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -5063,8 +5073,8 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  rsbuild-plugin-dts@0.21.5:
-    resolution: {integrity: sha512-tRSqSCmaY2Ef/FTxcLUw26jQxM/HJHAFqTsqngXnXnfic0BHlSCKzJuwjGoGUYimb3RdH6qnC7jzkXuoe+ZXOA==}
+  rsbuild-plugin-dts@0.22.0:
+    resolution: {integrity: sha512-Oyiu5oJDHWOnBv7yRr8eAGfoEddwxfPqUbAX6HvcJxrnR/h6Zd0VgTBWVTgqALYhLcL2ZdyZ2vwnqfhan4krwA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@microsoft/api-extractor': ^7
@@ -6778,6 +6788,15 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
+  '@rsbuild/core@2.0.8(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)':
+    dependencies:
+      '@rspack/core': 2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@swc/helpers': 0.5.23
+    optionalDependencies:
+      core-js: 3.49.0
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+
   '@rsbuild/plugin-check-syntax@1.6.1(@rsbuild/core@packages+core)':
     dependencies:
       acorn: 8.16.0
@@ -6914,10 +6933,10 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rslib/core@0.21.5(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)':
+  '@rslib/core@0.22.0(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
-      rsbuild-plugin-dts: 0.21.5(@rsbuild/core@2.0.7)(@typescript/native-preview@7.0.0-dev.20260524.1)(typescript@6.0.3)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      rsbuild-plugin-dts: 0.22.0(@rsbuild/core@2.0.8)(@typescript/native-preview@7.0.0-dev.20260524.1)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -7270,9 +7289,9 @@ snapshots:
     optionalDependencies:
       '@rspress/core': 2.0.12(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.5)(@types/mdast@4.0.4)(@types/react@19.2.15)(core-js@3.49.0)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
-  '@rstest/adapter-rslib@0.10.2(@rslib/core@0.21.5)(@rstest/core@0.10.2)(typescript@6.0.3)':
+  '@rstest/adapter-rslib@0.10.2(@rslib/core@0.22.0)(@rstest/core@0.10.2)(typescript@6.0.3)':
     dependencies:
-      '@rslib/core': 0.21.5(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
+      '@rslib/core': 0.22.0(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260524.1)(core-js@3.49.0)(typescript@6.0.3)
       '@rstest/core': 0.10.2(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
     optionalDependencies:
       typescript: 6.0.3
@@ -9763,16 +9782,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
 
-  rsbuild-plugin-arethetypeswrong@0.3.1(@rsbuild/core@2.0.7)(typescript@6.0.3):
+  rsbuild-plugin-arethetypeswrong@0.3.1(@rsbuild/core@2.0.8)(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
     optionalDependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
 
-  rsbuild-plugin-dts@0.21.5(@rsbuild/core@2.0.7)(@typescript/native-preview@7.0.0-dev.20260524.1)(typescript@6.0.3):
+  rsbuild-plugin-dts@0.22.0(@rsbuild/core@2.0.8)(@typescript/native-preview@7.0.0-dev.20260524.1)(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
     optionalDependencies:
       '@typescript/native-preview': 7.0.0-dev.20260524.1
       typescript: 6.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -67,7 +67,6 @@ catalog:
   '@types/react-dom': '^19.2.3'
   '@types/sass-loader': '^8.0.10'
   '@types/ws': '^8.18.1'
-  '@typescript/native-preview': '7.0.0-dev.20260524.1'
   'babel-loader': '10.1.1'
   'babel-plugin-react-compiler': '^1.0.0'
   'babel-preset-solid': '^1.9.12'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,7 +34,7 @@ catalog:
   '@rsbuild/plugin-rem': '^1.0.5'
   '@rsbuild/plugin-type-check': '^1.3.4'
   '@rsdoctor/rspack-plugin': '1.5.11'
-  '@rslib/core': '0.21.5'
+  '@rslib/core': '0.22.0'
   '@rslint/core': '^0.5.3'
   '@rspack/core': '~2.0.5'
   '@rspack/plugin-preact-refresh': '^1.1.5'

--- a/scripts/config/rslib.config.ts
+++ b/scripts/config/rslib.config.ts
@@ -24,8 +24,7 @@ export const nodeMinifyConfig: Rsbuild.Minify = {
 export const esmConfig: LibConfig = {
   syntax: 'es2023',
   dts: {
-    build: true,
-    tsgo: true,
+    isolated: true,
   },
   output: {
     minify: nodeMinifyConfig,


### PR DESCRIPTION
## Summary

This PR improves package declaration build performance by upgrading Rslib to 0.22.0 and switching Rsbuild's Rslib configs from `dts.build` + `tsgo` to `dts.isolated`, enabling isolated declaration generation for core and shared package builds. 

Since isolated declarations no longer need the native TypeScript preview package, it also removes the root `@typescript/native-preview` devDependency and catalog entry.

Local `node --run build` benchmark on macOS / Node v24.16.0, warm 3-run average:
- before (`origin/main`, Rslib 0.21.5 + tsgo) 5.11s
- after (this PR, Rslib 0.22.0 + isolated declarations) 2.75s
- about 46% faster (-2.36s).

## Related Links

https://www.npmjs.com/package/@rslib/core/v/0.22.0