### PR TITLE
chore: use npm staged publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,4 +59,4 @@ jobs:
 
       - name: Publish to npm
         run: |
-          pnpm --filter './packages/*' -r publish --tag ${{ github.event.inputs.npm_tag }} --publish-branch ${{ github.event.inputs.branch }}
+          pnpm --filter './packages/*' -r stage publish --tag ${{ github.event.inputs.npm_tag }} --no-git-checks

--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
     "simple-git-hooks": "catalog:",
     "typescript": "catalog:"
   },
-  "packageManager": "pnpm@11.3.0",
+  "packageManager": "pnpm@11.4.0",
   "engines": {
     "node": ">=22.18.0",
-    "pnpm": ">=11.3.0"
+    "pnpm": ">=11.0.0"
   }
 }


### PR DESCRIPTION
## Summary

This PR updates the release workflow to publish packages through pnpm's staged publishing flow. It also bumps the pinned pnpm version to 11.4.0 for the `stage publish` command.

## Related Links

https://docs.npmjs.com/staged-publishing/