### PR TITLE
fix(core): avoid shell interpolation in browser opener

### DIFF
--- a/packages/core/src/server/open.ts
+++ b/packages/core/src/server/open.ts
@@ -64,14 +64,14 @@ async function openBrowser(url: string, logger: Logger): Promise<boolean> {
   // a Chromium browser with AppleScript. This lets us reuse an
   // existing tab when possible instead of creating a new one.
   if (shouldTryAppleScript(browser, browserArgs)) {
-    const { exec } = await import('node:child_process');
+    const { exec, execFile } = await import('node:child_process');
     const { promisify } = await import('node:util');
-    const execAsync = promisify(exec);
 
     /**
      * Find the browser that is currently running
      */
     const getDefaultBrowserForAppleScript = async () => {
+      const execAsync = promisify(exec);
       const { stdout: ps } = await execAsync('ps cax');
       return supportedChromiumBrowsers.find((b) => ps.includes(b));
     };
@@ -82,9 +82,11 @@ async function openBrowser(url: string, logger: Logger): Promise<boolean> {
         : await getDefaultBrowserForAppleScript();
 
       if (chromiumBrowser) {
+        const execFileAsync = promisify(execFile);
         // Try to reuse existing tab with AppleScript
-        await execAsync(
-          `osascript openChrome.applescript "${encodeURI(url)}" "${chromiumBrowser}"`,
+        await execFileAsync(
+          'osascript',
+          ['openChrome.applescript', encodeURI(url), chromiumBrowser],
           {
             cwd: STATIC_PATH,
           },

--- a/packages/core/src/server/open.ts
+++ b/packages/core/src/server/open.ts
@@ -64,15 +64,15 @@ async function openBrowser(url: string, logger: Logger): Promise<boolean> {
   // a Chromium browser with AppleScript. This lets us reuse an
   // existing tab when possible instead of creating a new one.
   if (shouldTryAppleScript(browser, browserArgs)) {
-    const { exec, execFile } = await import('node:child_process');
+    const { execFile } = await import('node:child_process');
     const { promisify } = await import('node:util');
+    const execFileAsync = promisify(execFile);
 
     /**
      * Find the browser that is currently running
      */
     const getDefaultBrowserForAppleScript = async () => {
-      const execAsync = promisify(exec);
-      const { stdout: ps } = await execAsync('ps cax');
+      const { stdout: ps } = await execFileAsync('ps', ['cax']);
       return supportedChromiumBrowsers.find((b) => ps.includes(b));
     };
 
@@ -82,7 +82,6 @@ async function openBrowser(url: string, logger: Logger): Promise<boolean> {
         : await getDefaultBrowserForAppleScript();
 
       if (chromiumBrowser) {
-        const execFileAsync = promisify(execFile);
         // Try to reuse existing tab with AppleScript
         await execFileAsync(
           'osascript',


### PR DESCRIPTION
## Summary

This PR applies a security hardening fix to the macOS browser opener used by `server.open`. It preserves the existing AppleScript-based browser reuse behavior, but invokes `osascript` with an argument array so URL-like values are passed as data instead of being interpreted by a shell.