### PR TITLE
release: v2.0.9

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/core",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "The Rspack-based build tool.",
   "homepage": "https://rsbuild.rs",
   "bugs": {

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rsbuild",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "Create a new Rsbuild project",
   "homepage": "https://rsbuild.rs",
   "repository": {

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-babel",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Babel plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-less",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Less plugin for Rsbuild",
   "homepage": "https://rsbuild.rs",
   "repository": {

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-preact",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Preact plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-react",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "React plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-sass",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Sass plugin for Rsbuild",
   "homepage": "https://rsbuild.rs",
   "repository": {

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-solid",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Solid plugin for Rsbuild",
   "homepage": "https://rsbuild.rs",
   "repository": {

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svelte",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Svelte plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svgr",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "SVGR plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-tailwindcss/package.json
+++ b/packages/plugin-tailwindcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-tailwindcss",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Tailwind CSS plugin for Rsbuild",
   "homepage": "https://rsbuild.rs",
   "repository": {

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Vue 3 plugin of Rsbuild",
   "homepage": "https://rsbuild.rs",
   "repository": {


### PR DESCRIPTION
## Summary

Release Rsbuild packages v2.0.9 and bump each package under `packages/*` by one patch version.

## Related Links

https://github.com/web-infra-dev/rsbuild/releases/tag/v2.0.9
