### PR TITLE
test(e2e): enable Windows skipped cases

### DIFF
--- a/e2e/cases/lazy-compilation/add-initial-chunk/index.test.ts
+++ b/e2e/cases/lazy-compilation/add-initial-chunk/index.test.ts
@@ -5,11 +5,6 @@ test('should render pages correctly when using lazy compilation and add new init
   page,
   dev,
 }) => {
-  // TODO: fixme on Windows
-  if (process.platform === 'win32') {
-    test.skip();
-  }
-
   await dev();
 
   await expect(page.locator('#test')).toHaveText('Hello World!');

--- a/e2e/cases/plugin-preact/prefresh-context/index.test.ts
+++ b/e2e/cases/plugin-preact/prefresh-context/index.test.ts
@@ -7,11 +7,6 @@ test('HMR should work properly with `createContext`', async ({
   dev,
   editFile,
 }) => {
-  // Prefresh does not work as expected on Windows
-  if (process.platform === 'win32') {
-    test.skip();
-  }
-
   const root = import.meta.dirname;
   const compFilePath = path.join(root, 'src/test-temp-B.jsx');
   const compSourceCode = `const B = (props) => {

--- a/e2e/cases/plugin-preact/prefresh/index.test.ts
+++ b/e2e/cases/plugin-preact/prefresh/index.test.ts
@@ -3,11 +3,6 @@ import path from 'node:path';
 import { expect, test } from '@e2e/helper';
 
 test('HMR should work properly', async ({ page, dev, editFile }) => {
-  // Prefresh does not work as expected on Windows
-  if (process.platform === 'win32') {
-    test.skip();
-  }
-
   const root = import.meta.dirname;
   const compFilePath = path.join(root, 'src/test-temp-B.jsx');
   const compSourceCode = `const B = (props) => {

--- a/e2e/cases/resolve/tsconfig-paths-reload/index.test.ts
+++ b/e2e/cases/resolve/tsconfig-paths-reload/index.test.ts
@@ -8,10 +8,6 @@ test('should watch tsconfig.json and reload the server when it changes', async (
   editFile,
   execCli,
 }) => {
-  if (process.platform === 'win32') {
-    return;
-  }
-
   const dist = join(import.meta.dirname, 'dist');
 
   await fse.remove(dist);

--- a/e2e/cases/server/reload-html/index.test.ts
+++ b/e2e/cases/server/reload-html/index.test.ts
@@ -7,11 +7,6 @@ test('should reload page when HTML template changed', async ({
   editFile,
   copySrcDir,
 }) => {
-  // Failed to run this case on Windows
-  if (process.platform === 'win32') {
-    test.skip();
-  }
-
   const tempSrc = await copySrcDir();
 
   await dev();
@@ -32,11 +27,6 @@ test('should not reload page when HTML live reload is disabled', async ({
   logHelper,
   copySrcDir,
 }) => {
-  // Failed to run this case on Windows
-  if (process.platform === 'win32') {
-    test.skip();
-  }
-
   const tempSrc = await copySrcDir();
 
   await dev({


### PR DESCRIPTION
## Summary

Enable Windows coverage for the remaining e2e cases that were skipped with `process.platform === 'win32'`. This PR only removes e2e skip guards and is stacked on #7794, which contains the required `@rsbuild/plugin-preact` source change.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/7794
https://github.com/web-infra-dev/rspack/issues/6633
