### PR TITLE
fix(plugin-preact): enable Prefresh on Windows

### DIFF
--- a/e2e/cases/plugin-preact/prefresh-context/index.test.ts
+++ b/e2e/cases/plugin-preact/prefresh-context/index.test.ts
@@ -7,11 +7,6 @@ test('HMR should work properly with `createContext`', async ({
   dev,
   editFile,
 }) => {
-  // Prefresh does not work as expected on Windows
-  if (process.platform === 'win32') {
-    test.skip();
-  }
-
   const root = import.meta.dirname;
   const compFilePath = path.join(root, 'src/test-temp-B.jsx');
   const compSourceCode = `const B = (props) => {

--- a/e2e/cases/plugin-preact/prefresh/index.test.ts
+++ b/e2e/cases/plugin-preact/prefresh/index.test.ts
@@ -3,11 +3,6 @@ import path from 'node:path';
 import { expect, test } from '@e2e/helper';
 
 test('HMR should work properly', async ({ page, dev, editFile }) => {
-  // Prefresh does not work as expected on Windows
-  if (process.platform === 'win32') {
-    test.skip();
-  }
-
   const root = import.meta.dirname;
   const compFilePath = path.join(root, 'src/test-temp-B.jsx');
   const compSourceCode = `const B = (props) => {

--- a/packages/plugin-preact/src/index.ts
+++ b/packages/plugin-preact/src/index.ts
@@ -44,11 +44,6 @@ export const pluginPreact = (
       ...userOptions,
     };
 
-    // @rspack/plugin-preact-refresh does not support Windows yet
-    if (process.platform === 'win32') {
-      options.prefreshEnabled = false;
-    }
-
     api.modifyEnvironmentConfig((config, { mergeEnvironmentConfig }) => {
       const isDev = config.mode === 'development';
       const isV1 = api.context.version.startsWith('1.');


### PR DESCRIPTION
## Summary

Enable Prefresh on Windows for `@rsbuild/plugin-preact` by removing the stale platform guard that disabled it on `win32`. This PR also enables the two Prefresh e2e cases on Windows so the source change and its Windows coverage land together.

## Related Links

https://github.com/web-infra-dev/rspack/issues/6633