### PR TITLE
test(e2e): enable Windows skipped cases

### DIFF
--- a/e2e/cases/lazy-compilation/add-initial-chunk/index.test.ts
+++ b/e2e/cases/lazy-compilation/add-initial-chunk/index.test.ts
@@ -5,11 +5,6 @@ test('should render pages correctly when using lazy compilation and add new init
   page,
   dev,
 }) => {
-  // TODO: fixme on Windows
-  if (process.platform === 'win32') {
-    test.skip();
-  }
-
   await dev();
 
   await expect(page.locator('#test')).toHaveText('Hello World!');

--- a/e2e/cases/resolve/tsconfig-paths-reload/index.test.ts
+++ b/e2e/cases/resolve/tsconfig-paths-reload/index.test.ts
@@ -8,10 +8,6 @@ test('should watch tsconfig.json and reload the server when it changes', async (
   editFile,
   execCli,
 }) => {
-  if (process.platform === 'win32') {
-    return;
-  }
-
   const dist = join(import.meta.dirname, 'dist');
 
   await fse.remove(dist);

--- a/e2e/cases/server/reload-html/index.test.ts
+++ b/e2e/cases/server/reload-html/index.test.ts
@@ -7,11 +7,6 @@ test('should reload page when HTML template changed', async ({
   editFile,
   copySrcDir,
 }) => {
-  // Failed to run this case on Windows
-  if (process.platform === 'win32') {
-    test.skip();
-  }
-
   const tempSrc = await copySrcDir();
 
   await dev();
@@ -32,11 +27,6 @@ test('should not reload page when HTML live reload is disabled', async ({
   logHelper,
   copySrcDir,
 }) => {
-  // Failed to run this case on Windows
-  if (process.platform === 'win32') {
-    test.skip();
-  }
-
   const tempSrc = await copySrcDir();
 
   await dev({


### PR DESCRIPTION
## Summary

Enable Windows coverage for the remaining non-Preact e2e cases that were skipped with `process.platform === 'win32'`. Prefresh-specific e2e coverage now lives with the `@rsbuild/plugin-preact` source change in #7794 to avoid overlapping files between the two PRs.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/7793
https://github.com/web-infra-dev/rsbuild/pull/7794