### PR TITLE
fix: remove v2 prerelease from peer dependency ranges

### DIFF
--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -45,7 +45,7 @@
     "typescript": "catalog:"
   },
   "peerDependencies": {
-    "@rsbuild/core": "^1.0.0 || ^2.0.0-0"
+    "@rsbuild/core": "^1.0.0 || ^2.0.0"
   },
   "peerDependenciesMeta": {
     "@rsbuild/core": {

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -43,7 +43,7 @@
     "typescript": "catalog:"
   },
   "peerDependencies": {
-    "@rsbuild/core": "^1.3.0 || ^2.0.0-0"
+    "@rsbuild/core": "^1.3.0 || ^2.0.0"
   },
   "peerDependenciesMeta": {
     "@rsbuild/core": {

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -38,7 +38,7 @@
     "typescript": "catalog:"
   },
   "peerDependencies": {
-    "@rsbuild/core": "^1.0.0 || ^2.0.0-0"
+    "@rsbuild/core": "^1.0.0 || ^2.0.0"
   },
   "peerDependenciesMeta": {
     "@rsbuild/core": {

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -36,7 +36,7 @@
     "typescript": "catalog:"
   },
   "peerDependencies": {
-    "@rsbuild/core": "^2.0.0-0"
+    "@rsbuild/core": "^2.0.0"
   },
   "peerDependenciesMeta": {
     "@rsbuild/core": {

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -47,7 +47,7 @@
     "typescript": "catalog:"
   },
   "peerDependencies": {
-    "@rsbuild/core": "^1.3.0 || ^2.0.0-0"
+    "@rsbuild/core": "^1.3.0 || ^2.0.0"
   },
   "peerDependenciesMeta": {
     "@rsbuild/core": {

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -38,7 +38,7 @@
     "typescript": "catalog:"
   },
   "peerDependencies": {
-    "@rsbuild/core": "^1.0.0 || ^2.0.0-0"
+    "@rsbuild/core": "^1.0.0 || ^2.0.0"
   },
   "peerDependenciesMeta": {
     "@rsbuild/core": {

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -38,7 +38,7 @@
     "typescript": "catalog:"
   },
   "peerDependencies": {
-    "@rsbuild/core": "^1.4.0 || ^2.0.0-0"
+    "@rsbuild/core": "^1.4.0 || ^2.0.0"
   },
   "peerDependenciesMeta": {
     "@rsbuild/core": {

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -41,7 +41,7 @@
     "typescript": "catalog:"
   },
   "peerDependencies": {
-    "@rsbuild/core": "^2.0.0-0"
+    "@rsbuild/core": "^2.0.0"
   },
   "peerDependenciesMeta": {
     "@rsbuild/core": {

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -38,7 +38,7 @@
     "vue": "catalog:"
   },
   "peerDependencies": {
-    "@rsbuild/core": "^1.0.0 || ^2.0.0-0"
+    "@rsbuild/core": "^1.0.0 || ^2.0.0"
   },
   "peerDependenciesMeta": {
     "@rsbuild/core": {


### PR DESCRIPTION
## Summary

This PR updates the official plugin `peerDependencies` to use stable Rsbuild v2 ranges instead of prerelease-compatible `^2.0.0-0` ranges. Existing Rsbuild v1 compatibility is kept where the plugin already supports it.

## Validation

- `pnpm lint`
