### PR TITLE
feat(plugin-preact)!: publish as pure ESM package

### DIFF
--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -12,8 +12,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.js"
     }
   },
   "types": "./dist/index.d.ts",

--- a/packages/plugin-preact/rslib.config.ts
+++ b/packages/plugin-preact/rslib.config.ts
@@ -1,3 +1,3 @@
-import { dualPackage } from '@scripts/config/rslib.config.ts';
+import { pureEsmPackage } from '@scripts/config/rslib.config.ts';
 
-export default dualPackage;
+export default pureEsmPackage;


### PR DESCRIPTION
## Summary

This PR publishes `@rsbuild/plugin-preact` as a pure ESM package to align its package format with the existing pure ESM Rsbuild plugins. It removes the CommonJS export path and switches the Rslib config to emit only the ESM build, which is a breaking packaging change for CommonJS consumers.