### PR TITLE
feat(plugin-svelte)!: publish as pure ESM package

### DIFF
--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -12,8 +12,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.js"
     }
   },
   "types": "./dist/index.d.ts",

--- a/packages/plugin-svelte/rslib.config.ts
+++ b/packages/plugin-svelte/rslib.config.ts
@@ -1,3 +1,3 @@
-import { dualPackage } from '@scripts/config/rslib.config.ts';
+import { pureEsmPackage } from '@scripts/config/rslib.config.ts';
 
-export default dualPackage;
+export default pureEsmPackage;


### PR DESCRIPTION
## Summary

This PR updates `@rsbuild/plugin-svelte` to publish as a pure ESM package. The package export now points to the ESM entry through the `default` condition, and the Rslib config only emits the ESM build.