### PR TITLE
feat(plugin-svelte)!: drop Svelte 4 support

### DIFF
--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "@rsbuild/core": "^2.0.0",
-    "svelte": ">=5.0.0"
+    "svelte": "^5.0.0"
   },
   "peerDependenciesMeta": {
     "@rsbuild/core": {

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -36,7 +36,8 @@
     "typescript": "catalog:"
   },
   "peerDependencies": {
-    "@rsbuild/core": "^2.0.0"
+    "@rsbuild/core": "^2.0.0",
+    "svelte": ">=5.0.0"
   },
   "peerDependenciesMeta": {
     "@rsbuild/core": {

--- a/packages/plugin-svelte/src/index.ts
+++ b/packages/plugin-svelte/src/index.ts
@@ -54,11 +54,10 @@ const validateSvelteVersion = (rootPath: string) => {
     );
   }
 
-  const pkgRaw = readFileSync(pkgPath, 'utf-8');
-  const pkgJson = JSON.parse(pkgRaw) as { version?: unknown };
-  const version = typeof pkgJson.version === 'string' ? pkgJson.version : '';
-  const majorVersion = Number.parseInt(version, 10);
-
+  const { version } = JSON.parse(readFileSync(pkgPath, 'utf-8')) as {
+    version?: string;
+  };
+  const majorVersion = version ? Number(version.split('.')[0]) : 0;
   if (!(majorVersion >= 5)) {
     throw new Error(
       `[rsbuild:svelte] @rsbuild/plugin-svelte requires svelte >= 5.0.0, but found ${version || 'unknown'}.`,

--- a/packages/plugin-svelte/src/index.ts
+++ b/packages/plugin-svelte/src/index.ts
@@ -71,12 +71,7 @@ export function pluginSvelte(options: PluginSvelteOptions = {}): RsbuildPlugin {
     name: PLUGIN_SVELTE_NAME,
 
     setup(api) {
-      try {
-        validateSvelteVersion(api.context.rootPath);
-      } catch (err) {
-        api.logger.error(err);
-        throw err;
-      }
+      validateSvelteVersion(api.context.rootPath);
 
       api.modifyEnvironmentConfig((config, { mergeEnvironmentConfig }) => {
         const extraConfig: EnvironmentConfig = {

--- a/packages/plugin-svelte/src/index.ts
+++ b/packages/plugin-svelte/src/index.ts
@@ -60,7 +60,7 @@ const validateSvelteVersion = (rootPath: string) => {
   const majorVersion = version ? Number(version.split('.')[0]) : 0;
   if (!(majorVersion >= 5)) {
     throw new Error(
-      `[rsbuild:svelte] @rsbuild/plugin-svelte requires svelte >= 5.0.0, but found ${version || 'unknown'}.`,
+      `"@rsbuild/plugin-svelte" requires svelte >= 5.0.0, but found ${version || 'unknown'}.`,
     );
   }
 };

--- a/packages/plugin-svelte/src/index.ts
+++ b/packages/plugin-svelte/src/index.ts
@@ -1,6 +1,5 @@
-import { promises } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import path from 'node:path';
 import type { EnvironmentConfig, RsbuildPlugin } from '@rsbuild/core';
 import type { CompileOptions } from 'svelte/compiler';
 import { sveltePreprocess } from 'svelte-preprocess';
@@ -40,14 +39,30 @@ export type PluginSvelteOptions = {
 
 export const PLUGIN_SVELTE_NAME = 'rsbuild:svelte';
 
-const isSvelte5 = async (sveltePath: string) => {
+const validateSvelteVersion = (rootPath: string) => {
+  let pkgPath: string;
+
   try {
-    const pkgPath = path.join(sveltePath, 'package.json');
-    const pkgRaw = await promises.readFile(pkgPath, 'utf-8');
-    const pkgJson = JSON.parse(pkgRaw);
-    return pkgJson.version.startsWith('5.');
-  } catch {
-    return false;
+    // Resolve `svelte` package path from the project directory
+    pkgPath = require.resolve('svelte/package.json', {
+      paths: [rootPath],
+    });
+  } catch (err) {
+    throw new Error(
+      'Cannot resolve `svelte` package under the project directory, did you forget to install it?',
+      { cause: err },
+    );
+  }
+
+  const pkgRaw = readFileSync(pkgPath, 'utf-8');
+  const pkgJson = JSON.parse(pkgRaw) as { version?: unknown };
+  const version = typeof pkgJson.version === 'string' ? pkgJson.version : '';
+  const majorVersion = Number.parseInt(version, 10);
+
+  if (!(majorVersion >= 5)) {
+    throw new Error(
+      `[rsbuild:svelte] @rsbuild/plugin-svelte requires svelte >= 5.0.0, but found ${version || 'unknown'}.`,
+    );
   }
 };
 
@@ -56,21 +71,11 @@ export function pluginSvelte(options: PluginSvelteOptions = {}): RsbuildPlugin {
     name: PLUGIN_SVELTE_NAME,
 
     setup(api) {
-      let sveltePath = '';
       try {
-        // Resolve `svelte` package path from the project directory
-        sveltePath = path.dirname(
-          require.resolve('svelte/package.json', {
-            paths: [api.context.rootPath],
-          }),
-        );
+        validateSvelteVersion(api.context.rootPath);
       } catch (err) {
-        api.logger.error(
-          'Cannot resolve `svelte` package under the project directory, did you forget to install it?',
-        );
-        throw new Error('[rsbuild:svelte] Failed to resolve `svelte` package', {
-          cause: err,
-        });
+        api.logger.error(err);
+        throw err;
       }
 
       api.modifyEnvironmentConfig((config, { mergeEnvironmentConfig }) => {
@@ -85,17 +90,8 @@ export function pluginSvelte(options: PluginSvelteOptions = {}): RsbuildPlugin {
       });
 
       api.modifyBundlerChain(
-        async (chain, { CHAIN_ID, environment, isDev, isProd }) => {
-          const svelte5 = await isSvelte5(sveltePath);
-
+        (chain, { CHAIN_ID, environment, isDev, isProd }) => {
           const environmentConfig = environment.config;
-
-          if (!svelte5) {
-            chain.resolve.alias.set(
-              'svelte',
-              path.join(sveltePath, 'src/runtime'),
-            );
-          }
 
           chain.resolve.extensions.add('.svelte');
           chain.resolve.mainFields.add('svelte').add('...');
@@ -132,12 +128,10 @@ export function pluginSvelte(options: PluginSvelteOptions = {}): RsbuildPlugin {
             .rule(CHAIN_ID.RULE.SVELTE)
             .test(/\.svelte$/);
 
-          if (svelte5 && jsRule) {
-            svelteRule
-              .use(CHAIN_ID.USE.SWC)
-              .loader(swcUse.get('loader'))
-              .options(swcUse.get('options'));
-          }
+          svelteRule
+            .use(CHAIN_ID.USE.SWC)
+            .loader(swcUse.get('loader'))
+            .options(swcUse.get('options'));
 
           svelteRule
             .use(CHAIN_ID.USE.SVELTE)
@@ -145,22 +139,20 @@ export function pluginSvelte(options: PluginSvelteOptions = {}): RsbuildPlugin {
             .options(svelteLoaderOptions)
             .end();
 
-          if (svelte5 && jsRule) {
-            const regexp = /\.(?:svelte\.js|svelte\.ts)$/;
+          const regexp = /\.(?:svelte\.js|svelte\.ts)$/;
 
-            jsRule.exclude.add(regexp);
+          jsRule.exclude.add(regexp);
 
-            chain.module
-              .rule('svelte-js')
-              .test(regexp)
-              .use(CHAIN_ID.USE.SVELTE)
-              .loader(loaderPath)
-              .options(svelteLoaderOptions)
-              .end()
-              .use(CHAIN_ID.USE.SWC)
-              .loader(swcUse.get('loader'))
-              .options(swcUse.get('options'));
-          }
+          chain.module
+            .rule('svelte-js')
+            .test(regexp)
+            .use(CHAIN_ID.USE.SVELTE)
+            .loader(loaderPath)
+            .options(svelteLoaderOptions)
+            .end()
+            .use(CHAIN_ID.USE.SWC)
+            .loader(swcUse.get('loader'))
+            .options(swcUse.get('options'));
         },
       );
     },

--- a/packages/plugin-svelte/tests/index.test.ts
+++ b/packages/plugin-svelte/tests/index.test.ts
@@ -1,22 +1,6 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import path from 'node:path';
 import { createRsbuild } from '@rsbuild/core';
 import { matchRules } from '@scripts/test-helper';
 import { pluginSvelte } from '../src';
-
-const createFakeSvelteProject = (version: string) => {
-  const cwd = mkdtempSync(path.join(tmpdir(), 'rsbuild-plugin-svelte-'));
-  const svelteDir = path.join(cwd, 'node_modules/svelte');
-
-  mkdirSync(svelteDir, { recursive: true });
-  writeFileSync(
-    path.join(svelteDir, 'package.json'),
-    JSON.stringify({ name: 'svelte', version }),
-  );
-
-  return cwd;
-};
 
 describe('plugin-svelte', () => {
   afterEach(() => {
@@ -47,25 +31,6 @@ describe('plugin-svelte', () => {
     const rspackConfigs = await rsbuild.initConfigs();
     expect(matchRules(rspackConfigs[0], 'a.svelte.js')).toMatchSnapshot();
     expect(matchRules(rspackConfigs[0], 'a.svelte.ts')).toMatchSnapshot();
-  });
-
-  it('should reject svelte versions lower than 5', async () => {
-    const cwd = createFakeSvelteProject('4.2.20');
-
-    try {
-      const rsbuild = await createRsbuild({
-        cwd,
-        config: {
-          plugins: [pluginSvelte()],
-        },
-      });
-
-      await expect(rsbuild.initConfigs()).rejects.toThrow(
-        '@rsbuild/plugin-svelte requires svelte >= 5.0.0, but found 4.2.20',
-      );
-    } finally {
-      rmSync(cwd, { recursive: true, force: true });
-    }
   });
 
   it('should set dev and hotReload to false in production mode', async () => {

--- a/packages/plugin-svelte/tests/index.test.ts
+++ b/packages/plugin-svelte/tests/index.test.ts
@@ -1,6 +1,22 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { createRsbuild } from '@rsbuild/core';
 import { matchRules } from '@scripts/test-helper';
 import { pluginSvelte } from '../src';
+
+const createFakeSvelteProject = (version: string) => {
+  const cwd = mkdtempSync(path.join(tmpdir(), 'rsbuild-plugin-svelte-'));
+  const svelteDir = path.join(cwd, 'node_modules/svelte');
+
+  mkdirSync(svelteDir, { recursive: true });
+  writeFileSync(
+    path.join(svelteDir, 'package.json'),
+    JSON.stringify({ name: 'svelte', version }),
+  );
+
+  return cwd;
+};
 
 describe('plugin-svelte', () => {
   afterEach(() => {
@@ -31,6 +47,25 @@ describe('plugin-svelte', () => {
     const rspackConfigs = await rsbuild.initConfigs();
     expect(matchRules(rspackConfigs[0], 'a.svelte.js')).toMatchSnapshot();
     expect(matchRules(rspackConfigs[0], 'a.svelte.ts')).toMatchSnapshot();
+  });
+
+  it('should reject svelte versions lower than 5', async () => {
+    const cwd = createFakeSvelteProject('4.2.20');
+
+    try {
+      const rsbuild = await createRsbuild({
+        cwd,
+        config: {
+          plugins: [pluginSvelte()],
+        },
+      });
+
+      await expect(rsbuild.initConfigs()).rejects.toThrow(
+        '@rsbuild/plugin-svelte requires svelte >= 5.0.0, but found 4.2.20',
+      );
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
   });
 
   it('should set dev and hotReload to false in production mode', async () => {


### PR DESCRIPTION
## Summary

Drop Svelte 4 compatibility from `@rsbuild/plugin-svelte` by declaring `svelte >= 5.0.0` as a peer dependency, validating the resolved Svelte major version, and making the Svelte 5 loader/SWC rules unconditional.