### PR TITLE
release: @rsbuild/plugin-svelte v2.0.0

### DIFF
--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svelte",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Svelte plugin for Rsbuild",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Breaking Changes

Release @rsbuild/plugin-svelte v2.0.0:

- **Pure ESM package**: https://github.com/web-infra-dev/rsbuild/pull/7800
- **No longer supports Rsbuild v1**: https://github.com/web-infra-dev/rsbuild/pull/7803
- **No longer supports Svelte v4**: https://github.com/web-infra-dev/rsbuild/pull/7804