### PR TITLE
docs: update plugin-svelte version support

### DIFF
--- a/website/docs/en/plugins/list/plugin-svelte.mdx
+++ b/website/docs/en/plugins/list/plugin-svelte.mdx
@@ -20,6 +20,10 @@ import { PackageManagerTabs } from '@theme';
 
 <PackageManagerTabs command="add @rsbuild/plugin-svelte -D" />
 
+:::tip
+`@rsbuild/plugin-svelte` v2 no longer supports Rsbuild 1.x or Svelte 4.x. If your project uses these versions, install `@rsbuild/plugin-svelte@1` instead.
+:::
+
 ### Register plugin
 
 Register the plugin in Rsbuild config:

--- a/website/docs/zh/plugins/list/plugin-svelte.mdx
+++ b/website/docs/zh/plugins/list/plugin-svelte.mdx
@@ -20,6 +20,10 @@ import { PackageManagerTabs } from '@theme';
 
 <PackageManagerTabs command="add @rsbuild/plugin-svelte -D" />
 
+:::tip
+`@rsbuild/plugin-svelte` v2 不再支持 Rsbuild 1.x 和 Svelte 4.x。如果你的项目仍在使用这些版本，请安装 `@rsbuild/plugin-svelte@1`。
+:::
+
 ### 注册插件
 
 在 Rsbuild 配置中注册插件：


### PR DESCRIPTION
## Summary

This PR documents the compatibility constraints introduced in `@rsbuild/plugin-svelte` v2: it no longer supports Rsbuild 1.x or Svelte 4.x, and projects on those versions should install `@rsbuild/plugin-svelte@1` instead.