### PR TITLE
docs: update Vite migration guide

### DIFF
--- a/website/docs/en/guide/migration/vite.mdx
+++ b/website/docs/en/guide/migration/vite.mdx
@@ -102,6 +102,8 @@ Most common Vite plugins can be easily migrated to Rsbuild plugins, such as:
 | [vite-plugin-node-polyfills](https://npmjs.com/package/vite-plugin-node-polyfills)         | [@rsbuild/plugin-node-polyfill](https://github.com/rstackjs/rsbuild-plugin-node-polyfill)      |
 | [vite-plugin-solid](https://npmjs.com/package/vite-plugin-solid)                           | [@rsbuild/plugin-solid](/plugins/list/plugin-solid)                                            |
 | [@preact/preset-vite](https://npmjs.com/package/@preact/preset-vite)                       | [@rsbuild/plugin-preact](/plugins/list/plugin-preact)                                          |
+| [@tanstack/router-plugin/vite](https://npmjs.com/package/@tanstack/router-plugin)          | [@tanstack/router-plugin/rsbuild](https://npmjs.com/package/@tanstack/router-plugin)           |
+| [@sentry/vite-plugin](https://npmjs.com/package/@sentry/vite-plugin)                       | [@sentry/webpack-plugin](https://npmjs.com/package/@sentry/webpack-plugin)                     |
 | [vite-plugin-full-reload](https://npmjs.com/package/vite-plugin-full-reload)               | [dev.watchFiles](/config/dev/watch-files)                                                      |
 | [vite-plugin-html](https://npmjs.com/package/vite-plugin-html)                             | [html.template](/config/html/template)                                                         |
 | [vite-plugin-css-injected-by-js](https://npmjs.com/package/vite-plugin-css-injected-by-js) | [output.injectStyles](/config/output/inject-styles)                                            |
@@ -169,6 +171,18 @@ Here is the corresponding Rsbuild configuration for each Vite option:
 Notes:
 
 - The table above doesn't cover every Vite option; feel free to add more.
+
+## Server port
+
+Vite's dev server uses port `5173` by default, while Rsbuild uses port `3000` by default. If your project depends on `5173`, you can keep Vite's original port with the following configuration:
+
+```ts title="rsbuild.config.ts"
+export default {
+  server: {
+    port: 5173,
+  },
+};
+```
 
 ## Environment variables
 

--- a/website/docs/zh/guide/migration/vite.mdx
+++ b/website/docs/zh/guide/migration/vite.mdx
@@ -102,6 +102,8 @@ Rsbuild 会在构建时自动注入 `<script>` 标签到生成的 HTML 文件中
 | [vite-plugin-node-polyfills](https://npmjs.com/package/vite-plugin-node-polyfills)         | [@rsbuild/plugin-node-polyfill](https://github.com/rstackjs/rsbuild-plugin-node-polyfill) |
 | [vite-plugin-solid](https://npmjs.com/package/vite-plugin-solid)                           | [@rsbuild/plugin-solid](/plugins/list/plugin-solid)                                       |
 | [@preact/preset-vite](https://npmjs.com/package/@preact/preset-vite)                       | [@rsbuild/plugin-preact](/plugins/list/plugin-preact)                                     |
+| [@tanstack/router-plugin/vite](https://npmjs.com/package/@tanstack/router-plugin)          | [@tanstack/router-plugin/rsbuild](https://npmjs.com/package/@tanstack/router-plugin)      |
+| [@sentry/vite-plugin](https://npmjs.com/package/@sentry/vite-plugin)                       | [@sentry/webpack-plugin](https://npmjs.com/package/@sentry/webpack-plugin)                |
 | [vite-plugin-full-reload](https://npmjs.com/package/vite-plugin-full-reload)               | [dev.watchFiles](/config/dev/watch-files)                                                 |
 | [vite-plugin-html](https://npmjs.com/package/vite-plugin-html)                             | [html.template](/config/html/template)                                                    |
 | [vite-plugin-css-injected-by-js](https://npmjs.com/package/vite-plugin-css-injected-by-js) | [output.injectStyles](/config/output/inject-styles)                                       |
@@ -169,6 +171,18 @@ Rsbuild 会在构建时自动注入 `<script>` 标签到生成的 HTML 文件中
 说明：
 
 - 上述表格尚未覆盖到 Vite 的所有配置，欢迎补充。
+
+## 服务器端口
+
+Vite 开发服务器的默认端口是 `5173`，而 Rsbuild 的默认端口是 `3000`。如果你的项目依赖 `5173`，可以通过以下配置保持 Vite 原有的端口：
+
+```ts title="rsbuild.config.ts"
+export default {
+  server: {
+    port: 5173,
+  },
+};
+```
 
 ## 环境变量
 


### PR DESCRIPTION
## Summary

This PR updates the Vite migration guide to include additional plugin migration references for TanStack Router and Sentry, and documents how to keep Vite's default dev server port when moving to Rsbuild.