### PR TITLE
feat(plugin-preact)!: update @rspack/plugin-preact-refresh to v2.0.0

### DIFF
--- a/packages/plugin-preact/src/index.ts
+++ b/packages/plugin-preact/src/index.ts
@@ -37,7 +37,6 @@ export const pluginPreact = (
 
   setup(api) {
     const options = {
-      include: /\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/,
       exclude: /[\\/]node_modules[\\/]/,
       prefreshEnabled: true,
       reactAliasesEnabled: true,
@@ -117,16 +116,16 @@ export const pluginPreact = (
         return;
       }
 
-      const { default: PreactRefreshPlugin } =
+      const { PreactRefreshRspackPlugin } =
         await import('@rspack/plugin-preact-refresh');
 
       const preactPath = require.resolve('preact', {
         paths: [api.context.rootPath],
       });
 
-      chain.plugin('preact-refresh').use(PreactRefreshPlugin, [
+      chain.plugin('preact-refresh').use(PreactRefreshRspackPlugin, [
         {
-          include: options.include,
+          ...(options.include === undefined ? {} : { test: options.include }),
           exclude: options.exclude,
           preactPath,
         },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,8 +71,8 @@ catalogs:
       specifier: ~2.0.5
       version: 2.0.5
     '@rspack/plugin-preact-refresh':
-      specifier: ^1.1.6
-      version: 1.1.6
+      specifier: ^2.0.0
+      version: 2.0.0
     '@rspack/plugin-react-refresh':
       specifier: 2.0.1
       version: 2.0.1
@@ -1162,7 +1162,7 @@ importers:
         version: 1.2.1
       '@rspack/plugin-preact-refresh':
         specifier: 'catalog:'
-        version: 1.1.6(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)
+        version: 2.0.0(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)
       '@swc/plugin-prefresh':
         specifier: 'catalog:'
         version: 12.12.0
@@ -2702,8 +2702,8 @@ packages:
   '@rspack/lite-tapable@1.1.0':
     resolution: {integrity: sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==}
 
-  '@rspack/plugin-preact-refresh@1.1.6':
-    resolution: {integrity: sha512-aW6H+IXw4TpeovHb382idyxPMzjoXrBfR+VWZmjZcVIjVF9NqGVwhSg9LEkKHUugK8Z0QBS+D2yt5bd0S1q8ow==}
+  '@rspack/plugin-preact-refresh@2.0.0':
+    resolution: {integrity: sha512-zzpgqFcFyNRquY/pK7xayuCY/c5DbclgPTPlDuYyaTDRa/+1bimxIrWgaaTJD/rbf3aegA9ZkhfP/nnqHkLjTg==}
     peerDependencies:
       '@prefresh/core': ^1.5.0
       '@prefresh/utils': ^1.2.0
@@ -7031,7 +7031,7 @@ snapshots:
 
   '@rspack/lite-tapable@1.1.0': {}
 
-  '@rspack/plugin-preact-refresh@1.1.6(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)':
+  '@rspack/plugin-preact-refresh@2.0.0(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)':
     dependencies:
       '@prefresh/core': 1.5.10(preact@10.29.2)
       '@prefresh/utils': 1.2.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,7 +37,7 @@ catalog:
   '@rslib/core': '0.22.0'
   '@rslint/core': '^0.5.3'
   '@rspack/core': '~2.0.5'
-  '@rspack/plugin-preact-refresh': '^1.1.6'
+  '@rspack/plugin-preact-refresh': '^2.0.0'
   '@rspack/plugin-react-refresh': '2.0.1'
   '@rspress/core': '^2.0.13'
   '@rspress/plugin-algolia': '^2.0.13'


### PR DESCRIPTION
## Summary

Upgrade `@rspack/plugin-preact-refresh` to v2.0.0, which is pure ESM and no longer provides a default export. The Preact plugin now imports `PreactRefreshRspackPlugin` as a named export, relies on the v2 plugin's default `test` option, and only forwards Rsbuild's `include` option to `test` when users configure it explicitly.

## Related Links

https://github.com/rstackjs/rspack-plugin-preact-refresh/releases/tag/v2.0.0