### PR TITLE
feat(plugin-preact)!: require Rsbuild v2

### DIFF
--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -37,7 +37,7 @@
     "typescript": "catalog:"
   },
   "peerDependencies": {
-    "@rsbuild/core": "^1.0.0 || ^2.0.0"
+    "@rsbuild/core": "^2.0.0"
   },
   "peerDependenciesMeta": {
     "@rsbuild/core": {

--- a/packages/plugin-preact/src/index.ts
+++ b/packages/plugin-preact/src/index.ts
@@ -24,12 +24,22 @@ export type PluginPreactOptions = {
 
 export const PLUGIN_PREACT_NAME = 'rsbuild:preact';
 
+function assertCoreVersion(version: string): void {
+  if (version.split('.')[0] === '1') {
+    throw new Error(
+      `"@rsbuild/plugin-preact" v2 requires "@rsbuild/core" >= 2.0. Please upgrade "@rsbuild/core" or use "@rsbuild/plugin-preact" v1.`,
+    );
+  }
+}
+
 export const pluginPreact = (
   userOptions: PluginPreactOptions = {},
 ): RsbuildPlugin => ({
   name: PLUGIN_PREACT_NAME,
 
   setup(api) {
+    assertCoreVersion(api.context.version);
+
     const options = {
       prefreshEnabled: true,
       reactAliasesEnabled: true,
@@ -38,7 +48,6 @@ export const pluginPreact = (
 
     api.modifyEnvironmentConfig((config, { mergeEnvironmentConfig }) => {
       const isDev = config.mode === 'development';
-      const isV1 = api.context.version.startsWith('1.');
       const usePrefresh =
         isDev &&
         options.prefreshEnabled &&
@@ -56,15 +65,6 @@ export const pluginPreact = (
         tools: {
           swc: {
             jsc: {
-              ...(isV1
-                ? {
-                    parser: {
-                      syntax: 'typescript',
-                      // enable supports for JSX/TSX compilation
-                      tsx: true,
-                    },
-                  }
-                : {}),
               experimental: {
                 plugins: usePrefresh
                   ? [[require.resolve('@swc/plugin-prefresh'), {}]]

--- a/website/docs/en/plugins/list/plugin-preact.mdx
+++ b/website/docs/en/plugins/list/plugin-preact.mdx
@@ -20,6 +20,10 @@ import { PackageManagerTabs } from '@theme';
 
 <PackageManagerTabs command="add @rsbuild/plugin-preact -D" />
 
+:::tip
+`@rsbuild/plugin-preact` v2 no longer supports Rsbuild 1.x. If your project uses Rsbuild 1.x, install `@rsbuild/plugin-preact@1` instead.
+:::
+
 ### Register plugin
 
 Register the plugin in Rsbuild config:

--- a/website/docs/zh/plugins/list/plugin-preact.mdx
+++ b/website/docs/zh/plugins/list/plugin-preact.mdx
@@ -20,6 +20,10 @@ import { PackageManagerTabs } from '@theme';
 
 <PackageManagerTabs command="add @rsbuild/plugin-preact -D" />
 
+:::tip
+`@rsbuild/plugin-preact` v2 不再支持 Rsbuild 1.x。如果你的项目仍在使用 Rsbuild 1.x，请安装 `@rsbuild/plugin-preact@1`。
+:::
+
 ### 注册插件
 
 在 Rsbuild 配置中注册插件：


### PR DESCRIPTION
## Summary

This PR drops Rsbuild 1.x compatibility from `@rsbuild/plugin-preact` v2 by tightening its peer dependency and failing early when it is used with `@rsbuild/core` v1. It also removes the legacy v1 SWC parser branch and documents that Rsbuild 1.x projects should install `@rsbuild/plugin-preact@1`.