### PR TITLE
docs: disable top banner

### DIFF
--- a/website/theme/index.tsx
+++ b/website/theme/index.tsx
@@ -4,19 +4,19 @@ import {
   Link,
   type DocLayoutProps,
 } from '@rspress/core/theme-original';
-import { Announcement } from '@rstack-dev/doc-ui/announcement';
+// import { Announcement } from '@rstack-dev/doc-ui/announcement';
 import { BlogBackButton } from '@rstack-dev/doc-ui/blog-back-button';
 import { NavIcon } from '@rstack-dev/doc-ui/nav-icon';
 import { HomeLayout } from './pages';
 import './index.scss';
-import { NoSSR, useLang, usePage } from '@rspress/core/runtime';
+import { useLang, usePage } from '@rspress/core/runtime';
 import {
   Search as PluginAlgoliaSearch,
   ZH_LOCALES,
 } from '@rspress/plugin-algolia/runtime';
 
 // Enable announcement when we have something to announce
-const ANNOUNCEMENT_URL = '/blog/v2-0';
+// const ANNOUNCEMENT_URL = '/blog/v2-0';
 
 const DocLayout = (props: DocLayoutProps) => {
   const { page } = usePage();
@@ -39,34 +39,29 @@ const DocLayout = (props: DocLayoutProps) => {
   );
 };
 
-const Layout = () => {
-  const { page } = usePage();
-  const lang = useLang();
-
-  return (
-    <BaseLayout
-      beforeNavTitle={<NavIcon />}
-      beforeNav={
-        ANNOUNCEMENT_URL ? (
-          <NoSSR>
-            <Announcement
-              href={
-                lang === 'en' ? ANNOUNCEMENT_URL : `/${lang}${ANNOUNCEMENT_URL}`
-              }
-              message={
-                lang === 'en'
-                  ? 'Rsbuild 2.0 has been released!'
-                  : 'Rsbuild 2.0 正式发布！'
-              }
-              localStorageKey="rsbuild-v2-announcement-closed"
-              display={page.pageType === 'home'}
-            />
-          </NoSSR>
-        ) : null
-      }
-    />
-  );
-};
+const Layout = () => (
+  <BaseLayout
+    beforeNavTitle={<NavIcon />}
+    // beforeNav={
+    //   ANNOUNCEMENT_URL ? (
+    //     <NoSSR>
+    //       <Announcement
+    //         href={
+    //           lang === 'en' ? ANNOUNCEMENT_URL : `/${lang}${ANNOUNCEMENT_URL}`
+    //         }
+    //         message={
+    //           lang === 'en'
+    //             ? 'Rsbuild 2.0 has been released!'
+    //             : 'Rsbuild 2.0 正式发布！'
+    //         }
+    //         localStorageKey="rsbuild-v2-announcement-closed"
+    //         display={page.pageType === 'home'}
+    //       />
+    //     </NoSSR>
+    //   ) : null
+    // }
+  />
+);
 const Search = () => {
   const lang = useLang();
   return (


### PR DESCRIPTION
## Summary

This PR takes the Rsbuild 2.0 announcement banner offline now that it no longer needs to be shown in the docs. It comments out the announcement import, URL, and `beforeNav` rendering in the custom docs layout while keeping the nav icon unchanged.