### PR TITLE
docs: add Rsbuild monorepo tool links

### DIFF
--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -145,6 +145,13 @@ Optional skills:
   rsbuild-best-practices, rstest-best-practices, vercel-react-best-practices
 ```
 
+## Use Rsbuild in monorepos
+
+The following monorepo tools provide Rsbuild integrations or examples for creating and managing Rsbuild applications in a workspace.
+
+- [Nx](https://nx.dev/docs/technologies/build-tools/rsbuild/introduction) supports Rsbuild through the `@nx/rsbuild` plugin, including generators and executors for Nx workspaces.
+- [Turborepo](https://turborepo.dev/docs/guides/frameworks/rsbuild) provides examples and guides for creating Rsbuild applications and using Rsbuild with Module Federation.
+
 ## Migrate from existing projects
 
 To migrate from an existing project to Rsbuild, refer to the following guides:

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -145,6 +145,13 @@ Optional skills:
   rsbuild-best-practices, rstest-best-practices, vercel-react-best-practices
 ```
 
+## 在 Monorepo 中使用 Rsbuild \{#use-rsbuild-in-monorepos}
+
+以下 Monorepo 工具提供了 Rsbuild 集成或示例，可用于在工作区中创建和管理 Rsbuild 应用。
+
+- [Nx](https://nx.dev/docs/technologies/build-tools/rsbuild/introduction) 通过 `@nx/rsbuild` 插件支持 Rsbuild，为 Nx 工作区提供生成器和执行器。
+- [Turborepo](https://turborepo.dev/docs/guides/frameworks/rsbuild) 提供创建 Rsbuild 应用和使用 Module Federation 的示例和指南。
+
 ## 从现有项目迁移 \{#migrate-from-existing-projects}
 
 如需从现有项目迁移到 Rsbuild，参考以下指南：


### PR DESCRIPTION
## Summary

This PR updates the quick start docs to help users find monorepo workflows for Rsbuild. It adds a new monorepo section in both English and Chinese with links to the Nx Rsbuild plugin docs and Turborepo Rsbuild examples and guides.

## Related Links

- https://nx.dev/docs/technologies/build-tools/rsbuild/introduction
- https://turborepo.dev/docs/guides/frameworks/rsbuild