### PR TITLE
fix(core): correct one-byte asset response length

### DIFF
--- a/e2e/cases/assets/styles-as-assets/index.test.ts
+++ b/e2e/cases/assets/styles-as-assets/index.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@e2e/helper';
+import type { RsbuildPlugin } from '@rsbuild/core';
 
 test('should allow to use `new URL` to reference styles as assets', async ({
   page,
@@ -33,5 +34,41 @@ test('should allow to use `new URL` to reference styles as assets', async ({
   );
   expect(await page.evaluate('window.test3')).toBe(
     `http://localhost:${rsbuild.port}/static/assets/test3.scss`,
+  );
+});
+
+test('should serve one-byte assets', async ({ page, runBothServe }) => {
+  const emitOneByteAssetPlugin: RsbuildPlugin = {
+    name: 'emit-one-byte-asset',
+    setup(api) {
+      api.processAssets(
+        {
+          stage: 'additional',
+        },
+        ({ compilation, sources }) => {
+          compilation.emitAsset(
+            'static/assets/one-byte.txt',
+            new sources.RawSource('a'),
+          );
+        },
+      );
+    },
+  };
+
+  await runBothServe(
+    async ({ result }) => {
+      const res = await page.goto(
+        `http://localhost:${result.port}/static/assets/one-byte.txt`,
+      );
+
+      expect(res?.status()).toBe(200);
+      expect(res?.headers()['content-length']).toBe('1');
+      expect((await res?.body())?.toString()).toBe('a');
+    },
+    {
+      config: {
+        plugins: [emitOneByteAssetPlugin],
+      },
+    },
   );
 });

--- a/packages/core/src/server/assets-middleware/middleware.ts
+++ b/packages/core/src/server/assets-middleware/middleware.ts
@@ -18,6 +18,7 @@ function createReadStreamOrReadFileSync(
   outputFileSystem: Rspack.OutputFileSystem,
   start: number,
   end: number,
+  byteLength: number,
 ): { bufferOrStream: Buffer | ReadStream; byteLength: number } {
   const bufferOrStream = (
     outputFileSystem.createReadStream as (
@@ -28,7 +29,6 @@ function createReadStreamOrReadFileSync(
     start,
     end,
   });
-  const byteLength = end === 0 ? 0 : end - start + 1;
 
   return { bufferOrStream, byteLength };
 }
@@ -442,6 +442,7 @@ export function createMiddleware(
           outputFileSystem,
           start,
           end,
+          len,
         ));
       } catch {
         await goNext();


### PR DESCRIPTION
## Summary

This PR fixes an existing assets middleware edge case where a one-byte file is served with `Content-Length: 0` because the byte length was inferred from `end === 0`.

The middleware now uses the already computed response length, preserving empty-file responses while serving one-byte assets correctly. A dev-server e2e case emits a one-byte asset and verifies both the response body and content length.
