### PR TITLE
fix(core): align preview asset serving with dev

### DIFF
--- a/e2e/cases/server/preview/index.test.ts
+++ b/e2e/cases/server/preview/index.test.ts
@@ -94,4 +94,10 @@ test('should serve multi-environment assets before returned setup middleware', a
   );
   expect(serverBundleRes.status).toBe(404);
   expect(await serverBundleRes.text()).toBe('<html>SSR fallback</html>');
+
+  const nestedServerBundleRes = await fetch(
+    `http://localhost:${result.port}/server/index.js`,
+  );
+  expect(nestedServerBundleRes.status).toBe(404);
+  expect(await nestedServerBundleRes.text()).toBe('<html>SSR fallback</html>');
 });

--- a/packages/core/src/server/devMiddlewares.ts
+++ b/packages/core/src/server/devMiddlewares.ts
@@ -190,8 +190,9 @@ const applyDefaultMiddlewares = async ({
   if (buildManager) {
     middlewares.use(
       getHtmlCompletionMiddleware({
-        buildManager,
-        distPath: context.distPath,
+        assetsMiddleware: buildManager.assetsMiddleware,
+        distPaths: [context.distPath],
+        outputFileSystem: buildManager.outputFileSystem,
       }),
     );
   }
@@ -238,9 +239,10 @@ const applyDefaultMiddlewares = async ({
   if (buildManager && server.htmlFallback) {
     middlewares.use(
       getHtmlFallbackMiddleware({
-        buildManager,
-        distPath: context.distPath,
+        assetsMiddleware: buildManager.assetsMiddleware,
+        distPaths: [context.distPath],
         logger,
+        outputFileSystem: buildManager.outputFileSystem,
       }),
     );
   }

--- a/packages/core/src/server/middlewares.ts
+++ b/packages/core/src/server/middlewares.ts
@@ -5,7 +5,6 @@ import { color } from '../helpers';
 import { addTrailingSlash } from '../helpers/url';
 import { isVerbose, type Logger } from '../logger';
 import type { Connect, EnvironmentAPI, RequestHandler, Rspack } from '../types';
-import type { BuildManager } from './buildManager';
 import {
   HttpCode,
   isUrlPathUnderBase,
@@ -91,12 +90,25 @@ export const optionsFallbackMiddleware: RequestHandler = (req, res, next) => {
 const isFileExists = async (
   filePath: string,
   outputFileSystem: Rspack.OutputFileSystem,
-) =>
+): Promise<boolean> =>
   new Promise((resolve) => {
     outputFileSystem.stat(filePath, (_error, stats) => {
-      resolve(stats?.isFile());
+      resolve(Boolean(stats?.isFile()));
     });
   });
+
+const isFileExistsInDistPaths = async (
+  distPaths: string[],
+  filename: string,
+  outputFileSystem: Rspack.OutputFileSystem,
+): Promise<boolean> => {
+  for (const distPath of distPaths) {
+    if (await isFileExists(path.join(distPath, filename), outputFileSystem)) {
+      return true;
+    }
+  }
+  return false;
+};
 
 const maybeHTMLRequest = (req: IncomingMessage) => {
   if (
@@ -123,13 +135,18 @@ const getUrlPathname = (url: string): string => {
   return url.replace(postfixRE, '');
 };
 
+type HtmlAssetsMiddlewareOptions = {
+  distPaths: string[];
+  assetsMiddleware: RequestHandler;
+  outputFileSystem: Rspack.OutputFileSystem;
+};
+
 /**
  * Support access HTML without suffix
  */
-export const getHtmlCompletionMiddleware: (params: {
-  distPath: string;
-  buildManager: BuildManager;
-}) => RequestHandler = ({ distPath, buildManager }) => {
+export const getHtmlCompletionMiddleware: (
+  params: HtmlAssetsMiddlewareOptions,
+) => RequestHandler = ({ distPaths, assetsMiddleware, outputFileSystem }) => {
   return async function htmlCompletionMiddleware(req, res, next) {
     if (!maybeHTMLRequest(req)) {
       next();
@@ -141,7 +158,7 @@ export const getHtmlCompletionMiddleware: (params: {
 
     const rewrite = (newUrl: string) => {
       req.url = newUrl;
-      buildManager.assetsMiddleware(req, res, (...args) => {
+      assetsMiddleware(req, res, (...args) => {
         next(...args);
       });
       return;
@@ -150,9 +167,8 @@ export const getHtmlCompletionMiddleware: (params: {
     // '/' => '/index.html'
     if (pathname.endsWith('/')) {
       const newUrl = `${pathname}index.html`;
-      const filePath = path.join(distPath, newUrl);
 
-      if (await isFileExists(filePath, buildManager.outputFileSystem)) {
+      if (await isFileExistsInDistPaths(distPaths, newUrl, outputFileSystem)) {
         rewrite(newUrl);
         return;
       }
@@ -160,9 +176,8 @@ export const getHtmlCompletionMiddleware: (params: {
     // '/main' => '/main.html'
     else if (!path.extname(pathname)) {
       const newUrl = `${pathname}.html`;
-      const filePath = path.join(distPath, newUrl);
 
-      if (await isFileExists(filePath, buildManager.outputFileSystem)) {
+      if (await isFileExistsInDistPaths(distPaths, newUrl, outputFileSystem)) {
         rewrite(newUrl);
         return;
       }
@@ -227,19 +242,23 @@ export const getBaseUrlMiddleware: (params: {
 /**
  * support HTML fallback in some edge cases
  */
-export const getHtmlFallbackMiddleware: (params: {
-  distPath: string;
-  buildManager: BuildManager;
-  logger: Logger;
-}) => RequestHandler = ({ distPath, buildManager, logger }) => {
+export const getHtmlFallbackMiddleware: (
+  params: HtmlAssetsMiddlewareOptions & { logger: Logger },
+) => RequestHandler = ({
+  distPaths,
+  assetsMiddleware,
+  outputFileSystem,
+  logger,
+}) => {
   return async function htmlFallbackMiddleware(req, res, next) {
     if (!maybeHTMLRequest(req) || '/favicon.ico' === req.url) {
       next();
       return;
     }
 
-    const filePath = path.join(distPath, 'index.html');
-    if (await isFileExists(filePath, buildManager.outputFileSystem)) {
+    if (
+      await isFileExistsInDistPaths(distPaths, 'index.html', outputFileSystem)
+    ) {
       const newUrl = '/index.html';
 
       if (isVerbose(logger)) {
@@ -249,7 +268,7 @@ export const getHtmlFallbackMiddleware: (params: {
       }
 
       req.url = newUrl;
-      buildManager.assetsMiddleware(req, res, (...args) => {
+      assetsMiddleware(req, res, (...args) => {
         next(...args);
       });
       return;

--- a/packages/core/src/server/previewServer.ts
+++ b/packages/core/src/server/previewServer.ts
@@ -18,7 +18,6 @@ import {
   getAddressUrls,
   getRoutes,
   getServerTerminator,
-  isUrlPathUnderBase,
   printServerURLs,
   type RsbuildServerBase,
   resolvePort,
@@ -29,6 +28,8 @@ import { createHttpServer } from './httpServer';
 import {
   faviconFallbackMiddleware,
   getBaseUrlMiddleware,
+  getHtmlCompletionMiddleware,
+  getHtmlFallbackMiddleware,
   getRequestLoggerMiddleware,
   notFoundMiddleware,
   optionsFallbackMiddleware,
@@ -147,54 +148,18 @@ export async function startPreviewServer(
     environments: context.environments,
   });
 
-  const applyStaticAssetMiddleware = async () => {
-    const { default: sirv } = await import(
-      /* webpackChunkName: "sirv" */ 'sirv'
-    );
-    const previewAssetContext = getPreviewAssetContext(context);
-
-    const diskAssetsMiddleware = createAssetsMiddleware(
-      previewAssetContext,
-      (callback) => callback(),
-      fs,
-    );
-
-    const assetsMiddleware = sirv(context.distPath, {
-      etag: true,
-      dev: true,
-      ignores: ['favicon.ico'],
-      single: serverConfig.htmlFallback === 'index',
-    });
-
-    const assetPrefixes = previewAssetContext.publicPathnames;
-
-    middlewares.use(function staticAssetMiddleware(req, res, next) {
-      diskAssetsMiddleware(req, res, (err) => {
-        if (err) {
-          next(err);
-          return;
-        }
-
-        const { url } = req;
-        const assetPrefix =
-          url &&
-          assetPrefixes.find(
-            (prefix) =>
-              prefix && prefix !== '/' && isUrlPathUnderBase(url, prefix),
-          );
-
-        // handling assetPrefix
-        if (assetPrefix) {
-          req.url = url.slice(assetPrefix.length);
-          assetsMiddleware(req, res, (...args: unknown[]) => {
-            req.url = url;
-            next(...args);
-          });
-        } else {
-          assetsMiddleware(req, res, next);
-        }
-      });
-    });
+  const assetContext = getPreviewAssetContext(context);
+  const assetsMiddleware = createAssetsMiddleware(
+    assetContext,
+    (callback) => callback(),
+    fs,
+  );
+  const htmlMiddlewareOptions = {
+    assetsMiddleware,
+    distPaths: assetContext.environmentList.map(
+      (environment) => environment.distPath,
+    ),
+    outputFileSystem: fs,
   };
 
   if (isVerbose(logger)) {
@@ -249,7 +214,8 @@ export async function startPreviewServer(
     middlewares.use(getBaseUrlMiddleware({ base }));
   }
 
-  await applyStaticAssetMiddleware();
+  middlewares.use(assetsMiddleware);
+  middlewares.use(getHtmlCompletionMiddleware(htmlMiddlewareOptions));
 
   if (historyApiFallback) {
     middlewares.use(
@@ -259,12 +225,21 @@ export async function startPreviewServer(
       ),
     );
 
-    // ensure fallback request can be handled by sirv
-    await applyStaticAssetMiddleware();
+    // ensure fallback request can be handled by the built asset middleware
+    middlewares.use(assetsMiddleware);
   }
 
   for (const callback of postSetupCallbacks) {
     await callback();
+  }
+
+  if (serverConfig.htmlFallback) {
+    middlewares.use(
+      getHtmlFallbackMiddleware({
+        ...htmlMiddlewareOptions,
+        logger,
+      }),
+    );
   }
 
   middlewares.use(faviconFallbackMiddleware);


### PR DESCRIPTION
## Summary

This PR removes the preview server's separate `sirv` fallback for built assets and routes preview output through the shared assets middleware used by dev. Preview now serves assets from web-target environment dist paths and reuses the shared HTML completion/fallback middleware, so multi-environment layouts like `dist/client` + `dist/server` can resolve client assets without exposing server bundles as static files.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/7820
https://github.com/TanStack/router/pull/7372