### PR TITLE
fix(core): preserve query when removing base path

### DIFF
--- a/e2e/cases/server/base-url/index.test.ts
+++ b/e2e/cases/server/base-url/index.test.ts
@@ -111,6 +111,31 @@ test('should apply server.base in preview', async ({ page, buildPreview }) => {
   expect(await page.content()).toContain('aaaa');
 });
 
+test('should serve preview requests with query under server.base', async ({
+  page,
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview({
+    config: {
+      server: {
+        base: '/base',
+        htmlFallback: false,
+      },
+    },
+  });
+
+  const res = await page.goto(`http://localhost:${rsbuild.port}/base?foo=1`);
+  expect(res?.status()).toBe(200);
+
+  await expect(page.locator('#test')).toHaveText('Hello Rsbuild!');
+
+  const publicRes = await fetch(
+    `http://localhost:${rsbuild.port}/base/aaa.txt?foo=1`,
+  );
+  expect(publicRes.status).toBe(200);
+  expect((await publicRes.text()).trim()).toBe('aaaa');
+});
+
 test('should serve resource correctly when assetPrefix is a subPath of server.base', async ({
   page,
   dev,

--- a/packages/core/src/helpers/url.ts
+++ b/packages/core/src/helpers/url.ts
@@ -5,7 +5,8 @@ import { DEFAULT_ASSET_PREFIX } from '../constants';
 import type { Rspack } from '../types';
 
 export const removeLeadingSlash = (s: string): string => s.replace(/^\/+/, '');
-export const removeTailingSlash = (s: string): string => s.replace(/\/+$/, '');
+export const removeTailingSlash = (s: string): string =>
+  s.endsWith('/') ? s.replace(/\/+$/, '') : s;
 export const addTrailingSlash = (s: string): string =>
   s.endsWith('/') ? s : `${s}/`;
 

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -100,15 +100,25 @@ export const isUrlPathUnderBase = (pathname: string, base: string): boolean => {
 
 export const removeBasePath = (url: string, base: string): string => {
   const basePath = removeTailingSlash(base);
-  if (basePath === '') {
+  if (basePath === '' || !url.startsWith(basePath)) {
     return url;
   }
 
-  if (url === basePath) {
+  const nextChar = url[basePath.length];
+
+  if (nextChar === undefined) {
     return '/';
   }
 
-  return url.startsWith(`${basePath}/`) ? url.slice(basePath.length) : url;
+  if (nextChar === '/') {
+    return url.slice(basePath.length);
+  }
+
+  if (nextChar === '?' || nextChar === '#') {
+    return `/${url.slice(basePath.length)}`;
+  }
+
+  return url;
 };
 
 export const getRoutes = (context: InternalContext): Routes => {

--- a/packages/core/tests/helpers.test.ts
+++ b/packages/core/tests/helpers.test.ts
@@ -4,7 +4,7 @@ import { join, sep } from 'node:path';
 import { isPlainObject, isWebTarget, pick, prettyTime } from '../src/helpers';
 import { dedupeNestedPaths, getCommonParentPath } from '../src/helpers/path';
 import { readPackageJsonByPath } from '../src/helpers/packageJson';
-import { ensureAssetPrefix } from '../src/helpers/url';
+import { ensureAssetPrefix, removeTailingSlash } from '../src/helpers/url';
 import { getRoutes, normalizeUrl } from '../src/server/helper';
 import type { InternalContext, RsbuildTarget } from '../src/types';
 
@@ -191,6 +191,14 @@ it('should normalize URLs correctly', () => {
   expect(normalizeUrl('https://www.example.com/static/')).toBe(
     'https://www.example.com/static/',
   );
+});
+
+it('should remove trailing slashes correctly', () => {
+  expect(removeTailingSlash('/base')).toBe('/base');
+  expect(removeTailingSlash('/base/')).toBe('/base');
+  expect(removeTailingSlash('/base///')).toBe('/base');
+  expect(removeTailingSlash('/')).toBe('');
+  expect(removeTailingSlash('')).toBe('');
 });
 
 describe('ensureAssetPrefix', () => {

--- a/packages/core/tests/server.test.ts
+++ b/packages/core/tests/server.test.ts
@@ -180,8 +180,11 @@ test('should handle URL path helpers correctly', () => {
   expect(joinUrlPath('/base/', '/main')).toBe('/base/main');
 
   expect(removeBasePath('/base', '/base')).toBe('/');
+  expect(removeBasePath('/base?foo=1', '/base')).toBe('/?foo=1');
+  expect(removeBasePath('/base#foo', '/base')).toBe('/#foo');
   expect(removeBasePath('/base/', '/base')).toBe('/');
   expect(removeBasePath('/base/foo', '/base')).toBe('/foo');
+  expect(removeBasePath('/base/foo?foo=1', '/base')).toBe('/foo?foo=1');
   expect(removeBasePath('/baseball', '/base')).toBe('/baseball');
 
   expect(isUrlPathUnderBase('/base', '/base')).toBe(true);


### PR DESCRIPTION
## Summary

This PR fixes preview/base URL handling for requests that exactly match `server.base` and include a query or hash. `removeBasePath` now strips the base when the next URL character is `/`, `?`, or `#`, preserving query/hash while avoiding false matches like `/baseball`. It also adds unit and preview e2e coverage for the exact-prefix query case.