### PR TITLE
feat(core): enable Rspack pureFunctions optimization

### DIFF
--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -31,6 +31,11 @@ export const pluginBasic = (): RsbuildPlugin => ({
         // Disable performance hints, these logs are too complex
         chain.performance.hints(false);
 
+        chain.experiments({
+          ...chain.get('experiments'),
+          pureFunctions: true,
+        });
+
         chain.module.parser.merge({
           javascript: {
             typeReexportsPresence: 'tolerant',

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -9,6 +9,9 @@ exports[`default bundler > should use Rspack by default 1`] = `
       "./src/index.js",
     ],
   },
+  "experiments": {
+    "pureFunctions": true,
+  },
   "infrastructureLogging": {
     "level": "error",
   },

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -32,6 +32,9 @@ exports[`should apply default plugins correctly 1`] = `
 {
   "context": "<ROOT>",
   "devtool": "cheap-module-source-map",
+  "experiments": {
+    "pureFunctions": true,
+  },
   "infrastructureLogging": {
     "level": "error",
   },
@@ -516,6 +519,9 @@ exports[`should apply default plugins correctly in production 1`] = `
 {
   "context": "<ROOT>",
   "devtool": false,
+  "experiments": {
+    "pureFunctions": true,
+  },
   "infrastructureLogging": {
     "level": "error",
   },
@@ -1030,6 +1036,9 @@ exports[`should apply default plugins correctly when target is node 1`] = `
 {
   "context": "<ROOT>",
   "devtool": "cheap-module-source-map",
+  "experiments": {
+    "pureFunctions": true,
+  },
   "infrastructureLogging": {
     "level": "error",
   },
@@ -1494,6 +1503,9 @@ exports[`tools.rspack > should match snapshot 1`] = `
 {
   "context": "<ROOT>",
   "devtool": "cheap-module-source-map",
+  "experiments": {
+    "pureFunctions": true,
+  },
   "infrastructureLogging": {
     "level": "error",
   },

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -5,6 +5,9 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
   {
     "context": "<ROOT>",
     "devtool": "eval-source-map",
+    "experiments": {
+      "pureFunctions": true,
+    },
     "infrastructureLogging": {
       "level": "error",
     },
@@ -486,6 +489,9 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
   {
     "context": "<ROOT>",
     "devtool": "eval",
+    "experiments": {
+      "pureFunctions": true,
+    },
     "infrastructureLogging": {
       "level": "error",
     },

--- a/packages/core/tests/default.test.ts
+++ b/packages/core/tests/default.test.ts
@@ -39,6 +39,8 @@ it('should apply default plugins correctly when target is node', async () => {
 });
 
 it('should enable Rspack pureFunctions experiment by default', async () => {
+  rs.stubEnv('NODE_ENV', 'development');
+
   const rsbuild = await createRsbuild();
 
   const [rspackConfig] = await rsbuild.initConfigs();

--- a/packages/core/tests/default.test.ts
+++ b/packages/core/tests/default.test.ts
@@ -38,6 +38,13 @@ it('should apply default plugins correctly when target is node', async () => {
   expect(rspackConfigs[0]).toMatchSnapshot();
 });
 
+it('should enable Rspack pureFunctions experiment by default', async () => {
+  const rsbuild = await createRsbuild();
+
+  const [rspackConfig] = await rsbuild.initConfigs();
+  expect(rspackConfig.experiments?.pureFunctions).toBe(true);
+});
+
 describe('tools.rspack', () => {
   it('should match snapshot', async () => {
     rs.stubEnv('NODE_ENV', 'development');

--- a/packages/core/tests/default.test.ts
+++ b/packages/core/tests/default.test.ts
@@ -38,15 +38,6 @@ it('should apply default plugins correctly when target is node', async () => {
   expect(rspackConfigs[0]).toMatchSnapshot();
 });
 
-it('should enable Rspack pureFunctions experiment by default', async () => {
-  rs.stubEnv('NODE_ENV', 'development');
-
-  const rsbuild = await createRsbuild();
-
-  const [rspackConfig] = await rsbuild.initConfigs();
-  expect(rspackConfig.experiments?.pureFunctions).toBe(true);
-});
-
 describe('tools.rspack', () => {
   it('should match snapshot', async () => {
     rs.stubEnv('NODE_ENV', 'development');


### PR DESCRIPTION
## Summary

This PR enables Rspack's `experiments.pureFunctions` in Rsbuild's base Rspack config so pure-function hints can participate in tree shaking by default.

It also updates the related default config snapshots.

## Related Links

https://rspack.rs/config/experiments#experimentspurefunctions