### PR TITLE
fix(core): support loadBundle with natural chunk ids

### DIFF
--- a/e2e/cases/server/load-bundle-natural-chunk-ids/index.test.ts
+++ b/e2e/cases/server/load-bundle-natural-chunk-ids/index.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@e2e/helper';
+
+test('should load bundle with natural chunk ids', async ({
+  devOnly,
+  request,
+}) => {
+  const rsbuild = await devOnly();
+  const baseUrl = `http://localhost:${rsbuild.port}`;
+
+  const response = await request.get(`${baseUrl}/check`);
+
+  expect(response.status()).toBe(200);
+  expect(await response.text()).toBe('load-bundle-natural-chunk-ids');
+});

--- a/e2e/cases/server/load-bundle-natural-chunk-ids/rsbuild.config.ts
+++ b/e2e/cases/server/load-bundle-natural-chunk-ids/rsbuild.config.ts
@@ -1,0 +1,74 @@
+import { defineConfig, type RequestHandler } from '@rsbuild/core';
+
+export default defineConfig({
+  server: {
+    setup: ({ action, server }) => {
+      if (action !== 'dev') {
+        return;
+      }
+
+      const middleware: RequestHandler = async (req, res, next) => {
+        if (req.method !== 'GET' || req.url !== '/check') {
+          next();
+          return;
+        }
+
+        try {
+          const bundle = await server.environments.node.loadBundle<{
+            getPayload: () => string;
+          }>('index');
+
+          res.setHeader('Content-Type', 'text/plain');
+          res.end(bundle.getPayload());
+        } catch (error) {
+          res.statusCode = 500;
+          res.end(String(error));
+        }
+      };
+
+      server.middlewares.use(middleware);
+    },
+  },
+  environments: {
+    web: {
+      source: {
+        entry: {
+          index: './src/index.js',
+        },
+      },
+    },
+    node: {
+      output: {
+        target: 'node',
+      },
+      source: {
+        entry: {
+          index: './src/index.server.js',
+        },
+      },
+      tools: {
+        rspack: (config) => {
+          return {
+            ...config,
+            optimization: {
+              ...config.optimization,
+              chunkIds: 'natural',
+              runtimeChunk: true,
+              splitChunks: {
+                chunks: 'all',
+                minSize: 0,
+                cacheGroups: {
+                  shared: {
+                    test: /shared/,
+                    name: 'shared',
+                    enforce: true,
+                  },
+                },
+              },
+            },
+          };
+        },
+      },
+    },
+  },
+});

--- a/e2e/cases/server/load-bundle-natural-chunk-ids/src/index.js
+++ b/e2e/cases/server/load-bundle-natural-chunk-ids/src/index.js
@@ -1,0 +1,1 @@
+document.body.innerHTML = '<div id="root">load-bundle-natural-chunk-ids</div>';

--- a/e2e/cases/server/load-bundle-natural-chunk-ids/src/index.server.js
+++ b/e2e/cases/server/load-bundle-natural-chunk-ids/src/index.server.js
@@ -1,0 +1,3 @@
+import { getPayload } from './shared';
+
+export { getPayload };

--- a/e2e/cases/server/load-bundle-natural-chunk-ids/src/shared.js
+++ b/e2e/cases/server/load-bundle-natural-chunk-ids/src/shared.js
@@ -1,0 +1,1 @@
+export const getPayload = () => 'load-bundle-natural-chunk-ids';

--- a/packages/core/src/server/environment.ts
+++ b/packages/core/src/server/environment.ts
@@ -17,6 +17,7 @@ export const loadBundle = async <T>(
     all: false,
     chunks: true,
     entrypoints: true,
+    ids: true,
     outputPath: true,
   });
 
@@ -31,9 +32,9 @@ export const loadBundle = async <T>(
   const { chunks: entryChunks = [] } = entrypoints[entryName];
 
   // find main entryChunk from chunks
-  const files = entryChunks.reduce<string[]>((prev, entryChunkName) => {
+  const files = entryChunks.reduce<string[]>((prev, entryChunkId) => {
     const chunk = chunks?.find(
-      (chunk) => chunk.entry && chunk.names?.includes(String(entryChunkName)),
+      (chunk) => chunk.entry && chunk.id === entryChunkId,
     );
 
     return chunk?.files


### PR DESCRIPTION
## Summary

- Resolve `loadBundle()` entry chunks by chunk id as well as chunk name.
- Include chunk ids in stats used by `loadBundle()`.
- Add an e2e case covering `loadBundle()` with `optimization.chunkIds: 'natural'` and split chunks.

## Related Links

<!--- Provide links of related issues or pages -->
