### PR TITLE
test: simplify e2e configs

### DIFF
--- a/e2e/cases/lazy-compilation/add-initial-chunk/rsbuild.config.ts
+++ b/e2e/cases/lazy-compilation/add-initial-chunk/rsbuild.config.ts
@@ -3,11 +3,6 @@ import { pluginReact } from '@rsbuild/plugin-react';
 
 export default defineConfig({
   plugins: [pluginReact()],
-  source: {
-    entry: {
-      index: './src/index.js',
-    },
-  },
   tools: {
     rspack: {
       lazyCompilation: true,

--- a/e2e/cases/plugin-vue/sfc-css-modules-multi-target/rsbuild.config.ts
+++ b/e2e/cases/plugin-vue/sfc-css-modules-multi-target/rsbuild.config.ts
@@ -5,11 +5,6 @@ export default defineConfig({
   plugins: [pluginVue()],
   environments: {
     web: {
-      source: {
-        entry: {
-          index: './src/index.js',
-        },
-      },
       output: {
         target: 'web',
         distPath: {
@@ -18,11 +13,6 @@ export default defineConfig({
       },
     },
     node: {
-      source: {
-        entry: {
-          index: './src/index.js',
-        },
-      },
       output: {
         target: 'node',
         distPath: {

--- a/e2e/cases/server/load-bundle-cjs/rsbuild.config.ts
+++ b/e2e/cases/server/load-bundle-cjs/rsbuild.config.ts
@@ -30,13 +30,7 @@ export default defineConfig({
     },
   },
   environments: {
-    web: {
-      source: {
-        entry: {
-          index: './src/index.js',
-        },
-      },
-    },
+    web: {},
     node: {
       output: {
         target: 'node',

--- a/e2e/cases/server/load-bundle-natural-chunk-ids/rsbuild.config.ts
+++ b/e2e/cases/server/load-bundle-natural-chunk-ids/rsbuild.config.ts
@@ -30,13 +30,7 @@ export default defineConfig({
     },
   },
   environments: {
-    web: {
-      source: {
-        entry: {
-          index: './src/index.js',
-        },
-      },
-    },
+    web: {},
     node: {
       output: {
         target: 'node',
@@ -47,26 +41,22 @@ export default defineConfig({
         },
       },
       tools: {
-        rspack: (config) => {
-          return {
-            ...config,
-            optimization: {
-              ...config.optimization,
-              chunkIds: 'natural',
-              runtimeChunk: true,
-              splitChunks: {
-                chunks: 'all',
-                minSize: 0,
-                cacheGroups: {
-                  shared: {
-                    test: /shared/,
-                    name: 'shared',
-                    enforce: true,
-                  },
+        rspack: {
+          optimization: {
+            chunkIds: 'natural',
+            runtimeChunk: true,
+            splitChunks: {
+              chunks: 'all',
+              minSize: 0,
+              cacheGroups: {
+                shared: {
+                  test: /shared/,
+                  name: 'shared',
+                  enforce: true,
                 },
               },
             },
-          };
+          },
         },
       },
     },

--- a/e2e/cases/server/ssr-load-bundle-external/rsbuild.config.ts
+++ b/e2e/cases/server/ssr-load-bundle-external/rsbuild.config.ts
@@ -45,13 +45,7 @@ export default defineConfig({
     },
   },
   environments: {
-    web: {
-      source: {
-        entry: {
-          index: './src/index.js',
-        },
-      },
-    },
+    web: {},
     node: {
       source: {
         entry: {

--- a/e2e/cases/server/ssr/rsbuild.config.ts
+++ b/e2e/cases/server/ssr/rsbuild.config.ts
@@ -73,39 +73,31 @@ export default defineConfig({
         },
       },
       tools: {
-        rspack: (config) => {
-          if (process.env.TEST_ESM_LIBRARY) {
-            return {
-              ...config,
+        rspack: process.env.TEST_ESM_LIBRARY
+          ? {
               output: {
-                ...config.output,
                 filename: '[name].mjs',
                 chunkFilename: '[name].mjs',
               },
-            };
-          }
-
-          if (process.env.TEST_SPLIT_CHUNK) {
-            return {
-              ...config,
-              optimization: {
-                runtimeChunk: true,
-                splitChunks: {
-                  chunks: 'all',
-                  minSize: 0,
-                  cacheGroups: {
-                    'lib-react': {
-                      test: /node_modules[\\/](react|react-dom|scheduler|react-refresh|@rspack[\\/]plugin-react-refresh)[\\/]/,
-                      priority: 0,
-                      name: 'lib-react',
+            }
+          : process.env.TEST_SPLIT_CHUNK
+            ? {
+                optimization: {
+                  runtimeChunk: true,
+                  splitChunks: {
+                    chunks: 'all',
+                    minSize: 0,
+                    cacheGroups: {
+                      'lib-react': {
+                        test: /node_modules[\\/](react|react-dom|scheduler|react-refresh|@rspack[\\/]plugin-react-refresh)[\\/]/,
+                        priority: 0,
+                        name: 'lib-react',
+                      },
                     },
                   },
                 },
-              },
-            };
-          }
-          return config;
-        },
+              }
+            : {},
       },
     },
   },


### PR DESCRIPTION
## Summary

This PR simplifies e2e Rsbuild configs by relying on the default `index: './src/index.js'` entry where applicable and replacing fixed `tools.rspack` mutations with object config. It keeps environment-specific node entries explicit while reducing boilerplate in server, lazy-compilation, Vue, and SSR cases.