### PR TITLE
docs: fix tools.rspack examples

### DIFF
--- a/website/docs/en/config/tools/rspack.mdx
+++ b/website/docs/en/config/tools/rspack.mdx
@@ -135,10 +135,11 @@ A boolean value indicating whether this is a production build. Set to `true` whe
 ```ts title="rsbuild.config.ts"
 export default {
   tools: {
-    rspack: (chain, { isProd }) => {
+    rspack: (config, { isProd }) => {
       if (isProd) {
-        chain.devtool('source-map');
+        config.devtool = 'source-map';
       }
+      return config;
     },
   },
 };
@@ -247,7 +248,7 @@ Context information for all environments.
 ```ts title="rsbuild.config.ts"
 export default {
   tools: {
-    rspack: (chain, { environments }) => {
+    rspack: (config, { environments }) => {
       console.log(environments);
     },
   },

--- a/website/docs/zh/config/tools/rspack.mdx
+++ b/website/docs/zh/config/tools/rspack.mdx
@@ -135,10 +135,11 @@ export default {
 ```ts title="rsbuild.config.ts"
 export default {
   tools: {
-    rspack: (chain, { isProd }) => {
+    rspack: (config, { isProd }) => {
       if (isProd) {
-        chain.devtool('source-map');
+        config.devtool = 'source-map';
       }
+      return config;
     },
   },
 };
@@ -247,7 +248,7 @@ export default {
 ```ts title="rsbuild.config.ts"
 export default {
   tools: {
-    rspack: (chain, { environments }) => {
+    rspack: (config, { environments }) => {
       console.log(environments);
     },
   },


### PR DESCRIPTION
## Summary

This PR fixes `tools.rspack` documentation examples that incorrectly used `rspack-chain` style APIs. It updates the production-mode `devtool` example to mutate and return the Rspack config object, and aligns the `environments` example in both English and Chinese docs.