### PR TITLE
fix(plugin-solid): downgrade solid-refresh to 0.6.3

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -347,8 +347,8 @@ catalogs:
       specifier: ^1.9.13
       version: 1.9.13
     solid-refresh:
-      specifier: ^0.7.8
-      version: 0.7.8
+      specifier: ^0.6.3
+      version: 0.6.3
     stacktrace-parser:
       specifier: ^0.1.11
       version: 0.1.11
@@ -1270,7 +1270,7 @@ importers:
         version: 1.9.12(@babel/core@7.29.7)(solid-js@1.9.13)
       solid-refresh:
         specifier: 'catalog:'
-        version: 0.7.8(solid-js@1.9.13)
+        version: 0.6.3(solid-js@1.9.13)
     devDependencies:
       '@rsbuild/core':
         specifier: workspace:*
@@ -1603,10 +1603,6 @@ packages:
 
   '@babel/core@7.29.7':
     resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/generator@7.29.1':
-    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/generator@7.29.7':
@@ -5391,8 +5387,8 @@ packages:
   solid-js@1.9.13:
     resolution: {integrity: sha512-6hJeJMOcEX8ktqjpDoJZEmld3ijvcvWBDtiXBm7f4332SiFN66QeAQI1REQshvyUoISsSeJ4PHDauKYbwao9JQ==}
 
-  solid-refresh@0.7.8:
-    resolution: {integrity: sha512-iG442T3HXJp5jEebCy8okETrWnmX7CnxNOKrJQVeufh6WXSn+xtLXaptUXXMHTWcRqTJOJwQ8UwzxrRtVFSIzA==}
+  solid-refresh@0.6.3:
+    resolution: {integrity: sha512-F3aPsX6hVw9ttm5LYlth8Q15x6MlI/J3Dn+o3EQyRTtTxidepSTwAYdozt01/YA+7ObcciagGEyXIopGZzQtbA==}
     peerDependencies:
       solid-js: ^1.3
 
@@ -5878,14 +5874,6 @@ snapshots:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/generator@7.29.1':
-    dependencies:
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-      jsesc: 3.1.0
 
   '@babel/generator@7.29.7':
     dependencies:
@@ -10094,11 +10082,14 @@ snapshots:
       seroval: 1.5.2
       seroval-plugins: 1.5.2(seroval@1.5.2)
 
-  solid-refresh@0.7.8(solid-js@1.9.13):
+  solid-refresh@0.6.3(solid-js@1.9.13):
     dependencies:
-      '@babel/generator': 7.29.1
-      '@babel/types': 7.29.0
+      '@babel/generator': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/types': 7.29.7
       solid-js: 1.9.13
+    transitivePeerDependencies:
+      - supports-color
 
   sorted-array-functions@1.3.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -129,7 +129,7 @@ catalog:
   'simple-git-hooks': '^2.13.1'
   'sirv': '^3.0.2'
   'solid-js': '^1.9.13'
-  'solid-refresh': '^0.7.8'
+  'solid-refresh': '^0.6.3'
   'stacktrace-parser': '^0.1.11'
   'style-loader': '^4.0.0'
   'svelte': '^5.55.9'


### PR DESCRIPTION
## Summary

Downgrade the Solid Refresh dependency used by `@rsbuild/plugin-solid` from `^0.7.8` to `^0.6.3` to fix https://github.com/rstackjs/rstack-examples/issues/471.

## Related Links

- https://github.com/rstackjs/rstack-examples/issues/471
- https://github.com/solidjs/vite-plugin-solid/pull/240