### PR TITLE
docs: add Cloudflare Workers plugin tip

### DIFF
--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -71,6 +71,7 @@ Mergeable
 microfrontend
 microfrontends
 minifiers
+miniflare
 modularly
 mrmime
 mYbzBtlg6o

--- a/website/docs/en/guide/basic/static-deploy.mdx
+++ b/website/docs/en/guide/basic/static-deploy.mdx
@@ -103,6 +103,10 @@ When configuring, complete the following fields under "Build settings":
 
 Then click the **Save and Deploy** button to start the deployment.
 
+:::tip
+For Rsbuild projects deployed to Cloudflare Workers, [rsbuild-cloudflare](https://github.com/Nsttt/rsbuild-cloudflare) is an experimental plugin that reads Wrangler configuration, serves development requests through Miniflare, and emits deployable Worker output.
+:::
+
 ### GitHub pages
 
 [GitHub Pages](https://pages.github.com/) is a static site hosting service that takes HTML, CSS, and JavaScript files straight from a repository on GitHub.

--- a/website/docs/zh/guide/basic/static-deploy.mdx
+++ b/website/docs/zh/guide/basic/static-deploy.mdx
@@ -103,6 +103,10 @@ export default defineConfig({
 
 然后点击 **Save and Deploy** 按钮，就可以开始部署了。
 
+:::tip
+对于部署到 Cloudflare Workers 的 Rsbuild 项目，[rsbuild-cloudflare](https://github.com/Nsttt/rsbuild-cloudflare) 是一个实验性插件，可以读取 Wrangler 配置、通过 Miniflare 提供开发服务，并生成可部署的 Worker 产物。
+:::
+
 ### GitHub Pages
 
 [GitHub Pages](https://pages.github.com/) 是一个静态站点托管服务，可以直接从 GitHub 上的存储库获取 HTML、CSS 和 JavaScript 文件。


### PR DESCRIPTION
## Summary

Adds a tip to the static deployment docs pointing Cloudflare Workers users to the experimental `rsbuild-cloudflare` plugin, including its Wrangler, Miniflare, and Worker output capabilities.

## Related Links

https://github.com/Nsttt/rsbuild-cloudflare