### PR TITLE
docs: clarify SSR asset URL config

### DIFF
--- a/website/docs/en/guide/advanced/ssr.mdx
+++ b/website/docs/en/guide/advanced/ssr.mdx
@@ -269,3 +269,40 @@ export const myPlugin = () => ({
   },
 });
 ```
+
+## Keep asset URLs consistent
+
+In multi-environment SSR, keep [output.assetPrefix](/config/output/asset-prefix) and public asset [output.distPath](/config/output/dist-path) values consistent between server and client builds. This helps ensure that the server gets the same asset path as the client when using queries such as `?url`.
+
+```ts title="rsbuild.config.ts"
+const assetPaths = {
+  css: 'assets/css',
+  image: 'assets/image',
+};
+
+export default {
+  output: {
+    assetPrefix: '/',
+  },
+  environments: {
+    web: {
+      output: {
+        target: 'web',
+        distPath: {
+          root: 'dist/client',
+          ...assetPaths,
+        },
+      },
+    },
+    node: {
+      output: {
+        target: 'node',
+        distPath: {
+          root: 'dist/server',
+          ...assetPaths,
+        },
+      },
+    },
+  },
+};
+```

--- a/website/docs/zh/guide/advanced/ssr.mdx
+++ b/website/docs/zh/guide/advanced/ssr.mdx
@@ -269,3 +269,40 @@ export const myPlugin = () => ({
   },
 });
 ```
+
+## 保持资源 URL 一致
+
+在多环境 SSR 中，建议保持服务端和客户端构建的 [output.assetPrefix](/config/output/asset-prefix) 和静态资源的 [output.distPath](/config/output/dist-path) 配置一致。这有助于保障服务端使用 `?url` 等 query 时，拿到与客户端一致的资源路径。
+
+```ts title="rsbuild.config.ts"
+const assetPaths = {
+  css: 'assets/css',
+  image: 'assets/image',
+};
+
+export default {
+  output: {
+    assetPrefix: '/',
+  },
+  environments: {
+    web: {
+      output: {
+        target: 'web',
+        distPath: {
+          root: 'dist/client',
+          ...assetPaths,
+        },
+      },
+    },
+    node: {
+      output: {
+        target: 'node',
+        distPath: {
+          root: 'dist/server',
+          ...assetPaths,
+        },
+      },
+    },
+  },
+};
+```


### PR DESCRIPTION
## Summary

This PR updates the SSR guide to explain that multi-environment SSR setups should keep `output.assetPrefix` and public asset `output.distPath` aligned between server and client builds. It also adds a basic config example showing shared asset path values so server-side `?url` imports resolve to the same public paths as client assets.

## Related Links

https://github.com/TanStack/router/issues/7543