### PR TITLE
docs: add full-stack framework references

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,8 +212,8 @@ catalogs:
       specifier: ^11.3.5
       version: 11.3.5
     heading-case:
-      specifier: ^1.1.2
-      version: 1.1.2
+      specifier: ^1.1.3
+      version: 1.1.3
     hono:
       specifier: ^4.12.23
       version: 4.12.23
@@ -421,7 +421,7 @@ importers:
         version: 0.0.4
       heading-case:
         specifier: 'catalog:'
-        version: 1.1.2
+        version: 1.1.3
       nano-staged:
         specifier: 'catalog:'
         version: 1.0.2
@@ -4035,8 +4035,8 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
-  heading-case@1.1.2:
-    resolution: {integrity: sha512-lqWWmCd289iZEjO/RLUSx5rDlFM5XcdszFAZk5OzAbyVfOXss8h5Dr7SuPXzjIaA9rXlBKmA8fMdiOnSSL6oBg==}
+  heading-case@1.1.3:
+    resolution: {integrity: sha512-YwTSvHDNLKDwoBjbzt4w3USGcnUnUK9fjKbb9jNoAOop/z1Ldpp+2k+VxrzRYOIlslg2Dq3nSttGQ7sIdEtWxw==}
     hasBin: true
 
   homedir-polyfill@1.0.3:
@@ -8512,7 +8512,7 @@ snapshots:
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
 
-  heading-case@1.1.2: {}
+  heading-case@1.1.3: {}
 
   homedir-polyfill@1.0.3:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -84,7 +84,7 @@ catalog:
   'dotenv-expand': '^13.0.0'
   'fast-glob': '^3.3.3'
   'fs-extra': '^11.3.5'
-  'heading-case': '^1.1.2'
+  'heading-case': '^1.1.3'
   'hono': '^4.12.23'
   'html-loader': '^5.1.0'
   'html-rspack-plugin': '6.1.9'

--- a/website/docs/en/guide/framework/react.mdx
+++ b/website/docs/en/guide/framework/react.mdx
@@ -23,11 +23,11 @@ import { PackageManagerTabs } from '@theme';
 
 Then select `React` when prompted to "Select framework".
 
-## Full-stack Frameworks
+## Full-stack frameworks
 
 The following full-stack React frameworks are built on Rsbuild and reuse Rsbuild's plugin ecosystem.
 
-### TanStack start
+### TanStack Start
 
 [TanStack Start](https://tanstack.com/start/latest) is a full-stack React framework powered by TanStack Router. It provides full-document SSR, streaming, Server Functions, client/server builds, and more.
 

--- a/website/docs/en/guide/framework/react.mdx
+++ b/website/docs/en/guide/framework/react.mdx
@@ -27,7 +27,7 @@ Then select `React` when prompted to "Select framework".
 
 The following full-stack React frameworks are built on Rsbuild and reuse Rsbuild's plugin ecosystem.
 
-### TanStack Start
+### TanStack start
 
 [TanStack Start](https://tanstack.com/start/latest) is a full-stack React framework powered by TanStack Router. It provides full-document SSR, streaming, Server Functions, client/server builds, and more.
 

--- a/website/docs/en/guide/framework/react.mdx
+++ b/website/docs/en/guide/framework/react.mdx
@@ -23,6 +23,22 @@ import { PackageManagerTabs } from '@theme';
 
 Then select `React` when prompted to "Select framework".
 
+## Full-stack Frameworks
+
+The following full-stack React frameworks are built on Rsbuild and reuse Rsbuild's plugin ecosystem.
+
+### TanStack Start
+
+[TanStack Start](https://tanstack.com/start/latest) is a full-stack React framework powered by TanStack Router. It provides full-document SSR, streaming, Server Functions, client/server builds, and more.
+
+- [Documentation](https://tanstack.com/start/latest)
+- [Basic example](https://github.com/rstackjs/rstack-examples/tree/main/rsbuild/tanstack-start)
+- [RSC example](https://github.com/rstackjs/rstack-examples/tree/main/rsbuild/tanstack-start-rsc)
+
+### Modern.js
+
+[Modern.js](https://github.com/web-infra-dev/modern.js) is a progressive web framework built on Rsbuild that provides out-of-the-box full-stack development capabilities for React applications.
+
 ## Use React in an existing project
 
 To compile React's JSX syntax, register the Rsbuild [React Plugin](/plugins/list/plugin-react). The plugin automatically adds the necessary configuration for building React applications.

--- a/website/docs/en/guide/framework/solid.mdx
+++ b/website/docs/en/guide/framework/solid.mdx
@@ -27,7 +27,7 @@ Then select `Solid` when prompted to "Select framework".
 
 The following full-stack Solid frameworks are built on Rsbuild and reuse Rsbuild's plugin ecosystem.
 
-### TanStack Start
+### TanStack start
 
 [TanStack Start](https://tanstack.com/start/latest) is a full-stack framework powered by TanStack Router. It provides full-document SSR, streaming, Server Functions, client/server builds, and more.
 

--- a/website/docs/en/guide/framework/solid.mdx
+++ b/website/docs/en/guide/framework/solid.mdx
@@ -23,11 +23,11 @@ import { PackageManagerTabs } from '@theme';
 
 Then select `Solid` when prompted to "Select framework".
 
-## Full-stack Frameworks
+## Full-stack frameworks
 
 The following full-stack Solid frameworks are built on Rsbuild and reuse Rsbuild's plugin ecosystem.
 
-### TanStack start
+### TanStack Start
 
 [TanStack Start](https://tanstack.com/start/latest) is a full-stack framework powered by TanStack Router. It provides full-document SSR, streaming, Server Functions, client/server builds, and more.
 

--- a/website/docs/en/guide/framework/solid.mdx
+++ b/website/docs/en/guide/framework/solid.mdx
@@ -23,6 +23,17 @@ import { PackageManagerTabs } from '@theme';
 
 Then select `Solid` when prompted to "Select framework".
 
+## Full-stack Frameworks
+
+The following full-stack Solid frameworks are built on Rsbuild and reuse Rsbuild's plugin ecosystem.
+
+### TanStack Start
+
+[TanStack Start](https://tanstack.com/start/latest) is a full-stack framework powered by TanStack Router. It provides full-document SSR, streaming, Server Functions, client/server builds, and more.
+
+- [Documentation](https://tanstack.com/start/latest)
+- [Example project](https://github.com/rstackjs/rstack-examples/tree/main/rsbuild/tanstack-start-solid)
+
 ## Use Solid in an existing project
 
 To compile Solid components, you need to register the Rsbuild [Solid plugin](/plugins/list/plugin-solid). The plugin will automatically add the necessary configuration for Solid builds.

--- a/website/docs/zh/guide/framework/react.mdx
+++ b/website/docs/zh/guide/framework/react.mdx
@@ -23,6 +23,22 @@ import { PackageManagerTabs } from '@theme';
 
 然后在 `Select framework` 时选择 `React` 即可。
 
+## 全栈框架
+
+以下全栈 React 框架基于 Rsbuild 构建，并复用 Rsbuild 的插件生态。
+
+### TanStack Start
+
+[TanStack Start](https://tanstack.com/start/latest) 是一个由 TanStack Router 驱动的全栈 React 框架。它提供 full-document SSR、流式渲染、Server Functions、客户端/服务端构建等能力。
+
+- [文档](https://tanstack.com/start/latest)
+- [基础示例](https://github.com/rstackjs/rstack-examples/tree/main/rsbuild/tanstack-start)
+- [RSC 示例](https://github.com/rstackjs/rstack-examples/tree/main/rsbuild/tanstack-start-rsc)
+
+### Modern.js
+
+[Modern.js](https://github.com/web-infra-dev/modern.js) 是一个基于 Rsbuild 实现的渐进式 Web 开发框架，为 React 应用提供开箱即用的全栈开发能力。
+
 ## 在已有项目中使用 React
 
 为了能够编译 React 的 JSX 语法，你需要注册 Rsbuild 的 [React 插件](/plugins/list/plugin-react)，插件会自动添加构建一个 React 应用所需的配置。

--- a/website/docs/zh/guide/framework/react.mdx
+++ b/website/docs/zh/guide/framework/react.mdx
@@ -27,7 +27,7 @@ import { PackageManagerTabs } from '@theme';
 
 以下全栈 React 框架基于 Rsbuild 构建，并复用 Rsbuild 的插件生态。
 
-### TanStack start
+### TanStack Start
 
 [TanStack Start](https://tanstack.com/start/latest) 是一个由 TanStack Router 驱动的全栈 React 框架。它提供 full-document SSR、流式渲染、Server Functions、客户端/服务端构建等能力。
 

--- a/website/docs/zh/guide/framework/react.mdx
+++ b/website/docs/zh/guide/framework/react.mdx
@@ -27,7 +27,7 @@ import { PackageManagerTabs } from '@theme';
 
 以下全栈 React 框架基于 Rsbuild 构建，并复用 Rsbuild 的插件生态。
 
-### TanStack Start
+### TanStack start
 
 [TanStack Start](https://tanstack.com/start/latest) 是一个由 TanStack Router 驱动的全栈 React 框架。它提供 full-document SSR、流式渲染、Server Functions、客户端/服务端构建等能力。
 

--- a/website/docs/zh/guide/framework/solid.mdx
+++ b/website/docs/zh/guide/framework/solid.mdx
@@ -27,7 +27,7 @@ import { PackageManagerTabs } from '@theme';
 
 以下全栈 Solid 框架基于 Rsbuild 构建，并复用 Rsbuild 的插件生态。
 
-### TanStack Start
+### TanStack start
 
 [TanStack Start](https://tanstack.com/start/latest) 是一个由 TanStack Router 驱动的全栈框架。它提供 full-document SSR、流式渲染、Server Functions、客户端/服务端构建等能力。
 

--- a/website/docs/zh/guide/framework/solid.mdx
+++ b/website/docs/zh/guide/framework/solid.mdx
@@ -27,7 +27,7 @@ import { PackageManagerTabs } from '@theme';
 
 以下全栈 Solid 框架基于 Rsbuild 构建，并复用 Rsbuild 的插件生态。
 
-### TanStack start
+### TanStack Start
 
 [TanStack Start](https://tanstack.com/start/latest) 是一个由 TanStack Router 驱动的全栈框架。它提供 full-document SSR、流式渲染、Server Functions、客户端/服务端构建等能力。
 

--- a/website/docs/zh/guide/framework/solid.mdx
+++ b/website/docs/zh/guide/framework/solid.mdx
@@ -23,6 +23,17 @@ import { PackageManagerTabs } from '@theme';
 
 然后在 `Select framework` 时选择 `Solid` 即可。
 
+## 全栈框架
+
+以下全栈 Solid 框架基于 Rsbuild 构建，并复用 Rsbuild 的插件生态。
+
+### TanStack Start
+
+[TanStack Start](https://tanstack.com/start/latest) 是一个由 TanStack Router 驱动的全栈框架。它提供 full-document SSR、流式渲染、Server Functions、客户端/服务端构建等能力。
+
+- [文档](https://tanstack.com/start/latest)
+- [示例项目](https://github.com/rstackjs/rstack-examples/tree/main/rsbuild/tanstack-start-solid)
+
 ## 在已有项目中使用 Solid
 
 要编译 Solid 组件，需注册 Rsbuild 的 [Solid 插件](/plugins/list/plugin-solid)，插件会自动添加 Solid 构建所需的配置。


### PR DESCRIPTION
## Summary

This PR adds full-stack framework references to the React and Solid framework docs. It documents TanStack Start support with documentation and examples, adds Modern.js to the React docs, keeps the English and Chinese pages aligned, and upgrades heading-case so the TanStack Start heading can keep its brand casing.