### PR TITLE
docs: update SSR framework guidance

### DIFF
--- a/website/docs/en/guide/advanced/ssr.mdx
+++ b/website/docs/en/guide/advanced/ssr.mdx
@@ -6,7 +6,14 @@ description: 'This chapter introduces how to implement SSR functionality using R
 
 This chapter introduces how to implement SSR functionality using Rsbuild.
 
-Rsbuild does not ship with SSR by default. Instead, it offers low-level APIs and configurations so framework developers can build SSR support. If you need SSR that works out of the box, consider a full-stack framework built on Rsbuild, such as [Modern.js](https://github.com/web-infra-dev/modern.js).
+Rsbuild does not ship with SSR by default. Instead, it offers low-level APIs and configurations so framework developers can build SSR support.
+
+## Full-stack frameworks
+
+If you want to use SSR directly, we recommend using a full-stack framework built on Rsbuild because these frameworks already provide SSR support.
+
+- [React full-stack frameworks](/guide/framework/react#full-stack-frameworks)
+- [Solid full-stack frameworks](/guide/framework/solid#full-stack-frameworks)
 
 ## What is SSR
 

--- a/website/docs/zh/guide/advanced/ssr.mdx
+++ b/website/docs/zh/guide/advanced/ssr.mdx
@@ -6,7 +6,14 @@ description: '本章节介绍如何使用 Rsbuild 实现 SSR 功能。'
 
 本章节介绍如何使用 Rsbuild 实现 SSR 功能。
 
-值得注意的是，Rsbuild 自身不提供开箱即用的 SSR 能力，而是提供 low-level 的 API 和配置来允许框架开发者实现 SSR。如果你需要使用开箱即用的 SSR 支持，可以考虑使用基于 Rsbuild 的框架，例如 [Modern.js](https://github.com/web-infra-dev/modern.js)。
+值得注意的是，Rsbuild 自身不提供开箱即用的 SSR 能力，而是提供 low-level 的 API 和配置来允许框架开发者实现 SSR。
+
+## 全栈框架 \{#full-stack-frameworks}
+
+如果你希望直接使用 SSR，推荐使用基于 Rsbuild 的全栈框架，因为这些框架已经实现了 SSR 能力。
+
+- [React 全栈框架](/guide/framework/react#full-stack-frameworks)
+- [Solid 全栈框架](/guide/framework/solid#full-stack-frameworks)
 
 ## 什么是 SSR
 

--- a/website/docs/zh/guide/framework/react.mdx
+++ b/website/docs/zh/guide/framework/react.mdx
@@ -23,7 +23,7 @@ import { PackageManagerTabs } from '@theme';
 
 然后在 `Select framework` 时选择 `React` 即可。
 
-## 全栈框架
+## 全栈框架 \{#full-stack-frameworks}
 
 以下全栈 React 框架基于 Rsbuild 构建，并复用 Rsbuild 的插件生态。
 

--- a/website/docs/zh/guide/framework/solid.mdx
+++ b/website/docs/zh/guide/framework/solid.mdx
@@ -23,7 +23,7 @@ import { PackageManagerTabs } from '@theme';
 
 然后在 `Select framework` 时选择 `Solid` 即可。
 
-## 全栈框架
+## 全栈框架 \{#full-stack-frameworks}
 
 以下全栈 Solid 框架基于 Rsbuild 构建，并复用 Rsbuild 的插件生态。
 


### PR DESCRIPTION
## Summary

This PR updates the SSR guide to separate the framework recommendation into its own full-stack frameworks section. It clarifies that Rsbuild-based full-stack frameworks already provide SSR support and links readers to the React and Solid framework guides.