### PR TITLE
perf(server): optimize mime lookup in dev middleware

### DIFF
--- a/packages/core/src/plugins/appIcon.ts
+++ b/packages/core/src/plugins/appIcon.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { lookup } from 'mrmime';
 import { color, pick } from '../helpers';
 import {
   addCompilationError,
@@ -88,8 +89,6 @@ export const pluginAppIcon = (): RsbuildPlugin => ({
         if (!appIcon) {
           return;
         }
-
-        const { lookup } = await import('mrmime');
 
         const distDir = config.output.distPath.image;
         const manifestFile = appIcon.filename ?? 'manifest.webmanifest';

--- a/packages/core/src/server/assets-middleware/middleware.ts
+++ b/packages/core/src/server/assets-middleware/middleware.ts
@@ -1,5 +1,6 @@
 import type { Stats as FSStats, ReadStream } from 'node:fs';
 import type { ServerResponse } from 'node:http';
+import { lookup } from 'mrmime';
 import onFinished from 'on-finished';
 import type { Range, Result as RangeResult, Ranges } from 'range-parser';
 import type { InternalContext, RequestHandler, Rspack } from '../../types';
@@ -33,8 +34,7 @@ function createReadStreamOrReadFileSync(
   return { bufferOrStream, byteLength };
 }
 
-async function getContentType(str: string): Promise<false | string> {
-  const { lookup } = await import('mrmime');
+function getContentType(str: string): false | string {
   let mime = lookup(str);
   if (!mime) {
     return false;
@@ -101,8 +101,6 @@ const parseRangeHeaders = async (
   });
 };
 
-const acceptedMethods = ['GET', 'HEAD'];
-
 function sendError(res: ServerResponse, code: number): void {
   const errorMessages: Record<number, string> = {
     [HttpCode.BadRequest]: 'Bad Request',
@@ -156,7 +154,7 @@ export function createAssetsMiddleware(
       });
     }
 
-    if (req.method && !acceptedMethods.includes(req.method)) {
+    if (req.method && req.method !== 'GET' && req.method !== 'HEAD') {
       await goNext();
       return;
     }
@@ -338,7 +336,7 @@ export function createAssetsMiddleware(
       let offset = 0;
 
       if (!res.getHeader('Content-Type')) {
-        const contentType = await getContentType(filename);
+        const contentType = getContentType(filename);
         if (contentType) {
           res.setHeader('Content-Type', contentType);
         }


### PR DESCRIPTION
## Summary

This PR reduces per-request overhead in the dev server static asset middleware by importing `mrmime.lookup` synchronously at module scope and replacing the small accepted-method array lookup with direct `GET` / `HEAD` checks. It also applies the same `mrmime` import cleanup in the app icon plugin.

In a local real dev server benchmark using `examples/vanilla` and `ab -k -n 3000 -c 50 /static/js/index.js`, static asset throughput improved from `15186.72 req/s` baseline average to `16326.49 req/s` current average. The median improved from `15125.21 req/s` to `16535.85 req/s`.