### PR TITLE
perf(core): improve dev asset stream throughput

### DIFF
--- a/packages/core/src/server/assets-middleware/middleware.ts
+++ b/packages/core/src/server/assets-middleware/middleware.ts
@@ -14,6 +14,10 @@ function getEtag(stat: FSStats): string {
   return `W/"${size}-${mtime}"`;
 }
 
+// Large dev bundles pay noticeable overhead when streamed in many small chunks.
+// Use a larger read buffer while still keeping responses streamed with backpressure.
+const READ_STREAM_HIGH_WATER_MARK = 512 * 1024;
+
 function createReadStreamOrReadFileSync(
   filename: string,
   outputFileSystem: Rspack.OutputFileSystem,
@@ -21,14 +25,15 @@ function createReadStreamOrReadFileSync(
   end: number,
   byteLength: number,
 ): { bufferOrStream: Buffer | ReadStream; byteLength: number } {
-  const bufferOrStream = (
-    outputFileSystem.createReadStream as (
-      p: string,
-      opts: { start: number; end: number },
-    ) => ReadStream
-  )(filename, {
+  const createReadStream = outputFileSystem.createReadStream as unknown as (
+    p: string,
+    opts: { start: number; end: number; highWaterMark: number },
+  ) => ReadStream;
+
+  const bufferOrStream = createReadStream(filename, {
     start,
     end,
+    highWaterMark: READ_STREAM_HIGH_WATER_MARK,
   });
 
   return { bufferOrStream, byteLength };


### PR DESCRIPTION
## Summary

This PR improves Rsbuild dev server static asset throughput for large bundles by increasing the output file stream `highWaterMark` to 512 KiB.

The response still uses streaming with backpressure; this only reduces chunk/event overhead when serving large dev assets.

Benchmark with a real `examples/react` dev server, keep-alive, concurrency 50, 2000 requests per sample, 12 samples. The workload used 50% `/static/js/index.js` (66,837 bytes) and 50% `/static/js/lib-react.js` (1,184,686 bytes):

| Case | avg req/s | median req/s |
| --- | ---: | ---: |
| 64 KiB stream buffer | 3046.70 | 3080.55 |
| 512 KiB stream buffer | 4050.90 | 4111.63 |

Average throughput improved by about 33.0% in this mixed static asset workload.

