### PR TITLE
perf(core): lazy load open editor middleware

### DIFF
--- a/packages/core/src/server/devMiddlewares.ts
+++ b/packages/core/src/server/devMiddlewares.ts
@@ -158,11 +158,23 @@ const applyDefaultMiddlewares = async ({
     middlewares.use(getBaseUrlMiddleware({ base: server.base }));
   }
 
-  const { default: launchEditorMiddleware } = await import(
-    /* webpackChunkName: "launch-editor-middleware" */
-    'launch-editor-middleware'
-  );
-  middlewares.use('/__open-in-editor', launchEditorMiddleware());
+  let launchEditorHandlerPromise: Promise<RequestHandler> | undefined;
+  const getLaunchEditorHandler = () => {
+    launchEditorHandlerPromise ??= (async () => {
+      const { default: launchEditorMiddleware } = await import(
+        /* webpackChunkName: "launch-editor-middleware" */
+        'launch-editor-middleware'
+      );
+      return launchEditorMiddleware();
+    })();
+
+    return launchEditorHandlerPromise;
+  };
+
+  middlewares.use('/__open-in-editor', async (req, res, next) => {
+    const handler = await getLaunchEditorHandler();
+    handler(req, res, next);
+  });
 
   middlewares.use(
     viewingServedFilesMiddleware({

--- a/packages/core/src/server/devMiddlewares.ts
+++ b/packages/core/src/server/devMiddlewares.ts
@@ -172,8 +172,12 @@ const applyDefaultMiddlewares = async ({
   };
 
   middlewares.use('/__open-in-editor', async (req, res, next) => {
-    const handler = await getLaunchEditorHandler();
-    handler(req, res, next);
+    try {
+      const handler = await getLaunchEditorHandler();
+      handler(req, res, next);
+    } catch (err) {
+      next(err);
+    }
   });
 
   middlewares.use(


### PR DESCRIPTION
## Summary

This PR defers loading `launch-editor-middleware` until `/__open-in-editor` is requested. The dev server no longer imports the editor middleware during startup when the endpoint is unused, reducing baseline dev-server module work while preserving the same request behavior.