### PR TITLE
fix(core): match if-range etag exactly

### DIFF
--- a/packages/core/src/server/assets-middleware/middleware.ts
+++ b/packages/core/src/server/assets-middleware/middleware.ts
@@ -177,7 +177,12 @@ function isRangeFresh(headers: IncomingHttpHeaders, res: ServerResponse): boolea
     if (!etag) {
       return true;
     }
-    return Boolean(etag && ifRange.indexOf(etag) !== -1);
+    // If-Range entity-tags require strong comparison. Weak validators should
+    // fall back to the full response instead of serving partial content.
+    if (ifRange.startsWith('W/') || etag.startsWith('W/')) {
+      return false;
+    }
+    return ifRange === etag;
   }
 
   const lastModified = res.getHeader('Last-Modified') as string | undefined;


### PR DESCRIPTION
## Summary

This PR fixes `If-Range` ETag validation in the dev assets middleware. The previous substring check could treat a different validator containing the current ETag as fresh, so range requests may incorrectly return `206 Partial Content`. The check now uses strong entity-tag comparison: weak validators fall back to the full response, while matching strong validators can still serve partial content.

This was found while reviewing #7851, but the issue already existed on `main`, so it is split into a standalone fix.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/7851