### PR TITLE
ci: use pinned pnpm setup action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,16 +23,16 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Install Pnpm
-        run: |
-          npm install -g corepack@latest --force
-          corepack enable
-
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.16.0
           package-manager-cache: false
+
+      - name: Install Pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          run_install: false
 
       - name: Install Dependencies
         run: pnpm install

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,10 +32,7 @@ jobs:
       - name: Install Pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          run_install: false
-
-      - name: Install Dependencies
-        run: pnpm install
+          run_install: true
 
       - name: Lint
         run: node --run lint

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -34,10 +34,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          run_install: false
-
-      - name: Install Dependencies
-        run: pnpm install
+          run_install: true
 
       - name: Publish Preview
         run: pnpx pkg-pr-new publish --pnpm ./packages/*

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -25,16 +25,16 @@ jobs:
           fetch-depth: 1
           ref: ${{ github.event.inputs.branch }}
 
-      - name: Install pnpm
-        run: |
-          npm install -g corepack@latest --force
-          corepack enable
-
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.16.0
           package-manager-cache: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          run_install: false
 
       - name: Install Dependencies
         run: pnpm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,16 +46,7 @@ jobs:
       - name: Setup Pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          run_install: false
-
-      # Update npm to the latest version to enable OIDC
-      - name: Update npm
-        run: |
-          npm install -g npm@latest
-          npm --version
-
-      - name: Install Dependencies
-        run: pnpm install
+          run_install: true
 
       - name: Publish to npm
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,16 +37,16 @@ jobs:
           fetch-depth: 1
           ref: ${{ github.event.inputs.branch }}
 
-      - name: Setup Pnpm
-        run: |
-          npm install -g corepack@latest --force
-          corepack enable
-
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.16.0
           package-manager-cache: false
+
+      - name: Setup Pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          run_install: false
 
       # Update npm to the latest version to enable OIDC
       - name: Update npm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,11 +33,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Install Pnpm
-        run: |
-          npm install -g corepack@latest --force
-          corepack enable
-
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         with:
@@ -55,6 +50,12 @@ jobs:
         with:
           node-version: 24.16.0
           package-manager-cache: false
+
+      - name: Install Pnpm
+        if: steps.changes.outputs.changed == 'true'
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          run_install: false
 
       - name: Install Dependencies
         if: steps.changes.outputs.changed == 'true'
@@ -80,11 +81,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Install Pnpm
-        run: |
-          npm install -g corepack@latest --force
-          corepack enable
-
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         with:
@@ -102,6 +98,12 @@ jobs:
         with:
           node-version: 24.16.0
           package-manager-cache: false
+
+      - name: Install Pnpm
+        if: steps.changes.outputs.changed == 'true'
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          run_install: false
 
       - name: Install Dependencies
         if: steps.changes.outputs.changed == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,11 +55,7 @@ jobs:
         if: steps.changes.outputs.changed == 'true'
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          run_install: false
-
-      - name: Install Dependencies
-        if: steps.changes.outputs.changed == 'true'
-        run: pnpm install
+          run_install: true
 
       - name: Unit Test
         if: steps.changes.outputs.changed == 'true'
@@ -103,11 +99,7 @@ jobs:
         if: steps.changes.outputs.changed == 'true'
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          run_install: false
-
-      - name: Install Dependencies
-        if: steps.changes.outputs.changed == 'true'
-        run: pnpm install
+          run_install: true
 
       - name: Run E2E tests
         if: steps.changes.outputs.changed == 'true'


### PR DESCRIPTION
## Summary

Use pinned `pnpm/action-setup` to install the pnpm version from `package.json#packageManager` and run dependency installation in the same action. This removes the previous global `corepack@latest` install path and the separate `pnpm install` steps.

The Test workflow still runs pnpm setup after `paths-filter`, so docs-only Test jobs can skip pnpm setup and dependency installation entirely. The Release workflow also drops the extra `npm@latest` update step because CI already runs on Node.js 24.

Latest CI passed. Combined setup + install timing is roughly neutral compared with the previous PR run: Windows UT 50s -> 57s, Windows E2E 62s -> 53s, macOS UT 33s -> 37s, Ubuntu E2E 24s -> 20s, Lint 21s -> 25s.