### PR TITLE
docs: add TanStack Start setup commands

### DIFF
--- a/website/docs/en/guide/framework/react.mdx
+++ b/website/docs/en/guide/framework/react.mdx
@@ -35,6 +35,14 @@ The following full-stack React frameworks are built on Rsbuild and reuse Rsbuild
 - [Basic example](https://github.com/rstackjs/rstack-examples/tree/main/rsbuild/tanstack-start)
 - [RSC example](https://github.com/rstackjs/rstack-examples/tree/main/rsbuild/tanstack-start-rsc)
 
+You can initialize the TanStack Start example project with:
+
+```bash
+pnpx degit https://github.com/rstackjs/rstack-examples/rsbuild/tanstack-start tanstack-start
+cd tanstack-start
+pnpm i
+```
+
 ### Modern.js
 
 [Modern.js](https://github.com/web-infra-dev/modern.js) is a progressive web framework built on Rsbuild that provides out-of-the-box full-stack development capabilities for React applications.

--- a/website/docs/en/guide/framework/solid.mdx
+++ b/website/docs/en/guide/framework/solid.mdx
@@ -34,6 +34,14 @@ The following full-stack Solid frameworks are built on Rsbuild and reuse Rsbuild
 - [Documentation](https://tanstack.com/start/latest)
 - [Example project](https://github.com/rstackjs/rstack-examples/tree/main/rsbuild/tanstack-start-solid)
 
+You can initialize the TanStack Start example project with:
+
+```bash
+pnpx degit https://github.com/rstackjs/rstack-examples/rsbuild/tanstack-start-solid tanstack-start
+cd tanstack-start
+pnpm i
+```
+
 ## Use Solid in an existing project
 
 To compile Solid components, you need to register the Rsbuild [Solid plugin](/plugins/list/plugin-solid). The plugin will automatically add the necessary configuration for Solid builds.

--- a/website/docs/zh/guide/framework/react.mdx
+++ b/website/docs/zh/guide/framework/react.mdx
@@ -35,6 +35,14 @@ import { PackageManagerTabs } from '@theme';
 - [基础示例](https://github.com/rstackjs/rstack-examples/tree/main/rsbuild/tanstack-start)
 - [RSC 示例](https://github.com/rstackjs/rstack-examples/tree/main/rsbuild/tanstack-start-rsc)
 
+你可以运行以下命令来一键初始化 TanStack Start 示例项目：
+
+```bash
+pnpx degit https://github.com/rstackjs/rstack-examples/rsbuild/tanstack-start tanstack-start
+cd tanstack-start
+pnpm i
+```
+
 ### Modern.js
 
 [Modern.js](https://github.com/web-infra-dev/modern.js) 是一个基于 Rsbuild 实现的渐进式 Web 开发框架，为 React 应用提供开箱即用的全栈开发能力。

--- a/website/docs/zh/guide/framework/solid.mdx
+++ b/website/docs/zh/guide/framework/solid.mdx
@@ -34,6 +34,14 @@ import { PackageManagerTabs } from '@theme';
 - [文档](https://tanstack.com/start/latest)
 - [示例项目](https://github.com/rstackjs/rstack-examples/tree/main/rsbuild/tanstack-start-solid)
 
+你可以运行以下命令来一键初始化 TanStack Start 示例项目：
+
+```bash
+pnpx degit https://github.com/rstackjs/rstack-examples/rsbuild/tanstack-start-solid tanstack-start
+cd tanstack-start
+pnpm i
+```
+
 ## 在已有项目中使用 Solid
 
 要编译 Solid 组件，需注册 Rsbuild 的 [Solid 插件](/plugins/list/plugin-solid)，插件会自动添加 Solid 构建所需的配置。


### PR DESCRIPTION
## Summary

Add setup snippets for TanStack Start example projects in the React and Solid framework docs, covering clone, directory change, and dependency installation commands in both English and Chinese docs.