### PR TITLE
docs: add full-stack framework guidance

### DIFF
--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -154,7 +154,7 @@ The following monorepo tools provide Rsbuild integrations or examples for creati
 
 ## Full-stack frameworks
 
-If your application needs full-stack capabilities, you can directly use a full-stack framework built on Rsbuild, such as [TanStack Start](https://tanstack.com/start/latest) or [Modern.js](https://github.com/web-infra-dev/modern.js). These frameworks reuse Rsbuild's plugin ecosystem and provide SSR, routing, and Server Functions.
+If your application needs full-stack capabilities, you can directly use a full-stack framework built on Rsbuild, such as [TanStack Start](https://tanstack.com/start/latest) or [Modern.js](https://github.com/web-infra-dev/modern.js). These frameworks build on Rsbuild and add higher-level application features, such as SSR and routing.
 
 - [React full-stack frameworks](/guide/framework/react#full-stack-frameworks)
 - [Solid full-stack frameworks](/guide/framework/solid#full-stack-frameworks)

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -152,7 +152,7 @@ The following monorepo tools provide Rsbuild integrations or examples for creati
 - [Nx](https://nx.dev/docs/technologies/build-tools/rsbuild/introduction) supports Rsbuild through the `@nx/rsbuild` plugin, including generators and executors for Nx workspaces.
 - [Turborepo](https://turborepo.dev/docs/guides/frameworks/rsbuild) provides examples and guides for creating Rsbuild applications and using Rsbuild with Module Federation.
 
-### Full-stack frameworks
+## Full-stack frameworks
 
 If your application needs full-stack capabilities, you can directly use a full-stack framework built on Rsbuild, such as [TanStack Start](https://tanstack.com/start/latest) or [Modern.js](https://github.com/web-infra-dev/modern.js). These frameworks reuse Rsbuild's plugin ecosystem and provide SSR, routing, and Server Functions.
 

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -152,6 +152,13 @@ The following monorepo tools provide Rsbuild integrations or examples for creati
 - [Nx](https://nx.dev/docs/technologies/build-tools/rsbuild/introduction) supports Rsbuild through the `@nx/rsbuild` plugin, including generators and executors for Nx workspaces.
 - [Turborepo](https://turborepo.dev/docs/guides/frameworks/rsbuild) provides examples and guides for creating Rsbuild applications and using Rsbuild with Module Federation.
 
+### Full-stack frameworks
+
+If your application needs full-stack capabilities, you can directly use a full-stack framework built on Rsbuild, such as [TanStack Start](https://tanstack.com/start/latest) or [Modern.js](https://github.com/web-infra-dev/modern.js). These frameworks reuse Rsbuild's plugin ecosystem and provide SSR, routing, and Server Functions.
+
+- [React full-stack frameworks](/guide/framework/react#full-stack-frameworks)
+- [Solid full-stack frameworks](/guide/framework/solid#full-stack-frameworks)
+
 ## Migrate from existing projects
 
 To migrate from an existing project to Rsbuild, refer to the following guides:

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -152,6 +152,13 @@ Optional skills:
 - [Nx](https://nx.dev/docs/technologies/build-tools/rsbuild/introduction) 通过 `@nx/rsbuild` 插件支持 Rsbuild，为 Nx 工作区提供生成器和执行器。
 - [Turborepo](https://turborepo.dev/docs/guides/frameworks/rsbuild) 提供创建 Rsbuild 应用和使用 Module Federation 的示例和指南。
 
+### 全栈框架 \{#full-stack-frameworks}
+
+如果你的应用需要全栈能力，可以直接使用基于 Rsbuild 的全栈框架，例如 [TanStack Start](https://tanstack.com/start/latest) 或 [Modern.js](https://github.com/web-infra-dev/modern.js)。这些框架复用 Rsbuild 的插件生态，并提供 SSR、路由、Server Functions 等能力。
+
+- [React 全栈框架](/guide/framework/react#full-stack-frameworks)
+- [Solid 全栈框架](/guide/framework/solid#full-stack-frameworks)
+
 ## 从现有项目迁移 \{#migrate-from-existing-projects}
 
 如需从现有项目迁移到 Rsbuild，参考以下指南：

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -154,7 +154,7 @@ Optional skills:
 
 ## 全栈框架 \{#full-stack-frameworks}
 
-如果你的应用需要全栈能力，可以直接使用基于 Rsbuild 的全栈框架，例如 [TanStack Start](https://tanstack.com/start/latest) 或 [Modern.js](https://github.com/web-infra-dev/modern.js)。这些框架复用 Rsbuild 的插件生态，并提供 SSR、路由、Server Functions 等能力。
+如果你的应用需要全栈能力，可以直接使用基于 Rsbuild 的全栈框架，例如 [TanStack Start](https://tanstack.com/start/latest) 或 [Modern.js](https://github.com/web-infra-dev/modern.js)。这类框架基于 Rsbuild 构建，并提供 SSR、路由等更高层的能力。
 
 - [React 全栈框架](/guide/framework/react#full-stack-frameworks)
 - [Solid 全栈框架](/guide/framework/solid#full-stack-frameworks)

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -152,7 +152,7 @@ Optional skills:
 - [Nx](https://nx.dev/docs/technologies/build-tools/rsbuild/introduction) 通过 `@nx/rsbuild` 插件支持 Rsbuild，为 Nx 工作区提供生成器和执行器。
 - [Turborepo](https://turborepo.dev/docs/guides/frameworks/rsbuild) 提供创建 Rsbuild 应用和使用 Module Federation 的示例和指南。
 
-### 全栈框架 \{#full-stack-frameworks}
+## 全栈框架 \{#full-stack-frameworks}
 
 如果你的应用需要全栈能力，可以直接使用基于 Rsbuild 的全栈框架，例如 [TanStack Start](https://tanstack.com/start/latest) 或 [Modern.js](https://github.com/web-infra-dev/modern.js)。这些框架复用 Rsbuild 的插件生态，并提供 SSR、路由、Server Functions 等能力。
 


### PR DESCRIPTION
## Summary

This PR updates the quick-start docs to guide users who need full-stack capabilities toward Rsbuild-based frameworks such as TanStack Start and Modern.js. It also links to the React and Solid full-stack framework sections and keeps the Chinese docs in sync.