### PR TITLE
docs: fix config option type labels

### DIFF
--- a/website/docs/en/config/output/minify.mdx
+++ b/website/docs/en/config/output/minify.mdx
@@ -10,9 +10,9 @@ description: 'Controls whether code minification is enabled, and provides config
 type Minify =
   | boolean
   | {
-      js?: boolean;
+      js?: boolean | 'always';
       jsOptions?: Rspack.SwcJsMinimizerRspackPluginOptions;
-      css?: boolean;
+      css?: boolean | 'always';
       cssOptions?: Rspack.LightningcssMinimizerRspackPluginOptions;
     };
 ```

--- a/website/docs/en/config/source/transform-import.mdx
+++ b/website/docs/en/config/source/transform-import.mdx
@@ -57,7 +57,7 @@ Will be transformed into:
 
 ```js
 import Button from 'antd/es/button';
-import 'antd/es/button/style';
+import 'antd/es/button/style/css';
 ```
 
 ### Import lodash on demand
@@ -139,10 +139,14 @@ import Button from 'foo/lib/button';
 
 ### style
 
-- **Type:** `boolean`
+- **Type:** `string | boolean`
 - **Default:** `undefined`
 
-Determines whether to import related styles. If it is `true`, the path `${libraryName}/${libraryDirectory}/${member}/style` will be imported. If it is `false` or `undefined`, the style will not be imported.
+Determines whether to import related styles:
+
+- `true`: import `${libraryName}/${libraryDirectory}/${member}/style`.
+- `'css'`: import `${libraryName}/${libraryDirectory}/${member}/style/css`.
+- `false` or `undefined`: do not import styles.
 
 When it is set to `true`:
 
@@ -156,6 +160,21 @@ Out:
 import Button from 'foo/lib/button';
 import 'foo/lib/button/style';
 ```
+
+When it is set to `'css'`:
+
+```ts
+import { Button } from 'foo';
+```
+
+Out:
+
+```ts
+import Button from 'foo/lib/button';
+import 'foo/lib/button/style/css';
+```
+
+For custom style import paths, use [customStyleName](#customstylename) or [styleLibraryDirectory](#stylelibrarydirectory).
 
 ### styleLibraryDirectory
 

--- a/website/docs/zh/config/output/minify.mdx
+++ b/website/docs/zh/config/output/minify.mdx
@@ -10,9 +10,9 @@ description: '用于设置开启代码压缩，以及提供选项来配置压缩
 type Minify =
   | boolean
   | {
-      js?: boolean;
+      js?: boolean | 'always';
       jsOptions?: Rspack.SwcJsMinimizerRspackPluginOptions;
-      css?: boolean;
+      css?: boolean | 'always';
       cssOptions?: Rspack.LightningcssMinimizerRspackPluginOptions;
     };
 ```
@@ -66,7 +66,7 @@ export default {
 
 ### minify.js
 
-- **类型：** `boolean`
+- **类型：** `boolean | 'always'`
 - **默认值：** `true`
 
 是否开启对 JavaScript 代码的压缩：
@@ -126,7 +126,7 @@ export default {
 
 ### minify.css
 
-- **类型：** `boolean`
+- **类型：** `boolean | 'always'`
 - **默认值：** `true`
 
 是否开启对 CSS 代码的压缩：

--- a/website/docs/zh/config/source/transform-import.mdx
+++ b/website/docs/zh/config/source/transform-import.mdx
@@ -59,7 +59,7 @@ import { Button } from 'antd';
 
 ```js
 import Button from 'antd/es/button';
-import 'antd/es/button/style';
+import 'antd/es/button/style/css';
 ```
 
 ### 按需引入 lodash
@@ -141,10 +141,14 @@ import Button from 'foo/lib/button';
 
 ### style
 
-- **类型：** `boolean`
+- **类型：** `string | boolean`
 - **默认值：** `undefined`
 
-确定是否需要引入相关样式，若为 `true`，则会引入路径 `${libraryName}/${libraryDirectory}/${member}/style`。若为 `false` 或 `undefined` 则不会引入样式。
+确定是否需要引入相关样式：
+
+- `true`：引入 `${libraryName}/${libraryDirectory}/${member}/style`。
+- `'css'`：引入 `${libraryName}/${libraryDirectory}/${member}/style/css`。
+- `false` 或 `undefined`：不引入样式。
 
 当配置为 `true` 时：
 
@@ -158,6 +162,21 @@ import { Button } from 'foo';
 import Button from 'foo/lib/button';
 import 'foo/lib/button/style';
 ```
+
+当配置为 `'css'` 时：
+
+```ts
+import { Button } from 'foo';
+```
+
+转换结果:
+
+```ts
+import Button from 'foo/lib/button';
+import 'foo/lib/button/style/css';
+```
+
+如果需要自定义样式引入路径，请使用 [customStyleName](#customstylename) 或 [styleLibraryDirectory](#stylelibrarydirectory)。
 
 ### styleLibraryDirectory
 


### PR DESCRIPTION
## Summary

This PR fixes config reference type labels for `output.minify` and `source.transformImport.style` in both English and Chinese docs. It also clarifies the verified `style: 'css'` transform result and points custom style paths to `customStyleName` or `styleLibraryDirectory`.