### PR TITLE
chore: add react plugin support metadata

### DIFF
--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -2,6 +2,10 @@
   "name": "@rsbuild/plugin-react",
   "version": "2.0.1",
   "description": "React plugin for Rsbuild",
+  "homepage": "https://rsbuild.rs",
+  "bugs": {
+    "url": "https://github.com/web-infra-dev/rsbuild/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- add npm `homepage` metadata for `@rsbuild/plugin-react`
- add npm `bugs.url` metadata pointing to the Rsbuild issue tracker

## Verification
- `node -e "JSON.parse(require('fs').readFileSync('packages/plugin-react/package.json','utf8')); console.log('package.json OK')"`
- `git diff --check`
