### PR TITLE
docs: update preset types guidance

### DIFF
--- a/website/docs/en/guide/advanced/env-vars.mdx
+++ b/website/docs/en/guide/advanced/env-vars.mdx
@@ -536,10 +536,14 @@ declare const PUBLIC_FOO: string;
 
 ### import.meta.env
 
-Rsbuild provides default TypeScript type definitions for `import.meta.env` through [Preset types](/guide/basic/typescript#preset-types).
+Rsbuild provides default TypeScript type definitions for `import.meta.env` through [Preset types](/guide/basic/typescript#preset-types). Add them to `tsconfig.json`:
 
-```ts title="src/env.d.ts"
-/// <reference types="@rsbuild/core/types" />
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["@rsbuild/core/types"]
+  }
+}
 ```
 
 If you have customized environment variables starting with `import.meta.env`, you can extend the `ImportMetaEnv` interface:
@@ -559,11 +563,9 @@ By default, Rsbuild's preset types allow you to access any property on `import.m
 
 For stricter type safety, you can enable the `strictImportMetaEnv` option by extending the `RsbuildTypeOptions` interface. When this option is enabled, only properties predefined by Rsbuild or explicitly declared in your project can be accessed. Accessing any other property will cause a TypeScript type error.
 
-You can add the following code to your `src/env.d.ts` file:
+You can add the following code to your `src/env.d.ts` file. Make sure the Rsbuild preset types are already included in `tsconfig.json`.
 
 ```ts title="src/env.d.ts"
-/// <reference types="@rsbuild/core/types" />
-
 interface RsbuildTypeOptions {
   strictImportMetaEnv: true;
 }

--- a/website/docs/en/guide/advanced/env-vars.mdx
+++ b/website/docs/en/guide/advanced/env-vars.mdx
@@ -546,6 +546,8 @@ Rsbuild provides default TypeScript type definitions for `import.meta.env` throu
 }
 ```
 
+If your project already has `compilerOptions.types`, append `@rsbuild/core/types` to the existing list.
+
 If you have customized environment variables starting with `import.meta.env`, you can extend the `ImportMetaEnv` interface:
 
 ```ts title="src/env.d.ts"

--- a/website/docs/en/guide/advanced/env-vars.mdx
+++ b/website/docs/en/guide/advanced/env-vars.mdx
@@ -565,7 +565,7 @@ By default, Rsbuild's preset types allow you to access any property on `import.m
 
 For stricter type safety, you can enable the `strictImportMetaEnv` option by extending the `RsbuildTypeOptions` interface. When this option is enabled, only properties predefined by Rsbuild or explicitly declared in your project can be accessed. Accessing any other property will cause a TypeScript type error.
 
-You can add the following code to your `src/env.d.ts` file. Make sure the Rsbuild preset types are already included in `tsconfig.json`.
+You can add the following code to your `src/env.d.ts` file. Make sure the [Rsbuild preset types](/guide/basic/typescript#preset-types) are already included in `tsconfig.json`.
 
 ```ts title="src/env.d.ts"
 interface RsbuildTypeOptions {

--- a/website/docs/en/guide/basic/json-files.mdx
+++ b/website/docs/en/guide/basic/json-files.mdx
@@ -98,12 +98,16 @@ console.log(example.foo); // { bar: 'baz' };
 
 ## Type declaration
 
-When you import YAML or TOML files in TypeScript code, please create a `src/env.d.ts` file in your project and add the corresponding type declarations.
+When you import YAML or TOML files in TypeScript code, use one of the following methods to add type declarations:
 
-- Method 1: If the `@rsbuild/core` package is installed, you can reference the [preset types](/guide/basic/typescript#preset-types) provided by `@rsbuild/core`:
+- Method 1: If the `@rsbuild/core` package is installed, you can add the [preset types](/guide/basic/typescript#preset-types) provided by `@rsbuild/core` to `tsconfig.json`:
 
-```ts title="src/env.d.ts"
-/// <reference types="@rsbuild/core/types" />
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["@rsbuild/core/types"]
+  }
+}
 ```
 
 - Method 2: Manually add the required type declarations:

--- a/website/docs/en/guide/basic/static-assets.mdx
+++ b/website/docs/en/guide/basic/static-assets.mdx
@@ -285,12 +285,16 @@ When you import static assets in TypeScript code, TypeScript may prompt that the
 TS2307: Cannot find module './logo.png' or its corresponding type declarations.
 ```
 
-To fix this, you need to add a type declaration file for the static assets, please create a `src/env.d.ts` file, and add the corresponding type declaration.
+To fix this, use one of the following methods:
 
-- Method 1: If the `@rsbuild/core` package is installed, you can reference the [preset types](/guide/basic/typescript#preset-types) provided by `@rsbuild/core`:
+- Method 1: If the `@rsbuild/core` package is installed, you can add the [preset types](/guide/basic/typescript#preset-types) provided by `@rsbuild/core` to `tsconfig.json`:
 
-```ts
-/// <reference types="@rsbuild/core/types" />
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["@rsbuild/core/types"]
+  }
+}
 ```
 
 - Method 2: Manually add the required type declarations:

--- a/website/docs/en/guide/basic/typescript.mdx
+++ b/website/docs/en/guide/basic/typescript.mdx
@@ -50,11 +50,17 @@ export type { SomeType } from './types';
 
 `@rsbuild/core` provides preset type definitions, including CSS files, CSS Modules, static assets, `import.meta`, and other types.
 
-Create a `src/env.d.ts` file to reference these types:
+Add the preset types to `compilerOptions.types` in `tsconfig.json`:
 
-```ts title="src/env.d.ts"
-/// <reference types="@rsbuild/core/types" />
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["@rsbuild/core/types"]
+  }
+}
 ```
+
+If your project already has `compilerOptions.types`, append `@rsbuild/core/types` to the existing list.
 
 > See [types.d.ts](https://github.com/web-infra-dev/rsbuild/blob/main/packages/core/types.d.ts) for the complete preset type definitions that Rsbuild includes.
 

--- a/website/docs/en/guide/basic/web-workers.mdx
+++ b/website/docs/en/guide/basic/web-workers.mdx
@@ -101,10 +101,14 @@ When you import workers with `?worker` in TypeScript code, TypeScript may prompt
 TS2307: Cannot find module './worker.ts?worker' or its corresponding type declarations.
 ```
 
-To fix this, add a type declaration file, such as `src/env.d.ts`, and reference the [preset types](/guide/basic/typescript#preset-types) provided by `@rsbuild/core`:
+To fix this, add the [preset types](/guide/basic/typescript#preset-types) provided by `@rsbuild/core` to `tsconfig.json`:
 
-```ts
-/// <reference types="@rsbuild/core/types" />
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["@rsbuild/core/types"]
+  }
+}
 ```
 
 The preset types include declarations for `*?worker`, `*?worker&inline`, and `*?inline&worker`.

--- a/website/docs/en/guide/migration/vite.mdx
+++ b/website/docs/en/guide/migration/vite.mdx
@@ -212,13 +212,14 @@ Rsbuild injects the following [environment variables](/guide/advanced/env-vars) 
 
 ## Preset types
 
-Vite provides some preset type definitions through the `vite-env.d.ts` file. When migrating to Rsbuild, you can use the [preset types](/guide/basic/typescript#preset-types) provided by `@rsbuild/core`:
+Vite provides some preset type definitions through `vite/client`. When migrating to Rsbuild, replace it with the [preset types](/guide/basic/typescript#preset-types) provided by `@rsbuild/core`:
 
-```ts title="src/env.d.ts"
-// [!code --]
-/// <reference types="vite/client" />
-// [!code ++]
-/// <reference types="@rsbuild/core/types" />
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["@rsbuild/core/types"]
+  }
+}
 ```
 
 ## Web Workers

--- a/website/docs/en/guide/migration/vite.mdx
+++ b/website/docs/en/guide/migration/vite.mdx
@@ -217,7 +217,8 @@ Vite provides some preset type definitions through `vite/client`. When migrating
 ```json title="tsconfig.json"
 {
   "compilerOptions": {
-    "types": ["@rsbuild/core/types"]
+    "types": ["vite/client"], // [!code --]
+    "types": ["@rsbuild/core/types"] // [!code ++]
   }
 }
 ```

--- a/website/docs/en/guide/optimization/inline-assets.mdx
+++ b/website/docs/en/guide/optimization/inline-assets.mdx
@@ -131,12 +131,16 @@ When you use URL queries such as `?inline` and `?url` in TypeScript code, TypeSc
 TS2307: Cannot find module './logo.png?inline' or its corresponding type declarations.
 ```
 
-To fix this, you can add type declarations for these URL queries. Create a `src/env.d.ts` file and add the following type declarations:
+To fix this, use one of the following methods:
 
-- Method 1: If the `@rsbuild/core` package is installed, you can reference the [preset types](/guide/basic/typescript#preset-types) provided by `@rsbuild/core`:
+- Method 1: If the `@rsbuild/core` package is installed, you can add the [preset types](/guide/basic/typescript#preset-types) provided by `@rsbuild/core` to `tsconfig.json`:
 
-```ts
-/// <reference types="@rsbuild/core/types" />
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["@rsbuild/core/types"]
+  }
+}
 ```
 
 - Method 2: Manually add the required type declarations:

--- a/website/docs/en/guide/styling/css-modules.mdx
+++ b/website/docs/en/guide/styling/css-modules.mdx
@@ -164,12 +164,16 @@ When you import CSS Modules in TypeScript code, TypeScript may prompt that the m
 TS2307: Cannot find module './index.module.css' or its corresponding type declarations.
 ```
 
-To fix this, you need to add a type declaration file for CSS Modules. Create a `src/env.d.ts` file and add the corresponding type declaration.
+To fix this, use one of the following methods:
 
-- Method 1: If the `@rsbuild/core` package is installed, you can reference the [preset types](/guide/basic/typescript#preset-types) provided by `@rsbuild/core`:
+- Method 1: If the `@rsbuild/core` package is installed, you can add the [preset types](/guide/basic/typescript#preset-types) provided by `@rsbuild/core` to `tsconfig.json`:
 
-```ts
-/// <reference types="@rsbuild/core/types" />
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["@rsbuild/core/types"]
+  }
+}
 ```
 
 - Method 2: Manually add the required type declarations:

--- a/website/docs/zh/guide/advanced/env-vars.mdx
+++ b/website/docs/zh/guide/advanced/env-vars.mdx
@@ -567,7 +567,7 @@ interface ImportMeta {
 
 如果希望获得更严格的类型安全，你可以通过扩展 `RsbuildTypeOptions` interface 来开启 `strictImportMetaEnv` 选项。开启后，只有 Rsbuild 预定义或你在项目中明确声明的属性才能被访问，访问其他属性会导致 TypeScript 类型错误。
 
-你可以在 `src/env.d.ts` 文件中添加以下代码。请确保已经在 `tsconfig.json` 中引入了 Rsbuild 预设类型。
+你可以在 `src/env.d.ts` 文件中添加以下代码。请确保已经在 `tsconfig.json` 中引入了 [Rsbuild 预设类型](/guide/basic/typescript#preset-types)。
 
 ```ts title="src/env.d.ts"
 interface RsbuildTypeOptions {

--- a/website/docs/zh/guide/advanced/env-vars.mdx
+++ b/website/docs/zh/guide/advanced/env-vars.mdx
@@ -538,10 +538,14 @@ declare const PUBLIC_FOO: string;
 
 ### import.meta.env
 
-Rsbuild 通过 [预设类型](/guide/basic/typescript#preset-types) 为 `import.meta.env` 提供了默认的 TypeScript 类型定义。
+Rsbuild 通过 [预设类型](/guide/basic/typescript#preset-types) 为 `import.meta.env` 提供了默认的 TypeScript 类型定义。你可以在 `tsconfig.json` 中添加：
 
-```ts title="src/env.d.ts"
-/// <reference types="@rsbuild/core/types" />
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["@rsbuild/core/types"]
+  }
+}
 ```
 
 如果你自定义了以 `import.meta.env` 开头的环境变量，可以通过扩展 `ImportMetaEnv` interface 来实现：
@@ -561,11 +565,9 @@ interface ImportMeta {
 
 如果希望获得更严格的类型安全，你可以通过扩展 `RsbuildTypeOptions` interface 来开启 `strictImportMetaEnv` 选项。开启后，只有 Rsbuild 预定义或你在项目中明确声明的属性才能被访问，访问其他属性会导致 TypeScript 类型错误。
 
-你可以在 `src/env.d.ts` 文件中添加以下代码：
+你可以在 `src/env.d.ts` 文件中添加以下代码。请确保已经在 `tsconfig.json` 中引入了 Rsbuild 预设类型。
 
 ```ts title="src/env.d.ts"
-/// <reference types="@rsbuild/core/types" />
-
 interface RsbuildTypeOptions {
   strictImportMetaEnv: true;
 }

--- a/website/docs/zh/guide/advanced/env-vars.mdx
+++ b/website/docs/zh/guide/advanced/env-vars.mdx
@@ -548,6 +548,8 @@ Rsbuild 通过 [预设类型](/guide/basic/typescript#preset-types) 为 `import.
 }
 ```
 
+如果你的项目中已经配置了 `compilerOptions.types`，请将 `@rsbuild/core/types` 追加到已有列表中。
+
 如果你自定义了以 `import.meta.env` 开头的环境变量，可以通过扩展 `ImportMetaEnv` interface 来实现：
 
 ```ts title="src/env.d.ts"

--- a/website/docs/zh/guide/basic/json-files.mdx
+++ b/website/docs/zh/guide/basic/json-files.mdx
@@ -98,12 +98,16 @@ console.log(example.foo); // { bar: 'baz' };
 
 ## 类型声明
 
-当你在 TypeScript 代码中引用 YAML 或 TOML 文件时，请在项目中创建 `src/env.d.ts` 文件，并添加相应的类型声明。
+当你在 TypeScript 代码中引用 YAML 或 TOML 文件时，可以使用以下任一方法添加类型声明：
 
-- 方法一：如果项目里安装了 `@rsbuild/core` 包，你可以直接引用 `@rsbuild/core` 提供的 [预设类型](/guide/basic/typescript#preset-types)：
+- 方法一：如果项目里安装了 `@rsbuild/core` 包，你可以在 `tsconfig.json` 中添加 `@rsbuild/core` 提供的 [预设类型](/guide/basic/typescript#preset-types)：
 
-```ts title="src/env.d.ts"
-/// <reference types="@rsbuild/core/types" />
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["@rsbuild/core/types"]
+  }
+}
 ```
 
 - 方法二：手动添加需要的类型声明：

--- a/website/docs/zh/guide/basic/static-assets.mdx
+++ b/website/docs/zh/guide/basic/static-assets.mdx
@@ -285,12 +285,16 @@ export default {
 TS2307: Cannot find module './logo.png' or its corresponding type declarations.
 ```
 
-此时你需要为静态资源添加类型声明文件，请在项目中创建 `src/env.d.ts` 文件，并添加相应的类型声明。
+此时你可以使用以下任一方法添加类型声明：
 
-- 方法一：如果项目里安装了 `@rsbuild/core` 包，你可以直接引用 `@rsbuild/core` 提供的 [预设类型](/guide/basic/typescript#preset-types)：
+- 方法一：如果项目里安装了 `@rsbuild/core` 包，你可以在 `tsconfig.json` 中添加 `@rsbuild/core` 提供的 [预设类型](/guide/basic/typescript#preset-types)：
 
-```ts
-/// <reference types="@rsbuild/core/types" />
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["@rsbuild/core/types"]
+  }
+}
 ```
 
 - 方法二：手动添加需要的类型声明：

--- a/website/docs/zh/guide/basic/typescript.mdx
+++ b/website/docs/zh/guide/basic/typescript.mdx
@@ -50,11 +50,17 @@ export type { SomeType } from './types';
 
 `@rsbuild/core` 提供了一些预设的类型定义，包含 CSS 文件、CSS Modules、静态资源、`import.meta` 等类型。
 
-你可以创建一个 `src/env.d.ts` 文件来引用：
+你可以在 `tsconfig.json` 的 `compilerOptions.types` 中添加这些预设类型：
 
-```ts title="src/env.d.ts"
-/// <reference types="@rsbuild/core/types" />
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["@rsbuild/core/types"]
+  }
+}
 ```
+
+如果你的项目中已经配置了 `compilerOptions.types`，请将 `@rsbuild/core/types` 追加到已有列表中。
 
 > 参考 [types.d.ts](https://github.com/web-infra-dev/rsbuild/blob/main/packages/core/types.d.ts) 来了解 Rsbuild 提供的完整预设类型定义。
 

--- a/website/docs/zh/guide/basic/web-workers.mdx
+++ b/website/docs/zh/guide/basic/web-workers.mdx
@@ -101,10 +101,14 @@ worker.postMessage(10);
 TS2307: Cannot find module './worker.ts?worker' or its corresponding type declarations.
 ```
 
-此时你需要添加类型声明文件，例如创建 `src/env.d.ts`，并引用 `@rsbuild/core` 提供的 [预设类型](/guide/basic/typescript#preset-types)：
+此时你需要在 `tsconfig.json` 中添加 `@rsbuild/core` 提供的 [预设类型](/guide/basic/typescript#preset-types)：
 
-```ts
-/// <reference types="@rsbuild/core/types" />
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["@rsbuild/core/types"]
+  }
+}
 ```
 
 预设类型中已包含 `*?worker`、`*?worker&inline` 和 `*?inline&worker` 的类型声明。

--- a/website/docs/zh/guide/migration/vite.mdx
+++ b/website/docs/zh/guide/migration/vite.mdx
@@ -217,7 +217,8 @@ Vite 通过 `vite/client` 提供了一些预设的类型定义，迁移到 Rsbui
 ```json title="tsconfig.json"
 {
   "compilerOptions": {
-    "types": ["@rsbuild/core/types"]
+    "types": ["vite/client"], // [!code --]
+    "types": ["@rsbuild/core/types"] // [!code ++]
   }
 }
 ```

--- a/website/docs/zh/guide/migration/vite.mdx
+++ b/website/docs/zh/guide/migration/vite.mdx
@@ -212,13 +212,14 @@ Rsbuild 默认注入了以下 [环境变量](/guide/advanced/env-vars)：
 
 ## 预设类型
 
-Vite 通过 `vite-env.d.ts` 文件提供了一些预设的类型定义，迁移到 Rsbuild 时，你可以使用 `@rsbuild/core` 提供的 [预设类型](/guide/basic/typescript#preset-types)：
+Vite 通过 `vite/client` 提供了一些预设的类型定义，迁移到 Rsbuild 时，你可以将它替换为 `@rsbuild/core` 提供的 [预设类型](/guide/basic/typescript#preset-types)：
 
-```ts title="src/env.d.ts"
-// [!code --]
-/// <reference types="vite/client" />
-// [!code ++]
-/// <reference types="@rsbuild/core/types" />
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["@rsbuild/core/types"]
+  }
+}
 ```
 
 ## Web Workers

--- a/website/docs/zh/guide/optimization/inline-assets.mdx
+++ b/website/docs/zh/guide/optimization/inline-assets.mdx
@@ -131,12 +131,16 @@ export default {
 TS2307: Cannot find module './logo.png?inline' or its corresponding type declarations.
 ```
 
-此时你需要为这些 URL 参数添加类型声明，请在项目中创建 `src/env.d.ts` 文件，并添加类型声明。
+此时你可以使用以下任一方法添加类型声明：
 
-- 方法一：如果项目里安装了 `@rsbuild/core` 包，你可以直接引用 `@rsbuild/core` 提供的 [预设类型](/guide/basic/typescript#preset-types)：
+- 方法一：如果项目里安装了 `@rsbuild/core` 包，你可以在 `tsconfig.json` 中添加 `@rsbuild/core` 提供的 [预设类型](/guide/basic/typescript#preset-types)：
 
-```ts
-/// <reference types="@rsbuild/core/types" />
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["@rsbuild/core/types"]
+  }
+}
 ```
 
 - 方法二：手动添加需要的类型声明：

--- a/website/docs/zh/guide/styling/css-modules.mdx
+++ b/website/docs/zh/guide/styling/css-modules.mdx
@@ -164,12 +164,16 @@ CSS Modules 提供了 `:global()` 伪类选择器来实现这个功能，`:globa
 TS2307: Cannot find module './index.module.css' or its corresponding type declarations.
 ```
 
-此时你需要为 CSS Modules 添加类型声明文件，请在项目中创建 `src/env.d.ts` 文件，并添加相应的类型声明。
+此时你可以使用以下任一方法添加类型声明：
 
-- 方法一：如果项目里安装了 `@rsbuild/core` 包，你可以直接引用 `@rsbuild/core` 提供的 [预设类型](/guide/basic/typescript#preset-types)：
+- 方法一：如果项目里安装了 `@rsbuild/core` 包，你可以在 `tsconfig.json` 中添加 `@rsbuild/core` 提供的 [预设类型](/guide/basic/typescript#preset-types)：
 
-```ts
-/// <reference types="@rsbuild/core/types" />
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["@rsbuild/core/types"]
+  }
+}
 ```
 
 - 方法二：手动添加需要的类型声明：


### PR DESCRIPTION
## Summary

This PR updates the TypeScript preset types documentation to recommend adding `@rsbuild/core/types` through `compilerOptions.types` in `tsconfig.json`. It also updates related guide pages so `src/env.d.ts` is used only for project-specific declarations or interface extensions.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/7871