### PR TITLE
feat(create-rsbuild): use vue-tsc in Vue template

### DIFF
--- a/e2e/cases/create-rsbuild/helper.ts
+++ b/e2e/cases/create-rsbuild/helper.ts
@@ -4,10 +4,14 @@ import path from 'node:path';
 import { CREATE_RSBUILD_BIN_PATH, expect } from '@e2e/helper';
 import fse from 'fs-extra';
 
-export const expectPackageJson = (pkgJson: Record<string, any>, name: string) => {
+export const expectPackageJson = (
+  pkgJson: Record<string, any>,
+  name: string,
+  expectedBuildScript = 'rsbuild build',
+) => {
   expect(pkgJson.name).toBe(name);
   expect(pkgJson.scripts.dev).toBe('rsbuild --open');
-  expect(pkgJson.scripts.build).toBe('rsbuild build');
+  expect(pkgJson.scripts.build).toBe(expectedBuildScript);
   expect(pkgJson.devDependencies['@rsbuild/core']).toBeTruthy();
 };
 
@@ -18,10 +22,12 @@ export const createAndValidate = async (
     name = `test-temp-${template}`,
     tools = [],
     clean = true,
+    expectedBuildScript,
   }: {
     name?: string;
     tools?: string[];
     clean?: boolean;
+    expectedBuildScript?: string;
   } = {},
 ) => {
   const dir = path.join(cwd, name);
@@ -44,7 +50,7 @@ export const createAndValidate = async (
   });
 
   const pkgJson = await fse.readJSON(path.join(dir, 'package.json'));
-  expectPackageJson(pkgJson, path.basename(name));
+  expectPackageJson(pkgJson, path.basename(name), expectedBuildScript);
 
   if (template.endsWith('-ts')) {
     expect(pkgJson.devDependencies.typescript).toBeTruthy();

--- a/e2e/cases/create-rsbuild/tools.test.ts
+++ b/e2e/cases/create-rsbuild/tools.test.ts
@@ -123,6 +123,7 @@ test('should create Vue project with ESLint as expected', async () => {
     name: 'test-temp-vue-eslint',
     tools: ['eslint'],
     clean: false,
+    expectedBuildScript: 'vue-tsc && rsbuild build',
   });
   expect(pkgJson.devDependencies.eslint).toBeTruthy();
   expect(pkgJson.devDependencies['eslint-plugin-vue']).toBeTruthy();

--- a/e2e/cases/create-rsbuild/tsTemplates.test.ts
+++ b/e2e/cases/create-rsbuild/tsTemplates.test.ts
@@ -15,13 +15,17 @@ test('should create preact-ts project as expected', async () => {
 });
 
 test('should create vue-ts project as expected', async () => {
-  const { pkgJson } = await createAndValidate(import.meta.dirname, 'vue-ts');
+  const { pkgJson } = await createAndValidate(import.meta.dirname, 'vue-ts', {
+    expectedBuildScript: 'vue-tsc && rsbuild build',
+  });
   expect(pkgJson.dependencies.vue).toBeTruthy();
   expect(pkgJson.devDependencies['@rsbuild/plugin-vue']).toBeTruthy();
 });
 
 test('should create vue3-ts project alias as expected', async () => {
-  const { pkgJson } = await createAndValidate(import.meta.dirname, 'vue3-ts');
+  const { pkgJson } = await createAndValidate(import.meta.dirname, 'vue3-ts', {
+    expectedBuildScript: 'vue-tsc && rsbuild build',
+  });
   expect(pkgJson.dependencies.vue).toBeTruthy();
   expect(pkgJson.devDependencies['@rsbuild/plugin-vue']).toBeTruthy();
 });

--- a/packages/create-rsbuild/template-vue-ts/package.json
+++ b/packages/create-rsbuild/template-vue-ts/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "rsbuild build",
+    "build": "vue-tsc && rsbuild build",
     "dev": "rsbuild --open",
     "preview": "rsbuild preview"
   },
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@rsbuild/core": "^2.0.11",
     "@rsbuild/plugin-vue": "^1.2.9",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vue-tsc": "^3.3.3"
   }
 }

--- a/packages/create-rsbuild/template-vue-ts/src/env.d.ts
+++ b/packages/create-rsbuild/template-vue-ts/src/env.d.ts
@@ -1,6 +1,0 @@
-declare module '*.vue' {
-  import type { DefineComponent } from 'vue';
-
-  const component: DefineComponent;
-  export default component;
-}

--- a/packages/create-rsbuild/template-vue-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-vue-ts/tsconfig.json
@@ -20,5 +20,5 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true
   },
-  "include": ["src"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"]
 }


### PR DESCRIPTION
## Summary

This PR updates the create-rsbuild Vue TypeScript template to run Vue-aware type checking before production builds. It removes the generic `*.vue` declaration shim, adds `vue-tsc` as a dev dependency, and includes Vue SFC files explicitly in the template TypeScript config.