### PR TITLE
feat(create-rsbuild): add Node types to TS templates

### DIFF
--- a/packages/create-rsbuild/template-lit-ts/package.json
+++ b/packages/create-rsbuild/template-lit-ts/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "^2.0.11",
+    "@types/node": "^24.13.1",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/create-rsbuild/template-lit-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-lit-ts/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "ES2020",
     "noEmit": true,
     "skipLibCheck": true,
-    "types": ["@rsbuild/core/types"],
+    "types": ["@rsbuild/core/types", "node"],
     "experimentalDecorators": true,
     "useDefineForClassFields": false,
 

--- a/packages/create-rsbuild/template-preact-ts/package.json
+++ b/packages/create-rsbuild/template-preact-ts/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@rsbuild/core": "^2.0.11",
     "@rsbuild/plugin-preact": "^2.0.0",
+    "@types/node": "^24.13.1",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/create-rsbuild/template-preact-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-preact-ts/tsconfig.json
@@ -5,7 +5,7 @@
     "target": "ES2020",
     "noEmit": true,
     "skipLibCheck": true,
-    "types": ["@rsbuild/core/types"],
+    "types": ["@rsbuild/core/types", "node"],
     "jsxImportSource": "preact",
     "useDefineForClassFields": true,
 

--- a/packages/create-rsbuild/template-react-ts/package.json
+++ b/packages/create-rsbuild/template-react-ts/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@rsbuild/core": "^2.0.11",
     "@rsbuild/plugin-react": "^2.0.1",
+    "@types/node": "^24.13.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "typescript": "^6.0.3"

--- a/packages/create-rsbuild/template-react-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-react-ts/tsconfig.json
@@ -5,7 +5,7 @@
     "target": "ES2020",
     "noEmit": true,
     "skipLibCheck": true,
-    "types": ["@rsbuild/core/types"],
+    "types": ["@rsbuild/core/types", "node"],
     "useDefineForClassFields": true,
 
     /* modules */

--- a/packages/create-rsbuild/template-solid-ts/package.json
+++ b/packages/create-rsbuild/template-solid-ts/package.json
@@ -15,6 +15,7 @@
     "@rsbuild/core": "^2.0.11",
     "@rsbuild/plugin-babel": "^1.2.1",
     "@rsbuild/plugin-solid": "^1.2.2",
+    "@types/node": "^24.13.1",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/create-rsbuild/template-solid-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-solid-ts/tsconfig.json
@@ -5,7 +5,7 @@
     "target": "ES2020",
     "noEmit": true,
     "skipLibCheck": true,
-    "types": ["@rsbuild/core/types"],
+    "types": ["@rsbuild/core/types", "node"],
     "jsxImportSource": "solid-js",
     "useDefineForClassFields": true,
 

--- a/packages/create-rsbuild/template-svelte-ts/package.json
+++ b/packages/create-rsbuild/template-svelte-ts/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@rsbuild/core": "^2.0.11",
     "@rsbuild/plugin-svelte": "^2.0.0",
+    "@types/node": "^24.13.1",
     "svelte-check": "^4.6.0",
     "typescript": "^6.0.3"
   }

--- a/packages/create-rsbuild/template-svelte-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-svelte-ts/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "ES2022",
     "noEmit": true,
     "skipLibCheck": true,
-    "types": ["@rsbuild/core/types", "svelte"],
+    "types": ["@rsbuild/core/types", "node", "svelte"],
     "useDefineForClassFields": true,
 
     /* modules */

--- a/packages/create-rsbuild/template-vanilla-ts/package.json
+++ b/packages/create-rsbuild/template-vanilla-ts/package.json
@@ -10,6 +10,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "^2.0.11",
+    "@types/node": "^24.13.1",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/create-rsbuild/template-vanilla-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-vanilla-ts/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "ES2020",
     "noEmit": true,
     "skipLibCheck": true,
-    "types": ["@rsbuild/core/types"],
+    "types": ["@rsbuild/core/types", "node"],
     "useDefineForClassFields": true,
 
     /* modules */

--- a/packages/create-rsbuild/template-vue-ts/package.json
+++ b/packages/create-rsbuild/template-vue-ts/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@rsbuild/core": "^2.0.11",
     "@rsbuild/plugin-vue": "^1.2.9",
+    "@types/node": "^24.13.1",
     "typescript": "^6.0.3",
     "vue-tsc": "^3.3.3"
   }

--- a/packages/create-rsbuild/template-vue-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-vue-ts/tsconfig.json
@@ -5,7 +5,7 @@
     "target": "ES2020",
     "noEmit": true,
     "skipLibCheck": true,
-    "types": ["@rsbuild/core/types"],
+    "types": ["@rsbuild/core/types", "node"],
     "jsxImportSource": "vue",
     "useDefineForClassFields": true,
 


### PR DESCRIPTION
## Summary

This PR adds Node.js type declarations to the TypeScript create-rsbuild templates without changing the existing tsconfig include scope. The templates now install `@types/node` and add `node` to the explicit `types` list, while continuing to type-check only the current source files matched by each template tsconfig.