### PR TITLE
test: add transformImport ignore component e2e

### DIFF
--- a/e2e/cases/source/transform-import-ignore-component/foo/index.js
+++ b/e2e/cases/source/transform-import-ignore-component/foo/index.js
@@ -1,0 +1,1 @@
+export const IgnoredScript = 'ignoreEsComponent test succeed';

--- a/e2e/cases/source/transform-import-ignore-component/foo/lib/button.js
+++ b/e2e/cases/source/transform-import-ignore-component/foo/lib/button.js
@@ -1,0 +1,1 @@
+export default 'transformImport button component succeed';

--- a/e2e/cases/source/transform-import-ignore-component/foo/lib/button/style/index.js
+++ b/e2e/cases/source/transform-import-ignore-component/foo/lib/button/style/index.js
@@ -1,0 +1,1 @@
+console.log('transformImport button style succeed');

--- a/e2e/cases/source/transform-import-ignore-component/foo/lib/ignored-style.js
+++ b/e2e/cases/source/transform-import-ignore-component/foo/lib/ignored-style.js
@@ -1,0 +1,1 @@
+export default 'ignoreStyleComponent JS import succeed';

--- a/e2e/cases/source/transform-import-ignore-component/foo/lib/ignored-style/style/index.js
+++ b/e2e/cases/source/transform-import-ignore-component/foo/lib/ignored-style/style/index.js
@@ -1,0 +1,1 @@
+console.log('ignoreStyleComponent style import should not be bundled');

--- a/e2e/cases/source/transform-import-ignore-component/index.test.ts
+++ b/e2e/cases/source/transform-import-ignore-component/index.test.ts
@@ -1,0 +1,44 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { expect, test } from '@e2e/helper';
+import fse from 'fs-extra';
+
+function copyPkgToNodeModules() {
+  const nodeModules = path.resolve(import.meta.dirname, 'node_modules');
+  const target = path.resolve(nodeModules, 'foo');
+
+  fse.removeSync(target);
+  fse.ensureDirSync(nodeModules);
+  fs.cpSync(path.resolve(import.meta.dirname, 'foo'), target, {
+    recursive: true,
+  });
+}
+
+test('should support ignoreEsComponent and ignoreStyleComponent', async ({ build }) => {
+  copyPkgToNodeModules();
+
+  const rsbuild = await build({
+    config: {
+      source: {
+        transformImport: [
+          {
+            libraryName: 'foo',
+            libraryDirectory: 'lib',
+            style: true,
+            ignoreEsComponent: ['IgnoredScript'],
+            ignoreStyleComponent: ['IgnoredStyle'],
+          },
+        ],
+      },
+      splitChunks: false,
+    },
+  });
+  const content = await rsbuild.getIndexBundle();
+
+  expect(content).toContain('ignoreEsComponent test succeed');
+  expect(content).toContain('transformImport button component succeed');
+  expect(content).toContain('transformImport button style succeed');
+  expect(content).toContain('ignoreStyleComponent JS import succeed');
+  expect(content).not.toContain('ignoreStyleComponent style import should not be bundled');
+});

--- a/e2e/cases/source/transform-import-ignore-component/src/index.js
+++ b/e2e/cases/source/transform-import-ignore-component/src/index.js
@@ -1,0 +1,3 @@
+import { Button, IgnoredScript, IgnoredStyle } from 'foo';
+
+console.log(Button, IgnoredScript, IgnoredStyle);


### PR DESCRIPTION
## Summary

Add a focused e2e case for `source.transformImport.ignoreEsComponent` and `source.transformImport.ignoreStyleComponent`. The fixture verifies that ignored JavaScript imports stay on the package root, while style-only ignores still transform the JavaScript import and skip the related style side effect.