### PR TITLE
chore: configure VS Code JS formatter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,5 +25,11 @@
       "fileMatch": ["**/_nav.json"],
       "url": "./website/node_modules/@rspress/core/nav-json-schema.json"
     }
-  ]
+  ],
+  "[typescript]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  }
 }


### PR DESCRIPTION
## Summary

This PR configures the workspace VS Code settings to use the Oxc extension as the default formatter for JavaScript and TypeScript files, keeping editor formatting aligned with the repository's Oxfmt/Oxc tooling.