### PR TITLE
fix(core): infer lazy compilation server URL from client

### DIFF
--- a/e2e/cases/lazy-compilation/client-url/index.test.ts
+++ b/e2e/cases/lazy-compilation/client-url/index.test.ts
@@ -1,0 +1,122 @@
+import { createServer, type Server } from 'node:http';
+import { expect, getRandomPort, gotoPage, test } from '@e2e/helper';
+
+const listen = (server: Server, port: number) =>
+  new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, 'localhost', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+
+const close = (server: Server) =>
+  new Promise<void>((resolve, reject) => {
+    server.close((err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      resolve();
+    });
+  });
+
+test('should use dev.client URL for lazy compilation trigger requests', async ({
+  page,
+  devOnly,
+}) => {
+  const rsbuildPort = await getRandomPort();
+  const backendPort = await getRandomPort();
+  const lazyTriggerRequests: string[] = [];
+
+  page.on('request', (request) => {
+    if (request.url().includes('/_rspack/lazy/trigger')) {
+      lazyTriggerRequests.push(request.url());
+    }
+  });
+
+  const rsbuild = await devOnly({
+    config: {
+      server: {
+        port: rsbuildPort,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+        },
+      },
+      dev: {
+        assetPrefix: `http://localhost:${rsbuildPort}`,
+        client: {
+          port: rsbuildPort,
+        },
+      },
+    },
+  });
+
+  const htmlResponse = await fetch(`http://localhost:${rsbuild.port}/index.html`);
+  expect(htmlResponse.ok).toBeTruthy();
+
+  const html = await htmlResponse.text();
+  const backendServer = createServer((req, res) => {
+    if (req.url === '/' || req.url === '/index.html') {
+      res.setHeader('Content-Type', 'text/html');
+      res.end(html);
+      return;
+    }
+
+    res.statusCode = 404;
+    res.end('Not found');
+  });
+
+  await listen(backendServer, backendPort);
+
+  try {
+    await page.goto(`http://localhost:${backendPort}`);
+    await expect(page.locator('#result')).toHaveText('initial');
+
+    await page.locator('#load').click();
+    await rsbuild.expectLog('building src/lazy.js', { posix: true });
+    await rsbuild.expectBuildEnd();
+
+    await expect(page.locator('#result')).toHaveText('lazy loaded');
+    expect(lazyTriggerRequests).toContain(`http://localhost:${rsbuildPort}/_rspack/lazy/trigger`);
+  } finally {
+    await close(backendServer);
+  }
+});
+
+test('should prefer lazyCompilation.serverUrl over dev.client URL', async ({ page, devOnly }) => {
+  const wrongClientPort = await getRandomPort();
+  const lazyTriggerRequests: string[] = [];
+
+  page.on('request', (request) => {
+    if (request.url().includes('/_rspack/lazy/trigger')) {
+      lazyTriggerRequests.push(request.url());
+    }
+  });
+
+  const rsbuild = await devOnly({
+    config: {
+      dev: {
+        client: {
+          port: wrongClientPort,
+        },
+        lazyCompilation: {
+          imports: true,
+          entries: false,
+          serverUrl: 'http://localhost:<port>',
+        },
+      },
+    },
+  });
+
+  await gotoPage(page, rsbuild);
+  await expect(page.locator('#result')).toHaveText('initial');
+
+  await page.locator('#load').click();
+  await rsbuild.expectLog('building src/lazy.js', { posix: true });
+  await rsbuild.expectBuildEnd();
+
+  await expect(page.locator('#result')).toHaveText('lazy loaded');
+  expect(lazyTriggerRequests).toContain(`http://localhost:${rsbuild.port}/_rspack/lazy/trigger`);
+});

--- a/e2e/cases/lazy-compilation/client-url/src/index.js
+++ b/e2e/cases/lazy-compilation/client-url/src/index.js
@@ -1,0 +1,9 @@
+document.querySelector('#root').innerHTML = `
+  <button id="load" type="button">load</button>
+  <div id="result">initial</div>
+`;
+
+document.querySelector('#load').addEventListener('click', async () => {
+  const { value } = await import('./lazy');
+  document.querySelector('#result').textContent = value;
+});

--- a/e2e/cases/lazy-compilation/client-url/src/lazy.js
+++ b/e2e/cases/lazy-compilation/client-url/src/lazy.js
@@ -1,0 +1,1 @@
+export const value = 'lazy loaded';

--- a/packages/core/src/plugins/lazyCompilation.ts
+++ b/packages/core/src/plugins/lazyCompilation.ts
@@ -1,5 +1,30 @@
+import { getHostInUrl } from '../server/helper';
 import { replacePortPlaceholder } from '../server/open';
-import type { RsbuildPlugin } from '../types';
+import type { NormalizedEnvironmentConfig, RsbuildContext, RsbuildPlugin } from '../types';
+
+const getServerUrlFromClientConfig = async (
+  config: NormalizedEnvironmentConfig,
+  context: RsbuildContext,
+): Promise<string | undefined> => {
+  const { devServer } = context;
+  if (!devServer) {
+    return;
+  }
+
+  const { client } = config.dev;
+  const hasClientHost = Boolean(client.host);
+  const hasClientPort = client.port !== undefined && client.port !== '';
+
+  if (!hasClientHost && !hasClientPort) {
+    return;
+  }
+
+  const protocol = client.protocol ? `${client.protocol === 'wss' ? 'https' : 'http'}:` : '';
+  const hostname = await getHostInUrl(client.host || devServer.hostname);
+  const port = client.port && client.port !== '<port>' ? client.port : devServer.port;
+
+  return `${protocol}//${hostname}:${port}`;
+};
 
 export const pluginLazyCompilation = (): RsbuildPlugin => ({
   name: 'rsbuild:lazy-compilation',
@@ -7,7 +32,7 @@ export const pluginLazyCompilation = (): RsbuildPlugin => ({
   apply: 'serve',
 
   setup(api) {
-    api.modifyBundlerChain((chain, { environment, target }) => {
+    api.modifyBundlerChain(async (chain, { environment, target }) => {
       if (target !== 'web') {
         return;
       }
@@ -21,6 +46,7 @@ export const pluginLazyCompilation = (): RsbuildPlugin => ({
 
       if (options === true) {
         const entries = chain.entryPoints.entries() || {};
+        const serverUrl = await getServerUrlFromClientConfig(config, api.context);
 
         // If there is only one entry, do not enable lazy compilation for entries
         // this can reduce the rebuild time
@@ -28,6 +54,16 @@ export const pluginLazyCompilation = (): RsbuildPlugin => ({
           chain.lazyCompilation({
             entries: false,
             imports: true,
+            ...(serverUrl ? { serverUrl } : {}),
+          });
+          return;
+        }
+
+        if (serverUrl) {
+          chain.lazyCompilation({
+            entries: true,
+            imports: true,
+            serverUrl,
           });
           return;
         }
@@ -43,6 +79,12 @@ export const pluginLazyCompilation = (): RsbuildPlugin => ({
           ...options,
           serverUrl: replacePortPlaceholder(options.serverUrl, api.context.devServer.port),
         });
+        return;
+      }
+
+      if (typeof options === 'object') {
+        const serverUrl = await getServerUrlFromClientConfig(config, api.context);
+        chain.lazyCompilation(serverUrl ? { ...options, serverUrl } : options);
         return;
       }
 

--- a/website/docs/en/config/dev/lazy-compilation.mdx
+++ b/website/docs/en/config/dev/lazy-compilation.mdx
@@ -142,6 +142,12 @@ When the `imports` option is enabled, all async modules will only be compiled wh
 
 Use [lazyCompilation.serverUrl](https://rspack.rs/config/lazy-compilation#lazycompilationserverurl) to tell the client the server URL that needs to be requested.
 
+If `lazyCompilation.serverUrl` is not configured and `dev.client.host` or `dev.client.port` is specified, Rsbuild will use the `dev.client` URL as the default `serverUrl`.
+
+An explicitly configured `lazyCompilation.serverUrl` always takes priority over the default value inferred from `dev.client`.
+
+Example:
+
 ```ts title="rsbuild.config.ts"
 export default {
   dev: {

--- a/website/docs/zh/config/dev/lazy-compilation.mdx
+++ b/website/docs/zh/config/dev/lazy-compilation.mdx
@@ -140,7 +140,13 @@ export default {
 
 ### Server URL
 
-通过 [lazyCompilation.serverUrl](https://rspack.rs/zh/config/lazy-compilation#lazycompilationserverurl) 指定 client 需要请求的 server URL：
+通过 [lazyCompilation.serverUrl](https://rspack.rs/zh/config/lazy-compilation#lazycompilationserverurl) 可以指定 client 需要请求的 server URL。
+
+如果未配置 `lazyCompilation.serverUrl`，并且设置了 `dev.client.host` 或 `dev.client.port`，Rsbuild 会将 `dev.client` 对应的 URL 作为默认的 `serverUrl`。
+
+如果显式配置了 `lazyCompilation.serverUrl`，该配置始终优先于从 `dev.client` 推导出的默认值。
+
+示例如下：
 
 ```ts title="rsbuild.config.ts"
 export default {


### PR DESCRIPTION
## Summary

Fix lazy compilation trigger requests so Rsbuild uses the configured `dev.client` host or port as the default `lazyCompilation.serverUrl` when no explicit `serverUrl` is provided. This preserves user-defined `serverUrl` precedence, adds e2e coverage for cross-origin backend integration and explicit `serverUrl` priority, and documents the default behavior.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/7878