### PR TITLE
docs: add dev.client option sections

### DIFF
--- a/website/docs/en/config/dev/client.mdx
+++ b/website/docs/en/config/dev/client.mdx
@@ -101,9 +101,9 @@ Hot-update files are considered to be static assets. If you need to configure th
 - **Type:** `string`
 - **Default:** `'/rsbuild-hmr'`
 
-The `dev.client.path` option sets the path for the WebSocket request used by HMR.
+Sets the path for HMR WebSocket requests.
 
-By default, Rsbuild connects to the dev server through `/rsbuild-hmr`, so the WebSocket URL is generated as `ws://<host>:<port>/rsbuild-hmr`.
+By default, Rsbuild connects through `/rsbuild-hmr`, generating `ws://<host>:<port>/rsbuild-hmr`.
 
 ```ts title="rsbuild.config.ts"
 export default {
@@ -120,9 +120,9 @@ export default {
 - **Type:** `string | number`
 - **Default:** `''`
 
-The `dev.client.port` option sets the port number for the WebSocket request used by HMR.
+Sets the port for HMR WebSocket requests.
 
-By default, this option is an empty string, which means the browser uses `location.port` from the current page. You can set a fixed port number, or use the `<port>` placeholder to refer to the port that the Rsbuild dev server is listening on.
+Default is an empty string, so the browser uses the current page's `location.port`. You can set a fixed port, or use `<port>` to refer to the port used by the Rsbuild dev server.
 
 ```ts title="rsbuild.config.ts"
 export default {
@@ -139,9 +139,9 @@ export default {
 - **Type:** `string`
 - **Default:** `''`
 
-The `dev.client.host` option sets the host for the WebSocket request used by HMR.
+Sets the host for HMR WebSocket requests.
 
-By default, this option is an empty string, which means the browser uses `location.hostname` from the current page.
+Default is an empty string, so the browser uses the current page's `location.hostname`.
 
 ```ts title="rsbuild.config.ts"
 export default {
@@ -158,9 +158,9 @@ export default {
 - **Type:** `'ws' | 'wss'`
 - **Default:** `undefined`
 
-The `dev.client.protocol` option sets the protocol for the WebSocket request used by HMR.
+Sets the protocol for HMR WebSocket requests.
 
-By default, Rsbuild selects `wss` when the current page uses HTTPS, and selects `ws` otherwise.
+By default, Rsbuild uses `wss` for HTTPS pages and `ws` otherwise.
 
 ```ts title="rsbuild.config.ts"
 export default {

--- a/website/docs/en/config/dev/client.mdx
+++ b/website/docs/en/config/dev/client.mdx
@@ -69,12 +69,6 @@ export default {
 };
 ```
 
-## hot-update files
-
-During the HMR process, the page will make GET requests to get hot-update files, including `*.hot-update.json` and `*.hot-update.js`. These files contain the necessary information for hot updates, such as the updated modules and their code.
-
-Hot-update files are considered to be static assets. If you need to configure the URL for hot-update files, please use the [dev.assetPrefix](/config/dev/asset-prefix) option.
-
 ## Options
 
 ### path
@@ -364,6 +358,12 @@ export default function resolveWebSocketUrl(url: string): string {
 :::tip
 The input URL contains query parameters required by Rsbuild, such as `token`. When rewriting the URL, preserve the existing query string unless you intentionally want to override it.
 :::
+
+## hot-update files
+
+During the HMR process, the page will make GET requests to get hot-update files, including `*.hot-update.json` and `*.hot-update.js`. These files contain the necessary information for hot updates, such as the updated modules and their code.
+
+Hot-update files are considered to be static assets. If you need to configure the URL for hot-update files, please use the [dev.assetPrefix](/config/dev/asset-prefix) option.
 
 ## Version history
 

--- a/website/docs/en/config/dev/client.mdx
+++ b/website/docs/en/config/dev/client.mdx
@@ -69,25 +69,6 @@ export default {
 };
 ```
 
-### Port placeholder
-
-The port number that Rsbuild server listens on may change. For example, if the port is in use, Rsbuild will automatically increment the port number until it finds an available port.
-
-To avoid `client.port` becoming invalid due to port changes, you can use one of the following methods:
-
-- Enable [server.strictPort](/config/server/strict-port).
-- Use the `<port>` placeholder to refer to the current port number. Rsbuild will replace the placeholder with the actual port number it is listening on.
-
-```ts title="rsbuild.config.ts"
-export default {
-  dev: {
-    client: {
-      port: '<port>',
-    },
-  },
-};
-```
-
 ## hot-update files
 
 During the HMR process, the page will make GET requests to get hot-update files, including `*.hot-update.json` and `*.hot-update.js`. These files contain the necessary information for hot updates, such as the updated modules and their code.
@@ -122,13 +103,32 @@ export default {
 
 Sets the port for HMR WebSocket requests.
 
-Default is an empty string, so the browser uses the current page's `location.port`. You can set a fixed port, or use `<port>` to refer to the port used by the Rsbuild dev server.
+Default is an empty string, so the browser uses the current page's `location.port`.
+
+You can set a fixed port:
 
 ```ts title="rsbuild.config.ts"
 export default {
   dev: {
     client: {
       port: 3000,
+    },
+  },
+};
+```
+
+The port that the Rsbuild server listens on may change. For example, if the port is in use, Rsbuild will automatically increment the port number until it finds an available port.
+
+To avoid `client.port` becoming invalid due to port changes, you can:
+
+- Enable [server.strictPort](/config/server/strict-port).
+- Use the `<port>` placeholder to refer to the current port number. Rsbuild will replace the placeholder with the actual port number it is listening on.
+
+```ts title="rsbuild.config.ts"
+export default {
+  dev: {
+    client: {
+      port: '<port>',
     },
   },
 };

--- a/website/docs/en/config/dev/client.mdx
+++ b/website/docs/en/config/dev/client.mdx
@@ -96,6 +96,82 @@ Hot-update files are considered to be static assets. If you need to configure th
 
 ## Options
 
+### path
+
+- **Type:** `string`
+- **Default:** `'/rsbuild-hmr'`
+
+The `dev.client.path` option sets the path for the WebSocket request used by HMR.
+
+By default, Rsbuild connects to the dev server through `/rsbuild-hmr`, so the WebSocket URL is generated as `ws://<host>:<port>/rsbuild-hmr`.
+
+```ts title="rsbuild.config.ts"
+export default {
+  dev: {
+    client: {
+      path: '/custom-hmr',
+    },
+  },
+};
+```
+
+### port
+
+- **Type:** `string | number`
+- **Default:** `''`
+
+The `dev.client.port` option sets the port number for the WebSocket request used by HMR.
+
+By default, this option is an empty string, which means the browser uses `location.port` from the current page. You can set a fixed port number, or use the `<port>` placeholder to refer to the port that the Rsbuild dev server is listening on.
+
+```ts title="rsbuild.config.ts"
+export default {
+  dev: {
+    client: {
+      port: 3000,
+    },
+  },
+};
+```
+
+### host
+
+- **Type:** `string`
+- **Default:** `''`
+
+The `dev.client.host` option sets the host for the WebSocket request used by HMR.
+
+By default, this option is an empty string, which means the browser uses `location.hostname` from the current page.
+
+```ts title="rsbuild.config.ts"
+export default {
+  dev: {
+    client: {
+      host: '127.0.0.1',
+    },
+  },
+};
+```
+
+### protocol
+
+- **Type:** `'ws' | 'wss'`
+- **Default:** `undefined`
+
+The `dev.client.protocol` option sets the protocol for the WebSocket request used by HMR.
+
+By default, Rsbuild selects `wss` when the current page uses HTTPS, and selects `ws` otherwise.
+
+```ts title="rsbuild.config.ts"
+export default {
+  dev: {
+    client: {
+      protocol: 'wss',
+    },
+  },
+};
+```
+
 ### overlay
 
 - **Type:**

--- a/website/docs/zh/config/dev/client.mdx
+++ b/website/docs/zh/config/dev/client.mdx
@@ -69,25 +69,6 @@ export default {
 };
 ```
 
-### 端口号占位符
-
-Rsbuild server 监听的端口号可能会发生变更。比如，当端口被占用时，Rsbuild 会自动递增端口号，直至找到一个可用端口。
-
-为了避免端口变化导致 `client.port` 失效，你可以使用以下方法之一：
-
-- 开启 [server.strictPort](/config/server/strict-port)。
-- 使用 `<port>` 占位符来指代当前端口号，Rsbuild 会将占位符替换为实际监听的端口号。
-
-```ts title="rsbuild.config.ts"
-export default {
-  dev: {
-    client: {
-      port: '<port>',
-    },
-  },
-};
-```
-
 ## hot-update 文件
 
 在热更新过程中，页面会发起 GET 请求来获取 hot-update 文件，包括 `*.hot-update.json` 和 `*.hot-update.js`。这些文件包含了热更新所需的信息，比如被更新的模块、模块的代码等。
@@ -122,13 +103,32 @@ export default {
 
 用于设置 HMR WebSocket 请求的端口号。
 
-默认值为空字符串，浏览器会使用当前页面的 `location.port`。你可以设置固定端口号，也可以使用 `<port>` 占位符指代 Rsbuild dev server 实际监听的端口号。
+默认值为空字符串，浏览器会使用当前页面的 `location.port`。
+
+你可以设置固定端口号：
 
 ```ts title="rsbuild.config.ts"
 export default {
   dev: {
     client: {
       port: 3000,
+    },
+  },
+};
+```
+
+Rsbuild server 监听的端口号可能会发生变更。比如，当端口被占用时，Rsbuild 会自动递增端口号，直至找到一个可用端口。
+
+为了避免端口变化导致 `client.port` 失效，你可以：
+
+- 开启 [server.strictPort](/config/server/strict-port)。
+- 使用 `<port>` 占位符来指代当前端口号，Rsbuild 会将占位符替换为实际监听的端口号。
+
+```ts title="rsbuild.config.ts"
+export default {
+  dev: {
+    client: {
+      port: '<port>',
     },
   },
 };

--- a/website/docs/zh/config/dev/client.mdx
+++ b/website/docs/zh/config/dev/client.mdx
@@ -69,12 +69,6 @@ export default {
 };
 ```
 
-## hot-update 文件
-
-在热更新过程中，页面会发起 GET 请求来获取 hot-update 文件，包括 `*.hot-update.json` 和 `*.hot-update.js`。这些文件包含了热更新所需的信息，比如被更新的模块、模块的代码等。
-
-hot-update 文件属于静态资源，如果你需要配置 hot-update 文件的 URL，请使用 [dev.assetPrefix](/config/dev/asset-prefix) 选项。
-
 ## 选项
 
 ### path
@@ -364,6 +358,12 @@ export default function resolveWebSocketUrl(url: string): string {
 :::tip
 传入的 URL 包含 Rsbuild 所需的查询参数，比如 `token`。改写 URL 时，请保留已有 query string，除非你明确需要覆盖它们。
 :::
+
+## hot-update 文件
+
+在热更新过程中，页面会发起 GET 请求来获取 hot-update 文件，包括 `*.hot-update.json` 和 `*.hot-update.js`。这些文件包含了热更新所需的信息，比如被更新的模块、模块的代码等。
+
+hot-update 文件属于静态资源，如果你需要配置 hot-update 文件的 URL，请使用 [dev.assetPrefix](/config/dev/asset-prefix) 选项。
 
 ## 版本历史
 

--- a/website/docs/zh/config/dev/client.mdx
+++ b/website/docs/zh/config/dev/client.mdx
@@ -96,6 +96,82 @@ hot-update 文件属于静态资源，如果你需要配置 hot-update 文件的
 
 ## 选项
 
+### path
+
+- **类型：** `string`
+- **默认值：** `'/rsbuild-hmr'`
+
+`dev.client.path` 用于设置 HMR WebSocket 请求的路径。
+
+默认情况下，Rsbuild 会通过 `/rsbuild-hmr` 连接到 dev server，因此生成的 WebSocket URL 为 `ws://<host>:<port>/rsbuild-hmr`。
+
+```ts title="rsbuild.config.ts"
+export default {
+  dev: {
+    client: {
+      path: '/custom-hmr',
+    },
+  },
+};
+```
+
+### port
+
+- **类型：** `string | number`
+- **默认值：** `''`
+
+`dev.client.port` 用于设置 HMR WebSocket 请求的端口号。
+
+默认情况下，该选项为空字符串，表示浏览器会使用当前页面的 `location.port`。你可以设置一个固定端口号，也可以使用 `<port>` 占位符指代 Rsbuild dev server 实际监听的端口号。
+
+```ts title="rsbuild.config.ts"
+export default {
+  dev: {
+    client: {
+      port: 3000,
+    },
+  },
+};
+```
+
+### host
+
+- **类型：** `string`
+- **默认值：** `''`
+
+`dev.client.host` 用于设置 HMR WebSocket 请求的 host。
+
+默认情况下，该选项为空字符串，表示浏览器会使用当前页面的 `location.hostname`。
+
+```ts title="rsbuild.config.ts"
+export default {
+  dev: {
+    client: {
+      host: '127.0.0.1',
+    },
+  },
+};
+```
+
+### protocol
+
+- **类型：** `'ws' | 'wss'`
+- **默认值：** `undefined`
+
+`dev.client.protocol` 用于设置 HMR WebSocket 请求的协议。
+
+默认情况下，当当前页面使用 HTTPS 时，Rsbuild 会选择 `wss`；否则会选择 `ws`。
+
+```ts title="rsbuild.config.ts"
+export default {
+  dev: {
+    client: {
+      protocol: 'wss',
+    },
+  },
+};
+```
+
 ### overlay
 
 - **类型：**

--- a/website/docs/zh/config/dev/client.mdx
+++ b/website/docs/zh/config/dev/client.mdx
@@ -101,9 +101,9 @@ hot-update 文件属于静态资源，如果你需要配置 hot-update 文件的
 - **类型：** `string`
 - **默认值：** `'/rsbuild-hmr'`
 
-`dev.client.path` 用于设置 HMR WebSocket 请求的路径。
+用于设置 HMR WebSocket 请求的路径。
 
-默认情况下，Rsbuild 会通过 `/rsbuild-hmr` 连接到 dev server，因此生成的 WebSocket URL 为 `ws://<host>:<port>/rsbuild-hmr`。
+默认通过 `/rsbuild-hmr` 连接到 dev server，因此生成的 WebSocket URL 为 `ws://<host>:<port>/rsbuild-hmr`。
 
 ```ts title="rsbuild.config.ts"
 export default {
@@ -120,9 +120,9 @@ export default {
 - **类型：** `string | number`
 - **默认值：** `''`
 
-`dev.client.port` 用于设置 HMR WebSocket 请求的端口号。
+用于设置 HMR WebSocket 请求的端口号。
 
-默认情况下，该选项为空字符串，表示浏览器会使用当前页面的 `location.port`。你可以设置一个固定端口号，也可以使用 `<port>` 占位符指代 Rsbuild dev server 实际监听的端口号。
+默认值为空字符串，浏览器会使用当前页面的 `location.port`。你可以设置固定端口号，也可以使用 `<port>` 占位符指代 Rsbuild dev server 实际监听的端口号。
 
 ```ts title="rsbuild.config.ts"
 export default {
@@ -139,9 +139,9 @@ export default {
 - **类型：** `string`
 - **默认值：** `''`
 
-`dev.client.host` 用于设置 HMR WebSocket 请求的 host。
+用于设置 HMR WebSocket 请求的 host。
 
-默认情况下，该选项为空字符串，表示浏览器会使用当前页面的 `location.hostname`。
+默认值为空字符串，浏览器会使用当前页面的 `location.hostname`。
 
 ```ts title="rsbuild.config.ts"
 export default {
@@ -158,9 +158,9 @@ export default {
 - **类型：** `'ws' | 'wss'`
 - **默认值：** `undefined`
 
-`dev.client.protocol` 用于设置 HMR WebSocket 请求的协议。
+用于设置 HMR WebSocket 请求的协议。
 
-默认情况下，当当前页面使用 HTTPS 时，Rsbuild 会选择 `wss`；否则会选择 `ws`。
+默认在 HTTPS 页面使用 `wss`，其他情况使用 `ws`。
 
 ```ts title="rsbuild.config.ts"
 export default {


### PR DESCRIPTION
## Summary

This PR documents the existing `dev.client.path`, `dev.client.port`, `dev.client.host`, and `dev.client.protocol` options so each one has a dedicated option section with type, default value, description, and a minimal configuration example in both English and Chinese docs.