### PR TITLE
fix(core): skip lazy compilation without client updates

### DIFF
--- a/e2e/cases/lazy-compilation/no-client/index.test.ts
+++ b/e2e/cases/lazy-compilation/no-client/index.test.ts
@@ -1,0 +1,23 @@
+import { expect, gotoPage, test } from '@e2e/helper';
+
+test('should skip lazy compilation when hmr and liveReload are disabled', async ({
+  page,
+  devOnly,
+}) => {
+  const lazyTriggerRequests: string[] = [];
+
+  page.on('request', (request) => {
+    if (request.url().includes('/_rspack/lazy/trigger')) {
+      lazyTriggerRequests.push(request.url());
+    }
+  });
+
+  const rsbuild = await devOnly();
+
+  await rsbuild.expectBuildEnd();
+  await gotoPage(page, rsbuild);
+
+  const value = await page.evaluate(() => window.foo);
+  expect(value).toBe(42);
+  expect(lazyTriggerRequests).toHaveLength(0);
+});

--- a/e2e/cases/lazy-compilation/no-client/rsbuild.config.ts
+++ b/e2e/cases/lazy-compilation/no-client/rsbuild.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  dev: {
+    hmr: false,
+    liveReload: false,
+  },
+});

--- a/e2e/cases/lazy-compilation/no-client/src/foo.js
+++ b/e2e/cases/lazy-compilation/no-client/src/foo.js
@@ -1,0 +1,1 @@
+export const foo = 42;

--- a/e2e/cases/lazy-compilation/no-client/src/index.js
+++ b/e2e/cases/lazy-compilation/no-client/src/index.js
@@ -1,0 +1,1 @@
+window.foo = import('./foo').then(({ foo }) => foo);

--- a/packages/core/src/plugins/lazyCompilation.ts
+++ b/packages/core/src/plugins/lazyCompilation.ts
@@ -38,6 +38,10 @@ export const pluginLazyCompilation = (): RsbuildPlugin => ({
       }
 
       const { config } = environment;
+      // Lazy compilation needs the dev client to load the compiled modules.
+      if (!config.dev.hmr && !config.dev.liveReload) {
+        return;
+      }
 
       const options = config.dev?.lazyCompilation;
       if (!options) {

--- a/packages/core/tests/environments.test.ts
+++ b/packages/core/tests/environments.test.ts
@@ -390,4 +390,34 @@ describe('environment config', () => {
     expect(matchPlugin(configs[0], 'HotModuleReplacementPlugin')).toBeFalsy();
     expect(matchPlugin(configs[1], 'HotModuleReplacementPlugin')).toBeTruthy();
   });
+
+  it('should skip lazy compilation when environment disables hmr and liveReload', async () => {
+    rs.stubEnv('NODE_ENV', 'development');
+    const rsbuild = await createRsbuild({
+      config: {
+        dev: {
+          lazyCompilation: true,
+        },
+        environments: {
+          web: {
+            dev: {
+              hmr: false,
+              liveReload: false,
+            },
+          },
+          web2: {
+            dev: {
+              hmr: false,
+              liveReload: true,
+            },
+          },
+        },
+      },
+    });
+
+    const configs = await rsbuild.initConfigs({ action: 'dev' });
+
+    expect(configs[0].lazyCompilation).toBeFalsy();
+    expect(configs[1].lazyCompilation).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary

This PR skips applying Rspack lazy compilation when the final environment dev config has both `dev.hmr` and `dev.liveReload` disabled, because lazy triggers can compile modules but there is no client update channel to load the result. The default `dev.lazyCompilation` value remains unchanged, and regression coverage is added for environment-specific dev overrides and the no-client dynamic import case.