### PR TITLE
fix(core): apply assetPrefix to manifest entry assets

### DIFF
--- a/e2e/cases/manifest/entry-assets-prefix/index.test.ts
+++ b/e2e/cases/manifest/entry-assets-prefix/index.test.ts
@@ -1,0 +1,20 @@
+import { expect, getFileContent, test } from '@e2e/helper';
+
+test('should apply assetPrefix to assets in manifest entries', async ({ build }) => {
+  const rsbuild = await build();
+
+  const files = rsbuild.getDistFiles({ sourceMaps: true });
+  const manifestContent = getFileContent(files, 'manifest.json');
+  const manifest = JSON.parse(manifestContent);
+
+  expect(manifest.entries.index.assets).toEqual([
+    'https://cdn.example.com/assets/static/image/icon.png',
+    'https://cdn.example.com/assets/static/js/index.js.map',
+  ]);
+  expect(manifest.entries.index).toMatchObject({
+    initial: {
+      js: ['https://cdn.example.com/assets/static/js/index.js'],
+    },
+    html: ['https://cdn.example.com/assets/index.html'],
+  });
+});

--- a/e2e/cases/manifest/entry-assets-prefix/rsbuild.config.ts
+++ b/e2e/cases/manifest/entry-assets-prefix/rsbuild.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    assetPrefix: 'https://cdn.example.com/assets/',
+    dataUriLimit: 0,
+    manifest: true,
+    filenameHash: false,
+    sourceMap: true,
+  },
+  splitChunks: false,
+});

--- a/e2e/cases/manifest/entry-assets-prefix/src/index.ts
+++ b/e2e/cases/manifest/entry-assets-prefix/src/index.ts
@@ -1,0 +1,3 @@
+import icon from '@e2e/assets/icon.png';
+
+console.log(icon);

--- a/packages/core/src/plugins/manifest.ts
+++ b/packages/core/src/plugins/manifest.ts
@@ -98,7 +98,9 @@ const generateManifest =
 
         if (file.chunk) {
           for (const auxiliaryFile of file.chunk.auxiliaryFiles) {
-            assets.add(auxiliaryFile);
+            assets.add(
+              manifestOptions.prefix ? ensureAssetPrefix(auxiliaryFile, publicPath) : auxiliaryFile,
+            );
           }
         }
       }


### PR DESCRIPTION
## Summary

This PR fixes `manifest.json` generation so auxiliary assets listed under `entries.*.assets` also include the configured `output.assetPrefix`. The root cause was that chunk auxiliary files were read from Rspack's raw `chunk.auxiliaryFiles` set, unlike other manifest fields that already receive the manifest plugin's public path handling.

It also adds an isolated e2e regression covering a CDN `assetPrefix` with generated source maps and an emitted PNG asset.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/7883