### PR TITLE
docs: add server dist path to multiple environments examples

### DIFF
--- a/website/docs/en/config/environments.mdx
+++ b/website/docs/en/config/environments.mdx
@@ -71,6 +71,9 @@ export default {
       },
       output: {
         target: 'node',
+        distPath: {
+          root: 'dist/server',
+        },
       },
       resolve: {
         alias: {
@@ -114,6 +117,9 @@ const nodeConfig = {
   },
   output: {
     target: 'node',
+    distPath: {
+      root: 'dist/server',
+    },
   },
   resolve: {
     alias: {

--- a/website/docs/en/config/output/target.mdx
+++ b/website/docs/en/config/output/target.mdx
@@ -57,6 +57,9 @@ export default {
     node: {
       output: {
         target: 'node',
+        distPath: {
+          root: 'dist/server',
+        },
       },
     },
   },

--- a/website/docs/en/guide/advanced/environments.mdx
+++ b/website/docs/en/guide/advanced/environments.mdx
@@ -57,6 +57,9 @@ export default {
       output: {
         // Use 'node' target for the Node.js outputs
         target: 'node',
+        distPath: {
+          root: 'dist/server',
+        },
       },
       resolve: {
         alias: {
@@ -161,6 +164,9 @@ export default {
     node: {
       output: {
         target: 'node',
+        distPath: {
+          root: 'dist/server',
+        },
       },
     },
   },

--- a/website/docs/en/guide/advanced/ssr.mdx
+++ b/website/docs/en/guide/advanced/ssr.mdx
@@ -77,6 +77,9 @@ export default {
       output: {
         // Use 'node' target for the Node.js outputs
         target: 'node',
+        distPath: {
+          root: 'dist/server',
+        },
       },
     },
   },

--- a/website/docs/zh/config/environments.mdx
+++ b/website/docs/zh/config/environments.mdx
@@ -71,6 +71,9 @@ export default {
       },
       output: {
         target: 'node',
+        distPath: {
+          root: 'dist/server',
+        },
       },
       resolve: {
         alias: {
@@ -114,6 +117,9 @@ const nodeConfig = {
   },
   output: {
     target: 'node',
+    distPath: {
+      root: 'dist/server',
+    },
   },
   resolve: {
     alias: {

--- a/website/docs/zh/config/output/target.mdx
+++ b/website/docs/zh/config/output/target.mdx
@@ -57,6 +57,9 @@ export default {
     node: {
       output: {
         target: 'node',
+        distPath: {
+          root: 'dist/server',
+        },
       },
     },
   },

--- a/website/docs/zh/guide/advanced/environments.mdx
+++ b/website/docs/zh/guide/advanced/environments.mdx
@@ -57,6 +57,9 @@ export default {
       output: {
         // Node.js 产物的 target 类型为 'node'
         target: 'node',
+        distPath: {
+          root: 'dist/server',
+        },
       },
       resolve: {
         alias: {
@@ -161,6 +164,9 @@ export default {
     node: {
       output: {
         target: 'node',
+        distPath: {
+          root: 'dist/server',
+        },
       },
     },
   },

--- a/website/docs/zh/guide/advanced/ssr.mdx
+++ b/website/docs/zh/guide/advanced/ssr.mdx
@@ -77,6 +77,9 @@ export default {
       output: {
         // Node.js 产物的 target 类型为 'node'
         target: 'node',
+        distPath: {
+          root: 'dist/server',
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary

This PR updates the Node target examples in the environment, output target, and SSR docs to include `output.distPath.root: 'dist/server'`, so server builds are shown writing to a dedicated server output directory in both English and Chinese docs.