### PR TITLE
perf(core): resolve environment APIs per compiler

### DIFF
--- a/packages/core/src/server/compileState.ts
+++ b/packages/core/src/server/compileState.ts
@@ -1,0 +1,46 @@
+import type { Rspack } from '../types';
+
+type Deferred = {
+  promise: Promise<Rspack.Stats>;
+  resolve: (stats: Rspack.Stats) => void;
+};
+
+const createDeferred = (): Deferred => {
+  const deferred = {} as Deferred;
+
+  deferred.promise = new Promise<Rspack.Stats>((resolve) => {
+    deferred.resolve = resolve;
+  });
+
+  return deferred;
+};
+
+export const createCompileState = (environmentCount: number) => {
+  const stats: Array<Rspack.Stats | undefined> = new Array(environmentCount);
+  const waiters = Array.from({ length: environmentCount }, createDeferred);
+
+  return {
+    reset(index: number): void {
+      if (!stats[index]) {
+        return;
+      }
+
+      stats[index] = undefined;
+      waiters[index] = createDeferred();
+    },
+
+    done(index: number, nextStats: Rspack.Stats): void {
+      stats[index] = nextStats;
+      waiters[index].resolve(nextStats);
+    },
+
+    async wait(index: number): Promise<Rspack.Stats> {
+      const currentStats = stats[index];
+      if (currentStats) {
+        return currentStats;
+      }
+
+      return waiters[index].promise;
+    },
+  };
+};

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -9,10 +9,10 @@ import type {
   EnvironmentAPI,
   InternalContext,
   NormalizedConfig,
-  Rspack,
 } from '../types';
 import { BuildManager } from './buildManager';
 import { isCliShortcutsEnabled, setupCliShortcuts } from './cliShortcuts';
+import { createCompileState } from './compileState';
 import { type GetDevMiddlewaresResult, getDevMiddlewares } from './devMiddlewares';
 import { createCacheableFunction, getTransformedHtml, loadBundle } from './environment';
 import { registerCleanup, removeCleanup, setupGracefulShutdown } from './gracefulShutdown';
@@ -111,37 +111,7 @@ export async function createDevServer<
     https: isHttps,
   };
 
-  let lastStats: Rspack.Stats[];
-
-  let waitLastCompileDoneResolve: (() => void) | null = null;
-  let waitLastCompileDone = new Promise<void>((resolve) => {
-    waitLastCompileDoneResolve = resolve;
-  });
-
-  const resetWaitLastCompileDone = () => {
-    // No need to reset if lastStats is not set
-    if (!lastStats) {
-      return;
-    }
-
-    // Resolve the previous promise if it exists
-    if (waitLastCompileDoneResolve) {
-      waitLastCompileDoneResolve();
-      waitLastCompileDoneResolve = null;
-    }
-    waitLastCompileDone = new Promise<void>((resolve) => {
-      waitLastCompileDoneResolve = resolve;
-    });
-  };
-
-  // should register onAfterDevCompile hook before startCompile
-  context.hooks.onAfterDevCompile.tap(({ stats }) => {
-    lastStats = 'stats' in stats ? stats.stats : [stats];
-    if (waitLastCompileDoneResolve) {
-      waitLastCompileDoneResolve();
-      waitLastCompileDoneResolve = null;
-    }
-  });
+  const compileState = createCompileState(context.environmentList.length);
 
   const startCompile: () => Promise<BuildManager> = async () => {
     const compiler = await createCompiler();
@@ -156,9 +126,23 @@ export async function createDevServer<
 
     context.publicPathnames = getPublicPathnames(publicPaths, config.server.base);
 
-    compiler?.hooks.watchRun.tap('rsbuild:watchRun', () => {
-      resetWaitLastCompileDone();
-    });
+    if (isMultiCompiler(compiler)) {
+      compiler.compilers.forEach((compiler, index) => {
+        compiler.hooks.watchRun.tap({ name: 'rsbuild:environment-api', stage: -10000 }, () => {
+          compileState.reset(index);
+        });
+        compiler.hooks.done.tap({ name: 'rsbuild:environment-api', stage: -10000 }, (stats) => {
+          compileState.done(index, stats);
+        });
+      });
+    } else {
+      compiler.hooks.watchRun.tap({ name: 'rsbuild:environment-api', stage: -10000 }, () => {
+        compileState.reset(0);
+      });
+      compiler.hooks.done.tap({ name: 'rsbuild:environment-api', stage: -10000 }, (stats) => {
+        compileState.done(0, stats);
+      });
+    }
 
     const buildManager = new BuildManager({
       context,
@@ -284,15 +268,14 @@ export async function createDevServer<
         if (!state.buildManager) {
           throw new Error(getErrorMsg('getStats'));
         }
-        await waitLastCompileDone;
-        return lastStats[index];
+        return compileState.wait(index);
       },
       loadBundle: async <T>(entryName: string) => {
         if (!state.buildManager) {
           throw new Error(getErrorMsg('loadBundle'));
         }
-        await waitLastCompileDone;
-        return cacheableLoadBundle(lastStats[index], entryName, {
+        const stats = await compileState.wait(index);
+        return cacheableLoadBundle(stats, entryName, {
           readFileSync: state.buildManager.readFileSync,
           environment,
         }) as T;
@@ -301,8 +284,8 @@ export async function createDevServer<
         if (!state.buildManager) {
           throw new Error(getErrorMsg('getTransformedHtml'));
         }
-        await waitLastCompileDone;
-        return cacheableTransformedHtml(lastStats[index], entryName, {
+        const stats = await compileState.wait(index);
+        return cacheableTransformedHtml(stats, entryName, {
           readFileSync: state.buildManager.readFileSync,
           environment,
         });

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -35,8 +35,6 @@ import { setupWatchFiles, type WatchFilesResult } from './watchFiles';
 
 type HTTPServer = Server | Http2SecureServer;
 
-const ENVIRONMENT_API_HOOK_STAGE = -10000;
-
 type ExtractSocketMessageData<T extends ServerMessage['type']> = 'data' extends keyof Extract<
   ServerMessage,
   { type: T }
@@ -128,34 +126,27 @@ export async function createDevServer<
 
     context.publicPathnames = getPublicPathnames(publicPaths, config.server.base);
 
+    const hookOptions = {
+      name: 'rsbuild:environment-api',
+      // Reset API state before user watchRun hooks can read stale environment stats.
+      stage: -10000,
+    };
     if (isMultiCompiler(compiler)) {
       compiler.compilers.forEach((compiler, index) => {
-        compiler.hooks.watchRun.tap(
-          { name: 'rsbuild:environment-api', stage: ENVIRONMENT_API_HOOK_STAGE },
-          () => {
-            compileState.reset(index);
-          },
-        );
-        compiler.hooks.done.tap(
-          { name: 'rsbuild:environment-api', stage: ENVIRONMENT_API_HOOK_STAGE },
-          (stats) => {
-            compileState.done(index, stats);
-          },
-        );
+        compiler.hooks.watchRun.tap(hookOptions, () => {
+          compileState.reset(index);
+        });
+        compiler.hooks.done.tap(hookOptions, (stats) => {
+          compileState.done(index, stats);
+        });
       });
     } else {
-      compiler.hooks.watchRun.tap(
-        { name: 'rsbuild:environment-api', stage: ENVIRONMENT_API_HOOK_STAGE },
-        () => {
-          compileState.reset(0);
-        },
-      );
-      compiler.hooks.done.tap(
-        { name: 'rsbuild:environment-api', stage: ENVIRONMENT_API_HOOK_STAGE },
-        (stats) => {
-          compileState.done(0, stats);
-        },
-      );
+      compiler.hooks.watchRun.tap(hookOptions, () => {
+        compileState.reset(0);
+      });
+      compiler.hooks.done.tap(hookOptions, (stats) => {
+        compileState.done(0, stats);
+      });
     }
 
     const buildManager = new BuildManager({

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -35,6 +35,8 @@ import { setupWatchFiles, type WatchFilesResult } from './watchFiles';
 
 type HTTPServer = Server | Http2SecureServer;
 
+const ENVIRONMENT_API_HOOK_STAGE = -10000;
+
 type ExtractSocketMessageData<T extends ServerMessage['type']> = 'data' extends keyof Extract<
   ServerMessage,
   { type: T }
@@ -128,20 +130,32 @@ export async function createDevServer<
 
     if (isMultiCompiler(compiler)) {
       compiler.compilers.forEach((compiler, index) => {
-        compiler.hooks.watchRun.tap({ name: 'rsbuild:environment-api', stage: -10000 }, () => {
-          compileState.reset(index);
-        });
-        compiler.hooks.done.tap({ name: 'rsbuild:environment-api', stage: -10000 }, (stats) => {
-          compileState.done(index, stats);
-        });
+        compiler.hooks.watchRun.tap(
+          { name: 'rsbuild:environment-api', stage: ENVIRONMENT_API_HOOK_STAGE },
+          () => {
+            compileState.reset(index);
+          },
+        );
+        compiler.hooks.done.tap(
+          { name: 'rsbuild:environment-api', stage: ENVIRONMENT_API_HOOK_STAGE },
+          (stats) => {
+            compileState.done(index, stats);
+          },
+        );
       });
     } else {
-      compiler.hooks.watchRun.tap({ name: 'rsbuild:environment-api', stage: -10000 }, () => {
-        compileState.reset(0);
-      });
-      compiler.hooks.done.tap({ name: 'rsbuild:environment-api', stage: -10000 }, (stats) => {
-        compileState.done(0, stats);
-      });
+      compiler.hooks.watchRun.tap(
+        { name: 'rsbuild:environment-api', stage: ENVIRONMENT_API_HOOK_STAGE },
+        () => {
+          compileState.reset(0);
+        },
+      );
+      compiler.hooks.done.tap(
+        { name: 'rsbuild:environment-api', stage: ENVIRONMENT_API_HOOK_STAGE },
+        (stats) => {
+          compileState.done(0, stats);
+        },
+      );
     }
 
     const buildManager = new BuildManager({

--- a/packages/core/tests/compileState.test.ts
+++ b/packages/core/tests/compileState.test.ts
@@ -1,0 +1,76 @@
+import { createCompileState } from '../src/server/compileState';
+import type { Rspack } from '../src/types';
+
+const createStats = (name: string) => ({ name }) as unknown as Rspack.Stats;
+
+test('should resolve environment stats independently', async () => {
+  const compileState = createCompileState(2);
+  const webStats = createStats('web');
+  const nodeStats = createStats('node');
+
+  const webPromise = compileState.wait(0);
+  const nodePromise = compileState.wait(1);
+
+  let nodeResolved = false;
+  nodePromise.then(() => {
+    nodeResolved = true;
+  });
+
+  compileState.done(0, webStats);
+
+  await expect(webPromise).resolves.toBe(webStats);
+  await Promise.resolve();
+  expect(nodeResolved).toBe(false);
+
+  compileState.done(1, nodeStats);
+
+  await expect(nodePromise).resolves.toBe(nodeStats);
+});
+
+test('should wait for the next stats after resetting an environment', async () => {
+  const compileState = createCompileState(1);
+  const previousStats = createStats('previous');
+  const nextStats = createStats('next');
+
+  compileState.done(0, previousStats);
+
+  await expect(compileState.wait(0)).resolves.toBe(previousStats);
+
+  compileState.reset(0);
+
+  const nextPromise = compileState.wait(0);
+  let resolved = false;
+  nextPromise.then(() => {
+    resolved = true;
+  });
+
+  await Promise.resolve();
+  expect(resolved).toBe(false);
+
+  compileState.done(0, nextStats);
+
+  await expect(nextPromise).resolves.toBe(nextStats);
+});
+
+test('should not resolve pending waiters with stale stats during repeated resets', async () => {
+  const compileState = createCompileState(1);
+  const previousStats = createStats('previous');
+  const nextStats = createStats('next');
+
+  compileState.done(0, previousStats);
+  compileState.reset(0);
+
+  const nextPromise = compileState.wait(0);
+  let resolvedStats: Rspack.Stats | undefined;
+  nextPromise.then((stats) => {
+    resolvedStats = stats;
+  });
+
+  compileState.reset(0);
+  await Promise.resolve();
+  expect(resolvedStats).toBeUndefined();
+
+  compileState.done(0, nextStats);
+
+  await expect(nextPromise).resolves.toBe(nextStats);
+});


### PR DESCRIPTION
## Summary

This PR lets dev-server environment APIs resolve as soon as their own environment compiler finishes, instead of waiting for the whole MultiCompiler aggregate completion. This allows APIs like `server.environments.node.loadBundle()` to become available when the node compiler is ready while other environments continue compiling.

It also adds a small compile state helper to avoid returning stale stats across repeated invalidations, with focused tests for independent environment readiness and reset behavior.