### PR TITLE
chore(deps): upgrade rspack-chain to 2.1.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,8 +314,8 @@ catalogs:
       specifier: ^2.1.3
       version: 2.1.3
     rspack-chain:
-      specifier: ^2.0.2
-      version: 2.0.2
+      specifier: ^2.1.0
+      version: 2.1.0
     rspack-manifest-plugin:
       specifier: 5.2.2
       version: 5.2.2
@@ -1002,7 +1002,7 @@ importers:
         version: 2.1.3
       rspack-chain:
         specifier: 'catalog:'
-        version: 2.0.2(@rspack/core@2.0.8)
+        version: 2.1.0(@rspack/core@2.0.8)
       rspack-manifest-plugin:
         specifier: 'catalog:'
         version: 5.2.2(@rspack/core@2.0.8)
@@ -5176,10 +5176,10 @@ packages:
     resolution: {integrity: sha512-DCUkRKUBR1lSpHKRcxNvHaYwGrUVf9MsoE1u6gd0CF37I8vwwtWc4b+FA9OwYZ4QA/shslzAYorD3MMfd+Rs/Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  rspack-chain@2.0.2:
-    resolution: {integrity: sha512-AQzqq/pXCKhEOxITyOU0omwyu7c6wXGMjy6257MGnB0b7JnuJFHlwgTOX2nWTwynuFrAwCLnlx+VuUfaO808pQ==}
+  rspack-chain@2.1.0:
+    resolution: {integrity: sha512-FZJkUJaPn5zgidGQHRPvtJ6ECsGfdf1utiHIDKVkD+n9/6q9OQ5D9lKIOWKgrglfNnuACDPAL5FrXdI7ijw6xA==}
     peerDependencies:
-      '@rspack/core': ^2.0.0-0
+      '@rspack/core': ^2.0.0
     peerDependenciesMeta:
       '@rspack/core':
         optional: true
@@ -9934,7 +9934,7 @@ snapshots:
 
   rslog@2.1.3: {}
 
-  rspack-chain@2.0.2(@rspack/core@2.0.8):
+  rspack-chain@2.1.0(@rspack/core@2.0.8):
     optionalDependencies:
       '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -118,7 +118,7 @@ catalog:
   'rsbuild-plugin-google-analytics': '^1.0.6'
   'rsbuild-plugin-open-graph': '^1.1.3'
   'rslog': '^2.1.3'
-  'rspack-chain': '^2.0.2'
+  'rspack-chain': '^2.1.0'
   'rspack-manifest-plugin': '5.2.2'
   'rspack-merge': '1.0.1'
   'rspack-vue-loader': '^17.5.1'
@@ -171,6 +171,7 @@ hoistPattern: []
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - '@rspack/*'
+  - 'rspack-chain'
   - '@rsbuild/*'
   - '@rslib/*'
   - '@rspress/*'


### PR DESCRIPTION
## Summary

Update `rspack-chain` to v2.1.0 so Rsbuild can use the latest chain APIs and type updates. This also excludes `rspack-chain` from pnpm's minimum release age policy so freshly published versions can be installed when intentionally upgraded.

## Related Links

https://github.com/rstackjs/rspack-chain/releases/tag/v2.1.0