### PR TITLE
perf: skip css-loader for non-emitting global CSS

### DIFF
--- a/packages/core/src/helpers/css.ts
+++ b/packages/core/src/helpers/css.ts
@@ -1,0 +1,40 @@
+import type { CSSLoaderOptions } from '../types';
+
+const CSS_MODULE_REGEX = /\.module(s)?\.\w+$/i;
+const CSS_ICSS_REGEX = /\.icss\.\w+$/i;
+
+export const isCSSModules = (
+  modules: CSSLoaderOptions['modules'],
+  resourcePath: string,
+  resourceQuery: string,
+  resourceFragment: string,
+): boolean => {
+  if (!modules) {
+    return false;
+  }
+
+  if (modules === true || typeof modules === 'string') {
+    return true;
+  }
+
+  const { auto } = modules;
+
+  // Align with css-loader: object-form `modules` without `auto` enables CSS Modules for all files.
+  if (auto === undefined) {
+    return true;
+  }
+
+  if (auto === false) {
+    return false;
+  }
+
+  if (auto instanceof RegExp) {
+    return auto.test(resourcePath);
+  }
+
+  if (typeof auto === 'function') {
+    return auto(resourcePath, resourceQuery, resourceFragment);
+  }
+
+  return CSS_MODULE_REGEX.test(resourcePath) || CSS_ICSS_REGEX.test(resourcePath);
+};

--- a/packages/core/src/loader/cssUrlLoader.ts
+++ b/packages/core/src/loader/cssUrlLoader.ts
@@ -5,6 +5,7 @@ import type {
   PathData,
   PitchLoaderDefinitionFunction,
 } from '@rspack/core';
+import { isCSSModules } from '../helpers/css';
 import type { CSSLoaderOptions } from '../types';
 
 type CSSUrlLoaderOptions = {
@@ -12,7 +13,6 @@ type CSSUrlLoaderOptions = {
   modules: CSSLoaderOptions['modules'];
 };
 
-const CSS_MODULE_REGEX = /\.module\.\w+$/i;
 const HASH_PLACEHOLDER_REGEX =
   /\[(?:[^:\]]+:)?(?:chunkhash|contenthash|hash|fullhash)(?::[^\]]+)?]/i;
 
@@ -35,37 +35,6 @@ const getCSSUrlNameSource = (root: string, resourcePath: string) =>
 
 const getCSSUrlAssetName = (nameSource: string, ext: string) =>
   ext ? nameSource.slice(0, -ext.length) : nameSource;
-
-const isCSSModules = (
-  modules: CSSLoaderOptions['modules'],
-  resourcePath: string,
-  resourceQuery: string,
-  resourceFragment: string,
-) => {
-  if (!modules) {
-    return false;
-  }
-
-  if (modules === true || typeof modules === 'string') {
-    return true;
-  }
-
-  const { auto } = modules;
-
-  if (auto === false) {
-    return false;
-  }
-
-  if (auto instanceof RegExp) {
-    return auto.test(resourcePath);
-  }
-
-  if (typeof auto === 'function') {
-    return auto(resourcePath, resourceQuery, resourceFragment);
-  }
-
-  return CSS_MODULE_REGEX.test(resourcePath);
-};
 
 const getCSSContent = (moduleExports: unknown): string => {
   const content =

--- a/packages/core/src/loader/ignoreCssLoader.ts
+++ b/packages/core/src/loader/ignoreCssLoader.ts
@@ -1,8 +1,12 @@
-import type { LoaderDefinition } from '@rspack/core';
+import type { LoaderDefinition, PitchLoaderDefinitionFunction } from '@rspack/core';
+import { isCSSModules } from '../helpers/css';
+import type { CSSLoaderOptions } from '../types';
 
-const ignoreCssLoader: LoaderDefinition = function (source) {
-  this?.cacheable(true);
+type IgnoreCssLoaderOptions = {
+  modules?: CSSLoaderOptions['modules'];
+};
 
+const ignoreCssLoader: LoaderDefinition<IgnoreCssLoaderOptions> = function (source) {
   // if the source code include '___CSS_LOADER_EXPORT___'
   // It is not a CSS Modules file because exportOnlyLocals is enabled,
   // so we don't need to preserve it.
@@ -12,6 +16,18 @@ const ignoreCssLoader: LoaderDefinition = function (source) {
 
   // Preserve CSS Modules export for SSR.
   return source;
+};
+
+// In non-emitting builds, skip css-loader and following CSS transforms for global CSS.
+// CSS Modules must still pass through css-loader so SSR builds can export locals.
+export const pitch: PitchLoaderDefinitionFunction<IgnoreCssLoaderOptions> = function () {
+  const { modules } = this.getOptions();
+
+  if (isCSSModules(modules, this.resourcePath, this.resourceQuery, this.resourceFragment)) {
+    return;
+  }
+
+  return '';
 };
 
 export default ignoreCssLoader;

--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -440,6 +440,14 @@ export const pluginCss = (): RsbuildPlugin => ({
               importLoaders: importLoaders.normal,
             };
           }
+
+          // Let ignoreCssLoader skip non-CSS Modules before css-loader runs
+          if (!emitCss && type === 'main') {
+            rule.use(CHAIN_ID.USE.IGNORE_CSS).options({
+              modules: finalOptions.modules,
+            });
+          }
+
           rule.use(CHAIN_ID.USE.CSS).options(finalOptions);
 
           if (type !== 'url') {

--- a/packages/core/tests/__snapshots__/css.test.ts.snap
+++ b/packages/core/tests/__snapshots__/css.test.ts.snap
@@ -212,6 +212,16 @@ exports[`plugin-css injectStyles > should apply ignoreCssLoader when injectStyle
         "use": [
           {
             "loader": "<ROOT>/packages/core/src/ignoreCssLoader.mjs",
+            "options": {
+              "modules": {
+                "auto": true,
+                "exportGlobals": false,
+                "exportLocalsConvention": "camelCase",
+                "exportOnlyLocals": true,
+                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                "namedExport": false,
+              },
+            },
           },
           {
             "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -1140,6 +1140,16 @@ exports[`should apply default plugins correctly when target is node 1`] = `
             "use": [
               {
                 "loader": "<ROOT>/packages/core/src/ignoreCssLoader.mjs",
+                "options": {
+                  "modules": {
+                    "auto": true,
+                    "exportGlobals": false,
+                    "exportLocalsConvention": "camelCase",
+                    "exportOnlyLocals": true,
+                    "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                    "namedExport": false,
+                  },
+                },
               },
               {
                 "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -599,6 +599,16 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
               "use": [
                 {
                   "loader": "<ROOT>/packages/core/src/ignoreCssLoader.mjs",
+                  "options": {
+                    "modules": {
+                      "auto": true,
+                      "exportGlobals": false,
+                      "exportLocalsConvention": "camelCase",
+                      "exportOnlyLocals": true,
+                      "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                      "namedExport": false,
+                    },
+                  },
                 },
                 {
                   "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",


### PR DESCRIPTION
## Summary

This PR skips `css-loader` and the remaining CSS transform pipeline for global CSS in non-emitting builds such as Node targets, while still letting CSS Modules pass through `css-loader` so SSR builds can export locals.

Node target performance data from https://github.com/chenjiahan/tailwindcss-benchmark, using generated Tailwind CSS imported by a Node `emitCss: false` entry:

- Baseline mean real time: `0.223s` over 7 runs
- Optimized mean real time: `0.103s` over 7 runs, about `54%` lower / `2.17x` faster
- CPU profile `css-loader` samples: `58.96ms -> 0ms`
