### PR TITLE
fix(core): align CSS Modules detection with matchResource

### DIFF
--- a/packages/core/src/helpers/css.ts
+++ b/packages/core/src/helpers/css.ts
@@ -1,3 +1,4 @@
+import type { LoaderContext, NormalModule } from '@rspack/core';
 import type { CSSLoaderOptions } from '../types';
 
 const CSS_MODULE_REGEX = /\.module(s)?\.\w+$/i;
@@ -5,9 +6,7 @@ const CSS_ICSS_REGEX = /\.icss\.\w+$/i;
 
 export const isCSSModules = (
   modules: CSSLoaderOptions['modules'],
-  resourcePath: string,
-  resourceQuery: string,
-  resourceFragment: string,
+  loaderContext: LoaderContext,
 ): boolean => {
   if (!modules) {
     return false;
@@ -28,12 +27,18 @@ export const isCSSModules = (
     return false;
   }
 
+  // Only resolve the css-loader-compatible path for `auto` checks that need it.
+  // Align with css-loader: CSS Modules auto detection uses matchResource when present.
+  const resourcePath =
+    (loaderContext._module as NormalModule | undefined)?.matchResource ||
+    loaderContext.resourcePath;
+
   if (auto instanceof RegExp) {
     return auto.test(resourcePath);
   }
 
   if (typeof auto === 'function') {
-    return auto(resourcePath, resourceQuery, resourceFragment);
+    return auto(resourcePath, loaderContext.resourceQuery, loaderContext.resourceFragment);
   }
 
   return CSS_MODULE_REGEX.test(resourcePath) || CSS_ICSS_REGEX.test(resourcePath);

--- a/packages/core/src/loader/cssUrlLoader.ts
+++ b/packages/core/src/loader/cssUrlLoader.ts
@@ -70,7 +70,7 @@ export const pitch: PitchLoaderDefinitionFunction<CSSUrlLoaderOptions> = async f
 ) {
   const options = this.getOptions();
 
-  if (isCSSModules(options.modules, this.resourcePath, this.resourceQuery, this.resourceFragment)) {
+  if (isCSSModules(options.modules, this)) {
     throw new Error(
       '[rsbuild:css] CSS Modules do not support the ?url query. Use ?inline to import the compiled CSS content as a string.',
     );

--- a/packages/core/src/loader/ignoreCssLoader.ts
+++ b/packages/core/src/loader/ignoreCssLoader.ts
@@ -23,7 +23,7 @@ const ignoreCssLoader: LoaderDefinition<IgnoreCssLoaderOptions> = function (sour
 export const pitch: PitchLoaderDefinitionFunction<IgnoreCssLoaderOptions> = function () {
   const { modules } = this.getOptions();
 
-  if (isCSSModules(modules, this.resourcePath, this.resourceQuery, this.resourceFragment)) {
+  if (isCSSModules(modules, this)) {
     return;
   }
 


### PR DESCRIPTION
## Summary

This PR keeps Rsbuild's CSS Modules detection aligned with css-loader when `matchResource` is present on the current module. This preserves CSS Modules SSR locals in non-emitting builds while still resolving the css-loader-compatible resource path only for `modules.auto` checks that need filename-based detection.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/7904