### PR TITLE
fix(core): disable default pureFunctions experiment

### DIFF
--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -30,11 +30,6 @@ export const pluginBasic = (): RsbuildPlugin => ({
       // Disable performance hints, these logs are too complex
       chain.performance.hints(false);
 
-      chain.experiments({
-        ...chain.get('experiments'),
-        pureFunctions: true,
-      });
-
       chain.module.parser.merge({
         javascript: {
           typeReexportsPresence: 'tolerant',

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -9,9 +9,6 @@ exports[`default bundler > should use Rspack by default 1`] = `
       "./src/index.js",
     ],
   },
-  "experiments": {
-    "pureFunctions": true,
-  },
   "infrastructureLogging": {
     "level": "error",
   },

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -32,9 +32,6 @@ exports[`should apply default plugins correctly 1`] = `
 {
   "context": "<ROOT>",
   "devtool": "cheap-module-source-map",
-  "experiments": {
-    "pureFunctions": true,
-  },
   "infrastructureLogging": {
     "level": "error",
   },
@@ -519,9 +516,6 @@ exports[`should apply default plugins correctly in production 1`] = `
 {
   "context": "<ROOT>",
   "devtool": false,
-  "experiments": {
-    "pureFunctions": true,
-  },
   "infrastructureLogging": {
     "level": "error",
   },
@@ -1036,9 +1030,6 @@ exports[`should apply default plugins correctly when target is node 1`] = `
 {
   "context": "<ROOT>",
   "devtool": "cheap-module-source-map",
-  "experiments": {
-    "pureFunctions": true,
-  },
   "infrastructureLogging": {
     "level": "error",
   },
@@ -1513,9 +1504,6 @@ exports[`tools.rspack > should match snapshot 1`] = `
 {
   "context": "<ROOT>",
   "devtool": "cheap-module-source-map",
-  "experiments": {
-    "pureFunctions": true,
-  },
   "infrastructureLogging": {
     "level": "error",
   },

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -5,9 +5,6 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
   {
     "context": "<ROOT>",
     "devtool": "eval-source-map",
-    "experiments": {
-      "pureFunctions": true,
-    },
     "infrastructureLogging": {
       "level": "error",
     },
@@ -489,9 +486,6 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
   {
     "context": "<ROOT>",
     "devtool": "eval",
-    "experiments": {
-      "pureFunctions": true,
-    },
     "infrastructureLogging": {
       "level": "error",
     },


### PR DESCRIPTION
## Summary

This PR stops enabling Rspack's experimental `experiments.pureFunctions` option by default in Rsbuild because it can currently emit runtime-breaking code in some production builds. Users can still opt into the Rspack experiment manually through `tools.rspack` when needed.

## Related Links

https://github.com/web-infra-dev/rspack/issues/14387