### PR TITLE
fix(core): compact build time logs

### DIFF
--- a/e2e/cases/diagnostic/build-failed-time/index.test.ts
+++ b/e2e/cases/diagnostic/build-failed-time/index.test.ts
@@ -1,6 +1,6 @@
 import { test } from '@e2e/helper';
 
-const EXPECTED_LOG = /build failed in [\d.]+ s/;
+const EXPECTED_LOG = /build failed in (?:[\d.]+s|\d+m(?: [\d.]+s)?)/;
 
 test('should print build failed time', async ({ runBoth }) => {
   await runBoth(

--- a/e2e/cases/diagnostic/build-time/index.test.ts
+++ b/e2e/cases/diagnostic/build-time/index.test.ts
@@ -1,6 +1,6 @@
 import { test } from '@e2e/helper';
 
-const EXPECTED_LOG = /built in [\d.]+ s/;
+const EXPECTED_LOG = /built in (?:[\d.]+s|\d+m(?: [\d.]+s)?)/;
 
 test('should print build time', async ({ runBoth }) => {
   await runBoth(async ({ result }) => {

--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -195,26 +195,26 @@ export const camelCase = (input: string): string =>
   input.replace(/[-_](\w)/g, (_, c: string) => c.toUpperCase());
 
 export const prettyTime = (seconds: number): string => {
-  const format = (time: string) => color.bold(time);
+  const format = (time: string, unit: 'm' | 's') => color.bold(`${time}${unit}`);
 
   if (seconds < 10) {
     const digits = seconds >= 0.01 ? 2 : 3;
-    return `${format(seconds.toFixed(digits))} s`;
+    return format(seconds.toFixed(digits), 's');
   }
 
   if (seconds < 60) {
-    return `${format(seconds.toFixed(1))} s`;
+    return format(seconds.toFixed(1), 's');
   }
 
   const minutes = Math.floor(seconds / 60);
-  const minutesLabel = `${format(minutes.toFixed(0))} m`;
+  const minutesLabel = format(minutes.toFixed(0), 'm');
   const remainingSeconds = seconds % 60;
 
   if (remainingSeconds === 0) {
     return minutesLabel;
   }
 
-  const secondsLabel = `${format(remainingSeconds.toFixed(remainingSeconds % 1 === 0 ? 0 : 1))} s`;
+  const secondsLabel = format(remainingSeconds.toFixed(remainingSeconds % 1 === 0 ? 0 : 1), 's');
 
   return `${minutesLabel} ${secondsLabel}`;
 };

--- a/packages/core/tests/helpers.test.ts
+++ b/packages/core/tests/helpers.test.ts
@@ -124,15 +124,15 @@ test('should get routes correctly', () => {
 });
 
 test('should format time correctly', () => {
-  expect(prettyTime(0.0012)).toEqual('0.001 s');
-  expect(prettyTime(0.0123)).toEqual('0.01 s');
-  expect(prettyTime(0.1234)).toEqual('0.12 s');
-  expect(prettyTime(1.234)).toEqual('1.23 s');
-  expect(prettyTime(12.34)).toEqual('12.3 s');
-  expect(prettyTime(120)).toEqual('2 m');
-  expect(prettyTime(123.4)).toEqual('2 m 3.4 s');
-  expect(prettyTime(1234)).toEqual('20 m 34 s');
-  expect(prettyTime(1234.5)).toEqual('20 m 34.5 s');
+  expect(prettyTime(0.0012)).toEqual('0.001s');
+  expect(prettyTime(0.0123)).toEqual('0.01s');
+  expect(prettyTime(0.1234)).toEqual('0.12s');
+  expect(prettyTime(1.234)).toEqual('1.23s');
+  expect(prettyTime(12.34)).toEqual('12.3s');
+  expect(prettyTime(120)).toEqual('2m');
+  expect(prettyTime(123.4)).toEqual('2m 3.4s');
+  expect(prettyTime(1234)).toEqual('20m 34s');
+  expect(prettyTime(1234.5)).toEqual('20m 34.5s');
 });
 
 describe('pick', () => {


### PR DESCRIPTION
## Summary

This PR updates Rsbuild build duration logs to keep numeric values and units together, matching compact CLI output such as `built in 1m 3.2s`. It changes the shared time formatter so both successful and failed build logs use the same style, and updates unit and e2e assertions accordingly.