### PR TITLE
feat(core): limit printed server routes

### DIFF
--- a/e2e/cases/cli/shortcuts/devMany.js
+++ b/e2e/cases/cli/shortcuts/devMany.js
@@ -1,0 +1,26 @@
+import { createRsbuild } from '@rsbuild/core';
+
+process.stdin.isTTY = true;
+delete process.env.CI;
+
+const entry = Object.fromEntries(
+  Array.from({ length: 12 }, (_, index) => [`route${index}`, './src/index.js']),
+);
+
+async function main() {
+  const rsbuild = await createRsbuild({
+    cwd: import.meta.dirname,
+    config: {
+      source: {
+        entry,
+      },
+      dev: {
+        cliShortcuts: true,
+      },
+    },
+  });
+
+  await rsbuild.startDevServer();
+}
+
+await main();

--- a/e2e/cases/cli/shortcuts/index.test.ts
+++ b/e2e/cases/cli/shortcuts/index.test.ts
@@ -36,6 +36,18 @@ test('should display shortcuts as expected in preview', async ({ exec, logHelper
   await expectLog('➜  Local:    http://localhost:');
 });
 
+test('should show all collapsed urls through shortcuts in dev', async ({ exec, logHelper }) => {
+  const { childProcess } = exec('node ./devMany.js');
+  const { expectLog, expectNoLog, clearLogs } = logHelper;
+
+  await expectLog('... 2 more entries, press u + enter to show all');
+
+  clearLogs();
+  childProcess.stdin?.write('u\n');
+  await expectLog('route11    http://localhost:');
+  expectNoLog('more entries, press u + enter to show all');
+});
+
 test('should support custom shortcuts in dev', async ({ exec, logHelper }) => {
   const { childProcess } = exec('node ./devCustom.js');
   const { expectLog, clearLogs } = logHelper;

--- a/packages/core/src/server/cliShortcuts.ts
+++ b/packages/core/src/server/cliShortcuts.ts
@@ -2,6 +2,8 @@ import { color, isTTY } from '../helpers';
 import type { Logger } from '../logger';
 import type { CliShortcut, NormalizedConfig } from '../types/config';
 
+type PrintUrlsHandler = (options?: { showAllRoutes?: boolean }) => void;
+
 export const isCliShortcutsEnabled = (config: NormalizedConfig): boolean =>
   config.dev.cliShortcuts && isTTY('stdin');
 
@@ -21,7 +23,7 @@ export async function setupCliShortcuts({
   help?: boolean | string;
   openPage: () => Promise<void>;
   closeServer: () => Promise<void>;
-  printUrls: () => void;
+  printUrls: PrintUrlsHandler;
   restartServer?: () => Promise<boolean>;
   customShortcuts?: (shortcuts: CliShortcut[]) => CliShortcut[];
   logger: Logger;
@@ -60,7 +62,7 @@ export async function setupCliShortcuts({
     {
       key: 'u',
       description: `${color.bold('u + enter')}  ${color.dim('show urls')}`,
-      action: printUrls,
+      action: () => printUrls({ showAllRoutes: true }),
     },
   ].filter(Boolean) as CliShortcut[];
 

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -166,7 +166,7 @@ export async function createDevServer<
 
   const cliShortcutsEnabled = isCliShortcutsEnabled(config);
 
-  const printUrls = () =>
+  const printUrls = (options?: { showAllRoutes?: boolean }) =>
     printServerURLs({
       urls,
       port,
@@ -175,6 +175,7 @@ export async function createDevServer<
       printUrls: config.server.printUrls,
       fallbackPathname,
       trailingLineBreak: !cliShortcutsEnabled,
+      showAllRoutes: options?.showAllRoutes,
       originalConfig: context.originalConfig,
       logger,
     });

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -14,6 +14,7 @@ import type {
   NormalizedConfig,
   OutputStructure,
   PrintUrls,
+  PrintUrlsOptions,
   Routes,
   RsbuildConfig,
   RsbuildEntry,
@@ -79,6 +80,33 @@ export const joinUrlPath = (basePath: string, pathname: string): string => {
 
   return addTrailingSlash(basePath) + removeLeadingSlash(pathname);
 };
+
+const DEFAULT_MAX_ROUTES = 10;
+
+const normalizeMaxRoutes = (maxRoutes: number | undefined): number => {
+  if (maxRoutes === undefined) {
+    return DEFAULT_MAX_ROUTES;
+  }
+
+  if (maxRoutes === Number.POSITIVE_INFINITY) {
+    return maxRoutes;
+  }
+
+  return Math.max(0, Math.floor(maxRoutes));
+};
+
+const getPrintUrlsOptions = (printUrls: PrintUrls | undefined): PrintUrlsOptions => {
+  if (printUrls && typeof printUrls === 'object') {
+    return printUrls;
+  }
+
+  return {};
+};
+
+const getMoreEntriesMessage = (moreEntries: number): string =>
+  `  ${color.dim(`... ${moreEntries} more entries, press `)}${color.bold('u + enter')}${color.dim(
+    ' to show all',
+  )}\n`;
 
 export const isUrlPathUnderBase = (pathname: string, base: string): boolean => {
   const basePath = removeTailingSlash(base);
@@ -159,23 +187,43 @@ export const formatRoutes = (
   );
 };
 
-function getURLMessages(urls: { url: string; label: string }[], routes: Routes) {
-  if (routes.length <= 1) {
-    const pathname = routes.length ? routes[0].pathname : '';
+function getURLMessages(
+  urls: { url: string; label: string }[],
+  routes: Routes,
+  {
+    maxRoutes = DEFAULT_MAX_ROUTES,
+    showAllRoutes,
+  }: {
+    maxRoutes?: number;
+    showAllRoutes?: boolean;
+  } = {},
+) {
+  const routeLimit = showAllRoutes ? Number.POSITIVE_INFINITY : normalizeMaxRoutes(maxRoutes);
+  const printableRoutes = routeLimit === 0 ? [] : routes.slice(0, routeLimit);
+  const moreEntries = routeLimit > 0 ? routes.length - printableRoutes.length : 0;
+
+  if (routes.length <= 1 || printableRoutes.length === 0) {
+    const pathname = printableRoutes.length ? printableRoutes[0].pathname : '';
     const maxTrimmedLength = Math.max(...urls.map((u) => u.label.trimEnd().length));
     const padWidth = Math.max(maxTrimmedLength + 2, 10);
-    return urls
+    let message = urls
       .map(({ label, url }) => {
         const normalizedPathname = normalizeUrl(`${url}${pathname}`);
         const prefix = `➜  ${color.dim(label.trimEnd().padEnd(padWidth))}`;
         return `  ${prefix}${color.cyan(normalizedPathname)}\n`;
       })
       .join('');
+
+    if (moreEntries > 0) {
+      message += getMoreEntriesMessage(moreEntries);
+    }
+
+    return message;
   }
 
   let message = '';
   let prevLabel = '';
-  const maxNameLength = Math.max(...routes.map((r) => r.entryName.length));
+  const maxNameLength = Math.max(...printableRoutes.map((r) => r.entryName.length));
   urls.forEach(({ label, url }, index) => {
     if (prevLabel !== label) {
       if (index > 0) {
@@ -185,12 +233,16 @@ function getURLMessages(urls: { url: string; label: string }[], routes: Routes) 
       prevLabel = label;
     }
 
-    for (const { entryName, pathname } of routes) {
+    for (const { entryName, pathname } of printableRoutes) {
       message += `  ${color.dim('-')}  ${color.dim(
         entryName.padEnd(maxNameLength + 4),
       )}${color.cyan(normalizeUrl(`${url}${pathname}`))}\n`;
     }
   });
+
+  if (moreEntries > 0) {
+    message += getMoreEntriesMessage(moreEntries);
+  }
 
   return message;
 }
@@ -203,6 +255,7 @@ export function printServerURLs({
   printUrls,
   fallbackPathname,
   trailingLineBreak = true,
+  showAllRoutes,
   originalConfig,
   logger,
 }: {
@@ -213,6 +266,7 @@ export function printServerURLs({
   printUrls?: PrintUrls;
   fallbackPathname?: string;
   trailingLineBreak?: boolean;
+  showAllRoutes?: boolean;
   originalConfig?: Readonly<RsbuildConfig>;
   logger: Logger;
 }): string | null {
@@ -264,7 +318,11 @@ export function printServerURLs({
     return null;
   }
 
-  let message = getURLMessages(urls, printableRoutes);
+  const printUrlsOptions = getPrintUrlsOptions(printUrls);
+  let message = getURLMessages(urls, printableRoutes, {
+    maxRoutes: useCustomUrl ? Number.POSITIVE_INFINITY : printUrlsOptions.maxRoutes,
+    showAllRoutes,
+  });
 
   if (originalConfig && originalConfig.server?.host === undefined) {
     message += `  ➜  ${color.dim('Network:')}  ${color.dim('use')} ${color.bold('--host')} ${color.dim('to expose')}\n`;

--- a/packages/core/src/server/previewServer.ts
+++ b/packages/core/src/server/previewServer.ts
@@ -94,7 +94,7 @@ export async function startPreviewServer(
     return closingPromise;
   };
 
-  const printUrls = () =>
+  const printUrls = (options?: { showAllRoutes?: boolean }) =>
     printServerURLs({
       urls,
       port,
@@ -102,6 +102,7 @@ export async function startPreviewServer(
       protocol,
       printUrls: serverConfig.printUrls,
       trailingLineBreak: !cliShortcutsEnabled,
+      showAllRoutes: options?.showAllRoutes,
       originalConfig: context.originalConfig,
       logger,
     });

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -374,14 +374,26 @@ export type HistoryApiFallbackOptions = {
   }[];
 };
 
+export type PrintUrlsParams = {
+  urls: string[];
+  port: number;
+  routes: Routes;
+  protocol: string;
+};
+
+export type PrintUrlsOptions = {
+  /**
+   * The maximum number of entry URLs to print.
+   * Set to `0` to print only the server URL without entry routes.
+   * @default 10
+   */
+  maxRoutes?: number;
+};
+
 export type PrintUrls =
   | boolean
-  | ((params: {
-      urls: string[];
-      port: number;
-      routes: Routes;
-      protocol: string;
-    }) => (string | { url: string; label?: string })[] | void);
+  | PrintUrlsOptions
+  | ((params: PrintUrlsParams) => (string | { url: string; label?: string })[] | void);
 
 export type PublicDirOptions = {
   /**

--- a/packages/core/tests/server.test.ts
+++ b/packages/core/tests/server.test.ts
@@ -301,6 +301,147 @@ test('should print server URLs correctly', () => {
   `);
 });
 
+test('should limit printed server routes correctly', () => {
+  let message: string | null;
+
+  message = printServerURLs({
+    port: 3000,
+    protocol: 'http',
+    logger,
+    urls: [
+      {
+        url: 'http://localhost:3000',
+        label: 'local',
+      },
+    ],
+    routes: Array.from({ length: 12 }, (_, index) => ({
+      entryName: `route${index}`,
+      pathname: `/route${index}`,
+    })),
+  });
+
+  expect(message!).toMatchInlineSnapshot(`
+    "  ➜  local
+      -  route0    http://localhost:3000/route0
+      -  route1    http://localhost:3000/route1
+      -  route2    http://localhost:3000/route2
+      -  route3    http://localhost:3000/route3
+      -  route4    http://localhost:3000/route4
+      -  route5    http://localhost:3000/route5
+      -  route6    http://localhost:3000/route6
+      -  route7    http://localhost:3000/route7
+      -  route8    http://localhost:3000/route8
+      -  route9    http://localhost:3000/route9
+      ... 2 more entries, press u + enter to show all
+    "
+  `);
+
+  message = printServerURLs({
+    port: 3000,
+    protocol: 'http',
+    logger,
+    urls: [
+      {
+        url: 'http://localhost:3000',
+        label: 'local',
+      },
+    ],
+    routes: [
+      {
+        entryName: 'index',
+        pathname: '/',
+      },
+      {
+        entryName: 'foo',
+        pathname: '/foo',
+      },
+      {
+        entryName: 'bar',
+        pathname: '/bar',
+      },
+    ],
+    printUrls: {
+      maxRoutes: 2,
+    },
+  });
+
+  expect(message!).toMatchInlineSnapshot(`
+    "  ➜  local
+      -  index    http://localhost:3000/
+      -  foo      http://localhost:3000/foo
+      ... 1 more entries, press u + enter to show all
+    "
+  `);
+
+  message = printServerURLs({
+    port: 3000,
+    protocol: 'http',
+    logger,
+    urls: [
+      {
+        url: 'http://localhost:3000',
+        label: 'local',
+      },
+    ],
+    routes: [
+      {
+        entryName: 'index',
+        pathname: '/',
+      },
+      {
+        entryName: 'foo',
+        pathname: '/foo',
+      },
+    ],
+    printUrls: {
+      maxRoutes: 0,
+    },
+  });
+
+  expect(message!).toMatchInlineSnapshot(`
+    "  ➜  local     http://localhost:3000
+    "
+  `);
+
+  message = printServerURLs({
+    port: 3000,
+    protocol: 'http',
+    logger,
+    urls: [
+      {
+        url: 'http://localhost:3000',
+        label: 'local',
+      },
+    ],
+    routes: [
+      {
+        entryName: 'index',
+        pathname: '/',
+      },
+      {
+        entryName: 'foo',
+        pathname: '/foo',
+      },
+      {
+        entryName: 'bar',
+        pathname: '/bar',
+      },
+    ],
+    printUrls: {
+      maxRoutes: 1,
+    },
+    showAllRoutes: true,
+  });
+
+  expect(message!).toMatchInlineSnapshot(`
+    "  ➜  local
+      -  index    http://localhost:3000/
+      -  foo      http://localhost:3000/foo
+      -  bar      http://localhost:3000/bar
+    "
+  `);
+});
+
 describe('dev server', () => {
   test('should detect client compilers correctly', () => {
     expect(isClientCompiler(rspack({}))).toBeTruthy();

--- a/website/docs/en/config/server/print-urls.mdx
+++ b/website/docs/en/config/server/print-urls.mdx
@@ -12,8 +12,13 @@ type Routes = Array<{
   pathname: string;
 }>;
 
+type PrintUrlsOptions = {
+  maxRoutes?: number;
+};
+
 type PrintUrls =
   | boolean
+  | PrintUrlsOptions
   | ((params: {
       urls: string[];
       port: number;
@@ -32,6 +37,30 @@ By default, when you start the dev server or preview server, Rsbuild will print 
   ➜  Local:    http://localhost:3000
   ➜  Network:  use --host to expose
 ```
+
+## Limit entry URLs
+
+By default, Rsbuild prints up to 10 entry URLs. If the number of entries exceeds this limit, Rsbuild prints the remaining count:
+
+```
+  ... 5 more entries, press u + enter to show all
+```
+
+You can configure `maxRoutes` to change this limit:
+
+```ts title="rsbuild.config.ts"
+export default {
+  server: {
+    printUrls: {
+      maxRoutes: 20,
+    },
+  },
+};
+```
+
+Setting `maxRoutes` to `0` prints only the server URL without entry routes.
+
+The `maxRoutes` option only applies to the built-in URL output. If `server.printUrls` is a function, Rsbuild keeps the existing custom logging behavior.
 
 ## Custom logging
 
@@ -157,4 +186,5 @@ Output:
 
 | Version | Changes                    |
 | ------- | -------------------------- |
+| v2.0.16 | Support for `maxRoutes`    |
 | v1.5.17 | Support for custom `label` |

--- a/website/docs/zh/config/server/print-urls.mdx
+++ b/website/docs/zh/config/server/print-urls.mdx
@@ -12,8 +12,13 @@ type Routes = Array<{
   pathname: string;
 }>;
 
+type PrintUrlsOptions = {
+  maxRoutes?: number;
+};
+
 type PrintUrls =
   | boolean
+  | PrintUrlsOptions
   | ((params: {
       urls: string[];
       port: number;
@@ -32,6 +37,30 @@ type PrintUrls =
   ➜  Local:    http://localhost:3000
   ➜  Network:  use --host to expose
 ```
+
+## 限制 entry URL 输出
+
+默认情况下，Rsbuild 最多会打印 10 个 entry URL。如果 entry 数量超过限制，Rsbuild 会打印剩余数量：
+
+```
+  ... 5 more entries, press u + enter to show all
+```
+
+你可以通过 `maxRoutes` 修改这个限制：
+
+```ts title="rsbuild.config.ts"
+export default {
+  server: {
+    printUrls: {
+      maxRoutes: 20,
+    },
+  },
+};
+```
+
+将 `maxRoutes` 设置为 `0` 时，只会打印 server URL，不会打印 entry routes。
+
+`maxRoutes` 选项只对内置 URL 输出生效。如果 `server.printUrls` 被设置为函数，Rsbuild 会保持已有的自定义日志行为。
 
 ## 自定义日志
 
@@ -158,4 +187,5 @@ export default {
 
 | 版本    | 变更内容           |
 | ------- | ------------------ |
+| v2.0.16 | 支持 `maxRoutes`   |
 | v1.5.17 | 支持自定义 `label` |


### PR DESCRIPTION
## Summary

This PR adds a `server.printUrls.maxRoutes` option so dev and preview server startup logs stay compact when projects have many entries.

By default, Rsbuild prints up to 10 entry URLs, shows a remaining-entry hint with `u + enter`, and supports `maxRoutes: 0` for printing only the server URL.

The CLI `u` shortcut now prints all routes, and the docs and tests cover the new behavior.

```bash
  ➜  Local:  
  -  route0    http://localhost:3000/route0
  -  route1    http://localhost:3000/route1
  -  route2    http://localhost:3000/route2
  -  route3    http://localhost:3000/route3
  -  route4    http://localhost:3000/route4
  -  route5    http://localhost:3000/route5
  -  route6    http://localhost:3000/route6
  -  route7    http://localhost:3000/route7
  -  route8    http://localhost:3000/route8
  -  route9    http://localhost:3000/route9
  ... 5 more entries, press u + enter to show all
  ➜  Network:  use --host to expose
  ➜  press h + enter to show shortcuts

start   build started...
ready   built in 0.03s
```