### PR TITLE
fix(core): update route limit hint without shortcuts

### DIFF
--- a/e2e/cases/cli/shortcuts/devManyNoShortcuts.js
+++ b/e2e/cases/cli/shortcuts/devManyNoShortcuts.js
@@ -1,0 +1,26 @@
+import { createRsbuild } from '@rsbuild/core';
+
+process.stdin.isTTY = true;
+delete process.env.CI;
+
+const entry = Object.fromEntries(
+  Array.from({ length: 12 }, (_, index) => [`route${index}`, './src/index.js']),
+);
+
+async function main() {
+  const rsbuild = await createRsbuild({
+    cwd: import.meta.dirname,
+    config: {
+      source: {
+        entry,
+      },
+      dev: {
+        cliShortcuts: false,
+      },
+    },
+  });
+
+  await rsbuild.startDevServer();
+}
+
+await main();

--- a/e2e/cases/cli/shortcuts/index.test.ts
+++ b/e2e/cases/cli/shortcuts/index.test.ts
@@ -48,6 +48,18 @@ test('should show all collapsed urls through shortcuts in dev', async ({ exec, l
   expectNoLog('more entries, press u + enter to show all');
 });
 
+test('should limit urls without shortcut help when shortcuts are disabled', async ({
+  exec,
+  logHelper,
+}) => {
+  exec('node ./devManyNoShortcuts.js');
+  const { expectLog, expectNoLog } = logHelper;
+
+  await expectLog('... 2 more entries, set server.printUrls.maxRoutes to show more');
+  expectNoLog('press h + enter to show shortcuts');
+  expectNoLog('press u + enter to show all');
+});
+
 test('should support custom shortcuts in dev', async ({ exec, logHelper }) => {
   const { childProcess } = exec('node ./devCustom.js');
   const { expectLog, clearLogs } = logHelper;

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -174,8 +174,8 @@ export async function createDevServer<
       protocol,
       printUrls: config.server.printUrls,
       fallbackPathname,
-      trailingLineBreak: !cliShortcutsEnabled,
       showAllRoutes: options?.showAllRoutes,
+      cliShortcutsEnabled,
       originalConfig: context.originalConfig,
       logger,
     });

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -103,10 +103,17 @@ const getPrintUrlsOptions = (printUrls: PrintUrls | undefined): PrintUrlsOptions
   return {};
 };
 
-const getMoreEntriesMessage = (moreEntries: number): string =>
-  `  ${color.dim(`... ${moreEntries} more entries, press `)}${color.bold('u + enter')}${color.dim(
-    ' to show all',
-  )}\n`;
+const getMoreEntriesMessage = (moreEntries: number, cliShortcutsEnabled: boolean): string => {
+  if (cliShortcutsEnabled) {
+    return `  ${color.dim(`... ${moreEntries} more entries, press `)}${color.bold(
+      'u + enter',
+    )}${color.dim(' to show all')}\n`;
+  }
+
+  return `  ${color.dim(`... ${moreEntries} more entries, set `)}${color.bold(
+    'server.printUrls.maxRoutes',
+  )}${color.dim(' to show more')}\n`;
+};
 
 export const isUrlPathUnderBase = (pathname: string, base: string): boolean => {
   const basePath = removeTailingSlash(base);
@@ -193,10 +200,12 @@ function getURLMessages(
   {
     maxRoutes = DEFAULT_MAX_ROUTES,
     showAllRoutes,
+    cliShortcutsEnabled,
   }: {
     maxRoutes?: number;
     showAllRoutes?: boolean;
-  } = {},
+    cliShortcutsEnabled: boolean;
+  },
 ) {
   const routeLimit = showAllRoutes ? Number.POSITIVE_INFINITY : normalizeMaxRoutes(maxRoutes);
   const printableRoutes = routeLimit === 0 ? [] : routes.slice(0, routeLimit);
@@ -215,7 +224,7 @@ function getURLMessages(
       .join('');
 
     if (moreEntries > 0) {
-      message += getMoreEntriesMessage(moreEntries);
+      message += getMoreEntriesMessage(moreEntries, cliShortcutsEnabled);
     }
 
     return message;
@@ -241,7 +250,7 @@ function getURLMessages(
   });
 
   if (moreEntries > 0) {
-    message += getMoreEntriesMessage(moreEntries);
+    message += getMoreEntriesMessage(moreEntries, cliShortcutsEnabled);
   }
 
   return message;
@@ -254,8 +263,8 @@ export function printServerURLs({
   protocol,
   printUrls,
   fallbackPathname,
-  trailingLineBreak = true,
   showAllRoutes,
+  cliShortcutsEnabled,
   originalConfig,
   logger,
 }: {
@@ -265,8 +274,8 @@ export function printServerURLs({
   protocol: string;
   printUrls?: PrintUrls;
   fallbackPathname?: string;
-  trailingLineBreak?: boolean;
   showAllRoutes?: boolean;
+  cliShortcutsEnabled: boolean;
   originalConfig?: Readonly<RsbuildConfig>;
   logger: Logger;
 }): string | null {
@@ -322,13 +331,14 @@ export function printServerURLs({
   let message = getURLMessages(urls, printableRoutes, {
     maxRoutes: useCustomUrl ? Number.POSITIVE_INFINITY : printUrlsOptions.maxRoutes,
     showAllRoutes,
+    cliShortcutsEnabled,
   });
 
   if (originalConfig && originalConfig.server?.host === undefined) {
     message += `  ➜  ${color.dim('Network:')}  ${color.dim('use')} ${color.bold('--host')} ${color.dim('to expose')}\n`;
   }
 
-  if (!trailingLineBreak && message.endsWith('\n')) {
+  if (cliShortcutsEnabled === true && message.endsWith('\n')) {
     message = message.slice(0, -1);
   }
 

--- a/packages/core/src/server/previewServer.ts
+++ b/packages/core/src/server/previewServer.ts
@@ -101,8 +101,8 @@ export async function startPreviewServer(
       routes,
       protocol,
       printUrls: serverConfig.printUrls,
-      trailingLineBreak: !cliShortcutsEnabled,
       showAllRoutes: options?.showAllRoutes,
+      cliShortcutsEnabled,
       originalConfig: context.originalConfig,
       logger,
     });

--- a/packages/core/tests/server.test.ts
+++ b/packages/core/tests/server.test.ts
@@ -215,12 +215,12 @@ test('should print server URLs correctly', () => {
         pathname: '/',
       },
     ],
+    cliShortcutsEnabled: true,
   });
 
   expect(message!).toMatchInlineSnapshot(`
     "  ➜  local     http://localhost:3000/
-      ➜  network   http://192.168.0.1:3000/
-    "
+      ➜  network   http://192.168.0.1:3000/"
   `);
 
   message = printServerURLs({
@@ -251,6 +251,7 @@ test('should print server URLs correctly', () => {
         pathname: '/bar',
       },
     ],
+    cliShortcutsEnabled: true,
   });
 
   expect(message!).toMatchInlineSnapshot(`
@@ -262,8 +263,7 @@ test('should print server URLs correctly', () => {
       ➜  network
       -  index    http://192.168.0.1:3000/
       -  foo      http://192.168.0.1:3000/html/foo
-      -  bar      http://192.168.0.1:3000/bar
-    "
+      -  bar      http://192.168.0.1:3000/bar"
   `);
 
   message = printServerURLs({
@@ -272,6 +272,7 @@ test('should print server URLs correctly', () => {
     logger,
     urls: [],
     routes: [],
+    cliShortcutsEnabled: true,
   });
 
   expect(message).toEqual(null);
@@ -292,12 +293,12 @@ test('should print server URLs correctly', () => {
     ],
     routes: [],
     fallbackPathname: '/foo',
+    cliShortcutsEnabled: true,
   });
 
   expect(message!).toMatchInlineSnapshot(`
     "  ➜  local     http://localhost:3000/foo/
-      ➜  network   http://192.168.0.1:3000/foo/
-    "
+      ➜  network   http://192.168.0.1:3000/foo/"
   `);
 });
 
@@ -318,6 +319,7 @@ test('should limit printed server routes correctly', () => {
       entryName: `route${index}`,
       pathname: `/route${index}`,
     })),
+    cliShortcutsEnabled: true,
   });
 
   expect(message!).toMatchInlineSnapshot(`
@@ -332,7 +334,39 @@ test('should limit printed server routes correctly', () => {
       -  route7    http://localhost:3000/route7
       -  route8    http://localhost:3000/route8
       -  route9    http://localhost:3000/route9
-      ... 2 more entries, press u + enter to show all
+      ... 2 more entries, press u + enter to show all"
+  `);
+
+  message = printServerURLs({
+    port: 3000,
+    protocol: 'http',
+    logger,
+    urls: [
+      {
+        url: 'http://localhost:3000',
+        label: 'local',
+      },
+    ],
+    routes: Array.from({ length: 12 }, (_, index) => ({
+      entryName: `route${index}`,
+      pathname: `/route${index}`,
+    })),
+    cliShortcutsEnabled: false,
+  });
+
+  expect(message!).toMatchInlineSnapshot(`
+    "  ➜  local
+      -  route0    http://localhost:3000/route0
+      -  route1    http://localhost:3000/route1
+      -  route2    http://localhost:3000/route2
+      -  route3    http://localhost:3000/route3
+      -  route4    http://localhost:3000/route4
+      -  route5    http://localhost:3000/route5
+      -  route6    http://localhost:3000/route6
+      -  route7    http://localhost:3000/route7
+      -  route8    http://localhost:3000/route8
+      -  route9    http://localhost:3000/route9
+      ... 2 more entries, set server.printUrls.maxRoutes to show more
     "
   `);
 
@@ -363,13 +397,51 @@ test('should limit printed server routes correctly', () => {
     printUrls: {
       maxRoutes: 2,
     },
+    cliShortcutsEnabled: true,
   });
 
   expect(message!).toMatchInlineSnapshot(`
     "  ➜  local
       -  index    http://localhost:3000/
       -  foo      http://localhost:3000/foo
-      ... 1 more entries, press u + enter to show all
+      ... 1 more entries, press u + enter to show all"
+  `);
+
+  message = printServerURLs({
+    port: 3000,
+    protocol: 'http',
+    logger,
+    urls: [
+      {
+        url: 'http://localhost:3000',
+        label: 'local',
+      },
+    ],
+    routes: [
+      {
+        entryName: 'index',
+        pathname: '/',
+      },
+      {
+        entryName: 'foo',
+        pathname: '/foo',
+      },
+      {
+        entryName: 'bar',
+        pathname: '/bar',
+      },
+    ],
+    printUrls: {
+      maxRoutes: 2,
+    },
+    cliShortcutsEnabled: false,
+  });
+
+  expect(message!).toMatchInlineSnapshot(`
+    "  ➜  local
+      -  index    http://localhost:3000/
+      -  foo      http://localhost:3000/foo
+      ... 1 more entries, set server.printUrls.maxRoutes to show more
     "
   `);
 
@@ -396,11 +468,11 @@ test('should limit printed server routes correctly', () => {
     printUrls: {
       maxRoutes: 0,
     },
+    cliShortcutsEnabled: true,
   });
 
   expect(message!).toMatchInlineSnapshot(`
-    "  ➜  local     http://localhost:3000
-    "
+    "  ➜  local     http://localhost:3000"
   `);
 
   message = printServerURLs({
@@ -431,14 +503,14 @@ test('should limit printed server routes correctly', () => {
       maxRoutes: 1,
     },
     showAllRoutes: true,
+    cliShortcutsEnabled: true,
   });
 
   expect(message!).toMatchInlineSnapshot(`
     "  ➜  local
       -  index    http://localhost:3000/
       -  foo      http://localhost:3000/foo
-      -  bar      http://localhost:3000/bar
-    "
+      -  bar      http://localhost:3000/bar"
   `);
 });
 

--- a/website/docs/en/config/server/print-urls.mdx
+++ b/website/docs/en/config/server/print-urls.mdx
@@ -40,7 +40,7 @@ By default, when you start the dev server or preview server, Rsbuild will print 
 
 ## Limit entry URLs
 
-By default, Rsbuild prints up to 10 entry URLs. If the number of entries exceeds this limit, Rsbuild prints the remaining count:
+Rsbuild prints up to 10 entry URLs by default. If the number of entries exceeds this limit, Rsbuild prints the remaining count:
 
 ```
   ... 5 more entries, press u + enter to show all


### PR DESCRIPTION
## Summary

This PR follows up on the `server.printUrls.maxRoutes` behavior from #7912. When CLI shortcuts are unavailable, Rsbuild now still applies `maxRoutes` but avoids the `u + enter` shortcut hint, and instead points users to `server.printUrls.maxRoutes` for showing more entries.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/7912#discussion_r3418237386