### PR TITLE
chore: add plugin npm support metadata

### DIFF
--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -9,6 +9,9 @@
     "url": "https://github.com/web-infra-dev/rsbuild",
     "directory": "packages/plugin-solid"
   },
+  "bugs": {
+    "url": "https://github.com/web-infra-dev/rsbuild/issues"
+  },
   "files": [
     "dist"
   ],

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -2,11 +2,15 @@
   "name": "@rsbuild/plugin-svelte",
   "version": "2.0.0",
   "description": "Svelte plugin for Rsbuild",
+  "homepage": "https://rsbuild.rs",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsbuild",
     "directory": "packages/plugin-svelte"
+  },
+  "bugs": {
+    "url": "https://github.com/web-infra-dev/rsbuild/issues"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Summary

- Adds npm support metadata for `@rsbuild/plugin-svelte`
- Adds missing `bugs.url` metadata for `@rsbuild/plugin-solid`

## Why

Both packages already point to this GitHub repository, but their published npm metadata does not expose complete support links. Adding these fields helps npm users find the project site and issue tracker from registry/package manager metadata.

## Validation

- Parsed both package manifests with Node
- Confirmed the expected `homepage` / `bugs.url` values
- Ran `git diff --check`

No runtime code, dependencies, exports, or build outputs were changed.
