### PR TITLE
feat(plugin-svgr): add parallel option

### DIFF
--- a/e2e/cases/plugin-svgr/parallel/index.test.ts
+++ b/e2e/cases/plugin-svgr/parallel/index.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from '@e2e/helper';
+
+test('should compile SVG React components with `parallel` option', async ({
+  page,
+  runBothServe,
+}) => {
+  await runBothServe(async () => {
+    for (const id of ['icon-a', 'icon-b', 'icon-c', 'icon-d', 'icon-e']) {
+      await expect(page.locator(`#${id}`)).toHaveJSProperty('tagName', 'svg');
+    }
+  });
+});

--- a/e2e/cases/plugin-svgr/parallel/rsbuild.config.ts
+++ b/e2e/cases/plugin-svgr/parallel/rsbuild.config.ts
@@ -1,0 +1,14 @@
+import { pluginReact } from '@rsbuild/plugin-react';
+import { pluginSvgr } from '@rsbuild/plugin-svgr';
+
+export default {
+  plugins: [
+    pluginReact(),
+    pluginSvgr({
+      parallel: true,
+      svgrOptions: {
+        exportType: 'default',
+      },
+    }),
+  ],
+};

--- a/e2e/cases/plugin-svgr/parallel/src/App.jsx
+++ b/e2e/cases/plugin-svgr/parallel/src/App.jsx
@@ -1,0 +1,19 @@
+import { IconA } from './icons/IconA';
+import { IconB } from './icons/IconB';
+import { IconC } from './icons/IconC';
+import { IconD } from './icons/IconD';
+import { IconE } from './icons/IconE';
+
+function App() {
+  return (
+    <div>
+      <IconA />
+      <IconB />
+      <IconC />
+      <IconD />
+      <IconE />
+    </div>
+  );
+}
+
+export default App;

--- a/e2e/cases/plugin-svgr/parallel/src/icons/IconA.jsx
+++ b/e2e/cases/plugin-svgr/parallel/src/icons/IconA.jsx
@@ -1,0 +1,5 @@
+import Svg from '@e2e/assets/circle.svg';
+
+export function IconA() {
+  return <Svg id="icon-a" />;
+}

--- a/e2e/cases/plugin-svgr/parallel/src/icons/IconB.jsx
+++ b/e2e/cases/plugin-svgr/parallel/src/icons/IconB.jsx
@@ -1,0 +1,5 @@
+import Svg from '@e2e/assets/circle.svg';
+
+export function IconB() {
+  return <Svg id="icon-b" />;
+}

--- a/e2e/cases/plugin-svgr/parallel/src/icons/IconC.jsx
+++ b/e2e/cases/plugin-svgr/parallel/src/icons/IconC.jsx
@@ -1,0 +1,5 @@
+import Svg from '@e2e/assets/circle.svg?react';
+
+export function IconC() {
+  return <Svg id="icon-c" />;
+}

--- a/e2e/cases/plugin-svgr/parallel/src/icons/IconD.jsx
+++ b/e2e/cases/plugin-svgr/parallel/src/icons/IconD.jsx
@@ -1,0 +1,5 @@
+import Svg from '@e2e/assets/circle.svg?react';
+
+export function IconD() {
+  return <Svg id="icon-d" />;
+}

--- a/e2e/cases/plugin-svgr/parallel/src/icons/IconE.jsx
+++ b/e2e/cases/plugin-svgr/parallel/src/icons/IconE.jsx
@@ -1,0 +1,5 @@
+import Svg from '@e2e/assets/circle.svg';
+
+export function IconE() {
+  return <Svg id="icon-e" />;
+}

--- a/e2e/cases/plugin-svgr/parallel/src/index.js
+++ b/e2e/cases/plugin-svgr/parallel/src/index.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const container = document.getElementById('root');
+if (container) {
+  const root = createRoot(container);
+  root.render(React.createElement(App));
+}

--- a/packages/plugin-svgr/src/index.ts
+++ b/packages/plugin-svgr/src/index.ts
@@ -37,6 +37,16 @@ export type PluginSvgrOptions = {
   query?: RegExp;
 
   /**
+   * Whether to enable parallel loader execution, running SVGR loader in worker
+   * threads. When enabled, this typically improves build performance when compiling
+   * large numbers of SVG modules.
+   * @experimental This is an experimental Rspack feature and may not work if your SVGR
+   * options contain functions.
+   * @default false
+   */
+  parallel?: boolean;
+
+  /**
    * Exclude specific SVG files from SVGR transformation.
    */
   exclude?: Rspack.RuleSetCondition;
@@ -146,6 +156,7 @@ export const pluginSvgr = (options: PluginSvgrOptions = {}): RsbuildPlugin => ({
 
   setup(api) {
     assertCoreVersion(api.context.version);
+    const { parallel = false } = options;
 
     api.modifyBundlerChain((chain, { CHAIN_ID, environment }) => {
       const { config } = environment;
@@ -200,7 +211,7 @@ export const pluginSvgr = (options: PluginSvgrOptions = {}): RsbuildPlugin => ({
       }
 
       // force to react component: "foo.svg?react"
-      rule
+      const svgReactUse = rule
         .oneOf(CHAIN_ID.ONE_OF.SVG_REACT)
         .type('javascript/auto')
         .resourceQuery(options.query || /react/)
@@ -209,8 +220,11 @@ export const pluginSvgr = (options: PluginSvgrOptions = {}): RsbuildPlugin => ({
         .options({
           ...svgrOptions,
           exportType: 'default',
-        } satisfies SvgrOptions)
-        .end();
+        } satisfies SvgrOptions);
+
+      if (parallel) {
+        svgReactUse.parallel(true);
+      }
 
       // SVG in JS files
       const { mixedImport = false } = options;
@@ -228,7 +242,7 @@ export const pluginSvgr = (options: PluginSvgrOptions = {}): RsbuildPlugin => ({
           svgRule.exclude.add(options.exclude);
         }
 
-        svgRule
+        const svgUse = svgRule
           .type('javascript/auto')
           // The issuer option ensures that SVGR will only apply if the SVG is imported from a JS file.
           .set('issuer', issuer)
@@ -237,8 +251,11 @@ export const pluginSvgr = (options: PluginSvgrOptions = {}): RsbuildPlugin => ({
           .options({
             ...svgrOptions,
             exportType,
-          })
-          .end();
+          });
+
+        if (parallel) {
+          svgUse.parallel(true);
+        }
 
         /**
          * For mixed import.

--- a/website/docs/en/plugins/list/plugin-svgr.mdx
+++ b/website/docs/en/plugins/list/plugin-svgr.mdx
@@ -101,6 +101,11 @@ type PluginSvgrOptions = {
    */
   query?: RegExp;
   /**
+   * Whether to enable parallel loader execution.
+   * @default false
+   */
+  parallel?: boolean;
+  /**
    * Exclude specific SVG files from SVGR transformation.
    */
   exclude?: Rspack.RuleSetCondition;
@@ -289,6 +294,24 @@ import Logo from './logo.svg?svgr';
 
 export const App = () => <Logo />;
 ```
+
+### parallel
+
+- **Type:** `boolean`
+- **Default:** `false`
+- **Version:** Added in v2.0.4
+
+Whether to enable parallel loader execution, running SVGR loader in worker threads. When enabled, this typically improves build performance when compiling large numbers of SVG modules.
+
+Note that this option is experimental and may not work if your SVGR options contain functions.
+
+```ts
+pluginSvgr({
+  parallel: true,
+});
+```
+
+> See [Rspack - Rule.use.parallel](https://rspack.rs/config/module-rules#rulesuseparallel) for more details.
 
 ### exclude
 

--- a/website/docs/zh/plugins/list/plugin-svgr.mdx
+++ b/website/docs/zh/plugins/list/plugin-svgr.mdx
@@ -101,6 +101,11 @@ type PluginSvgrOptions = {
    */
   query?: RegExp;
   /**
+   * 是否开启并行 loader 执行
+   * @default false
+   */
+  parallel?: boolean;
+  /**
    * 排除一部分 SVG 文件，这些文件不会经过 SVGR 处理
    */
   exclude?: Rspack.RuleSetCondition;
@@ -289,6 +294,24 @@ import Logo from './logo.svg?svgr';
 
 export const App = () => <Logo />;
 ```
+
+### parallel
+
+- **类型：** `boolean`
+- **默认值：** `false`
+- **版本：** 添加于 v2.0.4
+
+是否开启并行 loader 执行，在 worker 线程中运行 SVGR loader。开启后，在编译大量 SVG 模块时通常会有构建性能提升。
+
+注意该选项为实验性功能，当 SVGR 选项中包含函数时，可能无法正常工作。
+
+```ts
+pluginSvgr({
+  parallel: true,
+});
+```
+
+> 详见 [Rspack - Rule.use.parallel](https://rspack.rs/zh/config/module-rules#rulesuseparallel)。
 
 ### exclude
 


### PR DESCRIPTION
## Summary

This PR adds a `parallel` option to `@rsbuild/plugin-svgr` so SVGR transforms can run in Rspack worker threads for projects that compile many SVG modules. It wires the option into both `?react` and SVG component import rules, documents the API with its release version, and adds an e2e case covering multiple modules importing SVG with `parallel: true`.