### PR TITLE
feat(plugin-babel): add parallel option

### DIFF
--- a/e2e/cases/plugin-babel/parallel/index.test.ts
+++ b/e2e/cases/plugin-babel/parallel/index.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from '@e2e/helper';
+
+test('should compile JavaScript with parallel Babel loader', async ({ page, runBothServe }) => {
+  await runBothServe(async () => {
+    expect(await page.evaluate('window.parallelBabelMessages')).toEqual(
+      Array.from({ length: 5 }, () => 'compiled by parallel babel-loader'),
+    );
+  });
+});

--- a/e2e/cases/plugin-babel/parallel/plugins/replace-message.mjs
+++ b/e2e/cases/plugin-babel/parallel/plugins/replace-message.mjs
@@ -1,0 +1,10 @@
+export default () => ({
+  name: 'replace-message',
+  visitor: {
+    StringLiteral(path) {
+      if (path.node.value === 'compiled without babel') {
+        path.node.value = 'compiled by parallel babel-loader';
+      }
+    },
+  },
+});

--- a/e2e/cases/plugin-babel/parallel/rsbuild.config.ts
+++ b/e2e/cases/plugin-babel/parallel/rsbuild.config.ts
@@ -1,0 +1,13 @@
+import path from 'node:path';
+import { pluginBabel } from '@rsbuild/plugin-babel';
+
+export default {
+  plugins: [
+    pluginBabel({
+      parallel: true,
+      babelLoaderOptions: {
+        plugins: [path.resolve(import.meta.dirname, './plugins/replace-message.mjs')],
+      },
+    }),
+  ],
+};

--- a/e2e/cases/plugin-babel/parallel/src/index.js
+++ b/e2e/cases/plugin-babel/parallel/src/index.js
@@ -1,0 +1,7 @@
+import { messageA } from './messageA.js';
+import { messageB } from './messageB.js';
+import { messageC } from './messageC.js';
+import { messageD } from './messageD.js';
+import { messageE } from './messageE.js';
+
+window.parallelBabelMessages = [messageA, messageB, messageC, messageD, messageE];

--- a/e2e/cases/plugin-babel/parallel/src/messageA.js
+++ b/e2e/cases/plugin-babel/parallel/src/messageA.js
@@ -1,0 +1,1 @@
+export const messageA = 'compiled without babel';

--- a/e2e/cases/plugin-babel/parallel/src/messageB.js
+++ b/e2e/cases/plugin-babel/parallel/src/messageB.js
@@ -1,0 +1,1 @@
+export const messageB = 'compiled without babel';

--- a/e2e/cases/plugin-babel/parallel/src/messageC.js
+++ b/e2e/cases/plugin-babel/parallel/src/messageC.js
@@ -1,0 +1,1 @@
+export const messageC = 'compiled without babel';

--- a/e2e/cases/plugin-babel/parallel/src/messageD.js
+++ b/e2e/cases/plugin-babel/parallel/src/messageD.js
@@ -1,0 +1,1 @@
+export const messageD = 'compiled without babel';

--- a/e2e/cases/plugin-babel/parallel/src/messageE.js
+++ b/e2e/cases/plugin-babel/parallel/src/messageE.js
@@ -1,0 +1,1 @@
+export const messageE = 'compiled without babel';

--- a/packages/plugin-babel/src/plugin.ts
+++ b/packages/plugin-babel/src/plugin.ts
@@ -116,7 +116,8 @@ export const pluginBabel = (options: PluginBabelOptions = {}): RsbuildPlugin => 
       handler: async (chain, { CHAIN_ID, environment }) => {
         const babelOptions = await getBabelOptions(environment);
         const babelLoader = path.resolve(__dirname, '../compiled/babel-loader/index.js');
-        const { include, exclude } = options;
+        const { include, exclude, parallel = false } = options;
+        const isV1 = api.context.version.startsWith('1.');
 
         if (include || exclude) {
           const rule = chain.module
@@ -136,17 +137,36 @@ export const pluginBabel = (options: PluginBabelOptions = {}): RsbuildPlugin => 
             }
           }
 
-          rule.test(SCRIPT_REGEX).use(CHAIN_ID.USE.BABEL).loader(babelLoader).options(babelOptions);
+          const loader = rule
+            .test(SCRIPT_REGEX)
+            .use(CHAIN_ID.USE.BABEL)
+            .loader(babelLoader)
+            .options(babelOptions);
+
+          if (parallel) {
+            loader.parallel(true);
+          }
         } else {
           // Compatibility for Rsbuild v1
-          const isV1 = api.context.version.startsWith('1.');
           const jsRule = chain.module.rule(CHAIN_ID.RULE.JS).test(SCRIPT_REGEX);
           const jsMainRule = isV1 ? jsRule : jsRule.oneOfs.get(CHAIN_ID.ONE_OF.JS_MAIN);
-          jsMainRule
+          const loader = jsMainRule
             .use(CHAIN_ID.USE.BABEL)
             .after(CHAIN_ID.USE.SWC)
             .loader(babelLoader)
             .options(babelOptions);
+
+          if (parallel) {
+            loader.parallel(true);
+          }
+        }
+
+        // `experiments.parallelLoader` is no longer required in Rspack 2.0+
+        if (parallel && isV1) {
+          chain.experiments({
+            ...chain.get('experiments'),
+            parallelLoader: true,
+          });
         }
       },
     });

--- a/packages/plugin-babel/src/types.ts
+++ b/packages/plugin-babel/src/types.ts
@@ -106,4 +106,11 @@ export type PluginBabelOptions = {
    * @see https://github.com/babel/babel-loader
    */
   babelLoaderOptions?: ConfigChainWithContext<BabelLoaderOptions, BabelConfigUtils>;
+  /**
+   * Whether to enable parallel loader execution, running `babel-loader` in worker
+   * threads. When enabled, this typically improves build performance when compiling
+   * large numbers of modules.
+   * @default false
+   */
+  parallel?: boolean;
 };

--- a/website/docs/en/plugins/list/plugin-babel.mdx
+++ b/website/docs/en/plugins/list/plugin-babel.mdx
@@ -270,6 +270,24 @@ pluginBabel({
 });
 ```
 
+### parallel
+
+- **Type:** `boolean`
+- **Default:** `false`
+- **Version:** `>= 1.2.2`
+
+Whether to enable parallel loader execution, running `babel-loader` in worker threads. When enabled, this typically improves build performance when compiling large numbers of JavaScript modules.
+
+Note that this option is experimental and may not work if your Babel options contain functions.
+
+```ts
+pluginBabel({
+  parallel: true,
+});
+```
+
+> See [Rspack - Rule.use.parallel](https://rspack.rs/config/module-rules#rulesuseparallel) for more details.
+
 :::tip
 When you configure the `include` or `exclude` options, Rsbuild will create a separate Rspack rule to apply babel-loader and swc-loader.
 

--- a/website/docs/zh/plugins/list/plugin-babel.mdx
+++ b/website/docs/zh/plugins/list/plugin-babel.mdx
@@ -269,6 +269,24 @@ pluginBabel({
 });
 ```
 
+### parallel
+
+- **类型：** `boolean`
+- **默认值：** `false`
+- **版本：** `>= 1.2.2`
+
+是否开启并行 loader 执行，在 worker 线程中运行 `babel-loader`。开启后，在编译大量模块时通常会有构建性能提升。
+
+注意该选项为实验性功能，当 Babel 选项中包含函数时可能无法正常工作。
+
+```ts
+pluginBabel({
+  parallel: true,
+});
+```
+
+> 详见 [Rspack - Rule.use.parallel](https://rspack.rs/zh/config/module-rules#rulesuseparallel)。
+
 :::tip
 当你配置 `include` 或 `exclude` 选项时，Rsbuild 会创建一条单独的 Rspack rule 来应用 babel-loader 和 swc-loader。
 


### PR DESCRIPTION
## Summary

This PR adds a `parallel` option to `@rsbuild/plugin-babel` so Babel loader work can run in Rspack worker threads for projects compiling many modules. It applies `Rule.use.parallel(true)` for both the built-in JS rule and custom `include`/`exclude` Babel rules, preserves Rspack v1 compatibility with `experiments.parallelLoader`, documents the new option in English and Chinese, and adds an e2e case using an ESM Babel plugin across multiple JS modules.