### PR TITLE
docs: use giget for example initialization

### DIFF
--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -43,6 +43,7 @@ flexbox
 flexbugs
 fnames
 frontends
+giget
 fullhash
 fullhref
 gzipped

--- a/website/docs/en/guide/framework/react.mdx
+++ b/website/docs/en/guide/framework/react.mdx
@@ -38,7 +38,7 @@ The following full-stack React frameworks are built on Rsbuild and reuse Rsbuild
 You can initialize the TanStack Start example project with:
 
 ```bash
-pnpm dlx giget@latest gh:rstackjs/rstack-examples/rsbuild/tanstack-start tanstack-start
+npx giget gh:rstackjs/rstack-examples/rsbuild/tanstack-start tanstack-start
 cd tanstack-start
 pnpm i
 ```

--- a/website/docs/en/guide/framework/react.mdx
+++ b/website/docs/en/guide/framework/react.mdx
@@ -38,7 +38,7 @@ The following full-stack React frameworks are built on Rsbuild and reuse Rsbuild
 You can initialize the TanStack Start example project with:
 
 ```bash
-pnpx degit https://github.com/rstackjs/rstack-examples/rsbuild/tanstack-start tanstack-start
+pnpm dlx giget@latest gh:rstackjs/rstack-examples/rsbuild/tanstack-start tanstack-start
 cd tanstack-start
 pnpm i
 ```

--- a/website/docs/en/guide/framework/solid.mdx
+++ b/website/docs/en/guide/framework/solid.mdx
@@ -37,7 +37,7 @@ The following full-stack Solid frameworks are built on Rsbuild and reuse Rsbuild
 You can initialize the TanStack Start example project with:
 
 ```bash
-pnpm dlx giget@latest gh:rstackjs/rstack-examples/rsbuild/tanstack-start-solid tanstack-start
+npx giget gh:rstackjs/rstack-examples/rsbuild/tanstack-start-solid tanstack-start
 cd tanstack-start
 pnpm i
 ```

--- a/website/docs/en/guide/framework/solid.mdx
+++ b/website/docs/en/guide/framework/solid.mdx
@@ -37,7 +37,7 @@ The following full-stack Solid frameworks are built on Rsbuild and reuse Rsbuild
 You can initialize the TanStack Start example project with:
 
 ```bash
-pnpx degit https://github.com/rstackjs/rstack-examples/rsbuild/tanstack-start-solid tanstack-start
+pnpm dlx giget@latest gh:rstackjs/rstack-examples/rsbuild/tanstack-start-solid tanstack-start
 cd tanstack-start
 pnpm i
 ```

--- a/website/docs/zh/guide/framework/react.mdx
+++ b/website/docs/zh/guide/framework/react.mdx
@@ -38,7 +38,7 @@ import { PackageManagerTabs } from '@theme';
 你可以运行以下命令来一键初始化 TanStack Start 示例项目：
 
 ```bash
-pnpm dlx giget@latest gh:rstackjs/rstack-examples/rsbuild/tanstack-start tanstack-start
+npx giget gh:rstackjs/rstack-examples/rsbuild/tanstack-start tanstack-start
 cd tanstack-start
 pnpm i
 ```

--- a/website/docs/zh/guide/framework/react.mdx
+++ b/website/docs/zh/guide/framework/react.mdx
@@ -38,7 +38,7 @@ import { PackageManagerTabs } from '@theme';
 你可以运行以下命令来一键初始化 TanStack Start 示例项目：
 
 ```bash
-pnpx degit https://github.com/rstackjs/rstack-examples/rsbuild/tanstack-start tanstack-start
+pnpm dlx giget@latest gh:rstackjs/rstack-examples/rsbuild/tanstack-start tanstack-start
 cd tanstack-start
 pnpm i
 ```

--- a/website/docs/zh/guide/framework/solid.mdx
+++ b/website/docs/zh/guide/framework/solid.mdx
@@ -37,7 +37,7 @@ import { PackageManagerTabs } from '@theme';
 你可以运行以下命令来一键初始化 TanStack Start 示例项目：
 
 ```bash
-pnpx degit https://github.com/rstackjs/rstack-examples/rsbuild/tanstack-start-solid tanstack-start
+pnpm dlx giget@latest gh:rstackjs/rstack-examples/rsbuild/tanstack-start-solid tanstack-start
 cd tanstack-start
 pnpm i
 ```

--- a/website/docs/zh/guide/framework/solid.mdx
+++ b/website/docs/zh/guide/framework/solid.mdx
@@ -37,7 +37,7 @@ import { PackageManagerTabs } from '@theme';
 你可以运行以下命令来一键初始化 TanStack Start 示例项目：
 
 ```bash
-pnpm dlx giget@latest gh:rstackjs/rstack-examples/rsbuild/tanstack-start-solid tanstack-start
+npx giget gh:rstackjs/rstack-examples/rsbuild/tanstack-start-solid tanstack-start
 cd tanstack-start
 pnpm i
 ```


### PR DESCRIPTION
## Summary

This PR updates the React and Solid full-stack framework docs to initialize rstack-examples with `giget` instead of `degit`, matching the updated example cloning guidance. It covers both English and Chinese docs. Validated with `pnpm exec oxfmt --check website/docs/en/guide/framework/react.mdx website/docs/zh/guide/framework/react.mdx website/docs/en/guide/framework/solid.mdx website/docs/zh/guide/framework/solid.mdx`.

## Related Links

- https://github.com/rstackjs/rstack-examples