### PR TITLE
feat(plugin-babel)!: publish as pure ESM package

### DIFF
--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -17,8 +17,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.js"
     }
   },
   "publishConfig": {

--- a/packages/plugin-babel/rslib.config.ts
+++ b/packages/plugin-babel/rslib.config.ts
@@ -1,3 +1,3 @@
-import { dualPackage } from '@scripts/config/rslib.config.ts';
+import { pureEsmPackage } from '@scripts/config/rslib.config.ts';
 
-export default dualPackage;
+export default pureEsmPackage;


### PR DESCRIPTION
## Summary

Publish `@rsbuild/plugin-babel` as a pure ESM package by removing its CommonJS export condition and switching the package to the shared ESM-only Rslib config. This keeps the existing Babel behavior and Rsbuild v1 compatibility tests intact while aligning the package metadata with the repository's pure ESM package shape.