### PR TITLE
docs: update parallel loader docs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,5 +31,8 @@
   },
   "[javascript]": {
     "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "[mdx]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
   }
 }

--- a/packages/plugin-babel/src/types.ts
+++ b/packages/plugin-babel/src/types.ts
@@ -107,9 +107,14 @@ export type PluginBabelOptions = {
    */
   babelLoaderOptions?: ConfigChainWithContext<BabelLoaderOptions, BabelConfigUtils>;
   /**
-   * Whether to enable parallel loader execution, running `babel-loader` in worker
-   * threads. When enabled, this typically improves build performance when compiling
-   * large numbers of modules.
+   * Whether to run Babel transformations in parallel using worker threads. When
+   * enabled, JavaScript modules are processed across multiple worker threads,
+   * reducing pressure on the main thread and improving overall build performance
+   * when compiling large numbers of modules.
+   *
+   * Options transferred to worker threads must comply with the HTML structured clone
+   * algorithm. For example, functions cannot be passed as options.
+   * @see https://nodejs.org/api/worker_threads.html#portpostmessagevalue-transferlist
    * @default false
    */
   parallel?: boolean;

--- a/packages/plugin-less/src/index.ts
+++ b/packages/plugin-less/src/index.ts
@@ -87,11 +87,14 @@ export type PluginLessOptions = {
    */
   exclude?: Rspack.RuleSetCondition;
   /**
-   * Whether to enable parallel loader execution, running `less-loader` in worker
-   * threads. When enabled, this typically improves build performance when compiling
-   * large numbers of Less modules.
-   * @experimental This is an experimental Rspack feature and will not work if your Less
-   * options contain functions.
+   * Whether to compile Less modules in parallel using worker threads. When enabled,
+   * Less modules are processed across multiple worker threads, reducing pressure on
+   * the main thread and improving overall build performance when compiling large
+   * numbers of Less modules.
+   *
+   * Options transferred to worker threads must comply with the HTML structured clone
+   * algorithm. For example, functions cannot be passed as options.
+   * @see https://nodejs.org/api/worker_threads.html#portpostmessagevalue-transferlist
    * @default false
    */
   parallel?: boolean;

--- a/packages/plugin-svgr/src/index.ts
+++ b/packages/plugin-svgr/src/index.ts
@@ -37,11 +37,14 @@ export type PluginSvgrOptions = {
   query?: RegExp;
 
   /**
-   * Whether to enable parallel loader execution, running SVGR loader in worker
-   * threads. When enabled, this typically improves build performance when compiling
-   * large numbers of SVG modules.
-   * @experimental This is an experimental Rspack feature and may not work if your SVGR
-   * options contain functions.
+   * Whether to transform SVG modules into React components in parallel using worker
+   * threads. When enabled, SVG modules are processed across multiple worker threads,
+   * reducing pressure on the main thread and improving overall build performance
+   * when compiling large numbers of SVG modules.
+   *
+   * Options transferred to worker threads must comply with the HTML structured clone
+   * algorithm. For example, functions cannot be passed as options.
+   * @see https://nodejs.org/api/worker_threads.html#portpostmessagevalue-transferlist
    * @default false
    */
   parallel?: boolean;

--- a/website/docs/en/plugins/list/plugin-babel.mdx
+++ b/website/docs/en/plugins/list/plugin-babel.mdx
@@ -252,6 +252,12 @@ pluginBabel({
 });
 ```
 
+:::tip
+When you configure the `include` or `exclude` options, Rsbuild will create a separate Rspack rule to apply babel-loader and swc-loader.
+
+This separate rule is completely independent of the SWC rule built into Rsbuild and is not affected by [source.include](/config/source/include) and [source.exclude](/config/source/exclude).
+:::
+
 ### exclude
 
 - **Type:** `string | RegExp | (string | RegExp)[]`
@@ -274,11 +280,9 @@ pluginBabel({
 
 - **Type:** `boolean`
 - **Default:** `false`
-- **Version:** `>= 1.2.2`
+- **Version:** `>= 2.0.0`
 
-Whether to enable parallel loader execution, running `babel-loader` in worker threads. When enabled, this typically improves build performance when compiling large numbers of JavaScript modules.
-
-Note that this option is experimental and may not work if your Babel options contain functions.
+Whether to run Babel transformations in parallel using worker threads. When enabled, JavaScript modules are processed across multiple worker threads, reducing pressure on the main thread and improving overall build performance when compiling large numbers of modules.
 
 ```ts
 pluginBabel({
@@ -286,13 +290,7 @@ pluginBabel({
 });
 ```
 
-> See [Rspack - Rule.use.parallel](https://rspack.rs/config/module-rules#rulesuseparallel) for more details.
-
-:::tip
-When you configure the `include` or `exclude` options, Rsbuild will create a separate Rspack rule to apply babel-loader and swc-loader.
-
-This separate rule is completely independent of the SWC rule built into Rsbuild and is not affected by [source.include](/config/source/include) and [source.exclude](/config/source/exclude).
-:::
+> This feature is based on Rspack's parallel loader. Options transferred to worker threads must comply with the [HTML structured clone algorithm](https://nodejs.org/api/worker_threads.html#portpostmessagevalue-transferlist). Otherwise, transmission will fail. For example, functions cannot be passed as options. See [Rspack - Rule.use.parallel](https://rspack.rs/config/module-rules#rulesuseparallel) for more details.
 
 ### Configure multiple Babel rules
 

--- a/website/docs/en/plugins/list/plugin-less.mdx
+++ b/website/docs/en/plugins/list/plugin-less.mdx
@@ -129,9 +129,7 @@ pluginLess({
 - **Default:** `false`
 - **Version:** Added in v1.4.0
 
-Whether to enable parallel loader execution, running `less-loader` in worker threads. When enabled, this typically improves build performance when compiling large numbers of Less modules.
-
-Note that this option is experimental and may not work if your Less options contain functions.
+Whether to compile Less modules in parallel using worker threads. When enabled, Less modules are processed across multiple worker threads, reducing pressure on the main thread and improving overall build performance when compiling large numbers of Less modules.
 
 ```ts
 pluginLess({
@@ -139,7 +137,7 @@ pluginLess({
 });
 ```
 
-> See [Rspack - Rule.use.parallel](https://rspack.rs/config/module-rules#rulesuseparallel) for more details.
+> This feature is based on Rspack's parallel loader. Options transferred to worker threads must comply with the [HTML structured clone algorithm](https://nodejs.org/api/worker_threads.html#portpostmessagevalue-transferlist). Otherwise, transmission will fail. For example, functions cannot be passed as options. See [Rspack - Rule.use.parallel](https://rspack.rs/config/module-rules#rulesuseparallel) for more details.
 
 ## Modifying Less version
 

--- a/website/docs/en/plugins/list/plugin-svgr.mdx
+++ b/website/docs/en/plugins/list/plugin-svgr.mdx
@@ -101,7 +101,7 @@ type PluginSvgrOptions = {
    */
   query?: RegExp;
   /**
-   * Whether to enable parallel loader execution.
+   * Whether to transform SVG modules into React components in parallel.
    * @default false
    */
   parallel?: boolean;
@@ -301,9 +301,7 @@ export const App = () => <Logo />;
 - **Default:** `false`
 - **Version:** Added in v2.0.4
 
-Whether to enable parallel loader execution, running SVGR loader in worker threads. When enabled, this typically improves build performance when compiling large numbers of SVG modules.
-
-Note that this option is experimental and may not work if your SVGR options contain functions.
+Whether to transform SVG modules into React components in parallel using worker threads. When enabled, SVG modules are processed across multiple worker threads, reducing pressure on the main thread and improving overall build performance when compiling large numbers of SVG modules.
 
 ```ts
 pluginSvgr({
@@ -311,7 +309,7 @@ pluginSvgr({
 });
 ```
 
-> See [Rspack - Rule.use.parallel](https://rspack.rs/config/module-rules#rulesuseparallel) for more details.
+> This feature is based on Rspack's parallel loader. Options transferred to worker threads must comply with the [HTML structured clone algorithm](https://nodejs.org/api/worker_threads.html#portpostmessagevalue-transferlist). Otherwise, transmission will fail. For example, functions cannot be passed as options. See [Rspack - Rule.use.parallel](https://rspack.rs/config/module-rules#rulesuseparallel) for more details.
 
 ### exclude
 

--- a/website/docs/zh/plugins/list/plugin-babel.mdx
+++ b/website/docs/zh/plugins/list/plugin-babel.mdx
@@ -251,6 +251,12 @@ pluginBabel({
 });
 ```
 
+:::tip
+当你配置 `include` 或 `exclude` 选项时，Rsbuild 会创建一条单独的 Rspack rule 来应用 babel-loader 和 swc-loader。
+
+这条单独的 rule 与 Rsbuild 内置的 SWC rule 是完全独立的，并且不会受到 [source.include](/config/source/include) 和 [source.exclude](/config/source/exclude) 的作用。
+:::
+
 ### exclude
 
 - **类型：** `string | RegExp | (string | RegExp)[]`
@@ -273,11 +279,9 @@ pluginBabel({
 
 - **类型：** `boolean`
 - **默认值：** `false`
-- **版本：** `>= 1.2.2`
+- **版本：** `>= 2.0.0`
 
-是否开启并行 loader 执行，在 worker 线程中运行 `babel-loader`。开启后，在编译大量模块时通常会有构建性能提升。
-
-注意该选项为实验性功能，当 Babel 选项中包含函数时可能无法正常工作。
+是否使用 worker 线程并行执行 Babel 转换。开启后，JavaScript 模块会被分配到多个 worker 线程中处理，降低主线程压力，并在编译大量模块时提升整体构建性能。
 
 ```ts
 pluginBabel({
@@ -285,13 +289,7 @@ pluginBabel({
 });
 ```
 
-> 详见 [Rspack - Rule.use.parallel](https://rspack.rs/zh/config/module-rules#rulesuseparallel)。
-
-:::tip
-当你配置 `include` 或 `exclude` 选项时，Rsbuild 会创建一条单独的 Rspack rule 来应用 babel-loader 和 swc-loader。
-
-这条单独的 rule 与 Rsbuild 内置的 SWC rule 是完全独立的，并且不会受到 [source.include](/config/source/include) 和 [source.exclude](/config/source/exclude) 的作用。
-:::
+> 该功能基于 Rspack 的 parallel loader 实现。传递给 worker 线程的选项必须符合 [HTML 结构化克隆算法](https://nodejs.org/api/worker_threads.html#portpostmessagevalue-transferlist) 的要求，否则会传输失败。例如，不能将函数作为选项传递。详见 [Rspack - Rule.use.parallel](https://rspack.rs/zh/config/module-rules#rulesuseparallel)。
 
 ### 配置多个 Babel 规则
 

--- a/website/docs/zh/plugins/list/plugin-less.mdx
+++ b/website/docs/zh/plugins/list/plugin-less.mdx
@@ -129,9 +129,7 @@ pluginLess({
 - **默认值：** `false`
 - **版本：** 添加于 v1.4.0
 
-是否开启并行 loader 执行，在 worker 线程中运行 `less-loader`。开启后，在编译大量 Less 模块时通常会有构建性能提升。
-
-注意该选项为实验性功能，当 Less 选项中包含函数时将无法正常工作。
+是否使用 worker 线程并行编译 Less 模块。开启后，Less 模块会被分配到多个 worker 线程中处理，降低主线程压力，并在编译大量 Less 模块时提升整体构建性能。
 
 ```ts
 pluginLess({
@@ -139,7 +137,7 @@ pluginLess({
 });
 ```
 
-> 详见 [Rspack - Rule.use.parallel](https://rspack.rs/zh/config/module-rules#rulesuseparallel)。
+> 该功能基于 Rspack 的 parallel loader 实现。传递给 worker 线程的选项必须符合 [HTML 结构化克隆算法](https://nodejs.org/api/worker_threads.html#portpostmessagevalue-transferlist) 的要求，否则会传输失败。例如，不能将函数作为选项传递。详见 [Rspack - Rule.use.parallel](https://rspack.rs/zh/config/module-rules#rulesuseparallel)。
 
 ## 修改 Less 版本
 

--- a/website/docs/zh/plugins/list/plugin-svgr.mdx
+++ b/website/docs/zh/plugins/list/plugin-svgr.mdx
@@ -101,7 +101,7 @@ type PluginSvgrOptions = {
    */
   query?: RegExp;
   /**
-   * 是否开启并行 loader 执行
+   * 是否并行将 SVG 模块转换为 React 组件
    * @default false
    */
   parallel?: boolean;
@@ -301,9 +301,7 @@ export const App = () => <Logo />;
 - **默认值：** `false`
 - **版本：** 添加于 v2.0.4
 
-是否开启并行 loader 执行，在 worker 线程中运行 SVGR loader。开启后，在编译大量 SVG 模块时通常会有构建性能提升。
-
-注意该选项为实验性功能，当 SVGR 选项中包含函数时，可能无法正常工作。
+是否使用 worker 线程并行将 SVG 模块转换为 React 组件。开启后，SVG 模块会被分配到多个 worker 线程中处理，降低主线程压力，并在编译大量 SVG 模块时提升整体构建性能。
 
 ```ts
 pluginSvgr({
@@ -311,7 +309,7 @@ pluginSvgr({
 });
 ```
 
-> 详见 [Rspack - Rule.use.parallel](https://rspack.rs/zh/config/module-rules#rulesuseparallel)。
+> 该功能基于 Rspack 的 parallel loader 实现。传递给 worker 线程的选项必须符合 [HTML 结构化克隆算法](https://nodejs.org/api/worker_threads.html#portpostmessagevalue-transferlist) 的要求，否则会传输失败。例如，不能将函数作为选项传递。详见 [Rspack - Rule.use.parallel](https://rspack.rs/zh/config/module-rules#rulesuseparallel)。
 
 ### exclude
 


### PR DESCRIPTION
## Summary

- Update the parallel option docs for Babel, Less, and SVGR to remove experimental wording and describe the user-facing transformation behavior.
- Clarify that the feature is based on Rspack's parallel loader and that worker-thread options must comply with the HTML structured clone algorithm.
- Align the related JSDoc comments and add MDX formatter settings for the workspace.