### PR TITLE
release: @rsbuild/plugin-babel v2.0.0

### DIFF
--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-babel",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "Babel plugin for Rsbuild",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Release `@rsbuild/plugin-babel` v2.0.0 after the recent breaking changes: publishing the package as pure ESM and dropping Rsbuild v1 support.

## Changes

- https://github.com/web-infra-dev/rsbuild/pull/7919
- https://github.com/web-infra-dev/rsbuild/pull/7922
- https://github.com/web-infra-dev/rsbuild/pull/7917
