### PR TITLE
chore(plugin-babel): add npm support metadata

### DIFF
--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -3,6 +3,10 @@
   "version": "2.0.0",
   "description": "Babel plugin for Rsbuild",
   "license": "MIT",
+  "homepage": "https://rsbuild.rs",
+  "bugs": {
+    "url": "https://github.com/web-infra-dev/rsbuild/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsbuild",


### PR DESCRIPTION
## Summary
- add `homepage` metadata to `@rsbuild/plugin-babel`
- add `bugs.url` metadata pointing to the Rsbuild issue tracker
- align the package metadata with `@rsbuild/core` and `@rsbuild/plugin-react`

## Validation
- `node -e "const p=require('./packages/plugin-babel/package.json'); console.log(JSON.stringify({name:p.name, version:p.version, homepage:p.homepage, bugs:p.bugs, repository:p.repository, license:p.license}, null, 2))"`
- compared `homepage` and `bugs.url` against `packages/core/package.json` and `packages/plugin-react/package.json`
- `git diff --check`