### PR TITLE
fix(plugin-babel): remove rspack cache guard

### DIFF
--- a/packages/plugin-babel/src/plugin.ts
+++ b/packages/plugin-babel/src/plugin.ts
@@ -83,11 +83,9 @@ export function getDefaultBabelOptions(
     ],
   };
 
+  // Enable caching by default to improve performance
   const { buildCache = true } = config.performance;
-
-  // Rspack does not yet support persistent cache
-  // so we use babel-loader's cache to improve rebuild performance
-  if (buildCache && context.bundlerType === 'rspack') {
+  if (buildCache) {
     const cacheDirectory = getCacheDirectory(
       context,
       typeof buildCache === 'boolean' ? undefined : buildCache.cacheDirectory,


### PR DESCRIPTION
## Summary

This PR removes the extra `context.bundlerType === 'rspack'` check before enabling babel-loader cache. The v2 version of `@rsbuild/plugin-babel` is only used for Rspack, so this bundler guard is unnecessary; cache behavior can follow `performance.buildCache` directly.