### PR TITLE
docs: remove buildCache experimental notices

### DIFF
--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -784,7 +784,6 @@ export interface PerformanceConfig {
 
   /**
    * To enable or configure persistent build cache.
-   * @experimental This feature is experimental and may be changed in the future.
    * @default false
    */
   buildCache?: BuildCacheOptions | boolean;

--- a/website/docs/en/config/performance/build-cache.mdx
+++ b/website/docs/en/config/performance/build-cache.mdx
@@ -23,12 +23,6 @@ To enable or configure persistent build cache.
 
 When enabled, Rspack will store the build snapshots in the cache directory. In subsequent builds, if the cache is hit, Rspack can reuse the cached results instead of rebuilding from scratch, which can reduce the build time.
 
-:::tip
-
-Rspack's persistent cache is [experimental](https://rspack.rs/config/cache#cache) and may change in the future.
-
-:::
-
 ## Enable cache
 
 Setting `performance.buildCache` to `true` will enable the persistent build cache:

--- a/website/docs/zh/config/performance/build-cache.mdx
+++ b/website/docs/zh/config/performance/build-cache.mdx
@@ -23,12 +23,6 @@ type BuildCacheConfig =
 
 当启用时，Rspack 会在缓存目录中存储构建快照。在后续的构建中，如果命中缓存，Rspack 可以重用缓存的结果，而不是从头开始重新构建，这可以显著减少构建时间。
 
-:::tip
-
-Rspack 的持久化缓存处于 [实验性阶段](https://rspack.rs/zh/config/cache#cache)，可能会在未来的版本中发生变化。
-
-:::
-
 ## 启用缓存
 
 设置 `performance.buildCache` 为 `true` 将启用持久化构建缓存：


### PR DESCRIPTION
## Summary

Remove outdated experimental notices for `performance.buildCache` from the docs and the core TypeScript config comments because Rspack v2 has stabilized persistent cache support.

No runtime behavior changes.