### PR TITLE
feat(core): enable source import by default

### DIFF
--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -30,6 +30,11 @@ export const pluginBasic = (): RsbuildPlugin => ({
       // Disable performance hints, these logs are too complex
       chain.performance.hints(false);
 
+      chain.experiments({
+        ...chain.get('experiments'),
+        sourceImport: true,
+      });
+
       chain.module.parser.merge({
         javascript: {
           typeReexportsPresence: 'tolerant',

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -9,6 +9,9 @@ exports[`default bundler > should use Rspack by default 1`] = `
       "./src/index.js",
     ],
   },
+  "experiments": {
+    "sourceImport": true,
+  },
   "infrastructureLogging": {
     "level": "error",
   },

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -32,6 +32,9 @@ exports[`should apply default plugins correctly 1`] = `
 {
   "context": "<ROOT>",
   "devtool": "cheap-module-source-map",
+  "experiments": {
+    "sourceImport": true,
+  },
   "infrastructureLogging": {
     "level": "error",
   },
@@ -516,6 +519,9 @@ exports[`should apply default plugins correctly in production 1`] = `
 {
   "context": "<ROOT>",
   "devtool": false,
+  "experiments": {
+    "sourceImport": true,
+  },
   "infrastructureLogging": {
     "level": "error",
   },
@@ -1030,6 +1036,9 @@ exports[`should apply default plugins correctly when target is node 1`] = `
 {
   "context": "<ROOT>",
   "devtool": "cheap-module-source-map",
+  "experiments": {
+    "sourceImport": true,
+  },
   "infrastructureLogging": {
     "level": "error",
   },
@@ -1504,6 +1513,9 @@ exports[`tools.rspack > should match snapshot 1`] = `
 {
   "context": "<ROOT>",
   "devtool": "cheap-module-source-map",
+  "experiments": {
+    "sourceImport": true,
+  },
   "infrastructureLogging": {
     "level": "error",
   },

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -5,6 +5,9 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
   {
     "context": "<ROOT>",
     "devtool": "eval-source-map",
+    "experiments": {
+      "sourceImport": true,
+    },
     "infrastructureLogging": {
       "level": "error",
     },
@@ -486,6 +489,9 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
   {
     "context": "<ROOT>",
     "devtool": "eval",
+    "experiments": {
+      "sourceImport": true,
+    },
     "infrastructureLogging": {
       "level": "error",
     },


### PR DESCRIPTION
## Summary

This PR enables Rspack's source phase import experiment by default in Rsbuild so projects can use `import.source()` / `import source` support provided by Rspack without extra configuration.

## Related Links

https://rspack.rs/config/experiments#experimentssourceimport