### PR TITLE
docs: add Wasm source import usage

### DIFF
--- a/website/docs/en/guide/basic/wasm-assets.mdx
+++ b/website/docs/en/guide/basic/wasm-assets.mdx
@@ -39,6 +39,25 @@ const wasmURL = new URL('./add.wasm', import.meta.url);
 console.log(wasmURL.pathname); // "/static/wasm/[contenthash:10].module.wasm"
 ```
 
+## Source import
+
+You can use [Source Phase Imports](https://github.com/tc39/proposal-source-phase-imports) to get a compiled `WebAssembly.Module` instead of the module exports:
+
+```js title="index.js"
+import source wasmModule from './add.wasm';
+
+const instance = await WebAssembly.instantiate(wasmModule);
+const { add } = instance.exports;
+
+console.log(add(1, 2)); // 3
+```
+
+This is useful when you need to instantiate a Wasm module yourself, create multiple instances with different imports, or transfer the module to a worker.
+
+:::tip
+`import source` is supported in Rsbuild v2.1.0 and later.
+:::
+
 ## Output directory
 
 When you import a `.wasm` asset, Rsbuild outputs it to the `dist/static/wasm` directory by default.

--- a/website/docs/zh/guide/basic/wasm-assets.mdx
+++ b/website/docs/zh/guide/basic/wasm-assets.mdx
@@ -39,6 +39,25 @@ const wasmURL = new URL('./add.wasm', import.meta.url);
 console.log(wasmURL.pathname); // "/static/wasm/[contenthash:10].module.wasm"
 ```
 
+## Source import
+
+你可以使用 [Source Phase Imports](https://github.com/tc39/proposal-source-phase-imports) 获取编译后的 `WebAssembly.Module`，而不是直接获取模块导出：
+
+```js title="index.js"
+import source wasmModule from './add.wasm';
+
+const instance = await WebAssembly.instantiate(wasmModule);
+const { add } = instance.exports;
+
+console.log(add(1, 2)); // 3
+```
+
+当你需要手动实例化 Wasm 模块、使用不同的 imports 创建多个实例，或将模块传递给 worker 时，这种方式会很有用。
+
+:::tip
+`import source` 用法在 Rsbuild v2.1.0 及以上版本中支持。
+:::
+
 ## 输出目录
 
 当 `.wasm` 资源被引用后，默认会被 Rsbuild 输出到 `dist/static/wasm` 目录下。


### PR DESCRIPTION
## Summary

Document how to use `import source` with Wasm assets now that the syntax is supported in Rsbuild v2.1.0.

The new section explains that source imports return a compiled `WebAssembly.Module`, shows a minimal instantiate example, and keeps the Chinese docs in sync.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/7931