### PR TITLE
fix(core): generate correct script paths in RsbuildHtmlPlugin

### DIFF
--- a/e2e/cases/html/html-tags/relative-path-multi-entry/index.test.ts
+++ b/e2e/cases/html/html-tags/relative-path-multi-entry/index.test.ts
@@ -1,0 +1,32 @@
+import { expect, getFileContent, test } from '@e2e/helper';
+
+test('should handle relative paths correctly for multiple entries in subdirectories', async ({
+  build,
+}) => {
+  const rsbuild = await build();
+  const files = rsbuild.getDistFiles();
+
+  // index.html should have the path relative to root
+  const indexHtml = getFileContent(files, 'index.html');
+  expect(
+    indexHtml.includes('src="env-config.js"') || indexHtml.includes('src="./env-config.js"'),
+  ).toBeTruthy();
+  expect(indexHtml).not.toContain('src="../env-config.js"');
+  expect(indexHtml).not.toContain('src="../../env-config.js"');
+
+  // subdir/main.html should have the path relative to the subdirectory
+  const mainHtml = getFileContent(files, 'subdir/main.html');
+  expect(mainHtml).toContain('src="../env-config.js"');
+  expect(mainHtml).not.toContain('src="env-config.js"');
+  expect(mainHtml).not.toContain('src="./env-config.js"');
+  expect(mainHtml).not.toContain('src="../../env-config.js"');
+
+  // subdir/test.html should also have the path relative to the subdirectory
+  // This is the case where the bug occurred - the second entry in the same subdir
+  // should have the same path as main.html
+  const testHtml = getFileContent(files, 'subdir/test.html');
+  expect(testHtml).toContain('src="../env-config.js"');
+  expect(testHtml).not.toContain('src="env-config.js"');
+  expect(testHtml).not.toContain('src="./env-config.js"');
+  expect(testHtml).not.toContain('src="../../env-config.js"');
+});

--- a/e2e/cases/html/html-tags/relative-path-multi-entry/rsbuild.config.ts
+++ b/e2e/cases/html/html-tags/relative-path-multi-entry/rsbuild.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  source: {
+    entry: {
+      index: './src/index',
+      'subdir/main': './src/index',
+      'subdir/test': './src/index',
+    },
+  },
+  html: {
+    tags: [
+      {
+        tag: 'script',
+        head: true,
+        append: false,
+        attrs: {
+          src: './env-config.js',
+        },
+      },
+    ],
+  },
+  output: {
+    assetPrefix: 'auto',
+  },
+});

--- a/e2e/cases/html/html-tags/relative-path-multi-entry/src/index.js
+++ b/e2e/cases/html/html-tags/relative-path-multi-entry/src/index.js
@@ -1,0 +1,1 @@
+console.log('index');

--- a/packages/core/src/rspack-plugins/RsbuildHtmlPlugin.ts
+++ b/packages/core/src/rspack-plugins/RsbuildHtmlPlugin.ts
@@ -172,10 +172,9 @@ const applyTagConfig = (
         }
 
         attrs[filenameTag] = filename;
-        tag.attrs = attrs;
       }
 
-      ret.push(fromBasicTag(tag));
+      ret.push(fromBasicTag({ ...tag, attrs }));
     }
     return ret;
   };


### PR DESCRIPTION
Avoid mutating shared HTML tag attributes.

Previously, processing a nested entrypoint could affect subsequently processed entrypoints, causing incorrect script paths to be generated.

## Summary
Fixes https://github.com/web-infra-dev/rsbuild/issues/7933 and adds a test

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/7933
<!--- Provide links of related issues or pages -->
