### PR TITLE
chore: add bugs metadata to remaining plugin packages

### DIFF
--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -9,6 +9,9 @@
     "url": "https://github.com/web-infra-dev/rsbuild",
     "directory": "packages/create-rsbuild"
   },
+  "bugs": {
+    "url": "https://github.com/web-infra-dev/rsbuild/issues"
+  },
   "bin": {
     "create-rsbuild": "./bin.js"
   },

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -9,6 +9,9 @@
     "url": "https://github.com/web-infra-dev/rsbuild",
     "directory": "packages/plugin-less"
   },
+  "bugs": {
+    "url": "https://github.com/web-infra-dev/rsbuild/issues"
+  },
   "files": [
     "dist",
     "compiled"

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -2,11 +2,15 @@
   "name": "@rsbuild/plugin-preact",
   "version": "2.0.0",
   "description": "Preact plugin for Rsbuild",
+  "homepage": "https://rsbuild.rs",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsbuild",
     "directory": "packages/plugin-preact"
+  },
+  "bugs": {
+    "url": "https://github.com/web-infra-dev/rsbuild/issues"
   },
   "files": [
     "dist"

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -9,6 +9,9 @@
     "url": "https://github.com/web-infra-dev/rsbuild",
     "directory": "packages/plugin-sass"
   },
+  "bugs": {
+    "url": "https://github.com/web-infra-dev/rsbuild/issues"
+  },
   "files": [
     "dist",
     "compiled"

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -2,11 +2,15 @@
   "name": "@rsbuild/plugin-svgr",
   "version": "2.0.4",
   "description": "SVGR plugin for Rsbuild",
+  "homepage": "https://rsbuild.rs",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsbuild",
     "directory": "packages/plugin-svgr"
+  },
+  "bugs": {
+    "url": "https://github.com/web-infra-dev/rsbuild/issues"
   },
   "files": [
     "dist"

--- a/packages/plugin-tailwindcss/package.json
+++ b/packages/plugin-tailwindcss/package.json
@@ -9,6 +9,9 @@
     "url": "https://github.com/web-infra-dev/rsbuild",
     "directory": "packages/plugin-tailwindcss"
   },
+  "bugs": {
+    "url": "https://github.com/web-infra-dev/rsbuild/issues"
+  },
   "files": [
     "dist"
   ],

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -9,6 +9,9 @@
     "url": "https://github.com/web-infra-dev/rsbuild",
     "directory": "packages/plugin-vue"
   },
+  "bugs": {
+    "url": "https://github.com/web-infra-dev/rsbuild/issues"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## Summary

Several Rsbuild plugin packages are missing npm `bugs` metadata (and some also lack `homepage`). This PR adds standard npm metadata fields to the remaining packages for consistency with `@rsbuild/core`, `@rsbuild/plugin-react`, `@rsbuild/plugin-babel`, `@rsbuild/plugin-solid`, and `@rsbuild/plugin-svelte` which already include these fields.

## Changes

| Package | Added `homepage` | Added `bugs.url` |
|---|---|---|
| `create-rsbuild` | already present | yes |
| `@rsbuild/plugin-less` | already present | yes |
| `@rsbuild/plugin-preact` | yes | yes |
| `@rsbuild/plugin-sass` | already present | yes |
| `@rsbuild/plugin-svgr` | yes | yes |
| `@rsbuild/plugin-tailwindcss` | already present | yes |
| `@rsbuild/plugin-vue` | already present | yes |

- `homepage`: `https://rsbuild.rs` (consistent with other packages)
- `bugs.url`: `https://github.com/web-infra-dev/rsbuild/issues`

No runtime code, dependencies, version, entry points, exports, or build configuration are changed. Metadata-only.

## Validation

- Verified metadata fields with `node -e` for each package
- `git diff --check` passed

Generated with [Qoder](https://qoder.com)