### PR TITLE
test: refine html tag relative path e2e

### DIFF
--- a/e2e/cases/html/html-tags/relative-path-multi-entry/index.test.ts
+++ b/e2e/cases/html/html-tags/relative-path-multi-entry/index.test.ts
@@ -1,32 +1,43 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, getFileContent, gotoPage, test } from '@e2e/helper';
 
 test('should handle relative paths correctly for multiple entries in subdirectories', async ({
-  build,
+  page,
+  buildPreview,
 }) => {
-  const rsbuild = await build();
+  const rsbuild = await buildPreview();
   const files = rsbuild.getDistFiles();
 
-  // index.html should have the path relative to root
-  const indexHtml = getFileContent(files, 'index.html');
-  expect(
-    indexHtml.includes('src="env-config.js"') || indexHtml.includes('src="./env-config.js"'),
-  ).toBeTruthy();
-  expect(indexHtml).not.toContain('src="../env-config.js"');
-  expect(indexHtml).not.toContain('src="../../env-config.js"');
+  const entries = [
+    {
+      entry: 'index',
+      filename: 'index.html',
+      pathname: '/index.html',
+      src: 'test.js',
+    },
+    {
+      entry: 'subdir/main',
+      filename: 'subdir/main.html',
+      pathname: '/subdir/main.html',
+      src: '../test.js',
+    },
+    {
+      entry: 'subdir/test',
+      filename: 'subdir/test.html',
+      pathname: '/subdir/test.html',
+      src: '../test.js',
+    },
+  ];
 
-  // subdir/main.html should have the path relative to the subdirectory
-  const mainHtml = getFileContent(files, 'subdir/main.html');
-  expect(mainHtml).toContain('src="../env-config.js"');
-  expect(mainHtml).not.toContain('src="env-config.js"');
-  expect(mainHtml).not.toContain('src="./env-config.js"');
-  expect(mainHtml).not.toContain('src="../../env-config.js"');
+  for (const { filename, src } of entries) {
+    const html = getFileContent(files, filename);
+    expect(html).toContain(`src="${src}"`);
+  }
 
-  // subdir/test.html should also have the path relative to the subdirectory
-  // This is the case where the bug occurred - the second entry in the same subdir
-  // should have the same path as main.html
-  const testHtml = getFileContent(files, 'subdir/test.html');
-  expect(testHtml).toContain('src="../env-config.js"');
-  expect(testHtml).not.toContain('src="env-config.js"');
-  expect(testHtml).not.toContain('src="./env-config.js"');
-  expect(testHtml).not.toContain('src="../../env-config.js"');
+  for (const { entry, pathname } of entries) {
+    await gotoPage(page, rsbuild, entry);
+    expect(await page.evaluate('window.__htmlTagTest')).toEqual({
+      loaded: true,
+      pathname,
+    });
+  }
 });

--- a/e2e/cases/html/html-tags/relative-path-multi-entry/public/test.js
+++ b/e2e/cases/html/html-tags/relative-path-multi-entry/public/test.js
@@ -1,0 +1,4 @@
+window.__htmlTagTest = {
+  loaded: true,
+  pathname: window.location.pathname,
+};

--- a/e2e/cases/html/html-tags/relative-path-multi-entry/rsbuild.config.ts
+++ b/e2e/cases/html/html-tags/relative-path-multi-entry/rsbuild.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
         head: true,
         append: false,
         attrs: {
-          src: './env-config.js',
+          src: './test.js',
         },
       },
     ],


### PR DESCRIPTION
## Summary

This PR improves the regression coverage for injected HTML tag relative paths by replacing static-only `env-config.js` assertions with a real public `test.js` script. The e2e now keeps the generated `src` checks table-driven and visits each generated page to assert the script is loaded and executed from the correct relative path.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/7933
https://github.com/web-infra-dev/rsbuild/pull/7934