### PR TITLE
feat(deps): update @rspack/core to 2.1.0-beta.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,8 +68,8 @@ catalogs:
       specifier: ^0.6.1
       version: 0.6.1
     '@rspack/core':
-      specifier: ~2.0.8
-      version: 2.0.8
+      specifier: ~2.1.0-beta.0
+      version: 2.1.0-beta.0
     '@rspack/plugin-preact-refresh':
       specifier: ^2.0.1
       version: 2.0.1
@@ -474,10 +474,10 @@ importers:
         version: 2.0.4(hono@4.12.25)
       '@module-federation/enhanced':
         specifier: 'catalog:'
-        version: 2.5.1(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)
+        version: 2.5.1(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.5.1(@rsbuild/core@packages+core)(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)
+        version: 2.5.1(@rsbuild/core@packages+core)(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.61.0
@@ -519,13 +519,13 @@ importers:
         version: link:../packages/plugin-tailwindcss
       '@rsbuild/plugin-type-check':
         specifier: 'catalog:'
-        version: 1.4.0(@rsbuild/core@packages+core)(@rspack/core@2.0.8)(typescript@6.0.3)
+        version: 1.4.0(@rsbuild/core@packages+core)(@rspack/core@2.1.0-beta.0)(typescript@6.0.3)
       '@rsbuild/plugin-vue':
         specifier: workspace:*
         version: link:../packages/plugin-vue
       '@rsdoctor/rspack-plugin':
         specifier: 'catalog:'
-        version: 1.5.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@packages+core)(@rspack/core@2.0.8)
+        version: 1.5.13(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@packages+core)(@rspack/core@2.1.0-beta.0)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../scripts/test-helper
@@ -534,7 +534,7 @@ importers:
         version: 4.3.1
       '@tailwindcss/webpack':
         specifier: 'catalog:'
-        version: 4.3.1(@rspack/core@2.0.8)
+        version: 4.3.1(@rspack/core@2.1.0-beta.0)
       '@types/fs-extra':
         specifier: 'catalog:'
         version: 11.0.4
@@ -721,10 +721,10 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 'catalog:'
-        version: 2.5.1(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)
+        version: 2.5.1(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.5.1(@rsbuild/core@packages+core)(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)
+        version: 2.5.1(@rsbuild/core@packages+core)(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)
       '@rsbuild/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -743,10 +743,10 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 'catalog:'
-        version: 2.5.1(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)
+        version: 2.5.1(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.5.1(@rsbuild/core@packages+core)(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)
+        version: 2.5.1(@rsbuild/core@packages+core)(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)
       '@rsbuild/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -900,7 +900,7 @@ importers:
     dependencies:
       '@rspack/core':
         specifier: 'catalog:'
-        version: 2.0.8(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
+        version: 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
       '@swc/helpers':
         specifier: 'catalog:'
         version: 0.5.23
@@ -949,7 +949,7 @@ importers:
         version: 2.8.6
       css-loader:
         specifier: 'catalog:'
-        version: 7.1.4(patch_hash=b504d70330b6625a20bc0cb1428c9787350fe6413c2947f42bd88ff22123a019)(@rspack/core@2.0.8)
+        version: 7.1.4(patch_hash=b504d70330b6625a20bc0cb1428c9787350fe6413c2947f42bd88ff22123a019)(@rspack/core@2.1.0-beta.0)
       deepmerge:
         specifier: 'catalog:'
         version: 4.3.1
@@ -958,7 +958,7 @@ importers:
         version: 13.0.0(patch_hash=5ff37847fa487be2db4e4f14c2b21937f4e51cc7a43deea4506d4aaf3fa6149c)
       html-rspack-plugin:
         specifier: 'catalog:'
-        version: 6.1.9(@rspack/core@2.0.8)
+        version: 6.1.9(@rspack/core@2.1.0-beta.0)
       http-proxy-middleware:
         specifier: 'catalog:'
         version: 4.1.0
@@ -988,7 +988,7 @@ importers:
         version: 6.0.1(jiti@2.7.0)(postcss@8.5.15)
       postcss-loader:
         specifier: 'catalog:'
-        version: 8.2.1(patch_hash=4829849d58d8366cd82cbdab1947d15f9e6d33e70f1e3d5310daffff152dff14)(@rspack/core@2.0.8)(postcss@8.5.15)(typescript@6.0.3)
+        version: 8.2.1(patch_hash=4829849d58d8366cd82cbdab1947d15f9e6d33e70f1e3d5310daffff152dff14)(@rspack/core@2.1.0-beta.0)(postcss@8.5.15)(typescript@6.0.3)
       prebundle:
         specifier: 'catalog:'
         version: 1.6.5(typescript@6.0.3)
@@ -1003,10 +1003,10 @@ importers:
         version: 2.1.3
       rspack-chain:
         specifier: 'catalog:'
-        version: 2.1.0(@rspack/core@2.0.8)
+        version: 2.1.0(@rspack/core@2.1.0-beta.0)
       rspack-manifest-plugin:
         specifier: 'catalog:'
-        version: 5.2.2(@rspack/core@2.0.8)
+        version: 5.2.2(@rspack/core@2.1.0-beta.0)
       rspack-merge:
         specifier: 'catalog:'
         version: 1.0.1
@@ -1809,11 +1809,20 @@ packages:
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@epic-web/invariant@1.0.0':
     resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
@@ -2147,6 +2156,12 @@ packages:
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@napi-rs/wasm-runtime@1.1.5':
+    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
@@ -2698,8 +2713,8 @@ packages:
   '@rslint/native@0.6.1':
     resolution: {integrity: sha512-WR/tITtBCjxkBhpDRip4h6n+gxMMqqijFKmDjuc3O/ScWMrX+KbeKcnS0u1Y8e0YfoAmk7dHR9HIT+IRHod1IQ==}
 
-  '@rspack/binding-darwin-arm64@1.7.11':
-    resolution: {integrity: sha512-oduECiZVqbO5zlVw+q7Vy65sJFth99fWPTyucwvLJJtJkPL5n17Uiql2cYP6Ijn0pkqtf1SXgK8WjiKLG5bIig==}
+  '@rspack/binding-darwin-arm64@1.7.12':
+    resolution: {integrity: sha512-rbFprJaJiqrmfy8SHth8EsoRS0wg4bXcucwj9NiMzpGFq14Opw8c04iQ6H9BECYzgmN0PKZ9rh41LdVvhdZe4A==}
     cpu: [arm64]
     os: [darwin]
 
@@ -2708,8 +2723,13 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@1.7.11':
-    resolution: {integrity: sha512-a1+TtTE9ap6RalgFi7FGIgkJP6O4Vy6ctv+9WGJy53E4kuqHR0RygzaiVxCI/GMc/vBT9vY23hyrpWb3d1vtXA==}
+  '@rspack/binding-darwin-arm64@2.1.0-beta.0':
+    resolution: {integrity: sha512-BE2O8aq/tzG9c3BHlsmH/cDnwr86wG68AQ/n1uaYEB5hoBJMk2eBJo/q2/CZ37ZT5ntVsCGkJpCPBT/Dh7q9PA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-x64@1.7.12':
+    resolution: {integrity: sha512-jnOp+/UXOJa9xqUb8KXH03sysoO2e4Ij6tw6MqDdmdj8n/A8PQENRPUbW9AwXpPtVDJPus9r4fi7b3+6e4B8Hg==}
     cpu: [x64]
     os: [darwin]
 
@@ -2718,8 +2738,13 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@1.7.11':
-    resolution: {integrity: sha512-P0QrGRPbTWu6RKWfN0bDtbnEps3rXH0MWIMreZABoUrVmNQKtXR6e73J3ub6a+di5s2+K0M2LJ9Bh2/H4UsDUA==}
+  '@rspack/binding-darwin-x64@2.1.0-beta.0':
+    resolution: {integrity: sha512-9icL31+mGJRKaU1i0IVbsBcmRWpUVfTM9TuLUHZOy0fnPhoZPDT0C/BZJxjvlvSeV2NNhh/NBEzUP3taZj7Zcg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack/binding-linux-arm64-gnu@1.7.12':
+    resolution: {integrity: sha512-C8owWG+yvo7X0oVLIXetkoJhIFBP1LYNcAQqtgLmJnQLQDklGuP83dKC+zISGQWpjawHfZ1ER96vLgoTrxKZdw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -2730,8 +2755,14 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-arm64-musl@1.7.11':
-    resolution: {integrity: sha512-6ky7R43VMjWwmx3Yx7Jl7faLBBMAgMDt+/bN35RgwjiPgsIByz65EwytUVuW9rikB43BGHvA/eqlnjLrUzNBqw==}
+  '@rspack/binding-linux-arm64-gnu@2.1.0-beta.0':
+    resolution: {integrity: sha512-92OuAccIQx5AQIWdhF5GaXmW0nsW+cApQYZ1PZ2kMfCe0kq8t4R5gLL2cuJ6a3Qo66TerFsj+ii5wx0qfP7aFA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-arm64-musl@1.7.12':
+    resolution: {integrity: sha512-i51WWI64aRpsfSki6rN0aepPqXkVfS+vZM7+4bWDcmnhUmdMvhIPcYg0QRk3DtyJnu33jqNLM0WHY78k00NyfA==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
@@ -2742,8 +2773,14 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-x64-gnu@1.7.11':
-    resolution: {integrity: sha512-cuOJMfCOvb2Wgsry5enXJ3iT1FGUjdPqtGUBVupQlEG4ntSYsQ2PtF4wIDVasR3wdxC5nQbipOrDiN/u6fYsdQ==}
+  '@rspack/binding-linux-arm64-musl@2.1.0-beta.0':
+    resolution: {integrity: sha512-YuaHU9A+vLBYNEbjUGHlEE/K4Ctt7kp34DaKlv9iShtOz7bIc3NRfFUIZEHjExhJ+wWYInrcIAIJeviOQJnHig==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-linux-x64-gnu@1.7.12':
+    resolution: {integrity: sha512-MSos0FuPEefqo9V92ULd5hggKG29EkSNg1zDcypy0OkpsKh5pfjVxTLYFXgTcVyFoUQQbdG8zFBzYbwmJ8V4ew==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -2754,8 +2791,14 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-x64-musl@1.7.11':
-    resolution: {integrity: sha512-CoK37hva4AmHGh3VCsQXmGr40L36m1/AdnN5LEjUX6kx5rEH7/1nEBN6Ii72pejqDVvk9anEROmPDiPw10tpFg==}
+  '@rspack/binding-linux-x64-gnu@2.1.0-beta.0':
+    resolution: {integrity: sha512-BA2j6CS8MJfT7o7oP2UFpucf3EAv4Does/D35SfRCdBKlgMXy8kG6zJXKLW3gzKSNUez5SZ26n/mPcHcX8A6zg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-x64-musl@1.7.12':
+    resolution: {integrity: sha512-JcAMVKXOnjfpC3coWjCFPWD3Yl8RBw6a+IXQQ8mfRlHaHMIiOv8IfZqx15XRxMUn49CtP7Z0Na8iiAg2aKrcfw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -2766,16 +2809,26 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-wasm32-wasi@1.7.11':
-    resolution: {integrity: sha512-OtrmnPUVJMxjNa3eDMfHyPdtlLRmmp/aIm0fQHlAOATbZvlGm12q7rhPW5BXTu1yh+1rQ1/uqvz+SzKEZXuJaQ==}
+  '@rspack/binding-linux-x64-musl@2.1.0-beta.0':
+    resolution: {integrity: sha512-riLlSAgbyGRXclLeK0y/FN0Qd+hHlwNj0lCdgh98sADUX62gaFcWFYizC8cnfxzlIUaTjQsPCy8PjWFEbSOmuQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-wasm32-wasi@1.7.12':
+    resolution: {integrity: sha512-n+ZqP6ZMc0nhOgvadg5VhEs9ojtbES80AcWeFnmGkbzIszvGSO63GKNiRkXtjJ9KFuRzytbbmsCqkUVH+Tywxg==}
     cpu: [wasm32]
 
   '@rspack/binding-wasm32-wasi@2.0.8':
     resolution: {integrity: sha512-Yf4SiqTUroT5Ju+te0YAY2xxKOb35tECsO21v7hYyGa705wrgoAK/MmF7enOvs9GR1iZIqgiLD/wxsIxl8GjJw==}
     cpu: [wasm32]
 
-  '@rspack/binding-win32-arm64-msvc@1.7.11':
-    resolution: {integrity: sha512-lObFW6e5lCWNgTBNwT//yiEDbsxm9QG4BYUojqeXxothuzJ/L6ibXz6+gLMvbOvLGV3nKgkXmx8GvT9WDKR0mA==}
+  '@rspack/binding-wasm32-wasi@2.1.0-beta.0':
+    resolution: {integrity: sha512-fYEvF3QAWZm6jUf74C2TT7gpllIGEghPEdBPRmdRGROesYSu0YZxikDdVwpQXnsymA5AnkaofCs/Sj+nvKyrXQ==}
+    cpu: [wasm32]
+
+  '@rspack/binding-win32-arm64-msvc@1.7.12':
+    resolution: {integrity: sha512-8+h5fYDXYdmugbdfZ+D1y8IQ3rv2EhSfyGP7vBe+bjNyaMa4jWrpucmZbtxojUL1AzaeuHbvMdj9UO/gelk/+g==}
     cpu: [arm64]
     os: [win32]
 
@@ -2784,8 +2837,13 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@1.7.11':
-    resolution: {integrity: sha512-0pYGnZd8PPqNR68zQ8skamqNAXEA1sUfXuAdYcknIIRq2wsbiwFzIc0Pov1cIfHYab37G7sSIPBiOUdOWF5Ivw==}
+  '@rspack/binding-win32-arm64-msvc@2.1.0-beta.0':
+    resolution: {integrity: sha512-bRv74lkzMcloJGYwzIrabLa73L23FTYjcB/GuZkgP8qsYpM20qyMFYo6szElbc/x1NxNSW5mjR4QKaNaIxRDhA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-ia32-msvc@1.7.12':
+    resolution: {integrity: sha512-cDMGwTRSa2p9fNBVe1wTRkF2AEXZ9ARWW36QeC5CkLaI0Ezz8lvhF2+CSOPnhaQ1O1qtn0L0SF+lFnrY+I7xGQ==}
     cpu: [ia32]
     os: [win32]
 
@@ -2794,8 +2852,13 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@1.7.11':
-    resolution: {integrity: sha512-EeQXayoQk/uBkI3pdoXfQBXNIUrADq56L3s/DFyM2pJeUDrWmhfIw2UFIGkYPTMSCo8F2JcdcGM32FGJrSnU0Q==}
+  '@rspack/binding-win32-ia32-msvc@2.1.0-beta.0':
+    resolution: {integrity: sha512-qvolIqHoH+KSJFi71jJde+HTIvAbVZ08VJvfzqjTQ6KktFoxAfg0FeM6zpq0aNDo14mCDzy5JFH2WGbYGxmYLQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rspack/binding-win32-x64-msvc@1.7.12':
+    resolution: {integrity: sha512-wIqFvlgFqrgUyj/6S/FJcvShnkZOmIeXTfqvheLY67MGq8qd8jb1YimQVKAIrmWB3yuJKUFACI3Ag1UBtEedEA==}
     cpu: [x64]
     os: [win32]
 
@@ -2804,14 +2867,22 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@1.7.11':
-    resolution: {integrity: sha512-2MGdy2s2HimsDT444Bp5XnALzNRxuBNc7y0JzyuqKbHBywd4x2NeXyhWXXoxufaCFu5PBc9Qq9jyfjW2Aeh06Q==}
+  '@rspack/binding-win32-x64-msvc@2.1.0-beta.0':
+    resolution: {integrity: sha512-Ge6VIpFH//LuN0ABCeHRMXuKYagRAN7rW8WIKAKO3R3WooTT8630W+dOCJ+6kiSQyTLyMrt5eg6Sufw0R6UUPg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rspack/binding@1.7.12':
+    resolution: {integrity: sha512-f4HHuLbvuld8Ba4iB/4ibse5XrKxFrgmM3S4P2AOKnPlekAFlBjmltCuaTL/W2ggYvILaVY+YcFXrEH1rrKeQA==}
 
   '@rspack/binding@2.0.8':
     resolution: {integrity: sha512-3uZ+y8aQxq33ty2srMxg2Nu0XuBI6vVrG50rkDaXqwWqOohfgGUSfFuQK7EnSUNy4aFUQlCG6NHialQHJov0wg==}
 
-  '@rspack/core@1.7.11':
-    resolution: {integrity: sha512-rsD9b+Khmot5DwCMiB3cqTQo53ioPG3M/A7BySu8+0+RS7GCxKm+Z+mtsjtG/vsu4Tn2tcqCdZtA3pgLoJB+ew==}
+  '@rspack/binding@2.1.0-beta.0':
+    resolution: {integrity: sha512-hSK6L966Y8l9z4ZMjRbz7lEmrk5IN+xSCQXkOL5VvtfBLvgk9AO91YEsDn5hCwNmTIdMFc2vScT2qwuIFF069w==}
+
+  '@rspack/core@1.7.12':
+    resolution: {integrity: sha512-6CwFIHlhRmXfZoMj3v9MZ1SMTPBn+cHVXeMIeaGp5sufqinKsISbsqHu6ZMJu2wDSmZLdmQJX6zLxkhcAUlhkQ==}
     engines: {node: '>=18.12.0'}
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
@@ -2821,6 +2892,18 @@ packages:
 
   '@rspack/core@2.0.8':
     resolution: {integrity: sha512-+NLGJf8gZxihDmMFzjlly3toc2SMjeDmuvz0/Cai9AMdV4F+Pqcnt2BA9V4e3SY2jmhJQtPwgyyLtR1RiJO77g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': ^0.5.23
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/core@2.1.0-beta.0':
+    resolution: {integrity: sha512-Trnjc1OPsAU+TamUtCoOfwFfqu0n1pClhmY6hX4hs55i8exv4muV6OR8g40j0I7fFPz1YdPArTQBeMKFlVSXsg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -3237,6 +3320,9 @@ packages:
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -6187,12 +6273,28 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -6491,7 +6593,7 @@ snapshots:
       - node-fetch
       - utf-8-validate
 
-  '@module-federation/enhanced@2.5.1(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)':
+  '@module-federation/enhanced@2.5.1(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.5.1(node-fetch@2.7.0)
       '@module-federation/cli': 2.5.1(node-fetch@2.7.0)(typescript@6.0.3)
@@ -6500,7 +6602,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.5.1(@module-federation/runtime-tools@2.5.1)
       '@module-federation/managers': 2.5.1(node-fetch@2.7.0)
       '@module-federation/manifest': 2.5.1(node-fetch@2.7.0)(typescript@6.0.3)
-      '@module-federation/rspack': 2.5.1(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)
+      '@module-federation/rspack': 2.5.1(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)
       '@module-federation/runtime-tools': 2.5.1(node-fetch@2.7.0)
       '@module-federation/sdk': 2.5.1(node-fetch@2.7.0)
       '@module-federation/webpack-bundler-runtime': 2.5.1(node-fetch@2.7.0)
@@ -6543,9 +6645,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.44(@rspack/core@2.0.8)(typescript@6.0.3)':
+  '@module-federation/node@2.7.44(@rspack/core@2.1.0-beta.0)(typescript@6.0.3)':
     dependencies:
-      '@module-federation/enhanced': 2.5.1(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)
+      '@module-federation/enhanced': 2.5.1(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)
       '@module-federation/runtime': 2.5.1(node-fetch@2.7.0)
       '@module-federation/sdk': 2.5.1(node-fetch@2.7.0)
       encoding: 0.1.13
@@ -6558,10 +6660,10 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@2.5.1(@rsbuild/core@packages+core)(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)':
+  '@module-federation/rsbuild-plugin@2.5.1(@rsbuild/core@packages+core)(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)':
     dependencies:
-      '@module-federation/enhanced': 2.5.1(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)
-      '@module-federation/node': 2.7.44(@rspack/core@2.0.8)(typescript@6.0.3)
+      '@module-federation/enhanced': 2.5.1(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)
+      '@module-federation/node': 2.7.44(@rspack/core@2.1.0-beta.0)(typescript@6.0.3)
       '@module-federation/sdk': 2.5.1(node-fetch@2.7.0)
     optionalDependencies:
       '@rsbuild/core': link:packages/core
@@ -6574,7 +6676,7 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rspack@2.5.1(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)':
+  '@module-federation/rspack@2.5.1(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.5.1(node-fetch@2.7.0)
       '@module-federation/dts-plugin': 2.5.1(node-fetch@2.7.0)(typescript@6.0.3)
@@ -6583,7 +6685,7 @@ snapshots:
       '@module-federation/manifest': 2.5.1(node-fetch@2.7.0)(typescript@6.0.3)
       '@module-federation/runtime-tools': 2.5.1(node-fetch@2.7.0)
       '@module-federation/sdk': 2.5.1(node-fetch@2.7.0)
-      '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -6655,9 +6757,9 @@ snapshots:
 
   '@napi-rs/wasm-runtime@1.0.7':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.1
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.2
     optional: true
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
@@ -6665,6 +6767,13 @@ snapshots:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.2
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -6886,7 +6995,7 @@ snapshots:
 
   '@rsbuild/core@1.7.5':
     dependencies:
-      '@rspack/core': 1.7.11(@swc/helpers@0.5.23)
+      '@rspack/core': 1.7.12(@swc/helpers@0.5.23)
       '@rspack/lite-tapable': 1.1.0
       '@swc/helpers': 0.5.23
       core-js: 3.47.0
@@ -6946,12 +7055,12 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': link:packages/core
 
-  '@rsbuild/plugin-type-check@1.4.0(@rsbuild/core@packages+core)(@rspack/core@2.0.8)(typescript@6.0.3)':
+  '@rsbuild/plugin-type-check@1.4.0(@rsbuild/core@packages+core)(@rspack/core@2.1.0-beta.0)(typescript@6.0.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.2
-      ts-checker-rspack-plugin: 1.4.0(@rspack/core@2.0.8)(typescript@6.0.3)
+      ts-checker-rspack-plugin: 1.4.0(@rspack/core@2.1.0-beta.0)(typescript@6.0.3)
     optionalDependencies:
       '@rsbuild/core': link:packages/core
     transitivePeerDependencies:
@@ -6960,14 +7069,14 @@ snapshots:
 
   '@rsdoctor/client@1.5.13': {}
 
-  '@rsdoctor/core@1.5.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@packages+core)(@rspack/core@2.0.8)':
+  '@rsdoctor/core@1.5.13(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@packages+core)(@rspack/core@2.1.0-beta.0)':
     dependencies:
       '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@packages+core)
-      '@rsdoctor/graph': 1.5.13(@rspack/core@2.0.8)
-      '@rsdoctor/sdk': 1.5.13(@rspack/core@2.0.8)
-      '@rsdoctor/types': 1.5.13(@rspack/core@2.0.8)
-      '@rsdoctor/utils': 1.5.13(@rspack/core@2.0.8)
-      '@rspack/resolver': 0.2.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@rsdoctor/graph': 1.5.13(@rspack/core@2.1.0-beta.0)
+      '@rsdoctor/sdk': 1.5.13(@rspack/core@2.1.0-beta.0)
+      '@rsdoctor/types': 1.5.13(@rspack/core@2.1.0-beta.0)
+      '@rsdoctor/utils': 1.5.13(@rspack/core@2.1.0-beta.0)
+      '@rspack/resolver': 0.2.8(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       browserslist-load-config: 1.0.3
       es-toolkit: 1.47.1
       filesize: 11.0.17
@@ -6984,10 +7093,10 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/graph@1.5.13(@rspack/core@2.0.8)':
+  '@rsdoctor/graph@1.5.13(@rspack/core@2.1.0-beta.0)':
     dependencies:
-      '@rsdoctor/types': 1.5.13(@rspack/core@2.0.8)
-      '@rsdoctor/utils': 1.5.13(@rspack/core@2.0.8)
+      '@rsdoctor/types': 1.5.13(@rspack/core@2.1.0-beta.0)
+      '@rsdoctor/utils': 1.5.13(@rspack/core@2.1.0-beta.0)
       es-toolkit: 1.47.1
       path-browserify: 1.0.1
       source-map: 0.7.6
@@ -6995,15 +7104,15 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rsdoctor/rspack-plugin@1.5.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@packages+core)(@rspack/core@2.0.8)':
+  '@rsdoctor/rspack-plugin@1.5.13(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@packages+core)(@rspack/core@2.1.0-beta.0)':
     dependencies:
-      '@rsdoctor/core': 1.5.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@packages+core)(@rspack/core@2.0.8)
-      '@rsdoctor/graph': 1.5.13(@rspack/core@2.0.8)
-      '@rsdoctor/sdk': 1.5.13(@rspack/core@2.0.8)
-      '@rsdoctor/types': 1.5.13(@rspack/core@2.0.8)
-      '@rsdoctor/utils': 1.5.13(@rspack/core@2.0.8)
+      '@rsdoctor/core': 1.5.13(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@packages+core)(@rspack/core@2.1.0-beta.0)
+      '@rsdoctor/graph': 1.5.13(@rspack/core@2.1.0-beta.0)
+      '@rsdoctor/sdk': 1.5.13(@rspack/core@2.1.0-beta.0)
+      '@rsdoctor/types': 1.5.13(@rspack/core@2.1.0-beta.0)
+      '@rsdoctor/utils': 1.5.13(@rspack/core@2.1.0-beta.0)
     optionalDependencies:
-      '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -7013,12 +7122,12 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/sdk@1.5.13(@rspack/core@2.0.8)':
+  '@rsdoctor/sdk@1.5.13(@rspack/core@2.1.0-beta.0)':
     dependencies:
       '@rsdoctor/client': 1.5.13
-      '@rsdoctor/graph': 1.5.13(@rspack/core@2.0.8)
-      '@rsdoctor/types': 1.5.13(@rspack/core@2.0.8)
-      '@rsdoctor/utils': 1.5.13(@rspack/core@2.0.8)
+      '@rsdoctor/graph': 1.5.13(@rspack/core@2.1.0-beta.0)
+      '@rsdoctor/types': 1.5.13(@rspack/core@2.1.0-beta.0)
+      '@rsdoctor/utils': 1.5.13(@rspack/core@2.1.0-beta.0)
       launch-editor: 2.14.1
       safer-buffer: 2.1.2
       socket.io: 4.8.1
@@ -7030,19 +7139,19 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/types@1.5.13(@rspack/core@2.0.8)':
+  '@rsdoctor/types@1.5.13(@rspack/core@2.1.0-beta.0)':
     dependencies:
       '@types/connect': 3.4.38
       '@types/estree': 1.0.5
       '@types/tapable': 2.3.0
       source-map: 0.7.6
     optionalDependencies:
-      '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
 
-  '@rsdoctor/utils@1.5.13(@rspack/core@2.0.8)':
+  '@rsdoctor/utils@1.5.13(@rspack/core@2.1.0-beta.0)':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@rsdoctor/types': 1.5.13(@rspack/core@2.0.8)
+      '@rsdoctor/types': 1.5.13(@rspack/core@2.1.0-beta.0)
       '@types/estree': 1.0.5
       acorn: 8.16.0
       acorn-import-attributes: 1.9.5(acorn@8.16.0)
@@ -7121,43 +7230,61 @@ snapshots:
       '@rslint/native-win32-arm64-msvc': 0.6.1
       '@rslint/native-win32-x64-msvc': 0.6.1
 
-  '@rspack/binding-darwin-arm64@1.7.11':
+  '@rspack/binding-darwin-arm64@1.7.12':
     optional: true
 
   '@rspack/binding-darwin-arm64@2.0.8':
     optional: true
 
-  '@rspack/binding-darwin-x64@1.7.11':
+  '@rspack/binding-darwin-arm64@2.1.0-beta.0':
+    optional: true
+
+  '@rspack/binding-darwin-x64@1.7.12':
     optional: true
 
   '@rspack/binding-darwin-x64@2.0.8':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@1.7.11':
+  '@rspack/binding-darwin-x64@2.1.0-beta.0':
+    optional: true
+
+  '@rspack/binding-linux-arm64-gnu@1.7.12':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@2.0.8':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@1.7.11':
+  '@rspack/binding-linux-arm64-gnu@2.1.0-beta.0':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@1.7.12':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@2.0.8':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@1.7.11':
+  '@rspack/binding-linux-arm64-musl@2.1.0-beta.0':
+    optional: true
+
+  '@rspack/binding-linux-x64-gnu@1.7.12':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@2.0.8':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@1.7.11':
+  '@rspack/binding-linux-x64-gnu@2.1.0-beta.0':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@1.7.12':
     optional: true
 
   '@rspack/binding-linux-x64-musl@2.0.8':
     optional: true
 
-  '@rspack/binding-wasm32-wasi@1.7.11':
+  '@rspack/binding-linux-x64-musl@2.1.0-beta.0':
+    optional: true
+
+  '@rspack/binding-wasm32-wasi@1.7.12':
     dependencies:
       '@napi-rs/wasm-runtime': 1.0.7
     optional: true
@@ -7169,36 +7296,52 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@1.7.11':
+  '@rspack/binding-wasm32-wasi@2.1.0-beta.0':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@1.7.12':
     optional: true
 
   '@rspack/binding-win32-arm64-msvc@2.0.8':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@1.7.11':
+  '@rspack/binding-win32-arm64-msvc@2.1.0-beta.0':
+    optional: true
+
+  '@rspack/binding-win32-ia32-msvc@1.7.12':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@2.0.8':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@1.7.11':
+  '@rspack/binding-win32-ia32-msvc@2.1.0-beta.0':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@1.7.12':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@2.0.8':
     optional: true
 
-  '@rspack/binding@1.7.11':
+  '@rspack/binding-win32-x64-msvc@2.1.0-beta.0':
+    optional: true
+
+  '@rspack/binding@1.7.12':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.7.11
-      '@rspack/binding-darwin-x64': 1.7.11
-      '@rspack/binding-linux-arm64-gnu': 1.7.11
-      '@rspack/binding-linux-arm64-musl': 1.7.11
-      '@rspack/binding-linux-x64-gnu': 1.7.11
-      '@rspack/binding-linux-x64-musl': 1.7.11
-      '@rspack/binding-wasm32-wasi': 1.7.11
-      '@rspack/binding-win32-arm64-msvc': 1.7.11
-      '@rspack/binding-win32-ia32-msvc': 1.7.11
-      '@rspack/binding-win32-x64-msvc': 1.7.11
+      '@rspack/binding-darwin-arm64': 1.7.12
+      '@rspack/binding-darwin-x64': 1.7.12
+      '@rspack/binding-linux-arm64-gnu': 1.7.12
+      '@rspack/binding-linux-arm64-musl': 1.7.12
+      '@rspack/binding-linux-x64-gnu': 1.7.12
+      '@rspack/binding-linux-x64-musl': 1.7.12
+      '@rspack/binding-wasm32-wasi': 1.7.12
+      '@rspack/binding-win32-arm64-msvc': 1.7.12
+      '@rspack/binding-win32-ia32-msvc': 1.7.12
+      '@rspack/binding-win32-x64-msvc': 1.7.12
 
   '@rspack/binding@2.0.8':
     optionalDependencies:
@@ -7213,10 +7356,23 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 2.0.8
       '@rspack/binding-win32-x64-msvc': 2.0.8
 
-  '@rspack/core@1.7.11(@swc/helpers@0.5.23)':
+  '@rspack/binding@2.1.0-beta.0':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 2.1.0-beta.0
+      '@rspack/binding-darwin-x64': 2.1.0-beta.0
+      '@rspack/binding-linux-arm64-gnu': 2.1.0-beta.0
+      '@rspack/binding-linux-arm64-musl': 2.1.0-beta.0
+      '@rspack/binding-linux-x64-gnu': 2.1.0-beta.0
+      '@rspack/binding-linux-x64-musl': 2.1.0-beta.0
+      '@rspack/binding-wasm32-wasi': 2.1.0-beta.0
+      '@rspack/binding-win32-arm64-msvc': 2.1.0-beta.0
+      '@rspack/binding-win32-ia32-msvc': 2.1.0-beta.0
+      '@rspack/binding-win32-x64-msvc': 2.1.0-beta.0
+
+  '@rspack/core@1.7.12(@swc/helpers@0.5.23)':
     dependencies:
       '@module-federation/runtime-tools': 0.22.0
-      '@rspack/binding': 1.7.11
+      '@rspack/binding': 1.7.12
       '@rspack/lite-tapable': 1.1.0
     optionalDependencies:
       '@swc/helpers': 0.5.23
@@ -7224,6 +7380,13 @@ snapshots:
   '@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)':
     dependencies:
       '@rspack/binding': 2.0.8
+    optionalDependencies:
+      '@module-federation/runtime-tools': 2.5.1(node-fetch@2.7.0)
+      '@swc/helpers': 0.5.23
+
+  '@rspack/core@2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)':
+    dependencies:
+      '@rspack/binding': 2.1.0-beta.0
     optionalDependencies:
       '@module-federation/runtime-tools': 2.5.1(node-fetch@2.7.0)
       '@swc/helpers': 0.5.23
@@ -7269,9 +7432,9 @@ snapshots:
   '@rspack/resolver-binding-linux-x64-musl@0.2.8':
     optional: true
 
-  '@rspack/resolver-binding-wasm32-wasi@0.2.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@rspack/resolver-binding-wasm32-wasi@0.2.8(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -7286,7 +7449,7 @@ snapshots:
   '@rspack/resolver-binding-win32-x64-msvc@0.2.8':
     optional: true
 
-  '@rspack/resolver@0.2.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@rspack/resolver@0.2.8(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     optionalDependencies:
       '@rspack/resolver-binding-darwin-arm64': 0.2.8
       '@rspack/resolver-binding-darwin-x64': 0.2.8
@@ -7294,7 +7457,7 @@ snapshots:
       '@rspack/resolver-binding-linux-arm64-musl': 0.2.8
       '@rspack/resolver-binding-linux-x64-gnu': 0.2.8
       '@rspack/resolver-binding-linux-x64-musl': 0.2.8
-      '@rspack/resolver-binding-wasm32-wasi': 0.2.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@rspack/resolver-binding-wasm32-wasi': 0.2.8(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@rspack/resolver-binding-win32-arm64-msvc': 0.2.8
       '@rspack/resolver-binding-win32-ia32-msvc': 0.2.8
       '@rspack/resolver-binding-win32-x64-msvc': 0.2.8
@@ -7656,7 +7819,21 @@ snapshots:
     optionalDependencies:
       '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
 
+  '@tailwindcss/webpack@4.3.1(@rspack/core@2.1.0-beta.0)':
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      '@tailwindcss/node': 4.3.1
+      '@tailwindcss/oxide': 4.3.1
+      tailwindcss: 4.3.1
+    optionalDependencies:
+      '@rspack/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
+
   '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -8137,7 +8314,7 @@ snapshots:
 
   cspell-ban-words@0.0.4: {}
 
-  css-loader@7.1.4(patch_hash=b504d70330b6625a20bc0cb1428c9787350fe6413c2947f42bd88ff22123a019)(@rspack/core@2.0.8):
+  css-loader@7.1.4(patch_hash=b504d70330b6625a20bc0cb1428c9787350fe6413c2947f42bd88ff22123a019)(@rspack/core@2.1.0-beta.0):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.15)
       postcss: 8.5.15
@@ -8148,7 +8325,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.4
     optionalDependencies:
-      '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
 
   css-select@5.2.2:
     dependencies:
@@ -8626,11 +8803,11 @@ snapshots:
       relateurl: 0.2.7
       terser: 5.47.1
 
-  html-rspack-plugin@6.1.9(@rspack/core@2.0.8):
+  html-rspack-plugin@6.1.9(@rspack/core@2.1.0-beta.0):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
     optionalDependencies:
-      '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
 
   html-void-elements@3.0.0: {}
 
@@ -9598,14 +9775,14 @@ snapshots:
       jiti: 2.7.0
       postcss: 8.5.15
 
-  postcss-loader@8.2.1(patch_hash=4829849d58d8366cd82cbdab1947d15f9e6d33e70f1e3d5310daffff152dff14)(@rspack/core@2.0.8)(postcss@8.5.15)(typescript@6.0.3):
+  postcss-loader@8.2.1(patch_hash=4829849d58d8366cd82cbdab1947d15f9e6d33e70f1e3d5310daffff152dff14)(@rspack/core@2.1.0-beta.0)(postcss@8.5.15)(typescript@6.0.3):
     dependencies:
       cosmiconfig: 9.0.1(typescript@6.0.3)
       jiti: 2.7.0
       postcss: 8.5.15
       semver: 7.7.4
     optionalDependencies:
-      '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
     transitivePeerDependencies:
       - typescript
 
@@ -9931,15 +10108,15 @@ snapshots:
 
   rslog@2.1.3: {}
 
-  rspack-chain@2.1.0(@rspack/core@2.0.8):
+  rspack-chain@2.1.0(@rspack/core@2.1.0-beta.0):
     optionalDependencies:
-      '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
 
-  rspack-manifest-plugin@5.2.2(@rspack/core@2.0.8):
+  rspack-manifest-plugin@5.2.2(@rspack/core@2.1.0-beta.0):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
     optionalDependencies:
-      '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
 
   rspack-merge@1.0.1: {}
 
@@ -10344,7 +10521,7 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-checker-rspack-plugin@1.4.0(@rspack/core@2.0.8)(typescript@6.0.3):
+  ts-checker-rspack-plugin@1.4.0(@rspack/core@2.1.0-beta.0)(typescript@6.0.3):
     dependencies:
       '@rspack/lite-tapable': 1.1.2
       chokidar: 3.6.0
@@ -10352,7 +10529,7 @@ snapshots:
       picocolors: 1.1.1
       typescript: 6.0.3
     optionalDependencies:
-      '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
 
   tslib@2.8.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,8 +314,8 @@ catalogs:
       specifier: ^2.1.3
       version: 2.1.3
     rspack-chain:
-      specifier: ^2.1.0
-      version: 2.1.0
+      specifier: ^2.1.1
+      version: 2.1.1
     rspack-manifest-plugin:
       specifier: 5.2.2
       version: 5.2.2
@@ -1003,7 +1003,7 @@ importers:
         version: 2.1.3
       rspack-chain:
         specifier: 'catalog:'
-        version: 2.1.0(@rspack/core@2.1.0-beta.0)
+        version: 2.1.1(@rspack/core@2.1.0-beta.0)
       rspack-manifest-plugin:
         specifier: 'catalog:'
         version: 5.2.2(@rspack/core@2.1.0-beta.0)
@@ -5260,8 +5260,8 @@ packages:
     resolution: {integrity: sha512-DCUkRKUBR1lSpHKRcxNvHaYwGrUVf9MsoE1u6gd0CF37I8vwwtWc4b+FA9OwYZ4QA/shslzAYorD3MMfd+Rs/Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  rspack-chain@2.1.0:
-    resolution: {integrity: sha512-FZJkUJaPn5zgidGQHRPvtJ6ECsGfdf1utiHIDKVkD+n9/6q9OQ5D9lKIOWKgrglfNnuACDPAL5FrXdI7ijw6xA==}
+  rspack-chain@2.1.1:
+    resolution: {integrity: sha512-oKKu7be3RMuaM1S8o+/XuS8L6bEcbYQ3944rTEG7f0AQSmKNO1EpWRANMq9/BrWpS7FHzlXwheBDcEo1+N24dw==}
     peerDependencies:
       '@rspack/core': ^2.0.0
     peerDependenciesMeta:
@@ -10108,7 +10108,7 @@ snapshots:
 
   rslog@2.1.3: {}
 
-  rspack-chain@2.1.0(@rspack/core@2.1.0-beta.0):
+  rspack-chain@2.1.1(@rspack/core@2.1.0-beta.0):
     optionalDependencies:
       '@rspack/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -118,7 +118,7 @@ catalog:
   'rsbuild-plugin-google-analytics': '^1.0.6'
   'rsbuild-plugin-open-graph': '^1.1.3'
   'rslog': '^2.1.3'
-  'rspack-chain': '^2.1.0'
+  'rspack-chain': '^2.1.1'
   'rspack-manifest-plugin': '5.2.2'
   'rspack-merge': '1.0.1'
   'rspack-vue-loader': '^17.5.1'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,7 +36,7 @@ catalog:
   '@rsdoctor/rspack-plugin': '1.5.13'
   '@rslib/core': '0.23.0'
   '@rslint/core': '^0.6.1'
-  '@rspack/core': '~2.0.8'
+  '@rspack/core': '~2.1.0-beta.0'
   '@rspack/plugin-preact-refresh': '^2.0.1'
   '@rspack/plugin-react-refresh': '^2.0.2'
   '@rspress/core': '^2.0.14'


### PR DESCRIPTION
## Summary

Update @rspack/core to 2.1.0-beta.0.
Update rspack-chain to 2.1.1 to remove the unsupported top-level snapshot option from bundled types and fix lint CI.

## Related Links

https://github.com/web-infra-dev/rspack/releases/tag/v2.1.0-beta.0
https://github.com/rstackjs/rspack-chain/releases/tag/v2.1.1