### PR TITLE
feat(create-rsbuild): use reactCompiler option

### DIFF
--- a/e2e/cases/create-rsbuild/tools.test.ts
+++ b/e2e/cases/create-rsbuild/tools.test.ts
@@ -197,26 +197,18 @@ test('should create React project with react-compiler as expected', async () => 
     tools: ['react-compiler'],
     clean: false,
   });
-  expect(pkgJson.devDependencies['@rsbuild/plugin-babel']).toBeTruthy();
-  expect(pkgJson.devDependencies['babel-plugin-react-compiler']).toBeTruthy();
   expect(pkgJson.dependencies['react-compiler-runtime']).toBeFalsy();
 
   const configContent = readCreatedFile(dir, 'rsbuild.config.js');
   expect(configContent).toBe(`// @ts-check
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
-import { pluginBabel } from '@rsbuild/plugin-babel';
 
 // Docs: https://rsbuild.rs/config/
 export default defineConfig({
   plugins: [
-    pluginReact(),
-    pluginBabel({
-      include: /\\.[jt]sx?$/,
-      exclude: [/[\\\\/]node_modules[\\\\/]/],
-      babelLoaderOptions(opts) {
-        opts.plugins?.unshift('babel-plugin-react-compiler');
-      },
+    pluginReact({
+      reactCompiler: true,
     }),
   ],
 });
@@ -230,27 +222,19 @@ test('should create React project with react-compiler and tailwindcss as expecte
     tools: ['react-compiler', 'tailwindcss'],
     clean: false,
   });
-  expect(pkgJson.devDependencies['@rsbuild/plugin-babel']).toBeTruthy();
   expect(pkgJson.devDependencies['@rsbuild/plugin-tailwindcss']).toBeTruthy();
-  expect(pkgJson.devDependencies['babel-plugin-react-compiler']).toBeTruthy();
 
   const configContent = readCreatedFile(dir, 'rsbuild.config.js');
   expect(configContent).toBe(`// @ts-check
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
-import { pluginBabel } from '@rsbuild/plugin-babel';
 import { pluginTailwindcss } from '@rsbuild/plugin-tailwindcss';
 
 // Docs: https://rsbuild.rs/config/
 export default defineConfig({
   plugins: [
-    pluginReact(),
-    pluginBabel({
-      include: /\\.[jt]sx?$/,
-      exclude: [/[\\\\/]node_modules[\\\\/]/],
-      babelLoaderOptions(opts) {
-        opts.plugins?.unshift('babel-plugin-react-compiler');
-      },
+    pluginReact({
+      reactCompiler: true,
     }),
     pluginTailwindcss(),
   ],
@@ -265,27 +249,19 @@ test('should preserve tailwindcss when react-compiler runs after it', async () =
     tools: ['tailwindcss', 'react-compiler'],
     clean: false,
   });
-  expect(pkgJson.devDependencies['@rsbuild/plugin-babel']).toBeTruthy();
   expect(pkgJson.devDependencies['@rsbuild/plugin-tailwindcss']).toBeTruthy();
-  expect(pkgJson.devDependencies['babel-plugin-react-compiler']).toBeTruthy();
 
   const configContent = readCreatedFile(dir, 'rsbuild.config.js');
   expect(configContent).toBe(`// @ts-check
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
-import { pluginBabel } from '@rsbuild/plugin-babel';
 import { pluginTailwindcss } from '@rsbuild/plugin-tailwindcss';
 
 // Docs: https://rsbuild.rs/config/
 export default defineConfig({
   plugins: [
-    pluginReact(),
-    pluginBabel({
-      include: /\\.[jt]sx?$/,
-      exclude: [/[\\\\/]node_modules[\\\\/]/],
-      babelLoaderOptions(opts) {
-        opts.plugins?.unshift('babel-plugin-react-compiler');
-      },
+    pluginReact({
+      reactCompiler: true,
     }),
     pluginTailwindcss(),
   ],
@@ -300,8 +276,6 @@ test('should ignore react-compiler for non-React projects', async () => {
     tools: ['react-compiler'],
     clean: false,
   });
-  expect(pkgJson.devDependencies['@rsbuild/plugin-babel']).toBeFalsy();
-  expect(pkgJson.devDependencies['babel-plugin-react-compiler']).toBeFalsy();
   expect(pkgJson.dependencies?.['react-compiler-runtime']).toBeFalsy();
 
   const configContent = readCreatedFile(dir, 'rsbuild.config.js');

--- a/packages/create-rsbuild/src/index.ts
+++ b/packages/create-rsbuild/src/index.ts
@@ -11,7 +11,7 @@ import {
 } from 'create-rstack';
 import {
   addPluginsToRsbuildConfig,
-  reactCompilerPlugin,
+  enableReactCompilerInRsbuildConfig,
   tailwindcssPlugin,
 } from './rsbuildConfig.js';
 
@@ -149,14 +149,8 @@ create({
       label: 'React Compiler - optimization',
       order: 'pre',
       when: ({ templateName }) => ['react-js', 'react-ts'].includes(templateName),
-      action: async ({ templateName, distFolder }) => {
-        const toolFolder = path.join(root, 'template-react-compiler');
-        copyFolder({
-          from: path.join(toolFolder, templateName),
-          to: distFolder,
-          isMergePackageJson: true,
-        });
-        await addPluginsToRsbuildConfig(distFolder, [reactCompilerPlugin]);
+      action: async ({ distFolder }) => {
+        await enableReactCompilerInRsbuildConfig(distFolder);
       },
     },
     {

--- a/packages/create-rsbuild/src/rsbuildConfig.ts
+++ b/packages/create-rsbuild/src/rsbuildConfig.ts
@@ -17,20 +17,6 @@ export const tailwindcssPlugin: ConfigPlugin = {
   order: 20,
 };
 
-export const reactCompilerPlugin: ConfigPlugin = {
-  id: 'react-compiler',
-  importName: 'pluginBabel',
-  source: '@rsbuild/plugin-babel',
-  call: `pluginBabel({
-  include: /\\.[jt]sx?$/,
-  exclude: [/[\\\\/]node_modules[\\\\/]/],
-  babelLoaderOptions(opts) {
-    opts.plugins?.unshift('babel-plugin-react-compiler');
-  },
-})`,
-  order: 10,
-};
-
 type ConfigState = {
   file: string;
   base: string;
@@ -83,6 +69,29 @@ const formatPlugins = (calls: string[]) => {
   return lines.join('\n');
 };
 
+const addReactCompilerOption = (code: string) => {
+  if (code.includes('reactCompiler:')) {
+    return code;
+  }
+
+  const reactCompilerCall = `pluginReact({
+  reactCompiler: true,
+})`;
+  const multiLineCall = `${indent}${indent}pluginReact(),`;
+  const replaceCall = (call: string) => (call === 'pluginReact()' ? reactCompilerCall : call);
+  const next = code
+    .replace(/^ {2}plugins: \[(.*pluginReact\(\).*)\],$/m, (_, calls: string) =>
+      formatPlugins(calls.split(', ').map(replaceCall)),
+    )
+    .replace(multiLineCall, formatCall(reactCompilerCall));
+
+  if (next !== code) {
+    return next;
+  }
+
+  throw new Error('Failed to update rsbuild.config: pluginReact call not found.');
+};
+
 const addPluginsField = (code: string, calls: string[]) => {
   if (code.includes('defineConfig({});')) {
     return code.replace('defineConfig({});', `defineConfig({\n${formatPlugins(calls)}\n});`);
@@ -131,9 +140,11 @@ const addCalls = (code: string, plugins: ConfigPlugin[]) => {
 
 const applyPlugins = (base: string, plugins: ConfigPlugin[]) => {
   let code = base;
+
   for (const plugin of plugins) {
     code = addImport(code, plugin);
   }
+
   return addCalls(code, plugins);
 };
 
@@ -166,4 +177,15 @@ export const addPluginsToRsbuildConfig = async (dir: string, plugins: ConfigPlug
   const ordered = [...state.plugins.values()].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
 
   await fs.promises.writeFile(state.file, applyPlugins(state.base, ordered));
+};
+
+export const enableReactCompilerInRsbuildConfig = async (dir: string) => {
+  const file = findConfig(dir);
+
+  if (!file) {
+    return;
+  }
+
+  const code = normalize(await fs.promises.readFile(file, 'utf-8'));
+  await fs.promises.writeFile(file, addReactCompilerOption(code));
 };

--- a/packages/create-rsbuild/template-react-compiler/react-js/package.json
+++ b/packages/create-rsbuild/template-react-compiler/react-js/package.json
@@ -1,6 +1,0 @@
-{
-  "devDependencies": {
-    "@rsbuild/plugin-babel": "^2.0.0",
-    "babel-plugin-react-compiler": "^1.0.0"
-  }
-}

--- a/packages/create-rsbuild/template-react-compiler/react-ts/package.json
+++ b/packages/create-rsbuild/template-react-compiler/react-ts/package.json
@@ -1,6 +1,0 @@
-{
-  "devDependencies": {
-    "@rsbuild/plugin-babel": "^2.0.0",
-    "babel-plugin-react-compiler": "^1.0.0"
-  }
-}


### PR DESCRIPTION
## Summary

This PR updates create-rsbuild's React Compiler tool to use the new `pluginReact({ reactCompiler: true })` option instead of injecting the Babel-based compiler setup. It removes the React Compiler-specific Babel dependency templates and updates the create-rsbuild e2e expectations for React and Tailwind combinations.