### PR TITLE
chore(deps): keep Babel updates on v7

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,6 +15,11 @@
       "matchPackageNames": ["/babel/"]
     },
     {
+      "description": "Keep Babel 7 packages on v7 until Babel 8 compatibility is handled.",
+      "matchPackageNames": ["/^@babel\\//", "/^@types\\/babel__/"],
+      "allowedVersions": ">=7.0.0 <8.0.0"
+    },
+    {
       "groupName": "Rspress",
       "groupSlug": "rspress",
       "matchPackageNames": ["/rspress/"]


### PR DESCRIPTION
## Summary

This PR updates the Renovate package rules so Babel 7 packages stay within the v7 range for now, avoiding automatic Babel 8 upgrade PRs until compatibility work is handled. The existing Babel dependency grouping remains unchanged, while the version cap applies only to `@babel/*` and `@types/babel__*` packages.
