### PR TITLE
chore: check formatting in lint CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,5 +37,8 @@ jobs:
       - name: Lint
         run: node --run lint
 
+      - name: Check Format
+        run: node --run format:check
+
       - name: Check Spell
         run: node --run check-spell

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "doc": "cd website && node --run dev",
     "e2e": "cd ./e2e && pnpm e2e",
     "format": "oxfmt . && heading-case --write",
+    "format:check": "oxfmt . --check",
     "lint": "rslint --type-check",
     "prebundle": "pnpm --parallel --filter \"./packages/*\" run prebundle",
     "prepare": "simple-git-hooks && node --run prebundle && node --run build",

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -3,14 +3,14 @@
   "version": "2.1.0-beta.0",
   "description": "Create a new Rsbuild project",
   "homepage": "https://rsbuild.rs",
+  "bugs": {
+    "url": "https://github.com/web-infra-dev/rsbuild/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsbuild",
     "directory": "packages/create-rsbuild"
-  },
-  "bugs": {
-    "url": "https://github.com/web-infra-dev/rsbuild/issues"
   },
   "bin": {
     "create-rsbuild": "./bin.js"

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -3,14 +3,14 @@
   "version": "1.6.4",
   "description": "Less plugin for Rsbuild",
   "homepage": "https://rsbuild.rs",
+  "bugs": {
+    "url": "https://github.com/web-infra-dev/rsbuild/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsbuild",
     "directory": "packages/plugin-less"
-  },
-  "bugs": {
-    "url": "https://github.com/web-infra-dev/rsbuild/issues"
   },
   "files": [
     "dist",

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -3,14 +3,14 @@
   "version": "2.0.0",
   "description": "Preact plugin for Rsbuild",
   "homepage": "https://rsbuild.rs",
+  "bugs": {
+    "url": "https://github.com/web-infra-dev/rsbuild/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsbuild",
     "directory": "packages/plugin-preact"
-  },
-  "bugs": {
-    "url": "https://github.com/web-infra-dev/rsbuild/issues"
   },
   "files": [
     "dist"

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -3,14 +3,14 @@
   "version": "1.5.3",
   "description": "Sass plugin for Rsbuild",
   "homepage": "https://rsbuild.rs",
+  "bugs": {
+    "url": "https://github.com/web-infra-dev/rsbuild/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsbuild",
     "directory": "packages/plugin-sass"
-  },
-  "bugs": {
-    "url": "https://github.com/web-infra-dev/rsbuild/issues"
   },
   "files": [
     "dist",

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -3,14 +3,14 @@
   "version": "2.0.4",
   "description": "SVGR plugin for Rsbuild",
   "homepage": "https://rsbuild.rs",
+  "bugs": {
+    "url": "https://github.com/web-infra-dev/rsbuild/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsbuild",
     "directory": "packages/plugin-svgr"
-  },
-  "bugs": {
-    "url": "https://github.com/web-infra-dev/rsbuild/issues"
   },
   "files": [
     "dist"

--- a/packages/plugin-tailwindcss/package.json
+++ b/packages/plugin-tailwindcss/package.json
@@ -3,14 +3,14 @@
   "version": "2.0.3",
   "description": "Tailwind CSS plugin for Rsbuild",
   "homepage": "https://rsbuild.rs",
+  "bugs": {
+    "url": "https://github.com/web-infra-dev/rsbuild/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsbuild",
     "directory": "packages/plugin-tailwindcss"
-  },
-  "bugs": {
-    "url": "https://github.com/web-infra-dev/rsbuild/issues"
   },
   "files": [
     "dist"

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -3,14 +3,14 @@
   "version": "1.2.9",
   "description": "Vue 3 plugin of Rsbuild",
   "homepage": "https://rsbuild.rs",
+  "bugs": {
+    "url": "https://github.com/web-infra-dev/rsbuild/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsbuild",
     "directory": "packages/plugin-vue"
-  },
-  "bugs": {
-    "url": "https://github.com/web-infra-dev/rsbuild/issues"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Summary

This PR fixes current format drift in package metadata and adds a `format:check` script to the lint CI workflow so formatting regressions are caught in pull requests.