### PR TITLE
feat(plugin-sass)!: publish as pure ESM

### DIFF
--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -21,8 +21,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.js"
     }
   },
   "publishConfig": {

--- a/packages/plugin-sass/rslib.config.ts
+++ b/packages/plugin-sass/rslib.config.ts
@@ -1,3 +1,3 @@
-import { dualPackage } from '@scripts/config/rslib.config.ts';
+import { pureEsmPackage } from '@scripts/config/rslib.config.ts';
 
-export default dualPackage;
+export default pureEsmPackage;


### PR DESCRIPTION
## Summary

This PR changes `@rsbuild/plugin-sass` to publish as a pure ESM package by removing the CommonJS export condition and switching its Rslib build config to `pureEsmPackage`.