### PR TITLE
feat(plugin-less)!: publish as pure ESM

### DIFF
--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -21,8 +21,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.js"
     }
   },
   "publishConfig": {

--- a/packages/plugin-less/rslib.config.ts
+++ b/packages/plugin-less/rslib.config.ts
@@ -1,3 +1,3 @@
-import { dualPackage } from '@scripts/config/rslib.config.ts';
+import { pureEsmPackage } from '@scripts/config/rslib.config.ts';
 
-export default dualPackage;
+export default pureEsmPackage;


### PR DESCRIPTION
## Summary

- Publish `@rsbuild/plugin-less` as a pure ESM package by removing the CommonJS export condition.
- Switch the package build from dual output to `pureEsmPackage`.