### PR TITLE
chore(deps): upgrade reduce-configs catalog to v2

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,6 +20,13 @@
       "allowedVersions": ">=7.0.0 <8.0.0"
     },
     {
+      "description": "Keep @rsbuild/plugin-babel on reduce-configs v1 because applyUserBabelConfig is an exported synchronous API.",
+      "matchManagers": ["npm"],
+      "matchFileNames": ["packages/plugin-babel/package.json"],
+      "matchPackageNames": ["reduce-configs"],
+      "enabled": false
+    },
+    {
       "groupName": "Rspress",
       "groupSlug": "rspress",
       "matchPackageNames": ["/rspress/"]

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -79,7 +79,7 @@
     "postcss-loader": "catalog:",
     "prebundle": "catalog:",
     "range-parser": "catalog:",
-    "reduce-configs": "^2.0.1",
+    "reduce-configs": "catalog:",
     "rslog": "catalog:",
     "rspack-chain": "catalog:",
     "rspack-manifest-plugin": "catalog:",

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -39,7 +39,7 @@
     "@babel/plugin-transform-class-properties": "catalog:",
     "@babel/preset-typescript": "catalog:",
     "@types/babel__core": "catalog:",
-    "reduce-configs": "catalog:"
+    "reduce-configs": "^1.1.2"
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",

--- a/packages/plugin-less/src/index.ts
+++ b/packages/plugin-less/src/index.ts
@@ -108,7 +108,7 @@ export type PluginLessOptions = {
   parallel?: boolean;
 };
 
-const getLessLoaderOptions = (
+const getLessLoaderOptions = async (
   userOptions: PluginLessOptions['lessLoaderOptions'],
   isUseCssSourceMap: boolean,
   rootPath: string,
@@ -149,7 +149,7 @@ const getLessLoaderOptions = (
     };
   };
 
-  const mergedOptions = reduceConfigsWithContext({
+  const mergedOptions = await reduceConfigsWithContext({
     initial: defaultLessLoaderOptions,
     config: userOptions,
     ctx: { addExcludes },
@@ -189,7 +189,7 @@ export const pluginLess = (pluginOptions: PluginLessOptions = {}): RsbuildPlugin
     const LESS_INLINE = 'less-inline';
     const LESS_RAW = 'less-raw';
 
-    api.modifyBundlerChain((chain, { CHAIN_ID, environment }) => {
+    api.modifyBundlerChain(async (chain, { CHAIN_ID, environment }) => {
       const { config } = environment;
 
       const lessRule = chain.module
@@ -220,7 +220,7 @@ export const pluginLess = (pluginOptions: PluginLessOptions = {}): RsbuildPlugin
       const lessMainRule = getRule(LESS_MAIN);
 
       const { sourceMap } = config.output;
-      const { excludes, options } = getLessLoaderOptions(
+      const { excludes, options } = await getLessLoaderOptions(
         pluginOptions.lessLoaderOptions,
         typeof sourceMap === 'boolean' ? sourceMap : sourceMap.css,
         api.context.rootPath,

--- a/packages/plugin-sass/src/index.ts
+++ b/packages/plugin-sass/src/index.ts
@@ -22,13 +22,13 @@ function assertCoreVersion(version: string): void {
   }
 }
 
-const getSassLoaderOptions = (
+const getSassLoaderOptions = async (
   userOptions: PluginSassOptions['sassLoaderOptions'],
   isUseCssSourceMap: boolean,
-): {
+): Promise<{
   options: SassLoaderOptions;
   excludes: (RegExp | string)[];
-} => {
+}> => {
   const excludes: (RegExp | string)[] = [];
 
   const addExcludes = (items: string | RegExp | (string | RegExp)[]) => {
@@ -53,7 +53,7 @@ const getSassLoaderOptions = (
     };
   };
 
-  const mergedOptions = reduceConfigsWithContext({
+  const mergedOptions = await reduceConfigsWithContext({
     initial: {
       sourceMap: isUseCssSourceMap,
       api: 'modern-compiler',
@@ -117,12 +117,12 @@ export const pluginSass = (pluginOptions: PluginSassOptions = {}): RsbuildPlugin
       patchCompilerGlobalLocation(compiler);
     });
 
-    api.modifyBundlerChain((chain, { CHAIN_ID, environment }) => {
+    api.modifyBundlerChain(async (chain, { CHAIN_ID, environment }) => {
       const { config } = environment;
       const { sourceMap } = config.output;
       const isUseSourceMap = typeof sourceMap === 'boolean' ? sourceMap : sourceMap.css;
 
-      const { excludes, options } = getSassLoaderOptions(
+      const { excludes, options } = await getSassLoaderOptions(
         pluginOptions.sassLoaderOptions,
         // If `rewriteUrls` is true, source maps are required for loaders that run before
         // `resolve-url-loader`, otherwise the `resolve-url-loader` will throw an error.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,8 +293,8 @@ catalogs:
       specifier: ^0.18.0
       version: 0.18.0
     reduce-configs:
-      specifier: ^1.1.2
-      version: 1.1.2
+      specifier: ^2.0.1
+      version: 2.0.1
     resolve-url-loader:
       specifier: ^5.0.0
       version: 5.0.0
@@ -989,7 +989,7 @@ importers:
         specifier: 'catalog:'
         version: 1.2.1
       reduce-configs:
-        specifier: ^2.0.1
+        specifier: 'catalog:'
         version: 2.0.1
       rslog:
         specifier: 'catalog:'
@@ -1077,7 +1077,7 @@ importers:
         specifier: 'catalog:'
         version: 7.20.5
       reduce-configs:
-        specifier: 'catalog:'
+        specifier: ^1.1.2
         version: 1.1.2
     devDependencies:
       '@rsbuild/core':
@@ -1115,7 +1115,7 @@ importers:
         version: 12.3.3(@rspack/core@2.0.8)(less@4.6.6)
       reduce-configs:
         specifier: 'catalog:'
-        version: 1.1.2
+        version: 2.0.1
     devDependencies:
       '@rsbuild/core':
         specifier: workspace:*
@@ -1208,7 +1208,7 @@ importers:
         version: 8.5.15
       reduce-configs:
         specifier: 'catalog:'
-        version: 1.1.2
+        version: 2.0.1
       sass-embedded:
         specifier: 'catalog:'
         version: 1.100.0
@@ -3304,9 +3304,6 @@ packages:
         optional: true
       webpack:
         optional: true
-
-  '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
@@ -6750,7 +6747,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.1
+      '@tybys/wasm-util': 0.10.2
     optional: true
 
   '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
@@ -7811,11 +7808,6 @@ snapshots:
       tailwindcss: 4.3.1
     optionalDependencies:
       '@rspack/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
-
-  '@tybys/wasm-util@0.10.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
 
   '@tybys/wasm-util@0.10.2':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -111,7 +111,7 @@ catalog:
   'react': '^19.2.7'
   'react-dom': '^19.2.7'
   'react-refresh': '^0.18.0'
-  'reduce-configs': '^1.1.2'
+  'reduce-configs': '^2.0.1'
   'resolve-url-loader': '^5.0.0'
   'rsbuild-plugin-arethetypeswrong': '0.3.1'
   'rsbuild-plugin-google-analytics': '^1.0.6'


### PR DESCRIPTION
## Summary

This PR updates the workspace `reduce-configs` catalog entry to v2 for Rsbuild core and the Less/Sass plugins. The Babel plugin keeps `reduce-configs` v1 so the exported synchronous `applyUserBabelConfig` API remains unchanged, and Renovate is configured to avoid upgrading that specific dependency. Less and Sass await the v2 async reducer before passing loader options to Rspack.

## Related Links

- https://github.com/rstackjs/reduce-configs/tree/v2.0.1