### PR TITLE
release: @rsbuild/plugin-less v2.0.0

### DIFF
--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-less",
-  "version": "1.6.4",
+  "version": "2.0.0",
   "description": "Less plugin for Rsbuild",
   "homepage": "https://rsbuild.rs",
   "bugs": {


### PR DESCRIPTION
## Summary

Release `@rsbuild/plugin-less` v2.0.0.

## Changes

- https://github.com/web-infra-dev/rsbuild/pull/7957
- https://github.com/web-infra-dev/rsbuild/pull/7959