### PR TITLE
docs(skills): add release plugin package skill

### DIFF
--- a/.agents/skills/release-core/SKILL.md
+++ b/.agents/skills/release-core/SKILL.md
@@ -25,7 +25,7 @@ If the version is missing, ask for it before making changes.
 
 5. Create a commit with this exact message: `release: v<version>`
 
-6. Push the branch, then create a GitHub PR with `gh pr create`. Use the same text for the PR title as the commit message: `release: v<version>`
+6. Push the branch. If running in Codex, create the PR with the GitHub connector/plugin. Otherwise, use the GitHub workflow available in the current environment. Use the same text for the PR title as the commit message: `release: v<version>`
 
 7. If `.github/PULL_REQUEST_TEMPLATE.md` exists, keep its structure.
    Fill it with:

--- a/.agents/skills/release-plugin-package/SKILL.md
+++ b/.agents/skills/release-plugin-package/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: release-plugin-package
+description: Use when asked to create a release PR for an official Rsbuild plugin package under `packages/plugin-*`, such as `@rsbuild/plugin-react v2.1.0` or `@rsbuild/plugin-sass v2.0.0`.
+---
+
+# Release Plugin Package
+
+## Input
+
+- Plugin package name or short name, for example `@rsbuild/plugin-react`, `plugin-react`, or `react`.
+- Target version, for example `2.1.0`.
+- Optional related PRs or issue links that should be listed as release changes.
+
+If the package or version is missing, ask for it before making changes.
+
+## Scope
+
+Use this skill only for official plugin packages in `packages/plugin-*`.
+
+Do not use it for:
+
+- `@rsbuild/core` or `create-rsbuild` releases. Use `release-core` instead.
+- Feature, bug fix, pure ESM, or v1 compatibility changes before the release version bump.
+- Publishing npm packages directly. This skill creates the release PR only.
+
+## Workflow
+
+1. Check the worktree:
+
+   ```bash
+   git status --short
+   git branch --show-current
+   ```
+
+   If there are uncommitted edits, stop and ask the user how to proceed.
+
+2. Resolve the package directory:
+
+   - `@rsbuild/plugin-react` -> `packages/plugin-react`
+   - `plugin-react` -> `packages/plugin-react`
+   - `react` -> `packages/plugin-react`
+
+   Confirm that `packages/plugin-<name>/package.json` exists and its `name` field matches the target package.
+
+3. Create and switch to a dedicated branch if the current branch is the default branch. Prefer:
+
+   ```text
+   release/plugin-<name>-v<version>
+   ```
+
+4. Update only the plugin package version first:
+
+   ```text
+   packages/plugin-<name>/package.json
+   ```
+
+5. Sync `create-rsbuild` template dependency versions only when that plugin appears in template `package.json` files:
+
+   ```bash
+   rg -n '@rsbuild/plugin-<name>' packages/create-rsbuild --glob 'package.json'
+   ```
+
+   Update matching template dependency ranges to `^<version>`. Do not change `workspace:*` dev dependencies in `packages/create-rsbuild/package.json`.
+
+6. Review the diff and confirm it is limited to:
+
+   - the released plugin package version
+   - matching `packages/create-rsbuild/template-*/package.json` dependency ranges, if any
+
+   If other files changed, stop and explain the unexpected diff.
+
+7. Validate JSON and run focused checks:
+
+   ```bash
+   node -e "for (const f of process.argv.slice(1)) JSON.parse(require('fs').readFileSync(f, 'utf8'))" <edited-package-json-files>
+   pnpm --filter @rsbuild/plugin-<name> run build
+   ```
+
+   If `create-rsbuild` templates changed, also run the focused create-rsbuild e2e case when practical:
+
+   ```bash
+   pnpm e2e create-rsbuild
+   ```
+
+   Report any skipped validation in the final response.
+
+8. Commit with this exact title:
+
+   ```text
+   release: @rsbuild/plugin-<name> v<version>
+   ```
+
+9. Push the branch after re-checking it is not the default branch.
+
+10. Create the PR with the GitHub connector/plugin when possible. Use `gh pr create` only as a fallback when the connector cannot complete the operation.
+
+## PR Body
+
+Use the repository PR template. Keep the body concise.
+
+For `Summary`, use:
+
+```markdown
+Release `@rsbuild/plugin-<name>` v<version>.
+```
+
+If related change PRs were provided or can be confidently identified, add a `Changes` section:
+
+```markdown
+## Changes
+
+- https://github.com/web-infra-dev/rsbuild/pull/<number>
+- https://github.com/web-infra-dev/rsbuild/pull/<number>
+```
+
+Do not invent change links. If no related links are known, omit `Changes` and `Related Links` instead of adding empty sections.

--- a/.agents/skills/release-plugin-package/SKILL.md
+++ b/.agents/skills/release-plugin-package/SKILL.md
@@ -89,7 +89,7 @@ Do not use it for:
 
 9. Push the branch after re-checking it is not the default branch.
 
-10. Create the PR using the GitHub workflow available in the current environment.
+10. If running in Codex, create the PR with the GitHub connector/plugin. Otherwise, use the GitHub workflow available in the current environment.
 
 ## PR Body
 

--- a/.agents/skills/release-plugin-package/SKILL.md
+++ b/.agents/skills/release-plugin-package/SKILL.md
@@ -7,9 +7,8 @@ description: Use when asked to create a release PR for an official Rsbuild plugi
 
 ## Input
 
-- Plugin package name or short name, for example `@rsbuild/plugin-react`, `plugin-react`, or `react`.
+- Plugin package name or short name, for example `@rsbuild/plugin-react` or `plugin-react`.
 - Target version, for example `2.1.0`.
-- Optional related PRs or issue links that should be listed as release changes.
 
 If the package or version is missing, ask for it before making changes.
 
@@ -20,7 +19,6 @@ Use this skill only for official plugin packages in `packages/plugin-*`.
 Do not use it for:
 
 - `@rsbuild/core` or `create-rsbuild` releases. Use `release-core` instead.
-- Feature, bug fix, pure ESM, or v1 compatibility changes before the release version bump.
 - Publishing npm packages directly. This skill creates the release PR only.
 
 ## Workflow
@@ -38,7 +36,6 @@ Do not use it for:
 
    - `@rsbuild/plugin-react` -> `packages/plugin-react`
    - `plugin-react` -> `packages/plugin-react`
-   - `react` -> `packages/plugin-react`
 
    Confirm that `packages/plugin-<name>/package.json` exists and its `name` field matches the target package.
 
@@ -92,7 +89,7 @@ Do not use it for:
 
 9. Push the branch after re-checking it is not the default branch.
 
-10. Create the PR with the GitHub connector/plugin when possible. Use `gh pr create` only as a fallback when the connector cannot complete the operation.
+10. Create the PR using the GitHub workflow available in the current environment.
 
 ## PR Body
 
@@ -113,4 +110,4 @@ If related change PRs were provided or can be confidently identified, add a `Cha
 - https://github.com/web-infra-dev/rsbuild/pull/<number>
 ```
 
-Do not invent change links. If no related links are known, omit `Changes` and `Related Links` instead of adding empty sections.
+Do not invent change links. If no related links are known, omit `Changes` instead of adding an empty section.

--- a/.agents/skills/release-plugin-package/agents/openai.yaml
+++ b/.agents/skills/release-plugin-package/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Release Plugin Package"
+  short_description: "Create release PRs for Rsbuild plugin packages."
+  default_prompt: "Create a release PR for an Rsbuild plugin package."

--- a/.agents/skills/release-plugin-package/agents/openai.yaml
+++ b/.agents/skills/release-plugin-package/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Release Plugin Package"
-  short_description: "Create release PRs for Rsbuild plugin packages."
-  default_prompt: "Create a release PR for an Rsbuild plugin package."


### PR DESCRIPTION
## Summary

Add a `release-plugin-package` skill for official Rsbuild plugin release PRs. It documents package resolution, version bump scope, create-rsbuild template sync, validation, commit title, and PR body conventions.