### PR TITLE
docs: add plugin changelogs

### DIFF
--- a/cspell.config.js
+++ b/cspell.config.js
@@ -18,6 +18,7 @@ export default {
     'coverage',
     'doc_build',
     'node_modules',
+    'packages/plugin-*/CHANGELOG.md',
     'pnpm-lock.yaml',
     'README.pt-BR.md',
   ],

--- a/packages/plugin-babel/CHANGELOG.md
+++ b/packages/plugin-babel/CHANGELOG.md
@@ -1,0 +1,154 @@
+# @rsbuild/plugin-babel
+
+## 2.0.0 (2026-06-16)
+
+### Breaking changes
+
+- feat(plugin-babel)!: publish as pure ESM package by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7919
+- feat(plugin-babel)!: drop Rsbuild v1 support by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7922
+
+### New features
+
+- feat(plugin-babel): add parallel option by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7917
+
+### Document
+
+- docs: update parallel loader docs by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7920
+
+## 1.2.1 (2026-05-30)
+
+- No plugin-specific changes.
+
+## 1.2.0 (2026-05-27)
+
+### New features
+
+- feat(plugin-babel): support multiple babel rules by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7764
+
+### Bug fixes
+
+- fix: remove redundant main fields from package.json files by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7338
+- fix(plugin-babel): restrict Babel rule ID matching by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7765
+
+## 1.1.2 (2026-03-11)
+
+### Bug fixes
+
+- fix: mark type-only plugin peers on @rsbuild/core as optional by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7316
+
+## 1.1.1 (2026-03-02)
+
+### Bug fixes
+
+- fix(plugin-babel): remove upath dependency by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7269
+- fix(plugin-babel): remove deepmerge dependency by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7274
+
+### Other changes
+
+- chore(deps): update babel to ^7.29.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/7108
+
+## 1.1.0 (2026-01-27)
+
+### New features
+
+- feat(plugin-babel): compatible with Rsbuild v1 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7062
+
+### Other changes
+
+- chore(deps): update dependency @babel/plugin-transform-class-properties to ^7.28.6 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/6997
+
+## 1.0.7 (2026-01-15)
+
+### Bug fixes
+
+- fix(plugins): update peerDependencies to support Rsbuild v2 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6976
+
+### Document
+
+- docs: update download badge links in README files by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6762
+
+## 1.0.6 (2025-08-04)
+
+### Performance
+
+- perf: bundle rspack-chain into main JS bundle by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5684
+
+### Document
+
+- docs(plugin-babel): add execution order section by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4995
+
+### Other changes
+
+- chore(deps): update babel to ^7.27.1 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/5142
+- chore(deps): update babel to ^7.28.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/5550
+- chore(workflow): enable npm trusted publishing by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5754
+
+## 1.0.5 (2025-04-08)
+
+- No plugin-specific changes.
+
+## 1.0.4 (2025-02-19)
+
+### Document
+
+- docs: update README files for plugin packages by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4590
+
+### Other changes
+
+- chore(deps): update dependency reduce-configs to ^1.1.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4042
+
+## 1.0.3 (2024-10-29)
+
+### Other changes
+
+- chore(deps): update babel to ^7.26.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3833
+
+## 1.0.2 (2024-10-14)
+
+### New features
+
+- feat(plugin-babel): use Rslib to bundle by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3691
+
+### Other changes
+
+- chore(deps): update babel to ^7.25.7 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3634
+
+## 1.0.1 (2024-09-10)
+
+### New features
+
+- feat(plugin-babel): add include and exclude option by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/833
+
+### Performance
+
+- perf(plugin-babel): skip schema-utils in babel-loader by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/853
+- perf(plugin-babel): enable compile cache to improve rebuild perf by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1621
+
+### Bug fixes
+
+- fix(plugin-babel): lodash breaks the mjs artifact by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/809
+- fix(plugin-babel): prebundle babel-loader to fix peer warning by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/831
+- fix(plugin-babel): failed to resolve babel-loader by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/842
+- fix(plugin-babel): export getDefaultBabelOptions util from index by @gaoyuan in https://github.com/web-infra-dev/rsbuild/pull/1179
+- fix(plugin-babel): missing babel loader types by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1620
+- fix(plugin-babel): run babel loader before builtin SWC loader by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2485
+
+### Document
+
+- docs(plugin-babel): fix outdated examples by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/799
+- docs(plugin-babel): add include and exclude options by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/925
+- docs(plugin-babel): compile jsx in node_modules by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2729
+
+### Other changes
+
+- chore(plugin-babel): mark addIncludes as deprecated by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/827
+- chore(plugin-babel): export helper to modify loader options by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/924
+- chore(deps): update babel to ^7.24.1 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/1883
+- chore(deps): update dependency @babel/core to ^7.25.2 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3130
+- chore(deps): update dependency @babel/plugin-transform-class-properties to ^7.25.4 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3283
+
+## 1.0.0 (2023-11-22)
+
+### Other changes
+
+- First stable release of `@rsbuild/plugin-babel`.

--- a/packages/plugin-less/CHANGELOG.md
+++ b/packages/plugin-less/CHANGELOG.md
@@ -1,0 +1,182 @@
+# @rsbuild/plugin-less
+
+## 2.0.0 (2026-06-21)
+
+### Breaking changes
+
+- feat(plugin-less)!: publish as pure ESM by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7957
+- feat(plugin-less)!: drop Rsbuild v1 support by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7959
+
+### Document
+
+- docs: update parallel loader docs by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7920
+
+### Other changes
+
+- chore: add bugs metadata to remaining plugin packages by @killernova in https://github.com/web-infra-dev/rsbuild/pull/7935
+- chore(deps): upgrade reduce-configs catalog to v2 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7960
+
+## 1.6.4 (2026-05-30)
+
+### Bug fixes
+
+- fix(plugin-styles): remove unused reduce-configs dep by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7580
+- fix(core): support url query with params by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7572
+
+## 1.6.3 (2026-04-28)
+
+### New features
+
+- feat(plugin-less): support Less URL query by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7557
+
+### Bug fixes
+
+- fix: remove redundant main fields from package.json files by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7338
+
+## 1.6.2 (2026-03-12)
+
+### Bug fixes
+
+- fix(plugin-less): update less and use default implementation by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7323
+
+## 1.6.1 (2026-03-11)
+
+### Bug fixes
+
+- fix(plugin-less): `parallelLoader` config is no longer needed in Rspack v2 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7166
+- fix: mark type-only plugin peers on @rsbuild/core as optional by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7316
+- fix(plugin-less): update less to ^4.6.2 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7318
+
+## 1.6.0 (2026-01-27)
+
+### New features
+
+- feat(plugin-less): compatible with Rsbuild v1 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7054
+
+## 1.5.1 (2026-01-15)
+
+### Bug fixes
+
+- fix(plugins): update peerDependencies to support Rsbuild v2 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6976
+
+### Document
+
+- docs: update download badge links in README files by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6762
+
+## 1.5.0 (2025-08-26)
+
+### Bug fixes
+
+- fix: enhance raw query regex to support more patterns by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5938
+- fix: enhance inline query regex to support more patterns by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5939
+
+### Refactor
+
+- refactor(css-plugins): inherit CSS options from the built-in rule by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5940
+
+## 1.4.0 (2025-08-10)
+
+### New features
+
+- feat(plugin-less): support for parallel loader execution by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5805
+
+## 1.3.2 (2025-08-04)
+
+### Other changes
+
+- chore(workflow): enable npm trusted publishing by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5754
+
+## 1.3.1 (2025-07-28)
+
+### Performance
+
+- perf: bundle rspack-chain into main JS bundle by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5684
+
+### Bug fixes
+
+- fix(plugin-less): pin less version to 4.3.0 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5690
+
+## 1.3.0 (2025-07-20)
+
+### Other changes
+
+- chore(deps): update dependency less to ^4.4.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/5630
+
+## 1.2.5 (2025-07-07)
+
+### New features
+
+- feat(plugin-less): add type for `lessLogAsWarnOrErr` option by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5427
+
+## 1.2.4 (2025-05-07)
+
+### New features
+
+- feat(plugin-less): update webpackImporter type to support 'only' by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5181
+- feat(plugin-less): improve loader options type with JSDoc by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5182
+
+## 1.2.3 (2025-05-06)
+
+### Other changes
+
+- chore(deps): update dependency less-loader to ^12.3.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/5149
+
+## 1.2.2 (2025-04-06)
+
+### Other changes
+
+- chore(deps): update dependency less to ^4.3.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4967
+
+## 1.2.1 (2025-03-29)
+
+### Bug fixes
+
+- fix: make CSS preprocessor plugins compat with Rsbuild 1.2 by @colinaaa in https://github.com/web-infra-dev/rsbuild/pull/4909
+- fix: improve inline rules in CSS preprocessor plugins by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4914
+
+## 1.2.0 (2025-03-28)
+
+### New features
+
+- feat(plugin-less): add support for raw query by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4844
+- feat: add types for raw imports of CSS preprocessors by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4846
+- feat(plugin-less): add support for inline query by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4859
+
+## 1.1.1 (2025-02-19)
+
+### Document
+
+- docs: update README files for plugin packages by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4590
+
+### Other changes
+
+- chore(deps): update dependency reduce-configs to ^1.1.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4042
+
+## 1.1.0 (2024-10-29)
+
+### New features
+
+- feat(plugin-less): allow to register multiple times by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3842
+- feat(plugin-less): add `include` option by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3843
+
+## 1.0.3 (2024-10-26)
+
+### Bug fixes
+
+- fix(plugin-less): lessLoaderOptions.lessOptions.plugins has lose it's prototype. by @Sang-Sang33 in https://github.com/web-infra-dev/rsbuild/pull/3815
+
+## 1.0.2 (2024-10-14)
+
+### Bug fixes
+
+- fix(plugin-less): missing `lessOptions` type with TS node16 resolution by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3695
+
+### Other changes
+
+- chore(plugin-less): use Rslib to bundle by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3502
+
+## 1.0.1 (2024-09-10)
+
+### Other changes
+
+- First stable release of `@rsbuild/plugin-less`.

--- a/packages/plugin-preact/CHANGELOG.md
+++ b/packages/plugin-preact/CHANGELOG.md
@@ -1,0 +1,126 @@
+# @rsbuild/plugin-preact
+
+## 2.0.0 (2026-06-02)
+
+### Breaking changes
+
+- feat(plugin-preact)!: publish as pure ESM package by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7799
+- feat(plugin-preact)!: update @rspack/plugin-preact-refresh to v2.0.0 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7808
+- feat(plugin-preact)!: update refresh options by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7809
+- feat(plugin-preact)!: require Rsbuild v2 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7810
+
+### Bug fixes
+
+- fix(plugin-preact): enable Prefresh on Windows by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7794
+
+## 1.7.3 (2026-05-30)
+
+### Bug fixes
+
+- fix: remove redundant main fields from package.json files by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7338
+
+### Other changes
+
+- chore(deps): update dependency preact to ^10.29.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/7321
+
+## 1.7.2 (2026-03-11)
+
+### Bug fixes
+
+- fix: mark type-only plugin peers on @rsbuild/core as optional by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7316
+
+## 1.7.1 (2026-01-15)
+
+### Bug fixes
+
+- fix(plugins): update peerDependencies to support Rsbuild v2 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6976
+
+## 1.7.0 (2025-12-31)
+
+### Document
+
+- docs: update download badge links in README files by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6762
+
+### Other changes
+
+- chore(deps): update dependency preact to ^10.28.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/6683
+
+## 1.6.0 (2025-10-30)
+
+- No plugin-specific changes.
+
+## 1.5.2 (2025-08-04)
+
+### Other changes
+
+- chore(deps): update dependency preact to ^10.27.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/5737
+- chore(workflow): enable npm trusted publishing by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5754
+
+## 1.5.1 (2025-07-22)
+
+- No plugin-specific changes.
+
+## 1.5.0 (2025-06-26)
+
+- No plugin-specific changes.
+
+## 1.4.0 (2025-06-07)
+
+### New features
+
+- feat(plugin-preact): update swc plugin to v7 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4695
+
+## 1.3.1 (2025-02-19)
+
+### Document
+
+- docs: update README files for plugin packages by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4590
+
+### Other changes
+
+- chore(deps): update dependency preact to ^10.26.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4575
+
+## 1.3.0 (2025-01-21)
+
+### Other changes
+
+- chore(deps): update dependency preact to ^10.25.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4047
+- chore(plugin-preact): use `resolve.alias` by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4107
+
+## 1.2.0 (2024-11-07)
+
+### Other changes
+
+- chore(deps): update dependency @swc/plugin-prefresh to v5 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3908
+
+## 1.1.1 (2024-10-29)
+
+### New features
+
+- feat(plugin-preact): integrate `@swc/plugin-prefresh` to enhance prefresh by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3861
+
+## 1.1.0 (2024-10-26)
+
+### New features
+
+- feat(plugin-preact): add `include` and `exclude` options by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3835
+
+### Bug fixes
+
+- fix(plugin-preact): allow to use Prefresh in IE11 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3831
+
+## 1.0.3 (2024-10-14)
+
+- No plugin-specific changes.
+
+## 1.0.2 (2024-09-29)
+
+### Other changes
+
+- chore(plugin-preact): use Rslib to bundle by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3563
+
+## 1.0.1 (2024-09-10)
+
+### Other changes
+
+- First stable release of `@rsbuild/plugin-preact`.

--- a/packages/plugin-react/CHANGELOG.md
+++ b/packages/plugin-react/CHANGELOG.md
@@ -1,0 +1,216 @@
+# @rsbuild/plugin-react
+
+## 2.1.0 (2026-06-18)
+
+### New features
+
+- feat(plugin-react): add reactCompiler option by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7938
+
+### Bug fixes
+
+- fix(plugin-react): check reactCompiler rspack version by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7940
+
+### Document
+
+- docs(plugin-react): document reactCompiler option by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7944
+
+## 2.0.1 (2026-05-30)
+
+- No plugin-specific changes.
+
+## 2.0.0 (2026-04-22)
+
+### Breaking changes
+
+- feat(plugin-react)!: drop Rsbuild v1 support by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7458
+- feat(plugin-react)!: publish as pure ESM package by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7461
+
+### Bug fixes
+
+- fix: remove redundant main fields from package.json files by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7338
+
+### Refactor
+
+- refactor(plugin-react): inline react setup into index by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7462
+
+### Other changes
+
+- chore(plugin-react): upgrade @rspack/plugin-react-refresh to v2.0.0 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7456
+
+## 1.4.6 (2026-03-11)
+
+### Bug fixes
+
+- fix: mark type-only plugin peers on @rsbuild/core as optional by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7316
+
+## 1.4.5 (2026-02-02)
+
+### Bug fixes
+
+- fix(plugin-react): failed to split chunks with Rsbuild v1 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7109
+
+## 1.4.4 (2026-01-30)
+
+### Bug fixes
+
+- fix(plugin-react): skip chunk splitting for non-web targets by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7090
+
+## 1.4.3 (2026-01-15)
+
+### Bug fixes
+
+- fix(plugins): update peerDependencies to support Rsbuild v2 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6976
+
+### Document
+
+- docs: update download badge links in README files by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6762
+
+### Other changes
+
+- chore(deps): update dependency @rspack/plugin-react-refresh to ^1.6.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/6938
+
+## 1.4.2 (2025-11-06)
+
+### New features
+
+- feat(plugin-react): enhance splitChunks option to support boolean type by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6515
+
+### Document
+
+- docs(plugin-react): add 'preserve' option to JSX runtime by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6244
+
+## 1.4.1 (2025-09-24)
+
+### New features
+
+- feat(plugin-react): complete `preserve` React runtime by @Wei in https://github.com/web-infra-dev/rsbuild/pull/6240
+
+## 1.4.0 (2025-08-28)
+
+### New features
+
+- feat(plugin-react): improve transpilation scope of ReactRefreshPlugin by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5969
+
+### Other changes
+
+- chore(plugin-react): update @rspack/plugin-react-refresh to ^1.5.0 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5968
+
+## 1.3.5 (2025-08-04)
+
+### Other changes
+
+- chore(workflow): enable npm trusted publishing by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5754
+
+## 1.3.4 (2025-07-07)
+
+- No plugin-specific changes.
+
+## 1.3.3 (2025-07-03)
+
+### Bug fixes
+
+- fix(plugin-react): profiling not work with React 19 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5524
+
+## 1.3.2 (2025-06-04)
+
+### Bug fixes
+
+- fix(plugin-react): skip React Refresh injection for raw JS content by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5354
+
+## 1.3.1 (2025-05-07)
+
+### Other changes
+
+- chore(deps): update @rspack/plugin-react-refresh to 1.4.2 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5185
+
+## 1.3.0 (2025-04-23)
+
+### Other changes
+
+- chore(deps): update dependency @rspack/plugin-react-refresh to ~1.4.1 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/5076
+
+## 1.2.0 (2025-04-08)
+
+### Other changes
+
+- chore(deps): update dependency @rspack/plugin-react-refresh to ~1.1.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4951
+- chore(deps): update dependency @rspack/plugin-react-refresh to ~1.2.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4984
+
+## 1.1.1 (2025-02-19)
+
+### Document
+
+- docs: update README files for plugin packages by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4590
+
+## 1.1.0 (2024-12-07)
+
+### Other changes
+
+- chore(deps): update dependency react-refresh to ^0.16.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4134
+
+## 1.0.7 (2024-11-07)
+
+### Bug fixes
+
+- fix(plugin-react): allow to override builtin split chunks by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3887
+
+## 1.0.6 (2024-10-29)
+
+- No plugin-specific changes.
+
+## 1.0.5 (2024-10-17)
+
+### New features
+
+- feat(plugin-react): allow to disable fast refresh by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3738
+
+## 1.0.4 (2024-10-14)
+
+### New features
+
+- feat(plugin-react): use Rslib to bundle by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3704
+
+## 1.0.3 (2024-09-29)
+
+### Bug fixes
+
+- fix(plugin-react): exclude node_modules from react-refresh plugin by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3575
+
+## 1.0.2 (2024-09-13)
+
+### Bug fixes
+
+- fix(plugin-react): allow configuring `tools.swc` to override react runtime by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3449
+
+## 1.0.1 (2024-09-10)
+
+### New features
+
+- feat(plugin-react): allow to enable/disable chunk splitting by @Timeless0911 in https://github.com/web-infra-dev/rsbuild/pull/746
+- feat(plugin-react): add jsxRuntime option to support React 16 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1189
+- feat(plugin-react): add jsxImportSource option by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1190
+- feat(plugin-react): allow to configure all SWC react options by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1191
+- feat(plugin-react): enable support for profiling React in prod env by @DennisMartinCual in https://github.com/web-infra-dev/rsbuild/pull/2143
+- feat(plugin-react): support for configuring react refresh plugin by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2190
+
+### Performance
+
+- perf(plugin-react): use prebundled semver by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/991
+- perf(plugin-react): reduce deps and fix peer dep warning by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/830
+- perf(plugin-react): reduce deepmerge overhead by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1481
+
+### Bug fixes
+
+- fix(plugin-react): split react-refresh utils to lib-react chunk by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/850
+- fix(plugin-react): should get the new targets from context by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/890
+- fix(plugin-react): no chunk group of react if federation enabled by @ZackJackson in https://github.com/web-infra-dev/rsbuild/pull/1942
+
+### Document
+
+- docs(plugin-react): translate enableProfiler to Chinese by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2157
+
+## 1.0.0 (2023-11-22)
+
+### Other changes
+
+- First stable release of `@rsbuild/plugin-react`.

--- a/packages/plugin-sass/CHANGELOG.md
+++ b/packages/plugin-sass/CHANGELOG.md
@@ -1,0 +1,220 @@
+# @rsbuild/plugin-sass
+
+## 2.0.0 (2026-06-21)
+
+### Breaking changes
+
+- feat(plugin-sass)!: publish as pure ESM by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7956
+- feat(plugin-sass)!: drop Rsbuild v1 support by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7958
+
+### Other changes
+
+- chore: add bugs metadata to remaining plugin packages by @killernova in https://github.com/web-infra-dev/rsbuild/pull/7935
+- chore(deps): update sass to ^1.101.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/7897
+- chore(deps): upgrade reduce-configs catalog to v2 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7960
+
+## 1.5.3 (2026-05-30)
+
+### Bug fixes
+
+- fix(core): support url query with params by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7572
+
+### Other changes
+
+- chore(deps): update sass to ^1.100.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/7733
+
+## 1.5.2 (2026-04-28)
+
+### New features
+
+- feat(plugin-sass): support Sass URL query by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7554
+
+### Other changes
+
+- chore(deps): update sass to ^1.98.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/7327
+- chore(deps): update sass to ^1.99.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/7434
+
+## 1.5.1 (2026-03-11)
+
+### Bug fixes
+
+- fix: mark type-only plugin peers on @rsbuild/core as optional by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7316
+
+## 1.5.0 (2026-01-27)
+
+### New features
+
+- feat(plugin-sass): compatible with Rsbuild v1 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7055
+
+## 1.4.1 (2026-01-15)
+
+### Bug fixes
+
+- fix(plugins): update peerDependencies to support Rsbuild v2 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6976
+
+### Other changes
+
+- chore(deps): update sass related packages by @renovate in https://github.com/web-infra-dev/rsbuild/pull/5965
+- chore(deps): update sass to ^1.92.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/6042
+- chore(deps): update sass to ^1.93.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/6209
+- chore(deps): update sass to ^1.96.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/6757
+- chore(deps): update sass to ^1.97.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/6789
+
+## 1.4.0 (2025-08-26)
+
+### Bug fixes
+
+- fix: enhance raw query regex to support more patterns by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5938
+- fix: enhance inline query regex to support more patterns by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5939
+
+### Refactor
+
+- refactor(css-plugins): inherit CSS options from the built-in rule by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5940
+
+## 1.3.5 (2025-08-07)
+
+### Other changes
+
+- chore(deps): update sass to ^1.90.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/5779
+
+## 1.3.4 (2025-08-04)
+
+### Performance
+
+- perf: bundle rspack-chain into main JS bundle by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5684
+
+### Other changes
+
+- chore(workflow): enable npm trusted publishing by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5754
+
+## 1.3.3 (2025-07-07)
+
+### Bug fixes
+
+- fix(plugin-sass): unpin sass-embedded and update to v1.89.2 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5404
+- fix: ensure that raw query of styles can be accurately matched by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5540
+
+## 1.3.2 (2025-06-05)
+
+### Bug fixes
+
+- fix(plugin-sass): pin sass-embedded to 1.89.0 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5360
+
+### Other changes
+
+- chore(deps): update sass to ^1.87.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/5072
+- chore(deps): update sass to ^1.88.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/5219
+- chore(deps): update sass to ^1.89.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/5262
+
+## 1.3.1 (2025-03-29)
+
+### Bug fixes
+
+- fix: make CSS preprocessor plugins compat with Rsbuild 1.2 by @colinaaa in https://github.com/web-infra-dev/rsbuild/pull/4909
+- fix: improve inline rules in CSS preprocessor plugins by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4914
+
+## 1.3.0 (2025-03-28)
+
+### New features
+
+- feat(plugin-sass): add support for raw query by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4843
+- feat(plugin-sass): add support for inline query by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4856
+
+### Other changes
+
+- chore(deps): update sass to ^1.86.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4821
+
+## 1.2.2 (2025-02-19)
+
+### Document
+
+- docs: update README files for plugin packages by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4590
+
+### Other changes
+
+- chore(deps): update sass to ^1.85.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4565
+
+## 1.2.1 (2025-02-05)
+
+### Bug fixes
+
+- fix(plugin-sass): allow to disable source map by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4445
+
+## 1.2.0 (2025-01-21)
+
+### New features
+
+- feat(plugin-sass): add `useOriginalUrlResolver` option to disable `resolve-url-loader` by @junhea in https://github.com/web-infra-dev/rsbuild/pull/4389
+
+### Document
+
+- docs(plugin-sass): improve `rewriteUrls` option by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4401
+
+### Other changes
+
+- chore(deps): update sass to ^1.83.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4194
+- chore(plugin-sass): rename unreleased option by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4398
+
+## 1.1.2 (2024-12-07)
+
+### Bug fixes
+
+- fix(plugin-sass): mute import deprecation warning by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4122
+
+### Other changes
+
+- chore(deps): update dependency reduce-configs to ^1.1.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4042
+- chore(deps): update dependency sass-embedded to ^1.82.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4138
+
+## 1.1.1 (2024-11-18)
+
+### New features
+
+- feat(plugin-sass): mute deprecation warnings of dependencies by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3998
+
+### Other changes
+
+- chore(deps): update dependency sass-embedded to ^1.81.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3989
+
+## 1.1.0 (2024-10-29)
+
+### New features
+
+- feat(plugin-sass): allow to register multiple times by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3844
+- feat(plugin-sass): add `include` option by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3845
+
+### Document
+
+- docs(plugin-sass): add note for deprecation warnings by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3840
+
+## 1.0.4 (2024-10-20)
+
+### Other changes
+
+- chore(deps): update dependency sass-embedded to ^1.80.3 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3763
+
+## 1.0.3 (2024-10-14)
+
+### New features
+
+- feat(plugin-sass): use Rslib to bundle by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3703
+
+## 1.0.2 (2024-10-04)
+
+### Bug fixes
+
+- fix(plugin-sass): mute the legacy API deprecation warnings by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3629
+
+### Document
+
+- docs(plugin-sass): add legacy API deprecation tip by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3631
+
+### Other changes
+
+- chore(deps): update dependency sass-embedded to ^1.79.2 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3504
+
+## 1.0.1 (2024-09-10)
+
+### Other changes
+
+- First stable release of `@rsbuild/plugin-sass`.

--- a/packages/plugin-solid/CHANGELOG.md
+++ b/packages/plugin-solid/CHANGELOG.md
@@ -1,0 +1,107 @@
+# @rsbuild/plugin-solid
+
+## 1.2.2 (2026-06-05)
+
+### Bug fixes
+
+- fix(plugin-solid): downgrade solid-refresh to 0.6.3 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7832
+
+## 1.2.1 (2026-05-30)
+
+- No plugin-specific changes.
+
+## 1.2.0 (2026-05-06)
+
+### New features
+
+- feat(plugin-solid): add solid resolve condition by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7592
+- feat(plugin-solid): add hot option by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7593
+- feat(plugin-solid): add dev option by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7595
+- feat(plugin-solid): add refresh disabled option by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7596
+- feat(plugin-solid): add ssr option by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7597
+- feat(plugin-solid): add solid option by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7598
+
+### Bug fixes
+
+- fix: remove redundant main fields from package.json files by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7338
+- fix(plugin-solid): use rspack esm refresh mode by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7594
+
+## 1.1.1 (2026-03-11)
+
+### Bug fixes
+
+- fix: mark type-only plugin peers on @rsbuild/core as optional by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7316
+
+## 1.1.0 (2026-02-28)
+
+### Other changes
+
+- chore(deps): update dependency solid-refresh to v0.7.6 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/7258
+
+## 1.0.8 (2026-02-19)
+
+### Bug fixes
+
+- fix(plugin-solid): fix missing parameter types by @AndrewAvsenin in https://github.com/web-infra-dev/rsbuild/pull/7202
+
+## 1.0.7 (2026-01-15)
+
+### Bug fixes
+
+- fix(plugins): update peerDependencies to support Rsbuild v2 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6976
+
+### Document
+
+- docs: update download badge links in README files by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6762
+
+## 1.0.6 (2025-08-04)
+
+### Other changes
+
+- chore(workflow): enable npm trusted publishing by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5754
+
+## 1.0.5 (2025-02-19)
+
+### Document
+
+- docs: update README files for plugin packages by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4590
+
+## 1.0.4 (2024-10-29)
+
+- No plugin-specific changes.
+
+## 1.0.3 (2024-10-14)
+
+### New features
+
+- feat(plugin-solid): use Rslib to bundle by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3693
+
+## 1.0.2 (2024-09-29)
+
+### Other changes
+
+- chore(deps): update dependency babel-preset-solid to ^1.9.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3552
+
+## 1.0.1 (2024-09-10)
+
+### New features
+
+- feat(plugin-solid): support solid-js HMR by @inottn in https://github.com/web-infra-dev/rsbuild/pull/740
+
+### Bug fixes
+
+- fix(plugin-solid): delegateEvents should be optional by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/950
+- fix(plugin-solid): lock solid-refresh to fix runtime error by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1567
+- fix(plugin-solid): downgrade solid-refresh to v0.6.3 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1966
+- fix(plugin-solid): only enable solid-refresh when target is web by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2069
+- fix(plugin-solid): remove `@babel/preset-typescript` for resolve the babel warning by @zhylmzr in https://github.com/web-infra-dev/rsbuild/pull/2842
+
+### Other changes
+
+- chore(deps): update dependency solid-refresh to ^0.7.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/1468
+
+## 1.0.0 (2023-11-22)
+
+### Other changes
+
+- First stable release of `@rsbuild/plugin-solid`.

--- a/packages/plugin-svelte/CHANGELOG.md
+++ b/packages/plugin-svelte/CHANGELOG.md
@@ -1,0 +1,177 @@
+# @rsbuild/plugin-svelte
+
+## 2.0.0 (2026-06-01)
+
+### Breaking changes
+
+- feat(plugin-svelte)!: publish as pure ESM package by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7800
+- feat(plugin-svelte)!: remove Rsbuild 1.x support by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7803
+- feat(plugin-svelte)!: drop Svelte 4 support by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7804
+
+## 1.1.2 (2026-05-30)
+
+### Bug fixes
+
+- fix: remove redundant main fields from package.json files by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7338
+
+### Other changes
+
+- chore(deps): update dependency svelte to ^5.54.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/7355
+- chore(deps): update dependency svelte to ^5.55.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/7400
+
+## 1.1.1 (2026-03-11)
+
+### Bug fixes
+
+- fix(plugin-svelte): replace imported logger with api logger by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7315
+
+### Other changes
+
+- chore(deps): update dependency svelte to ^5.49.1 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/7101
+- chore(deps): update dependency svelte to ^5.50.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/7156
+- chore(deps): update dependency svelte to ^5.51.1 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/7190
+- chore(deps): update dependency svelte to ^5.53.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/7211
+
+## 1.1.0 (2026-01-27)
+
+### New features
+
+- feat(plugin-svelte): compatible with Rsbuild v1 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7063
+
+### Other changes
+
+- chore(deps): update dependency svelte to ^5.48.2 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/7043
+
+## 1.0.12 (2026-01-15)
+
+### Bug fixes
+
+- fix(plugins): update peerDependencies to support Rsbuild v2 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6976
+
+### Document
+
+- docs: update download badge links in README files by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6762
+
+### Other changes
+
+- chore(deps): update dependency svelte to ^5.38.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/5801
+- chore(deps): update dependency svelte to ^5.39.3 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/6203
+- chore(deps): update dependency svelte to ^5.40.1 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/6370
+- chore(deps): update dependency svelte to ^5.41.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/6385
+- chore(deps): update dependency svelte to ^5.42.2 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/6445
+- chore(deps): update dependency svelte to ^5.43.2 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/6483
+- chore(deps): update dependency svelte to ^5.45.2 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/6652
+- chore(deps): update dependency svelte to ^5.46.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/6769
+
+## 1.0.11 (2025-08-04)
+
+### Other changes
+
+- chore(deps): update dependency svelte to ^5.33.1 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/5303
+- chore(deps): update dependency svelte to ^5.34.1 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/5417
+- chore(deps): update dependency svelte to ^5.35.2 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/5536
+- chore(deps): update dependency svelte to ^5.36.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/5597
+- chore(deps): update dependency svelte to ^5.37.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/5687
+- chore(workflow): enable npm trusted publishing by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5754
+
+## 1.0.10 (2025-05-19)
+
+### Bug fixes
+
+- fix(plugin-svelte): transpile the Svelte package to downgrade the syntax by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5272
+
+## 1.0.9 (2025-05-19)
+
+### Bug fixes
+
+- fix(plugin-svelte): should transpile JS code in .svelte files by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5270
+
+### Other changes
+
+- chore(deps): update dependency svelte to ^5.22.5 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4715
+- chore(deps): update dependency svelte to ^5.23.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4771
+- chore(deps): update dependency svelte to ^5.25.3 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4852
+- chore(deps): update dependency svelte to ^5.26.1 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/5011
+- chore(deps): update dependency svelte to ^5.27.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/5044
+- chore(deps): update dependency svelte to ^5.28.1 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/5057
+- chore(deps): update dependency svelte to ^5.30.1 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/5256
+
+## 1.0.8 (2025-02-19)
+
+### Document
+
+- docs: update README files for plugin packages by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4590
+
+### Other changes
+
+- chore(deps): update dependency svelte to ^5.15.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4245
+- chore(deps): update dependency svelte to ^5.16.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4286
+- chore(deps): update dependency svelte to ^5.17.3 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4353
+- chore(deps): update dependency svelte to ^5.18.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4379
+- chore(deps): update dependency svelte to ^5.19.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4394
+- chore(deps): update dependency svelte to ^5.20.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4552
+
+## 1.0.7 (2024-12-21)
+
+### Other changes
+
+- chore(deps): update dependency svelte to ^5.14.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4201
+
+## 1.0.6 (2024-12-14)
+
+### Bug fixes
+
+- fix(plugin-svelte): require is not defined in computing sveltePath variable by @LucaGuzzon in https://github.com/web-infra-dev/rsbuild/pull/4184
+
+### Other changes
+
+- chore(deps): update dependency svelte to ^5.2.2 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4000
+- chore(deps): update dependency svelte to ^5.3.1 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4105
+- chore(deps): update dependency svelte to ^5.4.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4111
+- chore(deps): update dependency svelte to ^5.6.2 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4130
+- chore(deps): update dependency svelte to ^5.8.1 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4145
+- chore(deps): update dependency svelte to ^5.9.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4158
+
+## 1.0.5 (2024-11-13)
+
+- No plugin-specific changes.
+
+## 1.0.4 (2024-11-08)
+
+### Bug fixes
+
+- fix(plugin-svelte): failed to compile \*.svslte.ts by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3918
+- fix(plugin-svelte): `*.svslte.ts` files are transformed twice by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3920
+
+## 1.0.3 (2024-10-29)
+
+- No plugin-specific changes.
+
+## 1.0.2 (2024-10-14)
+
+### New features
+
+- feat(plugin-svelte): use Rslib to bundle by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3705
+
+## 1.0.1 (2024-09-10)
+
+### New features
+
+- feat(plugin-svelte): support pass preprocess options by @Tmk in https://github.com/web-infra-dev/rsbuild/pull/1185
+
+### Bug fixes
+
+- fix(plugin-svelte): use wildcard in conditionNames by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/716
+- fix(plugin-svelte): missing default mainFields by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1063
+- fix(plugin-svelte): failed to HMR with style tag by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2749
+
+### Other changes
+
+- chore(deps): update dependency svelte-loader to v3.2.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/1793
+- chore(deps): update dependency svelte-preprocess to v6 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2605
+
+## 1.0.0 (2023-11-22)
+
+### Other changes
+
+- First stable release of `@rsbuild/plugin-svelte`.

--- a/packages/plugin-svgr/CHANGELOG.md
+++ b/packages/plugin-svgr/CHANGELOG.md
@@ -1,0 +1,176 @@
+# @rsbuild/plugin-svgr
+
+## 2.0.4 (2026-06-16)
+
+### New features
+
+- feat(plugin-svgr): add parallel option by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7915
+
+## 2.0.3 (2026-05-30)
+
+### Document
+
+- docs: improve plugin documentation by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7651
+
+## 2.0.2 (2026-05-01)
+
+### Bug fixes
+
+- fix(plugin-svgr): handle string svg base64 encoding by @yifancong in https://github.com/web-infra-dev/rsbuild/pull/7581
+
+## 2.0.1 (2026-04-22)
+
+### New features
+
+- feat(plugin-svgr): support publicPath options in internal assetLoader by @Timeless0911 in https://github.com/web-infra-dev/rsbuild/pull/7523
+
+## 2.0.0 (2026-04-22)
+
+### Breaking changes
+
+- feat(plugin-svgr)!: drop Rsbuild v1 support by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7460
+- feat(plugin-svgr)!: publish as pure ESM package by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7463
+
+### Bug fixes
+
+- fix: remove redundant main fields from package.json files by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7338
+
+### Refactor
+
+- refactor(plugin-svgr): use internal asset loader by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7482
+- refactor(plugin-svgr): use import.meta.dirname for loaders by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7483
+
+## 1.3.1 (2026-03-11)
+
+### Bug fixes
+
+- fix: mark type-only plugin peers on @rsbuild/core as optional by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7316
+
+## 1.3.0 (2026-01-27)
+
+### New features
+
+- feat(plugin-svgr): compatible with Rsbuild v1 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7061
+
+## 1.2.4 (2026-01-15)
+
+### Bug fixes
+
+- fix(plugins): update peerDependencies to support Rsbuild v2 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6976
+
+### Document
+
+- docs: update download badge links in README files by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6762
+
+## 1.2.3 (2025-12-08)
+
+### Bug fixes
+
+- fix(plugin-svgr): disable React refresh for transformed SVG by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6724
+
+### Document
+
+- docs(plugin-svgr): add note about default exportType with mixedImport by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5907
+
+## 1.2.2 (2025-08-04)
+
+### Performance
+
+- perf: bundle rspack-chain into main JS bundle by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5684
+
+### Other changes
+
+- chore(workflow): enable npm trusted publishing by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5754
+
+## 1.2.1 (2025-07-07)
+
+### Other changes
+
+- chore(plugin-svgr): improve SVGR options type by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5541
+
+## 1.2.0 (2025-04-13)
+
+### Bug fixes
+
+- fix(plugin-svgr): SVGs generated with different hash by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5016
+
+## 1.1.1 (2025-04-08)
+
+### Bug fixes
+
+- fix(plugin-svgr): unpin @rsbuild/plugin-react dependency version by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4988
+
+## 1.1.0 (2025-04-03)
+
+### Bug fixes
+
+- fix(plugin-svgr): support for raw query by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4944
+
+## 1.0.7 (2025-02-19)
+
+### Document
+
+- docs(plugin-svgr): explain base64 URL by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4168
+- docs: update README files for plugin packages by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4590
+
+## 1.0.6 (2024-12-07)
+
+- No plugin-specific changes.
+
+## 1.0.5 (2024-10-29)
+
+- No plugin-specific changes.
+
+## 1.0.4 (2024-10-14)
+
+### New features
+
+- feat(plugin-svgr): use Rslib to bundle by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3698
+
+## 1.0.3 (2024-09-29)
+
+- No plugin-specific changes.
+
+## 1.0.2 (2024-09-13)
+
+### Document
+
+- docs(plugin-svgr): correct named export guide by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3469
+
+## 1.0.1 (2024-09-10)
+
+### New features
+
+- feat(plugin-svgr): support configure SVGR options by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1122
+- feat(plugin-svgr): support for react query by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1783
+- feat(plugin-svgr): add mixedImport option by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1805
+- feat(plugin-svgr): add support for mdx by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1822
+- feat(plugin-svgr): add new query option by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1909
+- feat(plugin-svgr): add excludeImporter option by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2019
+
+### Performance
+
+- perf(plugin-svgr): prebundle url-loader to reduce dependencies by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1243
+- perf(plugin-svgr): reuse SWC loader to improve perf by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1070
+- perf(plugin-svgr): merge duplicated rules by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1652
+
+### Bug fixes
+
+- fix(plugin-svgr): missing file-loader peer dependency by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1239
+- fix(plugin-svgr): failed to reuse SWC react options by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1263
+- fix(plugin-svgr): prefer using svgrOptions.exportType option by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1789
+- fix(plugin-svgr): failed to resolve file-loader by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2273
+- fix(plugin-svgr): dedupe SVGO plugins config by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2984
+
+### Document
+
+- docs(plugin-svgr): add tip for named export by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1687
+- docs(plugin-svgr): add react query guide by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1786
+- docs(plugin-svgr): add mixed import document by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1820
+- docs(plugin-svgr): typo of export type by @Soon in https://github.com/web-infra-dev/rsbuild/pull/1982
+
+## 1.0.0 (2023-11-22)
+
+### Other changes
+
+- First stable release of `@rsbuild/plugin-svgr`.

--- a/packages/plugin-tailwindcss/CHANGELOG.md
+++ b/packages/plugin-tailwindcss/CHANGELOG.md
@@ -1,0 +1,27 @@
+# @rsbuild/plugin-tailwindcss
+
+## 2.0.3 (2026-06-13)
+
+### Bug fixes
+
+- fix(plugin-tailwindcss): upgrade Tailwind CSS to 4.3.1 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7884
+
+## 2.0.2 (2026-06-08)
+
+### New features
+
+- feat(plugin-tailwindcss): enable optimize in production by default by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7828
+
+## 2.0.1 (2026-05-30)
+
+### Document
+
+- docs(plugin-tailwindcss): add plugin docs by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7752
+- docs: update Tailwind CSS v4 guide by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7754
+- docs: clarify Tailwind CSS scan scope by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7759
+
+## 2.0.0 (2026-05-25)
+
+### Other changes
+
+- First stable release of `@rsbuild/plugin-tailwindcss`.

--- a/packages/plugin-vue/CHANGELOG.md
+++ b/packages/plugin-vue/CHANGELOG.md
@@ -1,0 +1,155 @@
+# @rsbuild/plugin-vue
+
+## 1.2.9 (2026-05-30)
+
+### Document
+
+- docs(plugin-vue): reflect integration with rspack-vue-loader by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7649
+
+## 1.2.8 (2026-05-08)
+
+### Bug fixes
+
+- fix: remove redundant main fields from package.json files by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7338
+- fix(plugin-vue): align CSS Modules hashes for SSR by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7625
+
+## 1.2.7 (2026-03-11)
+
+### Bug fixes
+
+- fix: mark type-only plugin peers on @rsbuild/core as optional by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7316
+
+## 1.2.6 (2026-02-05)
+
+### Bug fixes
+
+- fix(plugin-vue): remove webpack dependency by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7148
+
+## 1.2.5 (2026-02-02)
+
+### Bug fixes
+
+- fix(plugin-vue): failed to split chunks with Rsbuild v1 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7112
+
+## 1.2.4 (2026-01-30)
+
+### Bug fixes
+
+- fix(plugin-vue): skip chunk splitting for non-web targets by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/7091
+
+## 1.2.3 (2026-01-15)
+
+### New features
+
+- feat(plugin-vue): bump rspack-vue-loader to support hot update by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/6956
+
+### Bug fixes
+
+- fix(plugins): update peerDependencies to support Rsbuild v2 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6976
+
+### Refactor
+
+- refactor(plugin-vue): improve CSS module detection by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6879
+
+## 1.2.2 (2025-12-15)
+
+### Bug fixes
+
+- fix(plugin-vue): treat it as a client build when calling from Rstest by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/6779
+
+### Document
+
+- docs: update download badge links in README files by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6762
+
+## 1.2.1 (2025-12-09)
+
+### New features
+
+- feat(plugin-vue): add test option by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6729
+
+## 1.2.0 (2025-10-21)
+
+### New features
+
+- feat(plugin-vue): supersede vue-loader with rspack-vue-loader by @Wei in https://github.com/web-infra-dev/rsbuild/pull/6390
+
+## 1.1.2 (2025-08-23)
+
+### Bug fixes
+
+- fix(plugin-vue): allow CSS Modules with custom inject names by @EgorBlinov in https://github.com/web-infra-dev/rsbuild/pull/5931
+
+## 1.1.1 (2025-08-04)
+
+### Other changes
+
+- chore(plugin-vue): remove unused webpack dev deps by @thinkasany in https://github.com/web-infra-dev/rsbuild/pull/5608
+- chore(workflow): enable npm trusted publishing by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5754
+
+## 1.1.0 (2025-07-01)
+
+### Bug fixes
+
+- fix(plugin-vue): CSS Modules for SSR build by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/5517
+
+## 1.0.7 (2025-03-08)
+
+### Bug fixes
+
+- fix(plugin-vue): order problem with pluginReact by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4713
+
+## 1.0.6 (2025-02-19)
+
+### Document
+
+- docs: update README files for plugin packages by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4590
+
+## 1.0.5 (2024-11-14)
+
+### Bug fixes
+
+- fix(plugin-vue): should transpile all Vue SFC by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3964
+
+## 1.0.4 (2024-11-07)
+
+### Bug fixes
+
+- fix(plugin-vue): allow to override builtin split chunks by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3886
+
+## 1.0.3 (2024-10-29)
+
+- No plugin-specific changes.
+
+## 1.0.2 (2024-10-14)
+
+### New features
+
+- feat(plugin-vue): use Rslib to bundle by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3697
+
+## 1.0.1 (2024-09-10)
+
+### New features
+
+- feat(plugin-vue): apply default split chunk rules by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/851
+- feat(plugin-vue): add feature flag for Vue v3.4 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1062
+- feat(plugin-vue): support CSS Modules in SFC by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2374
+- feat(plugin-vue): support for lang="postcss" by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2422
+
+### Performance
+
+- perf(plugin-vue): bump vue-loader v17.4 to reuse AST by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1061
+
+### Bug fixes
+
+- fix(plugin-vue): failed to split lib-vue chunk in Windows by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/971
+
+### Other changes
+
+- types(plugin-vue): fix SplitChunks typing error by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/966
+- chore(deps): update dependency vue to ^3.5.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3367
+
+## 1.0.0 (2023-11-22)
+
+### Other changes
+
+- First stable release of `@rsbuild/plugin-vue`.


### PR DESCRIPTION
## Summary

This PR adds per-package `CHANGELOG.md` files for the official Rsbuild plugin packages so plugin-only upgrades can be tracked separately from `@rsbuild/core` release notes. The changelogs cover stable published versions, use npm publish dates, omit noisy version compare links, and keep release/bump PRs out of the change entries.

## Related Links

https://github.com/web-infra-dev/rsbuild/discussions/7150