### PR TITLE
chore: check plugin changelogs with cspell

### DIFF
--- a/cspell.config.js
+++ b/cspell.config.js
@@ -10,6 +10,8 @@ export default {
     '#.*?\\)',
     // ignore custom anchor declarations such as ## createRsbuild \{#creatersbuild}
     '\\\\\\{#[^}]+\\}',
+    // ignore release note author mentions such as "by @chenjiahan"
+    'by\\s+@[A-Za-z0-9_-]+',
   ],
   ignorePaths: [
     'dist',
@@ -18,7 +20,6 @@ export default {
     'coverage',
     'doc_build',
     'node_modules',
-    'packages/plugin-*/CHANGELOG.md',
     'pnpm-lock.yaml',
     'README.pt-BR.md',
   ],

--- a/packages/plugin-svelte/CHANGELOG.md
+++ b/packages/plugin-svelte/CHANGELOG.md
@@ -140,8 +140,8 @@
 
 ### Bug fixes
 
-- fix(plugin-svelte): failed to compile \*.svslte.ts by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3918
-- fix(plugin-svelte): `*.svslte.ts` files are transformed twice by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3920
+- fix(plugin-svelte): failed to compile \*.svelte.ts by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3918
+- fix(plugin-svelte): `*.svelte.ts` files are transformed twice by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3920
 
 ## 1.0.3 (2024-10-29)
 

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -102,6 +102,7 @@ pmmmwh
 postcssrc
 preact
 prebundle
+prebundled
 preconnecting
 preflights
 prefresh


### PR DESCRIPTION
## Summary

This PR enables CSpell checks for plugin `CHANGELOG.md` files so spelling issues in plugin release notes are caught in CI. It ignores release-note author mentions, adds `prebundled` to the project dictionary, and fixes a typo in the plugin-svelte changelog.