### PR TITLE
docs: fix onBeforeEnvironmentCompile config parameter

### DIFF
--- a/website/docs/en/shared/onBeforeEnvironmentCompile.mdx
+++ b/website/docs/en/shared/onBeforeEnvironmentCompile.mdx
@@ -1,8 +1,8 @@
 A callback function that is triggered before the compilation of a single environment.
 
-You can access the Rspack configuration array through the `bundlerConfigs` parameter. The array may contain one or more [Rspack configurations](https://rspack.rs/config/). It depends on whether multiple [environments](/config/environments) are configured.
+You can access the [Rspack configuration](https://rspack.rs/config/) for the current environment through the `bundlerConfig` parameter.
 
-Moreover, you can use `isWatch` to determine whether it is dev or build watch mode, and use `isFirstCompile` to determine whether it is the first build.
+Moreover, you can use `isWatch` to determine whether it is dev or build watch mode, and use `isFirstCompile` to determine whether it is the first build in watch mode.
 
 - **Type:**
 


### PR DESCRIPTION
## Summary

This PR fixes the English `onBeforeEnvironmentCompile` docs to describe the correct `bundlerConfig` parameter for the current environment instead of the `bundlerConfigs` array used by other hooks. It also clarifies the `isFirstCompile` wording for watch mode.