### PR TITLE
feat(plugin-vue)!: publish as pure ESM package

### DIFF
--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -20,8 +20,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.js"
     }
   },
   "publishConfig": {

--- a/packages/plugin-vue/rslib.config.ts
+++ b/packages/plugin-vue/rslib.config.ts
@@ -1,3 +1,3 @@
-import { dualPackage } from '@scripts/config/rslib.config.ts';
+import { pureEsmPackage } from '@scripts/config/rslib.config.ts';
 
-export default dualPackage;
+export default pureEsmPackage;


### PR DESCRIPTION
## Summary

This PR publishes `@rsbuild/plugin-vue` as a pure ESM package. It removes the CommonJS `require` export condition and switches the package to the shared pure ESM Rslib config, so the package only builds the ESM entry and declarations.