### PR TITLE
feat(plugin-vue): drop Rsbuild v1 support

### DIFF
--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -36,7 +36,6 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rsbuild/core-v1": "catalog:",
     "@rslib/core": "catalog:",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "catalog:",
@@ -44,7 +43,7 @@
     "vue": "catalog:"
   },
   "peerDependencies": {
-    "@rsbuild/core": "^1.0.0 || ^2.0.0"
+    "@rsbuild/core": "^2.0.0"
   },
   "peerDependenciesMeta": {
     "@rsbuild/core": {

--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -37,11 +37,21 @@ export type PluginVueOptions = {
 
 export const PLUGIN_VUE_NAME = 'rsbuild:vue';
 
+function assertCoreVersion(version: string): void {
+  if (version.split('.')[0] === '1') {
+    throw new Error(
+      `"@rsbuild/plugin-vue" v2 requires "@rsbuild/core" >= 2.0. Please upgrade "@rsbuild/core" or use "@rsbuild/plugin-vue" v1.`,
+    );
+  }
+}
+
 export function pluginVue(options: PluginVueOptions = {}): RsbuildPlugin {
   return {
     name: PLUGIN_VUE_NAME,
 
     setup(api) {
+      assertCoreVersion(api.context.version);
+
       const { test = /\.vue$/ } = options;
       const CSS_MODULES_REGEX = /\.modules?\.\w+$/i;
 

--- a/packages/plugin-vue/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-vue/tests/__snapshots__/index.test.ts.snap
@@ -74,29 +74,6 @@ exports[`plugin-vue > should allow to custom test condition 1`] = `
 }
 `;
 
-exports[`plugin-vue > should apply splitChunks with Rsbuild v1 1`] = `
-{
-  "cacheGroups": {
-    "lib-axios": {
-      "name": "lib-axios",
-      "priority": 0,
-      "test": /node_modules\\[\\\\\\\\/\\]axios\\(-\\.\\+\\)\\?\\[\\\\\\\\/\\]/,
-    },
-    "router": {
-      "name": "lib-router",
-      "priority": 0,
-      "test": /node_modules\\[\\\\\\\\/\\]vue-router\\[\\\\\\\\/\\]/,
-    },
-    "vue": {
-      "name": "lib-vue",
-      "priority": 0,
-      "test": /node_modules\\[\\\\\\\\/\\]\\(\\?:vue\\|rspack-vue-loader\\|@vue\\[\\\\\\\\/\\]shared\\|@vue\\[\\\\\\\\/\\]reactivity\\|@vue\\[\\\\\\\\/\\]runtime-dom\\|@vue\\[\\\\\\\\/\\]runtime-core\\)\\[\\\\\\\\/\\]/,
-    },
-  },
-  "chunks": "all",
-}
-`;
-
 exports[`plugin-vue > should define feature flags correctly 1`] = `
 DefinePlugin {
   "_args": [

--- a/packages/plugin-vue/tests/index.test.ts
+++ b/packages/plugin-vue/tests/index.test.ts
@@ -1,5 +1,4 @@
 import { createRsbuild } from '@rsbuild/core';
-import { createRsbuild as createRsbuildV1 } from '@rsbuild/core-v1';
 import { matchPlugin, matchRules } from '@scripts/test-helper';
 import { pluginVue } from '../src';
 
@@ -55,16 +54,5 @@ describe('plugin-vue', () => {
     });
     const config = await rsbuild.initConfigs();
     expect(matchRules(config[0], 'a.md')[0]).toMatchSnapshot();
-  });
-
-  it('should apply splitChunks with Rsbuild v1', async () => {
-    const rsbuild = await createRsbuildV1({
-      config: {
-        plugins: [pluginVue()],
-      },
-    });
-
-    const config = await rsbuild.initConfigs();
-    expect(config[0].optimization?.splitChunks).toMatchSnapshot();
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1365,9 +1365,6 @@ importers:
       '@rsbuild/core':
         specifier: workspace:*
         version: link:../core
-      '@rsbuild/core-v1':
-        specifier: 'catalog:'
-        version: '@rsbuild/core@1.7.5'
       '@rslib/core':
         specifier: 'catalog:'
         version: 0.23.0(@module-federation/runtime-tools@2.5.1)(core-js@3.49.0)(typescript@6.0.3)


### PR DESCRIPTION
## Summary

This PR drops Rsbuild v1 compatibility from `@rsbuild/plugin-vue`. The plugin now requires `@rsbuild/core` >= 2.0, reports a clear error for Rsbuild v1 at setup time, and removes the Rsbuild v1 test and dependency coverage.