### PR TITLE
docs(plugin-vue): update loader references in types

### DIFF
--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -7,7 +7,7 @@ const require = createRequire(import.meta.url);
 
 export type SplitVueChunkOptions = {
   /**
-   * Whether to enable split chunking for Vue-related dependencies (e.g., vue, vue-loader).
+   * Whether to enable split chunking for Vue-related dependencies (e.g., vue, rspack-vue-loader).
    * @default true
    */
   vue?: boolean;
@@ -25,7 +25,7 @@ export type PluginVueOptions = {
    */
   test?: Rspack.RuleSetCondition;
   /**
-   * Options passed to `vue-loader`.
+   * Options passed to `rspack-vue-loader`.
    * @see https://vue-loader.vuejs.org/
    */
   vueLoaderOptions?: VueLoaderOptions;


### PR DESCRIPTION
## Summary

This PR updates `@rsbuild/plugin-vue` public type comments to reference `rspack-vue-loader` consistently now that the plugin integrates `rspack-vue-loader`.