### PR TITLE
chore: move build out of prepare

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -47,7 +47,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Trigger Ecosystem CI
-        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@0e65507af053729fa482e81bbdf95cb46e363aa9 # v0.3.2
+        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@f0d685b33462055bb07a8a3620b753696ad5f515 # v0.3.3
         with:
           github-token: ${{ secrets.REPO_RSBUILD_ECO_CI_GITHUB_TOKEN_NEXT }}
           ecosystem-owner: web-infra-dev
@@ -65,7 +65,7 @@ jobs:
       contents: write
     steps:
       - name: Trigger Ecosystem CI
-        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_per_commit@0e65507af053729fa482e81bbdf95cb46e363aa9 # v0.3.2
+        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_per_commit@f0d685b33462055bb07a8a3620b753696ad5f515 # v0.3.3
         with:
           github-token: ${{ secrets.REPO_RSBUILD_ECO_CI_GITHUB_TOKEN_NEXT }}
           ecosystem-owner: web-infra-dev

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,6 +34,9 @@ jobs:
         with:
           run_install: true
 
+      - name: Build
+        run: node --run build
+
       - name: Lint
         run: node --run lint
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -36,5 +36,8 @@ jobs:
         with:
           run_install: true
 
+      - name: Build
+        run: node --run build
+
       - name: Publish Preview
         run: pnpx pkg-pr-new publish --pnpm ./packages/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,9 @@ jobs:
         with:
           run_install: true
 
+      - name: Build
+        run: node --run build
+
       - name: Publish to npm
         run: |
           pnpm --filter './packages/*' -r stage publish --tag ${{ github.event.inputs.npm_tag }} --no-git-checks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,10 @@ jobs:
         with:
           run_install: true
 
+      - name: Build
+        if: steps.changes.outputs.changed == 'true'
+        run: node --run build
+
       - name: Unit Test
         if: steps.changes.outputs.changed == 'true'
         run: node --run test
@@ -100,6 +104,10 @@ jobs:
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           run_install: true
+
+      - name: Build
+        if: steps.changes.outputs.changed == 'true'
+        run: node --run build
 
       - name: Run E2E tests
         if: steps.changes.outputs.changed == 'true'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,8 +28,6 @@ corepack enable
 pnpm install
 ```
 
-This installs dependencies, links packages inside the monorepo, and runs the Nx-powered `prepare` script.
-
 ---
 
 ## Making changes and building

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "format:check": "oxfmt . --check",
     "lint": "rslint --type-check",
     "prebundle": "pnpm --parallel --filter \"./packages/*\" run prebundle",
-    "prepare": "simple-git-hooks && node --run prebundle && node --run build",
+    "prepare": "simple-git-hooks && node --run prebundle",
     "sort-package-json": "pnpx sort-package-json \"./package.json\" \"packages/*/package.json\"",
     "test": "rstest",
     "test:watch": "rstest watch"


### PR DESCRIPTION
## Summary

This PR keeps dependency installation lighter by removing the full workspace build from the root `prepare` lifecycle. This became more noticeable with pnpm v11 because `verifyDepsBeforeRun` now defaults to `install`, so `pnpm run` and `pnpm exec` may automatically run `pnpm install` when `node_modules` is considered out of date, indirectly triggering `prepare`. CI workflows now run `node --run build` explicitly after dependency installation, preserving the previous built-artifact behavior for lint, test, preview, and release jobs.