### PR TITLE
fix(deps): update ws to version 8.21.0 to address vulnerability

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -102,7 +102,7 @@
     "webpack": "^5.104.1",
     "webpack-bundle-analyzer": "^5.3.0",
     "webpack-merge": "6.0.1",
-    "ws": "^8.18.3"
+    "ws": "^8.21.0"
   },
   "engines": {
     "node": ">=18.12.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -662,8 +662,8 @@ importers:
         specifier: 6.0.1
         version: 6.0.1
       ws:
-        specifier: ^8.18.3
-        version: 8.18.3
+        specifier: ^8.21.0
+        version: 8.21.0
 
   packages/create-rsbuild:
     dependencies:
@@ -6570,20 +6570,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -12604,7 +12592,7 @@ snapshots:
       opener: 1.5.2
       picocolors: 1.1.1
       sirv: 3.0.2
-      ws: 8.20.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -12682,9 +12670,7 @@ snapshots:
 
   ws@8.18.0: {}
 
-  ws@8.18.3: {}
-
-  ws@8.20.0: {}
+  ws@8.21.0: {}
 
   wsl-utils@0.3.0:
     dependencies:


### PR DESCRIPTION
## Summary
This PR updates the ws package from version 8.18.3 to 8.21.0 to address a known security vulnerability.

## Motivation
The ws package version 8.18.3 contains a security vulnerability that could affect Rsbuild users. Upgrading to version 8.21.0 resolves this issue while maintaining compatibility with the current codebase.

## Changes
- Updated ws dependency in package.json from 8.18.3 to 8.21.0
- Updated pnpm-lock.yaml with the new dependency tree

## Files Changed
- package.json
- pnpm-lock.yaml

## Related Links

<!--- Provide links of related issues or pages -->
