### PR TITLE
chore(ci): confirm release npm tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,16 @@ on:
           - rc
           - canary
           - latest
+      npm_tag_confirm:
+        type: choice
+        description: 'Confirm npm tag'
+        required: true
+        options:
+          - alpha
+          - beta
+          - rc
+          - canary
+          - latest
       branch:
         description: 'Release Branch (confirm release branch)'
         required: true
@@ -22,9 +32,28 @@ on:
 permissions: {}
 
 jobs:
+  validate_inputs:
+    name: Validate Inputs
+    if: github.repository == 'web-infra-dev/rsbuild' && github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate npm tag confirmation
+        env:
+          NPM_TAG: ${{ inputs.npm_tag }}
+          NPM_TAG_CONFIRM: ${{ inputs.npm_tag_confirm }}
+        run: |
+          if [ "$NPM_TAG" != "$NPM_TAG_CONFIRM" ]; then
+            echo "Error: npm_tag and npm_tag_confirm must match"
+            echo "npm_tag: $NPM_TAG"
+            echo "npm_tag_confirm: $NPM_TAG_CONFIRM"
+            exit 1
+          fi
+          echo "npm_tag validation passed: $NPM_TAG"
+
   release:
     name: Release
     if: github.repository == 'web-infra-dev/rsbuild' && github.event_name == 'workflow_dispatch'
+    needs: validate_inputs
     runs-on: ubuntu-latest
     environment: npm
     permissions:


### PR DESCRIPTION
## Summary

This PR adds a second npm tag confirmation input to the release workflow so publish runs fail before entering the npm environment when the selected tag does not match the confirmation. The validation job compares the two workflow dispatch inputs and makes the release job depend on that check.