### PR TITLE
chore: add latest-v1 release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ on:
           - rc
           - canary
           - latest
+          - latest-v1
       npm_tag_confirm:
         type: choice
         description: 'Confirm npm tag'
@@ -24,6 +25,7 @@ on:
           - rc
           - canary
           - latest
+          - latest-v1
       branch:
         description: 'Release Branch (confirm release branch)'
         required: true


### PR DESCRIPTION
## Summary

This PR adds `latest-v1` to the release workflow npm tag choices so maintainers can publish 1.x releases under a dedicated npm dist-tag. The same option is added to the confirmation field to keep the double-check validation working for this tag.

## Related Links

https://github.com/web-infra-dev/rsbuild/discussions/7983