### PR TITLE
chore: update agent skills

### DIFF
--- a/.agents/skills/pr-creator/SKILL.md
+++ b/.agents/skills/pr-creator/SKILL.md
@@ -22,6 +22,7 @@ description: Use when asked to create a pull request for this repository. It hel
    - `fix(types): ...`
    - `docs: ...`
    - `refactor(types): ...`
+   - `chore(ci): ...` for CI workflow, check, or release automation changes
    - `chore(deps): ...`
    - `release: v1.2.0`
 
@@ -43,7 +44,9 @@ description: Use when asked to create a pull request for this repository. It hel
 
 7. Push the branch only after re-checking the branch name. Never push the default branch directly.
 
-8. Create the PR with `gh pr create`.
+8. Create the PR.
+   When running in Codex, use the Codex GitHub connector/plugin for GitHub operations.
+   Use `gh pr create` only as a fallback when the connector is unavailable.
 
 ## Constraints
 

--- a/.agents/skills/release-blog-writer/SKILL.md
+++ b/.agents/skills/release-blog-writer/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: release-blog-writer
+description: Write or revise release blog posts for product releases. Use when the user asks to draft, polish, restructure, or adapt a release announcement.
+---
+
+# Release blog writer
+
+## Purpose
+
+Use this skill to write release blogs that feel like product communication, not raw changelog output. The blog may be written in English, Chinese, or another user-requested language, but these instructions stay language-agnostic and project-agnostic.
+
+## Core writing rules
+
+- Follow the user's requested language and the style of existing release blogs for the same product.
+- Use previous major or minor release posts as the primary style reference when available.
+- Prefer clear user value over implementation trivia.
+- Avoid turning the blog into a complete changelog.
+
+## Recommended shape
+
+Use the project's existing blog metadata and component conventions. If the product has neighboring release posts, mirror their frontmatter, author block, date format, title style, and navigation pattern.
+
+## Section writing
+
+Each feature section should usually follow this pattern:
+
+- Describe the change clearly so readers understand its background, purpose, use cases, and user-facing benefits such as performance gains.
+- If a code or configuration example is useful, include one precise and concise example that makes the change easy to understand at a glance.
+
+## Headings
+
+- Use sentence case for titles and headings.
+- Keep headings short and specific.
+- Keep anchors stable and readable.
+  - If the website is built with Rspress, use the Rspress anchor syntax, such as `\{#foo-bar}`.
+
+## Tone
+
+- Be professional, direct, and understated.
+- Avoid vague claims such as "greatly improved" unless the improvement is explained or quantified.
+- Qualify benchmark numbers with enough context to make them credible.
+- Use product and ecosystem terms consistently.
+- Write naturally in the target language; do not let the prose read like a literal translation from another language.
+
+## Links
+
+Add links where they help readers continue:
+
+- Product documentation for options, APIs, plugins, or migration steps.
+- Upstream PRs or specs for implementation context.
+- Platform documentation for browser, Node.js, or language features.
+
+Do not over-link common terms. Link the first meaningful occurrence or the option name users are likely to search for.
+
+## Revision behavior
+
+When revising an existing blog:
+
+- Keep the user's latest manual edits unless they conflict with the request.
+- Prefer small targeted edits over broad rewrites.
+- If the user asks to remove a kind of detail, remove it consistently across the post.

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -11,7 +11,13 @@
       "source": "rstackjs/agent-skills",
       "sourceType": "github",
       "skillPath": "skills/pr-creator/SKILL.md",
-      "computedHash": "a632c60f135594b5ec098ce6196c85395e448ade27882292bf0b68f9192e8278"
+      "computedHash": "065a131500e344efa79c620b4ccc8686ff375c4017f33929e4b00643e57cdc74"
+    },
+    "release-blog-writer": {
+      "source": "rstackjs/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/release-blog-writer/SKILL.md",
+      "computedHash": "964ac00607c45fd5004192f50e82019ee45b2c8e06e03fa7e06c35970b6388ce"
     },
     "rspress-description-generator": {
       "source": "rstackjs/agent-skills",


### PR DESCRIPTION
## Summary

This PR updates repository agent skills so release blog drafting and PR creation use the latest shared workflow guidance. It adds a `release-blog-writer` skill, refreshes the skill lock, and changes the PR creator instructions to prefer the Codex GitHub connector with `gh` only as a fallback.