### PR TITLE
ci: keep reproduction label until close

### DIFF
--- a/.github/workflows/issue-close-require.yml
+++ b/.github/workflows/issue-close-require.yml
@@ -20,6 +20,7 @@ jobs:
           days-before-pr-close: -1
           days-before-issue-close: 5
           stale-issue-label: 'need reproduction'
+          remove-issue-stale-when-updated: false
           close-issue-message: |
             As the issue was labelled with `need reproduction`, but no response in 5 days. This issue will be closed. Feel free to comment and reopen it if you have any further questions. For background, see [Why reproductions are required](https://antfu.me/posts/why-reproductions-are-required).
 


### PR DESCRIPTION
## Summary

This PR fixes the inactive issue close workflow for `need reproduction` issues. That label triggers an automatic guidance comment from `github-actions[bot]`, so the scheduled stale job now keeps the label instead of removing it because of that workflow-driven update.

## Related Links

https://github.com/web-infra-dev/rspack/pull/14570