### PR TITLE
docs(skills): require build before e2e

### DIFF
--- a/.agents/skills/release-plugin-package/SKILL.md
+++ b/.agents/skills/release-plugin-package/SKILL.md
@@ -127,9 +127,10 @@ To collect changelog items:
    pnpm --filter @rsbuild/plugin-<name> run build
    ```
 
-   If `create-rsbuild` templates changed, also run the focused create-rsbuild e2e case when practical:
+   If `create-rsbuild` templates changed, also run `pnpm build` once and then the focused create-rsbuild e2e case when practical:
 
    ```bash
+   pnpm build
    pnpm e2e create-rsbuild
    ```
 

--- a/.agents/skills/upgrade-rspack/SKILL.md
+++ b/.agents/skills/upgrade-rspack/SKILL.md
@@ -19,7 +19,7 @@ If the version is missing, ask for it before making changes.
 
 3. Run `pnpm i` at the repository root.
 
-4. Run `pnpm test` and `pnpm e2e`. If either command fails, stop, report the failure, and do not commit or create a PR.
+4. Run `pnpm build`, `pnpm test`, and then `pnpm e2e`. If any command fails, stop, report the failure, and do not commit or create a PR.
 
 5. Review the diff and confirm it only contains the intended dependency upgrade and lockfile changes. If `@rspack/core` is already at the target version and there is no diff, report that nothing changed and stop.
 

--- a/.agents/skills/write-e2e-cases/SKILL.md
+++ b/.agents/skills/write-e2e-cases/SKILL.md
@@ -17,7 +17,7 @@ description: Use when adding or updating Rsbuild end-to-end tests in `e2e/cases`
 
 5. Use short, direct, and stable assertions. Avoid redundant setup and checks.
 
-6. Run `pnpm e2e` to validate.
+6. Run `pnpm build` once, then run `pnpm e2e` to validate.
 
 ## Case Structure
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,8 @@ pnpm e2e css
 pnpm e2e
 ```
 
+Run `pnpm build` once before any `pnpm e2e` command, including focused cases.
+
 ## Project structure
 
 ```text


### PR DESCRIPTION
## Summary

Require agents and repository skills to run `pnpm build` once before any `pnpm e2e` command. This keeps focused e2e validation aligned with the project build prerequisite across general instructions, e2e authoring, Rspack upgrade, and plugin release workflows.