### PR TITLE
feat(core): add source-map CLI option

### DIFF
--- a/e2e/cases/cli/source-map/index.test.ts
+++ b/e2e/cases/cli/source-map/index.test.ts
@@ -1,0 +1,35 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { expect, readDirContents, test } from '@e2e/helper';
+
+const distPath = path.join(import.meta.dirname, 'dist');
+
+test.beforeEach(() => {
+  fs.rmSync(distPath, { recursive: true, force: true });
+});
+
+test('should enable source map from CLI', async ({ execCliSync }) => {
+  execCliSync('build --source-map');
+
+  const outputs = await readDirContents(distPath);
+  const outputFiles = Object.keys(outputs);
+
+  expect(outputFiles.some((file) => file.endsWith('.js.map'))).toBeTruthy();
+});
+
+test('should disable source map from CLI', async ({ execCliSync }) => {
+  execCliSync('build --config source-map.config.ts --no-source-map');
+
+  const outputs = await readDirContents(distPath);
+  const outputFiles = Object.keys(outputs);
+
+  expect(outputFiles.some((file) => file.endsWith('.js.map'))).toBeFalsy();
+});
+
+test('should reject source map type from CLI', async ({ execCliSync }) => {
+  expect(() => {
+    execCliSync('build --source-map hidden-source-map', {
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+  }).toThrowError(/The "--source-map" option only accepts a boolean value/);
+});

--- a/e2e/cases/cli/source-map/source-map.config.ts
+++ b/e2e/cases/cli/source-map/source-map.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    sourceMap: true,
+  },
+});

--- a/e2e/cases/cli/source-map/src/index.js
+++ b/e2e/cases/cli/source-map/src/index.js
@@ -1,0 +1,1 @@
+console.log('hello!');

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -10,6 +10,7 @@ import { init } from './init';
 export type CommonOptions = {
   base?: string;
   distPath?: string;
+  sourceMap?: boolean;
   root?: string;
   mode?: RsbuildMode;
   config?: string;
@@ -46,6 +47,7 @@ const applyCommonOptions = (cli: CAC) => {
       default: 'auto',
     })
     .option('--dist-path <dir>', 'Set the root directory of output files')
+    .option('--source-map', 'Enable source map')
     .option('--env-dir <dir>', 'Set the directory for loading `.env` files')
     .option('--env-mode <mode>', 'Set the env mode to load the `.env.[mode]` file')
     .option('--environment <name>', 'Set the environment name(s) to build', {

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -67,6 +67,17 @@ const loadConfig = async (root: string) => {
         : { root: commonOpts.distPath };
   }
 
+  if (commonOpts.sourceMap !== undefined) {
+    const sourceMap = commonOpts.sourceMap as unknown;
+
+    if (typeof sourceMap !== 'boolean') {
+      throw new Error('The "--source-map" option only accepts a boolean value.');
+    }
+
+    config.output ||= {};
+    config.output.sourceMap = sourceMap;
+  }
+
   // enable CLI shortcuts by default when using Rsbuild CLI
   if (config.dev.cliShortcuts === undefined) {
     config.dev.cliShortcuts = true;

--- a/website/docs/en/guide/basic/cli.mdx
+++ b/website/docs/en/guide/basic/cli.mdx
@@ -45,6 +45,7 @@ The Rsbuild CLI includes several common flags that work with all commands:
 | `-m, --mode <mode>`        | Set the build mode (`development` \| `production` \| `none`), see [mode](/config/mode)                                                     |
 | `--no-env`                 | Disable loading of `.env` files                                                                                                            |
 | `-r, --root <root>`        | Set the project root directory (absolute path or relative to [cwd](https://nodejs.org/api/process.html#processcwd))                        |
+| `--source-map`             | Enable source maps, see [output.sourceMap](/config/output/source-map)                                                                      |
 
 ## rsbuild
 

--- a/website/docs/zh/guide/basic/cli.mdx
+++ b/website/docs/zh/guide/basic/cli.mdx
@@ -45,6 +45,7 @@ Rsbuild CLI 提供了一些公共选项，可以用于所有命令：
 | `-m, --mode <mode>`        | 指定构建模式（`development` \| `production` \| `none`），详见 [mode](/config/mode)                                            |
 | `--no-env`                 | 禁用 `.env` 文件的加载                                                                                                        |
 | `-r, --root <root>`        | 指定项目根目录（绝对路径或者相对于 [cwd](https://nodejs.org/api/process.html#processcwd) 的路径）                             |
+| `--source-map`             | 启用 source map，详见 [output.sourceMap](/config/output/source-map)                                                           |
 
 ## rsbuild
 


### PR DESCRIPTION
## Summary

Adds a boolean `--source-map` CLI config override. Passing `--source-map` enables `output.sourceMap`, and `--no-source-map` disables it. The option intentionally does not support a string value for selecting JavaScript source map types.