### PR TITLE
fix(core): remove rsbuild prefix from loadConfig error

### DIFF
--- a/packages/core/src/loadConfig.ts
+++ b/packages/core/src/loadConfig.ts
@@ -78,9 +78,7 @@ const resolveConfigPath = (root: string, customConfig?: string) => {
     if (fs.existsSync(customConfigPath)) {
       return customConfigPath;
     }
-    throw new Error(
-      `${color.dim('[rsbuild:loadConfig]')} Cannot find config file: ${color.dim(customConfigPath)}`,
-    );
+    throw new Error(`Cannot find config file: ${color.dim(customConfigPath)}`);
   }
 
   // Resolve the most commonly used config file types first


### PR DESCRIPTION
## Summary

`loadConfig` can be called by upper-level tools such as Rslib and Rspress, so the Rsbuild-specific prefix in its config-resolution error can be misleading outside Rsbuild. This PR removes the `[rsbuild:loadConfig]` prefix from the missing custom config file error while keeping the resolved path in the message.