### PR TITLE
docs: enable anchor link check

### DIFF
--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -156,6 +156,9 @@ export default defineConfig({
   },
   llms: true,
   markdown: {
+    link: {
+      checkAnchors: true,
+    },
     shiki: {
       langs: ['styl', 'html', 'toml'],
       langAlias: {


### PR DESCRIPTION
## Summary

Enable Rspress anchor checking for website Markdown links so broken heading hash links are detected during docs builds. This uses `markdown.link.checkAnchors` introduced in Rspress v2.0.15.

## Related Links

https://github.com/web-infra-dev/rspress/releases/tag/v2.0.15