### PR TITLE
fix(core): align hidden import trace ellipsis

### DIFF
--- a/e2e/cases/diagnostic/import-traces-cut/index.test.ts
+++ b/e2e/cases/diagnostic/import-traces-cut/index.test.ts
@@ -3,7 +3,7 @@ import { expect, test } from '@e2e/helper';
 const EXPECTED_LOG = `Import traces (entry → error):
   ./src/index.js
   ./src/child1.js
-  … (3 hidden)
+  ... (3 hidden)
   ./src/child5.js
   ./src/child6.js ×`;
 

--- a/packages/core/src/helpers/format.ts
+++ b/packages/core/src/helpers/format.ts
@@ -117,7 +117,7 @@ function formatModuleTrace(
     const TAIL = 2;
     trace = [
       ...trace.slice(0, HEAD),
-      `… (${trace.length - HEAD - TAIL} hidden)`,
+      `... (${trace.length - HEAD - TAIL} hidden)`,
       ...trace.slice(trace.length - TAIL),
     ];
   }


### PR DESCRIPTION
## Summary

This PR aligns the hidden import trace marker with Node-style truncation output by using ASCII `...` instead of the Unicode ellipsis. It also updates the diagnostic e2e expectation for the truncated import trace output.
