### PR TITLE
chore(ci): run lint checks in parallel

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,11 +37,12 @@ jobs:
       - name: Build
         run: node --run build
 
-      - name: Lint
-        run: node --run lint
+      - parallel:
+          - name: Lint
+            run: node --run lint
 
-      - name: Check Format
-        run: node --run format:check
+          - name: Check Format
+            run: node --run format:check
 
-      - name: Check Spell
-        run: node --run check-spell
+          - name: Check Spell
+            run: node --run check-spell


### PR DESCRIPTION
## Summary

Run the lint, format, and spell checks in a GitHub Actions `parallel` group after the build step so independent lint workflow checks can complete concurrently while preserving separate logs.

## Related Links

https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/
