### PR TITLE
refactor: use import.meta Rspack module variables

### DIFF
--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -137,8 +137,8 @@ export default defineConfig({
           overlay: 'src/client/overlay.ts',
         },
         define: {
-          // use define to avoid compile time evaluation of __webpack_hash__
-          BUILD_HASH: '__webpack_hash__',
+          // use define to avoid compile time evaluation of import.meta.rspackHash
+          BUILD_HASH: 'import.meta.rspackHash',
         },
       },
       output: {

--- a/packages/core/src/client/hmr.ts
+++ b/packages/core/src/client/hmr.ts
@@ -207,8 +207,8 @@ export function init(
     );
   }
 
-  // __webpack_hash__ is the hash of the current compilation.
-  // It's a global variable injected by Rspack.
+  // BUILD_HASH is replaced with import.meta.rspackHash when the client is prebuilt,
+  // then resolved to the current compilation hash.
   const shouldUpdate = () => lastHash !== BUILD_HASH;
 
   const handleApplyUpdates = (err: unknown, updatedModules: (string | number)[] | null) => {

--- a/packages/core/src/loader/cssUrlLoader.ts
+++ b/packages/core/src/loader/cssUrlLoader.ts
@@ -112,7 +112,7 @@ export const pitch: PitchLoaderDefinitionFunction<CSSUrlLoaderOptions> = async f
     immutable: info.immutable || HASH_PLACEHOLDER_REGEX.test(filenameTemplate),
   });
 
-  return `export default __webpack_public_path__ + ${JSON.stringify(filename)};`;
+  return `export default import.meta.rspackPublicPath + ${JSON.stringify(filename)};`;
 };
 
 export default cssUrlLoader;

--- a/packages/core/src/plugins/nonce.ts
+++ b/packages/core/src/plugins/nonce.ts
@@ -26,9 +26,11 @@ export const pluginNonce = (): RsbuildPlugin => ({
           return;
         }
 
-        // apply __webpack_nonce__
-        // https://rspack.rs/api/runtime-api/module-variables#__webpack_nonce__
-        const injectCode = createVirtualModule(`__webpack_nonce__ = "${nonce}";`);
+        // apply import.meta.rspackNonce
+        // https://rspack.rs/api/runtime-api/module-variables#importmetarspacknonce
+        const injectCode = createVirtualModule(
+          `import.meta.rspackNonce = ${JSON.stringify(nonce)};`,
+        );
         new rspack.EntryPlugin(compiler.context, injectCode, {
           name: undefined,
         }).apply(compiler);

--- a/packages/plugin-svgr/src/assetLoader.ts
+++ b/packages/plugin-svgr/src/assetLoader.ts
@@ -59,7 +59,7 @@ const assetLoader: RawLoaderDefinition<SvgAssetLoaderOptions> = function (conten
       ? JSON.stringify(publicPath(filename, this.resourcePath, this.rootContext))
       : typeof publicPath === 'string'
         ? JSON.stringify(`${publicPath.endsWith('/') ? publicPath : `${publicPath}/`}${filename}`)
-        : `__webpack_public_path__ + ${JSON.stringify(filename)}`;
+        : `import.meta.rspackPublicPath + ${JSON.stringify(filename)}`;
 
   return `export default ${publicPathCode};`;
 };


### PR DESCRIPTION
## Summary

This PR updates Rsbuild runtime code and the SVGR asset loader to use Rspack's `import.meta` module variables introduced in Rspack v2.1.2. It replaces the deprecated CommonJS-style runtime variables for public path, nonce, and compilation hash while preserving the existing publicPath option behavior.

## Related Links

https://github.com/web-infra-dev/rspack/releases/tag/v2.1.2