### PR TITLE
fix(svgr): revert public path runtime variable

### DIFF
--- a/packages/plugin-svgr/src/assetLoader.ts
+++ b/packages/plugin-svgr/src/assetLoader.ts
@@ -59,7 +59,7 @@ const assetLoader: RawLoaderDefinition<SvgAssetLoaderOptions> = function (conten
       ? JSON.stringify(publicPath(filename, this.resourcePath, this.rootContext))
       : typeof publicPath === 'string'
         ? JSON.stringify(`${publicPath.endsWith('/') ? publicPath : `${publicPath}/`}${filename}`)
-        : `import.meta.rspackPublicPath + ${JSON.stringify(filename)}`;
+        : `__webpack_public_path__ + ${JSON.stringify(filename)}`;
 
   return `export default ${publicPathCode};`;
 };


### PR DESCRIPTION
## Summary

This PR reverts the SVGR asset loader fallback back to `__webpack_public_path__`. The loader keeps its existing `publicPath` option compatibility behavior while avoiding the `import.meta.rspackPublicPath` change for SVGR output.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/8017/changes#r3497842286