### PR TITLE
perf(core): prefer var for web runtime output

### DIFF
--- a/packages/core/src/plugins/output.ts
+++ b/packages/core/src/plugins/output.ts
@@ -99,6 +99,15 @@ export const pluginOutput = (): RsbuildPlugin => ({
           )
           .publicPath(publicPath);
 
+        if (target === 'web' || target === 'web-worker') {
+          // Prefer var in Rspack runtime for web-like targets to avoid TDZ checks in browsers.
+          chain.output.merge({
+            environment: {
+              const: false,
+            },
+          });
+        }
+
         const isESM = config.output.module;
 
         if (isServer) {

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -427,6 +427,9 @@ exports[`default bundler > should use Rspack by default 1`] = `
     "chunkFilename": "static/js/async/[name].js",
     "devtoolFallbackModuleFilenameTemplate": [Function],
     "devtoolModuleFilenameTemplate": [Function],
+    "environment": {
+      "const": false,
+    },
     "filename": "static/js/[name].js",
     "path": "<ROOT>/dist",
     "publicPath": "/",

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -450,6 +450,9 @@ exports[`should apply default plugins correctly 1`] = `
     "chunkFilename": "static/js/async/[name].js",
     "devtoolFallbackModuleFilenameTemplate": [Function],
     "devtoolModuleFilenameTemplate": [Function],
+    "environment": {
+      "const": false,
+    },
     "filename": "static/js/[name].js",
     "path": "<ROOT>/dist",
     "publicPath": "/",
@@ -971,6 +974,9 @@ exports[`should apply default plugins correctly in production 1`] = `
     "chunkFilename": "static/js/async/[name].[contenthash:10].js",
     "devtoolFallbackModuleFilenameTemplate": "[relative-resource-path]?[hash]",
     "devtoolModuleFilenameTemplate": "[relative-resource-path]",
+    "environment": {
+      "const": false,
+    },
     "filename": "static/js/[name].[contenthash:10].js",
     "path": "<ROOT>/dist",
     "publicPath": "/",
@@ -1943,6 +1949,9 @@ exports[`tools.rspack > should match snapshot 1`] = `
     "chunkFilename": "static/js/async/[name].js",
     "devtoolFallbackModuleFilenameTemplate": [Function],
     "devtoolModuleFilenameTemplate": [Function],
+    "environment": {
+      "const": false,
+    },
     "filename": "static/js/[name].js",
     "path": "<ROOT>/dist",
     "publicPath": "/",

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -423,6 +423,9 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
       "chunkFilename": "static/js/async/[name].js",
       "devtoolFallbackModuleFilenameTemplate": [Function],
       "devtoolModuleFilenameTemplate": [Function],
+      "environment": {
+        "const": false,
+      },
       "filename": "static/js/[name].js",
       "path": "<ROOT>/dist",
       "publicPath": "/",

--- a/packages/core/tests/__snapshots__/output.test.ts.snap
+++ b/packages/core/tests/__snapshots__/output.test.ts.snap
@@ -6,6 +6,9 @@ exports[`plugin-output > should allow customizing filename hash format with obje
   "chunkFilename": "static/js/async/[name].[contenthash:16].js",
   "devtoolFallbackModuleFilenameTemplate": "[relative-resource-path]?[hash]",
   "devtoolModuleFilenameTemplate": "[relative-resource-path]",
+  "environment": {
+    "const": false,
+  },
   "filename": "static/js/[name].[contenthash:16].js",
   "path": "<ROOT>/dist",
   "publicPath": "/",
@@ -39,6 +42,9 @@ exports[`plugin-output > should allow disabling filename hash with object config
   "chunkFilename": "static/js/async/[name].js",
   "devtoolFallbackModuleFilenameTemplate": "[relative-resource-path]?[hash]",
   "devtoolModuleFilenameTemplate": "[relative-resource-path]",
+  "environment": {
+    "const": false,
+  },
   "filename": "static/js/[name].js",
   "path": "<ROOT>/dist",
   "publicPath": "/",
@@ -52,6 +58,9 @@ exports[`plugin-output > should allow enabling filename hash in development mode
   "chunkFilename": "static/js/async/[name].[contenthash:10].js",
   "devtoolFallbackModuleFilenameTemplate": [Function],
   "devtoolModuleFilenameTemplate": [Function],
+  "environment": {
+    "const": false,
+  },
   "filename": "static/js/[name].[contenthash:10].js",
   "path": "<ROOT>/dist",
   "publicPath": "/",
@@ -65,6 +74,9 @@ exports[`plugin-output > should allow setting distPath.js and distPath.css to em
   "chunkFilename": "async/[name].js",
   "devtoolFallbackModuleFilenameTemplate": "[relative-resource-path]?[hash]",
   "devtoolModuleFilenameTemplate": "[relative-resource-path]",
+  "environment": {
+    "const": false,
+  },
   "filename": "[name].js",
   "path": "<ROOT>/dist",
   "publicPath": "/",
@@ -112,6 +124,9 @@ exports[`plugin-output > should allow using filename.js to modify filename 1`] =
   "chunkFilename": "static/js/async/foo.js",
   "devtoolFallbackModuleFilenameTemplate": "[relative-resource-path]?[hash]",
   "devtoolModuleFilenameTemplate": "[relative-resource-path]",
+  "environment": {
+    "const": false,
+  },
   "filename": "static/js/foo.js",
   "path": "<ROOT>/dist",
   "publicPath": "/",
@@ -145,6 +160,9 @@ exports[`plugin-output > should set output correctly 1`] = `
   "chunkFilename": "static/js/async/[name].js",
   "devtoolFallbackModuleFilenameTemplate": "[relative-resource-path]?[hash]",
   "devtoolModuleFilenameTemplate": "[relative-resource-path]",
+  "environment": {
+    "const": false,
+  },
   "filename": "static/js/[name].js",
   "path": "<ROOT>/dist",
   "publicPath": "/",


### PR DESCRIPTION
## Summary

This PR sets Rspack `output.environment.const: false` for Rsbuild `web` and `web-worker` targets so generated Rspack runtime code prefers `var` and avoids TDZ checks in browser engines. Node target output keeps the existing target-derived runtime syntax.

## Related Links

- https://esbuild.github.io/faq/#top-level-var
- https://issues.chromium.org/issues/42203665
- https://bugs.webkit.org/show_bug.cgi?id=199866
- https://github.com/microsoft/TypeScript/issues/52924
