### PR TITLE
chore: relax pnpm engine requirement

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -59,6 +59,12 @@
       "enabled": false
     },
     {
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["engines"],
+      "matchPackageNames": ["pnpm"],
+      "enabled": false
+    },
+    {
       "description": "Keep .node-version pinned until Cloudflare Pages can install newer Node.js releases reliably.",
       "matchManagers": ["nodenv"],
       "matchFileNames": [".node-version"],

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "engines": {
     "node": ">=22.18.0",
-    "pnpm": ">= 11.0.0"
+    "pnpm": ">=11.0.0"
   },
   "packageManager": "pnpm@11.9.0"
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "engines": {
     "node": ">=22.18.0",
-    "pnpm": ">=11.9.0"
+    "pnpm": ">= 11.0.0"
   },
   "packageManager": "pnpm@11.9.0"
 }


### PR DESCRIPTION
## Summary

This PR relaxes the root `engines.pnpm` requirement from `>=11.9.0` to `>= 11.0.0` to avoid frequent Codex failures caused by its available pnpm version being lower than the current requirement.

It also disables Renovate updates for the `pnpm` engines field so the relaxed range is not tightened automatically.