### PR TITLE
test: add dead code elimination e2e case

### DIFF
--- a/e2e/cases/optimization/dead-code-elimination/index.test.ts
+++ b/e2e/cases/optimization/dead-code-elimination/index.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from '@e2e/helper';
+
+test('should remove dead branches guarded by unused exported state', async ({ build }) => {
+  const rsbuild = await build();
+  const indexJs = await rsbuild.getIndexBundle();
+
+  expect(indexJs).toContain('dce-expected-value');
+  expect(indexJs).not.toContain('dce-removed-value');
+});

--- a/e2e/cases/optimization/dead-code-elimination/index.test.ts
+++ b/e2e/cases/optimization/dead-code-elimination/index.test.ts
@@ -4,6 +4,7 @@ test('should remove dead branches guarded by unused exported bindings', async ({
   const rsbuild = await build();
   const indexJs = await rsbuild.getIndexBundle();
 
+  // Keep the assertions marker-based so they do not depend on minified syntax.
   expect(indexJs).toContain('dce-unused-mutator-expected');
   expect(indexJs).not.toContain('dce-unused-mutator-removed');
   expect(indexJs).toContain('dce-exported-state-expected');

--- a/e2e/cases/optimization/dead-code-elimination/index.test.ts
+++ b/e2e/cases/optimization/dead-code-elimination/index.test.ts
@@ -1,9 +1,11 @@
 import { expect, test } from '@e2e/helper';
 
-test('should remove dead branches guarded by unused exported state', async ({ build }) => {
+test('should remove dead branches guarded by unused exported bindings', async ({ build }) => {
   const rsbuild = await build();
   const indexJs = await rsbuild.getIndexBundle();
 
-  expect(indexJs).toContain('dce-expected-value');
-  expect(indexJs).not.toContain('dce-removed-value');
+  expect(indexJs).toContain('dce-unused-mutator-expected');
+  expect(indexJs).not.toContain('dce-unused-mutator-removed');
+  expect(indexJs).toContain('dce-exported-state-expected');
+  expect(indexJs).not.toContain('dce-exported-state-removed');
 });

--- a/e2e/cases/optimization/dead-code-elimination/index.test.ts
+++ b/e2e/cases/optimization/dead-code-elimination/index.test.ts
@@ -4,7 +4,6 @@ test('should remove dead branches guarded by unused exported bindings', async ({
   const rsbuild = await build();
   const indexJs = await rsbuild.getIndexBundle();
 
-  // Keep the assertions marker-based so they do not depend on minified syntax.
   expect(indexJs).toContain('dce-unused-mutator-expected');
   expect(indexJs).not.toContain('dce-unused-mutator-removed');
   expect(indexJs).toContain('dce-exported-state-expected');

--- a/e2e/cases/optimization/dead-code-elimination/src/exported-state.js
+++ b/e2e/cases/optimization/dead-code-elimination/src/exported-state.js
@@ -1,3 +1,4 @@
+// Covers an exported state binding that is never imported by the app.
 export let used = false;
 
 export function use() {

--- a/e2e/cases/optimization/dead-code-elimination/src/exported-state.js
+++ b/e2e/cases/optimization/dead-code-elimination/src/exported-state.js
@@ -1,0 +1,13 @@
+export let used = false;
+
+export function use() {
+  used = true;
+}
+
+export function test() {
+  if (used) {
+    return 'dce-exported-state-removed';
+  }
+
+  return 'dce-exported-state-expected';
+}

--- a/e2e/cases/optimization/dead-code-elimination/src/index.js
+++ b/e2e/cases/optimization/dead-code-elimination/src/index.js
@@ -1,3 +1,4 @@
-import { test } from './lib';
+import { test as testExportedMutator } from './lib';
+import { test as testExportedState } from './exported-state';
 
-console.log(test());
+console.log(testExportedMutator(), testExportedState());

--- a/e2e/cases/optimization/dead-code-elimination/src/index.js
+++ b/e2e/cases/optimization/dead-code-elimination/src/index.js
@@ -1,0 +1,3 @@
+import { test } from './lib';
+
+console.log(test());

--- a/e2e/cases/optimization/dead-code-elimination/src/lib.js
+++ b/e2e/cases/optimization/dead-code-elimination/src/lib.js
@@ -1,0 +1,13 @@
+let used = false;
+
+export function use() {
+  used = true;
+}
+
+export function test() {
+  if (used) {
+    return 'dce-removed-value';
+  }
+
+  return 'dce-expected-value';
+}

--- a/e2e/cases/optimization/dead-code-elimination/src/lib.js
+++ b/e2e/cases/optimization/dead-code-elimination/src/lib.js
@@ -1,5 +1,6 @@
 let used = false;
 
+// This unused export is the only possible mutator of the branch guard.
 export function use() {
   used = true;
 }

--- a/e2e/cases/optimization/dead-code-elimination/src/lib.js
+++ b/e2e/cases/optimization/dead-code-elimination/src/lib.js
@@ -6,8 +6,8 @@ export function use() {
 
 export function test() {
   if (used) {
-    return 'dce-removed-value';
+    return 'dce-unused-mutator-removed';
   }
 
-  return 'dce-expected-value';
+  return 'dce-unused-mutator-expected';
 }


### PR DESCRIPTION
## Summary

Add a minimal e2e regression case that verifies production builds remove unreachable branches guarded by unused exported bindings. The fixture covers both an unused exported mutator and an exported state binding, and checks the generated bundle keeps the reachable markers while dropping the dead-branch markers.