### PR TITLE
docs: clarify negated CLI flags

### DIFF
--- a/website/docs/en/guide/basic/cli.mdx
+++ b/website/docs/en/guide/basic/cli.mdx
@@ -44,8 +44,11 @@ The Rsbuild CLI includes several common flags that work with all commands:
 | `--log-level <level>`      | Set the log level (`info` \| `warn` \| `error` \| `silent`), see [logLevel](/config/log-level)                                             |
 | `-m, --mode <mode>`        | Set the build mode (`development` \| `production` \| `none`), see [mode](/config/mode)                                                     |
 | `--no-env`                 | Disable loading of `.env` files                                                                                                            |
+| `--no-source-map`          | Disable source maps, see [output.sourceMap](/config/output/source-map)                                                                     |
 | `-r, --root <root>`        | Set the project root directory (absolute path or relative to [cwd](https://nodejs.org/api/process.html#processcwd))                        |
 | `--source-map`             | Enable source maps, see [output.sourceMap](/config/output/source-map)                                                                      |
+
+For boolean flags, the `--no-` prefix can be used to explicitly disable the corresponding feature, such as `--no-env` or `--no-source-map`.
 
 ## rsbuild
 

--- a/website/docs/zh/guide/basic/cli.mdx
+++ b/website/docs/zh/guide/basic/cli.mdx
@@ -44,8 +44,11 @@ Rsbuild CLI 提供了一些公共选项，可以用于所有命令：
 | `--log-level <level>`      | 指定日志级别（`info` \| `warn` \| `error` \| `silent`），详见 [logLevel](/config/log-level)                                   |
 | `-m, --mode <mode>`        | 指定构建模式（`development` \| `production` \| `none`），详见 [mode](/config/mode)                                            |
 | `--no-env`                 | 禁用 `.env` 文件的加载                                                                                                        |
+| `--no-source-map`          | 禁用 source map，详见 [output.sourceMap](/config/output/source-map)                                                           |
 | `-r, --root <root>`        | 指定项目根目录（绝对路径或者相对于 [cwd](https://nodejs.org/api/process.html#processcwd) 的路径）                             |
 | `--source-map`             | 启用 source map，详见 [output.sourceMap](/config/output/source-map)                                                           |
+
+对于布尔类型的选项，可以使用 `--no-` 前缀来显式禁用对应功能，例如 `--no-env` 或 `--no-source-map`。
 
 ## rsbuild
 


### PR DESCRIPTION
## Summary

Document `--no-source-map` and clarify that boolean CLI flags can use the `--no-` prefix to explicitly disable features.

## Related Links

-