### PR TITLE
feat(core): add strict-port CLI option

### DIFF
--- a/e2e/cases/cli/strict-port/index.test.ts
+++ b/e2e/cases/cli/strict-port/index.test.ts
@@ -1,0 +1,42 @@
+import net from 'node:net';
+import { stripVTControlCharacters as stripAnsi } from 'node:util';
+import { expect, getRandomPort, test } from '@e2e/helper';
+
+const HOST = '0.0.0.0';
+
+const occupyPort = async () => {
+  const port = await getRandomPort();
+  const blocker = net.createServer();
+
+  await new Promise<void>((resolve, reject) => {
+    blocker.once('error', reject);
+    blocker.listen({ port, host: HOST }, resolve);
+  });
+
+  return {
+    port,
+    close: () =>
+      new Promise<void>((resolve) => {
+        blocker.close(() => resolve());
+      }),
+  };
+};
+
+test('should exit when port is occupied and --strict-port is used', async ({ execCliSync }) => {
+  const blocker = await occupyPort();
+
+  let message = '';
+  try {
+    execCliSync(`dev --host ${HOST} --port ${blocker.port} --strict-port`, {
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+  } catch (error) {
+    if (error instanceof Error) {
+      message = stripAnsi(error.message);
+    }
+  } finally {
+    await blocker.close();
+  }
+
+  expect(message).toContain(`Port ${blocker.port} is occupied`);
+});

--- a/e2e/cases/cli/strict-port/src/index.js
+++ b/e2e/cases/cli/strict-port/src/index.js
@@ -1,0 +1,1 @@
+console.log('hello!');

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -21,6 +21,7 @@ export type CommonOptions = {
   open?: boolean | string;
   host?: true | string;
   port?: number;
+  strictPort?: boolean;
   environment?: string[];
   logLevel?: LogLevel;
 };
@@ -67,6 +68,7 @@ const applyServerOptions = (command: Command) => {
   command
     .option('-o, --open [url]', 'Open the page in browser on startup')
     .option('--port <port>', 'Set the port number for the server')
+    .option('--strict-port', 'Exit if the specified port is already in use')
     .option('--host [host]', 'Set the host that the server listens to');
 };
 

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -57,6 +57,10 @@ const loadConfig = async (root: string) => {
     config.server.port = commonOpts.port;
   }
 
+  if (commonOpts.strictPort !== undefined) {
+    config.server.strictPort = commonOpts.strictPort;
+  }
+
   if (commonOpts.distPath !== undefined) {
     config.output ||= {};
 

--- a/website/docs/en/guide/basic/cli.mdx
+++ b/website/docs/en/guide/basic/cli.mdx
@@ -59,6 +59,7 @@ Usage:
 Options:
   -o, --open [url]      Open the page in browser on startup
   --port <port>         Set the port number for the server
+  --strict-port         Exit if the specified port is already in use
   --host [host]         Set the host that the server listens to
 ```
 
@@ -118,6 +119,7 @@ Usage: rsbuild preview [options]
 Options:
   -o, --open [url]      Open the page in browser on startup
   --port <port>         Set a port number for Rsbuild server to listen
+  --strict-port         Exit if the specified port is already in use
   --host [host]         Set the host that the Rsbuild server listens to
 ```
 

--- a/website/docs/zh/guide/basic/cli.mdx
+++ b/website/docs/zh/guide/basic/cli.mdx
@@ -59,6 +59,7 @@ Usage:
 Options:
   -o, --open [url]      启动时是否在浏览器中打开页面
   --port <port>         设置 Rsbuild server 监听的端口号
+  --strict-port         当指定端口已被占用时退出
   --host [host]         指定 Rsbuild server 启动时监听的 host
 ```
 
@@ -118,6 +119,7 @@ Usage: rsbuild preview [options]
 Options:
   -o, --open [url]      启动时是否在浏览器中打开页面
   --port <port>         设置 Rsbuild server 监听的端口号
+  --strict-port         当指定端口已被占用时退出
   --host [host]         指定 Rsbuild server 启动时监听的 host
 ```
 


### PR DESCRIPTION
## Summary

Adds a `--strict-port` option to the dev and preview CLI commands so users can fail fast when the requested port is unavailable.

The option maps to `server.strictPort` and is covered by a CLI e2e case.

## Related Links

-