### PR TITLE
feat(core): track native config dependencies

### DIFF
--- a/e2e/cases/cli/config-loader-native-deps/index.test.ts
+++ b/e2e/cases/cli/config-loader-native-deps/index.test.ts
@@ -1,0 +1,62 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { expect, getRandomPort, gotoPage, test } from '@e2e/helper';
+
+const tempConfig = path.join(import.meta.dirname, 'test-temp.config.mjs');
+const tempConfigDep = path.join(import.meta.dirname, 'test-temp-dep.mjs');
+const distDir = path.join(import.meta.dirname, 'dist');
+
+test.afterEach(() => {
+  fs.rmSync(tempConfig, { force: true });
+  fs.rmSync(tempConfigDep, { force: true });
+  fs.rmSync(distDir, { recursive: true, force: true });
+});
+
+test('should restart dev server when native config dependency changed', async ({
+  page,
+  execCli,
+  logHelper,
+}) => {
+  const port = await getRandomPort();
+
+  fs.writeFileSync(tempConfigDep, `export const value = '1';\n`);
+  fs.writeFileSync(
+    tempConfig,
+    `import { value } from './test-temp-dep.mjs';
+
+export default {
+  dev: {
+    writeToDisk: true,
+  },
+  source: {
+    define: {
+      CONFIG_VALUE: JSON.stringify(value),
+    },
+  },
+  server: {
+    port: Number(process.env.PORT),
+  },
+};
+`,
+  );
+
+  execCli(`dev --config-loader native --config ${path.basename(tempConfig)}`, {
+    env: {
+      PORT: String(port),
+    },
+  });
+
+  const { clearLogs, expectBuildEnd, expectLog } = logHelper;
+
+  await expectBuildEnd();
+  await gotoPage(page, { port });
+  await expect(page.locator('#test')).toHaveText('1');
+
+  clearLogs();
+  fs.writeFileSync(tempConfigDep, `export const value = '2';\n`);
+
+  await expectLog('restarting server');
+  await expectBuildEnd();
+  await gotoPage(page, { port });
+  await expect(page.locator('#test')).toHaveText('2');
+});

--- a/e2e/cases/cli/config-loader-native-deps/src/index.js
+++ b/e2e/cases/cli/config-loader-native-deps/src/index.js
@@ -1,0 +1,4 @@
+const el = document.createElement('div');
+el.id = 'test';
+el.textContent = CONFIG_VALUE;
+document.body.appendChild(el);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -66,6 +66,7 @@
     "css-loader": "catalog:",
     "deepmerge": "catalog:",
     "dotenv-expand": "catalog:",
+    "fresh-import": "catalog:",
     "html-rspack-plugin": "catalog:",
     "http-proxy-middleware": "catalog:",
     "jiti": "catalog:",

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -18,7 +18,11 @@ const getEnvDir = (cwd: string, envDir?: string) => {
 };
 
 const loadConfig = async (root: string) => {
-  const { content: config, filePath } = await baseLoadConfig({
+  const {
+    content: config,
+    filePath,
+    dependencies,
+  } = await baseLoadConfig({
     cwd: root,
     path: commonOpts.config,
     envMode: commonOpts.envMode,
@@ -92,7 +96,7 @@ const loadConfig = async (root: string) => {
     config.dev.watchFiles = [
       ...(config.dev.watchFiles ? castArray(config.dev.watchFiles) : []),
       {
-        paths: filePath,
+        paths: [filePath, ...dependencies],
         type: 'reload-server',
       },
     ];

--- a/packages/core/src/loadConfig.ts
+++ b/packages/core/src/loadConfig.ts
@@ -58,6 +58,10 @@ export type LoadConfigResult = {
    * Return `null` if the configuration file is not found.
    */
   filePath: string | null;
+  /**
+   * Files imported by the configuration file.
+   */
+  dependencies: string[];
 };
 
 /**
@@ -105,6 +109,48 @@ const resolveConfigPath = (root: string, customConfig?: string) => {
 
 export type ConfigLoader = 'auto' | 'jiti' | 'native';
 
+const getConfigExport = (module: unknown): RsbuildConfigExport =>
+  (module && typeof module === 'object' && 'default' in module
+    ? module.default
+    : module) as RsbuildConfigExport;
+
+const tryFreshImport = async (configFileURL: string) => {
+  try {
+    const { freshImport } = await import('fresh-import');
+    return freshImport(configFileURL);
+  } catch (err) {
+    defaultLogger.debug('failed to initialize fresh-import, fallback to dynamic import.');
+    defaultLogger.debug(err);
+  }
+};
+
+const loadConfigWithNative = async (
+  configFilePath: string,
+  collectDependencies: boolean,
+): Promise<{
+  configExport: RsbuildConfigExport;
+  dependencies: string[];
+}> => {
+  const configFileURL = pathToFileURL(configFilePath).href;
+
+  if (collectDependencies) {
+    const freshImportResult = await tryFreshImport(configFileURL);
+
+    if (freshImportResult) {
+      return {
+        configExport: getConfigExport(freshImportResult.result),
+        dependencies: freshImportResult.dependencies.sort(),
+      };
+    }
+  }
+
+  const exportModule = await import(`${configFileURL}?t=${Date.now()}`);
+  return {
+    configExport: getConfigExport(exportModule),
+    dependencies: [],
+  };
+};
+
 export async function loadConfig({
   cwd = process.cwd(),
   path,
@@ -119,8 +165,11 @@ export async function loadConfig({
     return {
       content: {},
       filePath: configFilePath,
+      dependencies: [],
     };
   }
+
+  let dependencies: string[] = [];
 
   const applyMetaInfo = (config: RsbuildConfig) => {
     config._privateMeta = { configFilePath };
@@ -138,9 +187,10 @@ export async function loadConfig({
 
   if (useNative || /\.(?:js|mjs|cjs)$/.test(configFilePath)) {
     try {
-      const configFileURL = pathToFileURL(configFilePath).href;
-      const exportModule = await import(`${configFileURL}?t=${Date.now()}`);
-      configExport = exportModule.default ? exportModule.default : exportModule;
+      ({ configExport, dependencies } = await loadConfigWithNative(
+        configFilePath,
+        loader === 'native',
+      ));
     } catch (err) {
       const errorMessage = `Failed to load file with native loader: ${color.dim(configFilePath)}`;
       if (loader === 'native') {
@@ -195,6 +245,7 @@ export async function loadConfig({
     return {
       content: applyMetaInfo(result),
       filePath: configFilePath,
+      dependencies,
     };
   }
 
@@ -211,5 +262,6 @@ export async function loadConfig({
   return {
     content: applyMetaInfo(configExport),
     filePath: configFilePath,
+    dependencies,
   };
 }

--- a/packages/core/src/loadConfig.ts
+++ b/packages/core/src/loadConfig.ts
@@ -126,22 +126,18 @@ const tryFreshImport = async (configFileURL: string) => {
 
 const loadConfigWithNative = async (
   configFilePath: string,
-  collectDependencies: boolean,
 ): Promise<{
   configExport: RsbuildConfigExport;
   dependencies: string[];
 }> => {
   const configFileURL = pathToFileURL(configFilePath).href;
+  const freshImportResult = await tryFreshImport(configFileURL);
 
-  if (collectDependencies) {
-    const freshImportResult = await tryFreshImport(configFileURL);
-
-    if (freshImportResult) {
-      return {
-        configExport: getConfigExport(freshImportResult.result),
-        dependencies: freshImportResult.dependencies.sort(),
-      };
-    }
+  if (freshImportResult) {
+    return {
+      configExport: getConfigExport(freshImportResult.result),
+      dependencies: freshImportResult.dependencies.sort(),
+    };
   }
 
   const exportModule = await import(`${configFileURL}?t=${Date.now()}`);
@@ -187,10 +183,7 @@ export async function loadConfig({
 
   if (useNative || /\.(?:js|mjs|cjs)$/.test(configFilePath)) {
     try {
-      ({ configExport, dependencies } = await loadConfigWithNative(
-        configFilePath,
-        loader === 'native',
-      ));
+      ({ configExport, dependencies } = await loadConfigWithNative(configFilePath));
     } catch (err) {
       const errorMessage = `Failed to load file with native loader: ${color.dim(configFilePath)}`;
       if (loader === 'native') {

--- a/packages/core/src/loadConfig.ts
+++ b/packages/core/src/loadConfig.ts
@@ -59,7 +59,8 @@ export type LoadConfigResult = {
    */
   filePath: string | null;
   /**
-   * Files imported by the configuration file.
+   * Absolute file paths of statically imported (relative) dependencies of the
+   * config file.
    */
   dependencies: string[];
 };
@@ -117,7 +118,7 @@ const getConfigExport = (module: unknown): RsbuildConfigExport =>
 const tryFreshImport = async (configFileURL: string) => {
   try {
     const { freshImport } = await import('fresh-import');
-    return freshImport(configFileURL);
+    return await freshImport(configFileURL);
   } catch (err) {
     defaultLogger.debug('failed to initialize fresh-import, fallback to dynamic import.');
     defaultLogger.debug(err);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,9 @@ catalogs:
     fast-glob:
       specifier: ^3.3.3
       version: 3.3.3
+    fresh-import:
+      specifier: ^0.2.1
+      version: 0.2.1
     fs-extra:
       specifier: ^11.3.5
       version: 11.3.5
@@ -943,6 +946,9 @@ importers:
       dotenv-expand:
         specifier: 'catalog:'
         version: 13.0.0(patch_hash=5ff37847fa487be2db4e4f14c2b21937f4e51cc7a43deea4506d4aaf3fa6149c)
+      fresh-import:
+        specifier: 'catalog:'
+        version: 0.2.1
       html-rspack-plugin:
         specifier: 'catalog:'
         version: 6.1.9(@rspack/core@2.1.2)
@@ -3851,6 +3857,10 @@ packages:
 
   flexsearch@0.8.212:
     resolution: {integrity: sha512-wSyJr1GUWoOOIISRu+X2IXiOcVfg9qqBRyCPRUdLMIGJqPzMo+jMRlvE83t14v1j0dRMEaBbER/adQjp6Du2pw==}
+
+  fresh-import@0.2.1:
+    resolution: {integrity: sha512-fwvkgwvZ60xFe0FQ5nynh9mgayR5HY0e0rzPs2cDiGhrOo7N8ARyMHP0Ew7bUFe7QAaZmouphLnCoJKAe6dTog==}
+    engines: {node: ^20.19.0 || >=22.12.0}
 
   fs-extra@11.3.5:
     resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
@@ -7983,6 +7993,8 @@ snapshots:
       path-exists: 4.0.0
 
   flexsearch@0.8.212: {}
+
+  fresh-import@0.2.1: {}
 
   fs-extra@11.3.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -81,6 +81,7 @@ catalog:
   'deepmerge': '^4.3.1'
   'dotenv-expand': '^13.0.0'
   'fast-glob': '^3.3.3'
+  'fresh-import': '^0.2.1'
   'fs-extra': '^11.3.5'
   'heading-case': '^1.1.3'
   'hono': '^4.12.27'


### PR DESCRIPTION
## Summary

This PR adds native config dependency tracking so the CLI reload-server watcher can restart when a statically imported config dependency changes. It uses `fresh-import` for dependency collection in the native config loader path and falls back to regular dynamic import when dependency collection is unavailable.

Credits to sapphi-red, author of [fresh-import](https://github.com/sapphi-red/fresh-import), for the dependency collection approach.

## Related Links

- https://github.com/sapphi-red/fresh-import