### PR TITLE
feat(core): support custom argv in runCLI

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -72,7 +72,7 @@ const applyServerOptions = (command: Command) => {
     .option('--host [host]', 'Set the host that the server listens to');
 };
 
-export function setupCommands(): void {
+export function setupCommands(argv: string[]): void {
   const cli = cac('rsbuild');
 
   cli.version(RSBUILD_VERSION);
@@ -224,5 +224,5 @@ export function setupCommands(): void {
     }
   });
 
-  cli.parse();
+  cli.parse(argv);
 }

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -2,7 +2,13 @@ import { defaultLogger, isDebug } from '../logger';
 import type { LogLevel } from '../types';
 import { setupCommands } from './commands';
 
-const { argv } = process;
+export type RunCLIOptions = {
+  /**
+   * The command line arguments to parse.
+   * @default process.argv
+   */
+  argv?: string[];
+};
 
 function initNodeEnv(command: string | undefined) {
   if (!process.env.NODE_ENV) {
@@ -24,29 +30,29 @@ function showGreeting() {
 }
 
 // ensure log level is set before any log is printed
-function setupLogLevel() {
+function setupLogLevel(argv: string[]) {
   if (argv.length <= 3) {
     return;
   }
 
   const logLevelIndex = argv.findIndex((item) => item === '--log-level' || item === '--logLevel');
   if (logLevelIndex !== -1) {
-    const level = process.argv[logLevelIndex + 1];
+    const level = argv[logLevelIndex + 1];
     if (level && ['warn', 'error', 'silent'].includes(level) && !isDebug()) {
       defaultLogger.level = level as LogLevel;
     }
   }
 }
 
-export function runCLI(): void {
+export function runCLI({ argv = process.argv }: RunCLIOptions = {}): void {
   const command = argv[2];
 
   initNodeEnv(command);
-  setupLogLevel();
+  setupLogLevel(argv);
   showGreeting();
 
   try {
-    setupCommands();
+    setupCommands(argv);
   } catch (err) {
     defaultLogger.error('Failed to start Rsbuild CLI.');
     defaultLogger.error(err);

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -4,7 +4,7 @@ import { setupCommands } from './commands';
 
 export type RunCLIOptions = {
   /**
-   * The command line arguments to parse.
+   * The command-line arguments to parse, matching the shape of Node.js `process.argv`
    * @default process.argv
    */
   argv?: string[];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,7 +6,7 @@
 import type * as Rspack from '@rspack/core';
 import { rspack } from '@rspack/core';
 
-export { runCLI } from './cli';
+export { type RunCLIOptions, runCLI } from './cli';
 export { createRsbuild } from './createRsbuild';
 export {
   type ConfigParams,


### PR DESCRIPTION
## Summary

This PR adds a `RunCLIOptions` parameter so programmatic callers can run `runCLI({ argv })` with isolated CLI arguments while preserving `process.argv` as the default. The CLI now uses the provided argv for early log-level detection and `cac` parsing without changing `loadConfig`.