### PR TITLE
feat(core): add loadConfig command option

### DIFF
--- a/e2e/cases/javascript-api/load-config/index.test.ts
+++ b/e2e/cases/javascript-api/load-config/index.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from '@e2e/helper';
+import { loadConfig } from '@rsbuild/core';
+
+test('should pass command to config function', async () => {
+  const { content } = await loadConfig({
+    cwd: import.meta.dirname,
+    command: 'build',
+  });
+
+  expect(content.source?.define).toEqual({
+    COMMAND: JSON.stringify('build'),
+  });
+});

--- a/e2e/cases/javascript-api/load-config/rsbuild.config.ts
+++ b/e2e/cases/javascript-api/load-config/rsbuild.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig(({ command }) => ({
+  source: {
+    define: {
+      COMMAND: JSON.stringify(command),
+    },
+  },
+}));

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -95,6 +95,7 @@ export function setupCommands(argv: string[]): void {
     try {
       const rsbuild = await init({
         cliOptions: options,
+        argv,
       });
       if (!rsbuild) {
         return;
@@ -120,6 +121,7 @@ export function setupCommands(argv: string[]): void {
         const rsbuild = await init({
           cliOptions: options,
           isBuildWatch: options.watch,
+          argv,
         });
         if (!rsbuild) {
           return;
@@ -153,6 +155,7 @@ export function setupCommands(argv: string[]): void {
     try {
       const rsbuild = await init({
         cliOptions: options,
+        argv,
       });
 
       if (!rsbuild) {
@@ -175,6 +178,7 @@ export function setupCommands(argv: string[]): void {
       try {
         const rsbuild = await init({
           cliOptions: options,
+          argv,
         });
 
         if (!rsbuild) {

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -5,7 +5,7 @@ import type { ConfigLoader } from '../loadConfig';
 import { defaultLogger } from '../logger';
 import { onBeforeRestartServer } from '../restart';
 import type { LogLevel, RsbuildMode } from '../types';
-import { init } from './init';
+import { init, setCliState } from './init';
 
 export type CommonOptions = {
   base?: string;
@@ -92,11 +92,9 @@ export function setupCommands(argv: string[]): void {
   let logger = defaultLogger;
 
   devCommand.action(async (options: DevOptions) => {
+    setCliState(argv, options);
     try {
-      const rsbuild = await init({
-        cliOptions: options,
-        argv,
-      });
+      const rsbuild = await init();
       if (!rsbuild) {
         return;
       }
@@ -113,15 +111,14 @@ export function setupCommands(argv: string[]): void {
   buildCommand
     .option('-w, --watch', 'Enable watch mode to automatically rebuild on file changes')
     .action(async (options: BuildOptions) => {
+      setCliState(argv, options);
       try {
         if (!options.watch) {
           process.env.RSPACK_UNSAFE_FAST_DROP = 'true';
         }
 
         const rsbuild = await init({
-          cliOptions: options,
           isBuildWatch: options.watch,
-          argv,
         });
         if (!rsbuild) {
           return;
@@ -152,11 +149,9 @@ export function setupCommands(argv: string[]): void {
     });
 
   previewCommand.action(async (options: PreviewOptions) => {
+    setCliState(argv, options);
     try {
-      const rsbuild = await init({
-        cliOptions: options,
-        argv,
-      });
+      const rsbuild = await init();
 
       if (!rsbuild) {
         return;
@@ -175,11 +170,9 @@ export function setupCommands(argv: string[]): void {
     .option('--output <output>', 'Set the output path for inspection results')
     .option('--verbose', 'Show complete function definitions in output')
     .action(async (options: InspectOptions) => {
+      setCliState(argv, options);
       try {
-        const rsbuild = await init({
-          cliOptions: options,
-          argv,
-        });
+        const rsbuild = await init();
 
         if (!rsbuild) {
           return;

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -8,7 +8,8 @@ import { watchFilesForRestart } from '../restart';
 import type { RsbuildInstance } from '../types';
 import type { CommonOptions } from './commands';
 
-let commonOpts: CommonOptions = {};
+let cliOptions: CommonOptions = {};
+let argv: string[] | undefined;
 
 const getEnvDir = (cwd: string, envDir?: string) => {
   if (envDir) {
@@ -24,59 +25,60 @@ const loadConfig = async (root: string) => {
     dependencies,
   } = await baseLoadConfig({
     cwd: root,
-    path: commonOpts.config,
-    envMode: commonOpts.envMode,
-    loader: commonOpts.configLoader,
+    path: cliOptions.config,
+    envMode: cliOptions.envMode,
+    loader: cliOptions.configLoader,
+    command: argv?.[2],
   });
 
   config.dev ||= {};
   config.source ||= {};
   config.server ||= {};
 
-  if (commonOpts.base) {
-    config.server.base = commonOpts.base;
+  if (cliOptions.base) {
+    config.server.base = cliOptions.base;
   }
 
-  if (commonOpts.root) {
+  if (cliOptions.root) {
     config.root = root;
   }
 
-  if (commonOpts.mode) {
-    config.mode = commonOpts.mode;
+  if (cliOptions.mode) {
+    config.mode = cliOptions.mode;
   }
 
-  if (commonOpts.logLevel) {
-    config.logLevel = commonOpts.logLevel;
+  if (cliOptions.logLevel) {
+    config.logLevel = cliOptions.logLevel;
   }
 
-  if (commonOpts.open && !config.server?.open) {
-    config.server.open = commonOpts.open;
+  if (cliOptions.open && !config.server?.open) {
+    config.server.open = cliOptions.open;
   }
 
-  if (commonOpts.host !== undefined) {
-    config.server.host = commonOpts.host;
+  if (cliOptions.host !== undefined) {
+    config.server.host = cliOptions.host;
   }
 
-  if (commonOpts.port) {
-    config.server.port = commonOpts.port;
+  if (cliOptions.port) {
+    config.server.port = cliOptions.port;
   }
 
-  if (commonOpts.strictPort !== undefined) {
-    config.server.strictPort = commonOpts.strictPort;
+  if (cliOptions.strictPort !== undefined) {
+    config.server.strictPort = cliOptions.strictPort;
   }
 
-  if (commonOpts.distPath !== undefined) {
+  if (cliOptions.distPath !== undefined) {
     config.output ||= {};
 
     const { distPath } = config.output;
     config.output.distPath =
       distPath && typeof distPath === 'object'
-        ? { ...distPath, root: commonOpts.distPath }
-        : { root: commonOpts.distPath };
+        ? { ...distPath, root: cliOptions.distPath }
+        : { root: cliOptions.distPath };
   }
 
-  if (commonOpts.sourceMap !== undefined) {
-    const sourceMap = commonOpts.sourceMap as unknown;
+  if (cliOptions.sourceMap !== undefined) {
+    const sourceMap = cliOptions.sourceMap as unknown;
 
     if (typeof sourceMap !== 'boolean') {
       throw new Error('The "--source-map" option only accepts a boolean value.');
@@ -106,39 +108,45 @@ const loadConfig = async (root: string) => {
 };
 
 export async function init({
-  cliOptions,
+  cliOptions: currentCliOptions,
   isRestart,
   isBuildWatch = false,
+  argv: currentArgv,
 }: {
   cliOptions?: CommonOptions;
   isRestart?: boolean;
   isBuildWatch?: boolean;
+  argv?: string[];
 }): Promise<RsbuildInstance | undefined> {
-  if (cliOptions) {
-    commonOpts = cliOptions;
+  if (currentCliOptions) {
+    cliOptions = currentCliOptions;
+  }
+
+  if (currentArgv) {
+    argv = currentArgv;
   }
 
   // Build multiple environments can be shortened to: --environment name1,name2
-  if (commonOpts.environment?.some((env) => env.includes(','))) {
-    commonOpts.environment = commonOpts.environment.flatMap((env) => env.split(','));
+  if (cliOptions.environment?.some((env) => env.includes(','))) {
+    cliOptions.environment = cliOptions.environment.flatMap((env) => env.split(','));
   }
 
   let logger = defaultLogger;
 
   try {
     const cwd = process.cwd();
-    const root = commonOpts.root ? ensureAbsolutePath(cwd, commonOpts.root) : cwd;
+    const root = cliOptions.root ? ensureAbsolutePath(cwd, cliOptions.root) : cwd;
 
     const rsbuild = await createRsbuild({
       cwd: root,
       config: () => loadConfig(root),
-      environment: commonOpts.environment,
+      environment: cliOptions.environment,
       loadEnv:
-        commonOpts.env === false
+        cliOptions.env === false
           ? false
           : {
-              cwd: getEnvDir(root, commonOpts.envDir),
-              mode: commonOpts.envMode,
+              cwd: getEnvDir(root, cliOptions.envDir),
+              mode: cliOptions.envMode,
             },
     });
     logger = rsbuild.logger;

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -8,8 +8,19 @@ import { watchFilesForRestart } from '../restart';
 import type { RsbuildInstance } from '../types';
 import type { CommonOptions } from './commands';
 
-let cliOptions: CommonOptions = {};
-let argv: string[] | undefined;
+const cliState = {
+  options: {} as CommonOptions,
+  argv: process.argv,
+};
+
+export const setCliState = (argv: string[], options: CommonOptions): void => {
+  // Build multiple environments can be shortened to: --environment name1,name2
+  if (options.environment?.some((env) => env.includes(','))) {
+    options.environment = options.environment.flatMap((env) => env.split(','));
+  }
+  cliState.argv = argv;
+  cliState.options = options;
+};
 
 const getEnvDir = (cwd: string, envDir?: string) => {
   if (envDir) {
@@ -19,66 +30,67 @@ const getEnvDir = (cwd: string, envDir?: string) => {
 };
 
 const loadConfig = async (root: string) => {
+  const { options, argv } = cliState;
   const {
     content: config,
     filePath,
     dependencies,
   } = await baseLoadConfig({
     cwd: root,
-    path: cliOptions.config,
-    envMode: cliOptions.envMode,
-    loader: cliOptions.configLoader,
-    command: argv?.[2],
+    path: options.config,
+    envMode: options.envMode,
+    loader: options.configLoader,
+    command: argv[2],
   });
 
   config.dev ||= {};
   config.source ||= {};
   config.server ||= {};
 
-  if (cliOptions.base) {
-    config.server.base = cliOptions.base;
+  if (options.base) {
+    config.server.base = options.base;
   }
 
-  if (cliOptions.root) {
+  if (options.root) {
     config.root = root;
   }
 
-  if (cliOptions.mode) {
-    config.mode = cliOptions.mode;
+  if (options.mode) {
+    config.mode = options.mode;
   }
 
-  if (cliOptions.logLevel) {
-    config.logLevel = cliOptions.logLevel;
+  if (options.logLevel) {
+    config.logLevel = options.logLevel;
   }
 
-  if (cliOptions.open && !config.server?.open) {
-    config.server.open = cliOptions.open;
+  if (options.open && !config.server?.open) {
+    config.server.open = options.open;
   }
 
-  if (cliOptions.host !== undefined) {
-    config.server.host = cliOptions.host;
+  if (options.host !== undefined) {
+    config.server.host = options.host;
   }
 
-  if (cliOptions.port) {
-    config.server.port = cliOptions.port;
+  if (options.port) {
+    config.server.port = options.port;
   }
 
-  if (cliOptions.strictPort !== undefined) {
-    config.server.strictPort = cliOptions.strictPort;
+  if (options.strictPort !== undefined) {
+    config.server.strictPort = options.strictPort;
   }
 
-  if (cliOptions.distPath !== undefined) {
+  if (options.distPath !== undefined) {
     config.output ||= {};
 
     const { distPath } = config.output;
     config.output.distPath =
       distPath && typeof distPath === 'object'
-        ? { ...distPath, root: cliOptions.distPath }
-        : { root: cliOptions.distPath };
+        ? { ...distPath, root: options.distPath }
+        : { root: options.distPath };
   }
 
-  if (cliOptions.sourceMap !== undefined) {
-    const sourceMap = cliOptions.sourceMap as unknown;
+  if (options.sourceMap !== undefined) {
+    const sourceMap = options.sourceMap as unknown;
 
     if (typeof sourceMap !== 'boolean') {
       throw new Error('The "--source-map" option only accepts a boolean value.');
@@ -108,45 +120,29 @@ const loadConfig = async (root: string) => {
 };
 
 export async function init({
-  cliOptions: currentCliOptions,
   isRestart,
   isBuildWatch = false,
-  argv: currentArgv,
 }: {
-  cliOptions?: CommonOptions;
   isRestart?: boolean;
   isBuildWatch?: boolean;
-  argv?: string[];
-}): Promise<RsbuildInstance | undefined> {
-  if (currentCliOptions) {
-    cliOptions = currentCliOptions;
-  }
-
-  if (currentArgv) {
-    argv = currentArgv;
-  }
-
-  // Build multiple environments can be shortened to: --environment name1,name2
-  if (cliOptions.environment?.some((env) => env.includes(','))) {
-    cliOptions.environment = cliOptions.environment.flatMap((env) => env.split(','));
-  }
-
+} = {}): Promise<RsbuildInstance | undefined> {
   let logger = defaultLogger;
+  const { options } = cliState;
 
   try {
     const cwd = process.cwd();
-    const root = cliOptions.root ? ensureAbsolutePath(cwd, cliOptions.root) : cwd;
+    const root = options.root ? ensureAbsolutePath(cwd, options.root) : cwd;
 
     const rsbuild = await createRsbuild({
       cwd: root,
       config: () => loadConfig(root),
-      environment: cliOptions.environment,
+      environment: options.environment,
       loadEnv:
-        cliOptions.env === false
+        options.env === false
           ? false
           : {
-              cwd: getEnvDir(root, cliOptions.envDir),
-              mode: cliOptions.envMode,
+              cwd: getEnvDir(root, options.envDir),
+              mode: options.envMode,
             },
     });
     logger = rsbuild.logger;

--- a/packages/core/src/loadConfig.ts
+++ b/packages/core/src/loadConfig.ts
@@ -46,6 +46,11 @@ export type LoadConfigOptions = {
    * @default 'auto'
    */
   loader?: ConfigLoader;
+  /**
+   * The command passed to the config function.
+   * @default process.argv[2]
+   */
+  command?: string;
 };
 
 export type LoadConfigResult = {
@@ -154,6 +159,7 @@ export async function loadConfig({
   envMode,
   meta,
   loader = 'auto',
+  command,
 }: LoadConfigOptions = {}): Promise<LoadConfigResult> {
   const configFilePath = resolveConfigPath(cwd, path);
 
@@ -219,11 +225,10 @@ export async function loadConfig({
   }
 
   if (typeof configExport === 'function') {
-    const command = process.argv[2];
     const nodeEnv = getNodeEnv();
     const configParams: ConfigParams = {
       env: nodeEnv,
-      command,
+      command: command ?? process.argv[2],
       envMode: envMode || nodeEnv,
       meta,
     };

--- a/website/docs/en/api/javascript-api/core.mdx
+++ b/website/docs/en/api/javascript-api/core.mdx
@@ -140,6 +140,11 @@ function loadConfig(params?: {
   meta?: Record<string, unknown>;
   envMode?: string;
   /**
+   * The command passed to the config function.
+   * @default process.argv[2]
+   */
+  command?: string;
+  /**
    * Specify the config loader, can be `auto`, `jiti` or `native`.
    * - 'auto': Use native Node.js loader first, fallback to jiti if failed
    * - 'jiti': Use jiti as loader, which supports TypeScript and ESM out of the box
@@ -216,6 +221,18 @@ In the `defineConfig` configuration function, you can access the `foo` variable 
 export default defineConfig(({ meta }) => {
   console.log(meta.foo); // bar
   return config;
+});
+```
+
+### Passing command
+
+By default, `loadConfig` passes `process.argv[2]` as the `command` value to the config function. Use the `command` option to explicitly set this value.
+
+```ts
+import { loadConfig } from '@rsbuild/core';
+
+const { content } = await loadConfig({
+  command: 'build',
 });
 ```
 

--- a/website/docs/zh/api/javascript-api/core.mdx
+++ b/website/docs/zh/api/javascript-api/core.mdx
@@ -140,6 +140,11 @@ function loadConfig(params?: {
   meta?: Record<string, unknown>;
   envMode?: string;
   /**
+   * 传给配置函数的 command 参数。
+   * @default process.argv[2]
+   */
+  command?: string;
+  /**
    * 指定配置文件加载器，可选值为 `auto`、`jiti` 或 `native`。
    * - `auto`：优先使用 Node.js 原生加载器，若加载失败则回退到 jiti
    * - `jiti`：使用 jiti 作为加载器，开箱即用地支持 TypeScript 和 ESM
@@ -216,6 +221,18 @@ const { content } = await loadConfig({
 export default defineConfig(({ meta }) => {
   console.log(meta.foo); // bar
   return config;
+});
+```
+
+### 传入 command
+
+默认情况下，`loadConfig` 会将 `process.argv[2]` 作为 `command` 传给配置函数。你可以通过 `command` 选项显式设置该值。
+
+```ts
+import { loadConfig } from '@rsbuild/core';
+
+const { content } = await loadConfig({
+  command: 'build',
 });
 ```
 


### PR DESCRIPTION
## Summary

This PR adds a `command` option to `loadConfig` so callers can control the `command` value passed to config functions without conflicting with existing `meta` and `envMode` options. The Rsbuild CLI forwards the command parsed from `argv` into `loadConfig`, and docs plus a JavaScript API e2e case cover the new behavior.