### PR TITLE
feat(core): support Helium browser

### DIFF
--- a/packages/core/src/server/open.ts
+++ b/packages/core/src/server/open.ts
@@ -17,6 +17,7 @@ const supportedChromiumBrowsers = [
   'Brave Browser',
   'Vivaldi',
   'Chromium',
+  'Helium',
 ];
 
 /**

--- a/website/docs/en/config/server/open.mdx
+++ b/website/docs/en/config/server/open.mdx
@@ -152,6 +152,7 @@ The following are the browser names supported by AppleScript:
 - Brave Browser
 - Vivaldi
 - Chromium
+- Helium
 
 For example:
 

--- a/website/docs/zh/config/server/open.mdx
+++ b/website/docs/zh/config/server/open.mdx
@@ -152,6 +152,7 @@ BROWSER=chrome BROWSER_ARGS="--incognito" npx rsbuild
 - Brave Browser
 - Vivaldi
 - Chromium
+- Helium
 
 比如：
 


### PR DESCRIPTION
## Summary

Add Helium to the list of Chromium browsers that can use Rsbuild's macOS AppleScript open flow.

I noticed this after moving to Helium: `rsbuild --open` opened a new tab each time instead of reusing the existing dev server tab.

This lets Helium users reuse an existing dev server tab when Rsbuild opens the browser through the macOS AppleScript path.

## Related Links

- Helium website: https://helium.computer/
