### PR TITLE
fix(core): parse command after global options

### DIFF
--- a/e2e/cases/cli/function-config/index.test.ts
+++ b/e2e/cases/cli/function-config/index.test.ts
@@ -32,3 +32,11 @@ test('should specify env mode as expected', async ({ execCliSync }) => {
   const content = getFileContent(files, 'index.js');
   expect(content.includes('production-staging-build')).toBeTruthy();
 });
+
+test('should allow global options before build command', async ({ execCliSync }) => {
+  await fse.remove(distDir);
+  execCliSync('--env-mode staging build');
+  const files = await readDirContents(distDir);
+  const content = getFileContent(files, 'index.js');
+  expect(content.includes('production-staging-build')).toBeTruthy();
+});

--- a/e2e/cases/cli/function-config/index.test.ts
+++ b/e2e/cases/cli/function-config/index.test.ts
@@ -33,10 +33,10 @@ test('should specify env mode as expected', async ({ execCliSync }) => {
   expect(content.includes('production-staging-build')).toBeTruthy();
 });
 
-test('should allow global options before build command', async ({ execCliSync }) => {
+test('should parse build command after global option values', async ({ execCliSync }) => {
   await fse.remove(distDir);
-  execCliSync('--env-mode staging build');
+  execCliSync('--env-mode inspect build');
   const files = await readDirContents(distDir);
   const content = getFileContent(files, 'index.js');
-  expect(content.includes('production-staging-build')).toBeTruthy();
+  expect(content.includes('production-inspect-build')).toBeTruthy();
 });

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -5,7 +5,7 @@ import type { ConfigLoader } from '../loadConfig';
 import { defaultLogger } from '../logger';
 import { onBeforeRestartServer } from '../restart';
 import type { LogLevel, RsbuildMode } from '../types';
-import { init, setCliState } from './init';
+import { init, setCliOptions } from './init';
 
 export type CommonOptions = {
   base?: string;
@@ -92,7 +92,7 @@ export function setupCommands(argv: string[]): void {
   let logger = defaultLogger;
 
   devCommand.action(async (options: DevOptions) => {
-    setCliState(argv, options);
+    setCliOptions(options);
     try {
       const rsbuild = await init();
       if (!rsbuild) {
@@ -111,7 +111,7 @@ export function setupCommands(argv: string[]): void {
   buildCommand
     .option('-w, --watch', 'Enable watch mode to automatically rebuild on file changes')
     .action(async (options: BuildOptions) => {
-      setCliState(argv, options);
+      setCliOptions(options);
       try {
         if (!options.watch) {
           process.env.RSPACK_UNSAFE_FAST_DROP = 'true';
@@ -149,7 +149,7 @@ export function setupCommands(argv: string[]): void {
     });
 
   previewCommand.action(async (options: PreviewOptions) => {
-    setCliState(argv, options);
+    setCliOptions(options);
     try {
       const rsbuild = await init();
 
@@ -170,7 +170,7 @@ export function setupCommands(argv: string[]): void {
     .option('--output <output>', 'Set the output path for inspection results')
     .option('--verbose', 'Show complete function definitions in output')
     .action(async (options: InspectOptions) => {
-      setCliState(argv, options);
+      setCliOptions(options);
       try {
         const rsbuild = await init();
 

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -5,7 +5,7 @@ import type { ConfigLoader } from '../loadConfig';
 import { defaultLogger } from '../logger';
 import { onBeforeRestartServer } from '../restart';
 import type { LogLevel, RsbuildMode } from '../types';
-import { init, setCliOptions } from './init';
+import { init, setCliOptions, setCommand } from './init';
 
 export type CommonOptions = {
   base?: string;
@@ -72,6 +72,13 @@ const applyServerOptions = (command: Command) => {
     .option('--host [host]', 'Set the host that the server listens to');
 };
 
+function initNodeEnv(command: string) {
+  if (!process.env.NODE_ENV) {
+    process.env.NODE_ENV =
+      command === 'build' || command === 'preview' ? 'production' : 'development';
+  }
+}
+
 export function setupCommands(argv: string[]): void {
   const cli = cac('rsbuild');
 
@@ -92,6 +99,8 @@ export function setupCommands(argv: string[]): void {
   let logger = defaultLogger;
 
   devCommand.action(async (options: DevOptions) => {
+    initNodeEnv('dev');
+    setCommand('dev');
     setCliOptions(options);
     try {
       const rsbuild = await init();
@@ -111,6 +120,8 @@ export function setupCommands(argv: string[]): void {
   buildCommand
     .option('-w, --watch', 'Enable watch mode to automatically rebuild on file changes')
     .action(async (options: BuildOptions) => {
+      initNodeEnv('build');
+      setCommand('build');
       setCliOptions(options);
       try {
         if (!options.watch) {
@@ -149,6 +160,8 @@ export function setupCommands(argv: string[]): void {
     });
 
   previewCommand.action(async (options: PreviewOptions) => {
+    initNodeEnv('preview');
+    setCommand('preview');
     setCliOptions(options);
     try {
       const rsbuild = await init();
@@ -170,6 +183,8 @@ export function setupCommands(argv: string[]): void {
     .option('--output <output>', 'Set the output path for inspection results')
     .option('--verbose', 'Show complete function definitions in output')
     .action(async (options: InspectOptions) => {
+      initNodeEnv('inspect');
+      setCommand('inspect');
       setCliOptions(options);
       try {
         const rsbuild = await init();

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -5,7 +5,7 @@ import type { ConfigLoader } from '../loadConfig';
 import { defaultLogger } from '../logger';
 import { onBeforeRestartServer } from '../restart';
 import type { LogLevel, RsbuildMode } from '../types';
-import { init, setCliOptions, setCommand } from './init';
+import { init, initCliAction } from './init';
 
 export type CommonOptions = {
   base?: string;
@@ -72,13 +72,6 @@ const applyServerOptions = (command: Command) => {
     .option('--host [host]', 'Set the host that the server listens to');
 };
 
-function initNodeEnv(command: string) {
-  if (!process.env.NODE_ENV) {
-    process.env.NODE_ENV =
-      command === 'build' || command === 'preview' ? 'production' : 'development';
-  }
-}
-
 export function setupCommands(argv: string[]): void {
   const cli = cac('rsbuild');
 
@@ -99,9 +92,7 @@ export function setupCommands(argv: string[]): void {
   let logger = defaultLogger;
 
   devCommand.action(async (options: DevOptions) => {
-    initNodeEnv('dev');
-    setCommand('dev');
-    setCliOptions(options);
+    initCliAction('dev', options);
     try {
       const rsbuild = await init();
       if (!rsbuild) {
@@ -120,9 +111,7 @@ export function setupCommands(argv: string[]): void {
   buildCommand
     .option('-w, --watch', 'Enable watch mode to automatically rebuild on file changes')
     .action(async (options: BuildOptions) => {
-      initNodeEnv('build');
-      setCommand('build');
-      setCliOptions(options);
+      initCliAction('build', options);
       try {
         if (!options.watch) {
           process.env.RSPACK_UNSAFE_FAST_DROP = 'true';
@@ -160,9 +149,7 @@ export function setupCommands(argv: string[]): void {
     });
 
   previewCommand.action(async (options: PreviewOptions) => {
-    initNodeEnv('preview');
-    setCommand('preview');
-    setCliOptions(options);
+    initCliAction('preview', options);
     try {
       const rsbuild = await init();
 
@@ -183,9 +170,7 @@ export function setupCommands(argv: string[]): void {
     .option('--output <output>', 'Set the output path for inspection results')
     .option('--verbose', 'Show complete function definitions in output')
     .action(async (options: InspectOptions) => {
-      initNodeEnv('inspect');
-      setCommand('inspect');
-      setCliOptions(options);
+      initCliAction('inspect', options);
       try {
         const rsbuild = await init();
 

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -1,7 +1,6 @@
 import { defaultLogger, isDebug } from '../logger';
 import type { LogLevel } from '../types';
 import { setupCommands } from './commands';
-import { setCommand } from './init';
 
 export type RunCLIOptions = {
   /**
@@ -10,13 +9,6 @@ export type RunCLIOptions = {
    */
   argv?: string[];
 };
-
-function initNodeEnv(command: string | undefined) {
-  if (!process.env.NODE_ENV) {
-    process.env.NODE_ENV =
-      command === 'build' || command === 'preview' ? 'production' : 'development';
-  }
-}
 
 function showGreeting() {
   // Ensure consistent spacing before the greeting message.
@@ -45,22 +37,7 @@ function setupLogLevel(argv: string[]) {
   }
 }
 
-function parseCommand(argv: string[]): string {
-  const commandNames = ['build', 'preview', 'inspect'];
-  for (let i = 2; i < argv.length; i++) {
-    const command = argv[i];
-    if (command && commandNames.includes(command)) {
-      return command;
-    }
-  }
-  return 'dev';
-}
-
 export function runCLI({ argv = process.argv }: RunCLIOptions = {}): void {
-  const command = parseCommand(argv);
-
-  initNodeEnv(command);
-  setCommand(command);
   setupLogLevel(argv);
   showGreeting();
 

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -1,6 +1,7 @@
 import { defaultLogger, isDebug } from '../logger';
 import type { LogLevel } from '../types';
 import { setupCommands } from './commands';
+import { setCommand } from './init';
 
 export type RunCLIOptions = {
   /**
@@ -44,10 +45,22 @@ function setupLogLevel(argv: string[]) {
   }
 }
 
+function parseCommand(argv: string[]): string {
+  const commandNames = ['build', 'preview', 'inspect'];
+  for (let i = 2; i < argv.length; i++) {
+    const command = argv[i];
+    if (command && commandNames.includes(command)) {
+      return command;
+    }
+  }
+  return 'dev';
+}
+
 export function runCLI({ argv = process.argv }: RunCLIOptions = {}): void {
-  const command = argv[2];
+  const command = parseCommand(argv);
 
   initNodeEnv(command);
+  setCommand(command);
   setupLogLevel(argv);
   showGreeting();
 

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -8,12 +8,14 @@ import { watchFilesForRestart } from '../restart';
 import type { RsbuildInstance } from '../types';
 import type { CommonOptions } from './commands';
 
-const cliState = {
-  options: {} as CommonOptions,
-  command: '',
-};
+export type CommandName = 'dev' | 'build' | 'preview' | 'inspect';
 
-type CommandName = 'dev' | 'build' | 'preview' | 'inspect';
+const cliState: {
+  options: CommonOptions;
+  command?: CommandName;
+} = {
+  options: {} as CommonOptions,
+};
 
 export const initCliAction = (command: CommandName, options: CommonOptions): void => {
   if (!process.env.NODE_ENV) {

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -10,16 +10,19 @@ import type { CommonOptions } from './commands';
 
 const cliState = {
   options: {} as CommonOptions,
-  argv: process.argv,
+  command: '',
 };
 
-export const setCliState = (argv: string[], options: CommonOptions): void => {
+export const setCliOptions = (options: CommonOptions): void => {
   // Build multiple environments can be shortened to: --environment name1,name2
   if (options.environment?.some((env) => env.includes(','))) {
     options.environment = options.environment.flatMap((env) => env.split(','));
   }
-  cliState.argv = argv;
   cliState.options = options;
+};
+
+export const setCommand = (command: string): void => {
+  cliState.command = command;
 };
 
 const getEnvDir = (cwd: string, envDir?: string) => {
@@ -30,7 +33,7 @@ const getEnvDir = (cwd: string, envDir?: string) => {
 };
 
 const loadConfig = async (root: string) => {
-  const { options, argv } = cliState;
+  const { options, command } = cliState;
   const {
     content: config,
     filePath,
@@ -40,7 +43,7 @@ const loadConfig = async (root: string) => {
     path: options.config,
     envMode: options.envMode,
     loader: options.configLoader,
-    command: argv[2],
+    command,
   });
 
   config.dev ||= {};

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -13,16 +13,21 @@ const cliState = {
   command: '',
 };
 
-export const setCliOptions = (options: CommonOptions): void => {
+type CommandName = 'dev' | 'build' | 'preview' | 'inspect';
+
+export const initCliAction = (command: CommandName, options: CommonOptions): void => {
+  if (!process.env.NODE_ENV) {
+    process.env.NODE_ENV =
+      command === 'build' || command === 'preview' ? 'production' : 'development';
+  }
+
   // Build multiple environments can be shortened to: --environment name1,name2
   if (options.environment?.some((env) => env.includes(','))) {
     options.environment = options.environment.flatMap((env) => env.split(','));
   }
-  cliState.options = options;
-};
 
-export const setCommand = (command: string): void => {
   cliState.command = command;
+  cliState.options = options;
 };
 
 const getEnvDir = (cwd: string, envDir?: string) => {


### PR DESCRIPTION
## Summary

This PR fixes CLI command detection when global options are placed before the command, such as `rsbuild --env-mode staging build`. The parsed command is stored in CLI state before loading the config, so config functions receive `command: 'build'` instead of the leading option name.