### PR TITLE
feat(core): export config definition types

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,9 @@ export {
   defineConfig,
   type LoadConfigOptions,
   type LoadConfigResult,
+  type RsbuildConfigAsyncFn,
+  type RsbuildConfigDefinition,
+  type RsbuildConfigSyncFn,
   loadConfig,
 } from './loadConfig';
 // Core methods

--- a/packages/core/src/loadConfig.ts
+++ b/packages/core/src/loadConfig.ts
@@ -16,7 +16,7 @@ export type RsbuildConfigAsyncFn = (env: ConfigParams) => Promise<RsbuildConfig>
 
 export type RsbuildConfigSyncFn = (env: ConfigParams) => RsbuildConfig;
 
-export type RsbuildConfigExport = RsbuildConfig | RsbuildConfigSyncFn | RsbuildConfigAsyncFn;
+export type RsbuildConfigDefinition = RsbuildConfig | RsbuildConfigSyncFn | RsbuildConfigAsyncFn;
 
 export type LoadConfigOptions = {
   /**
@@ -77,8 +77,8 @@ export type LoadConfigResult = {
 export function defineConfig(config: RsbuildConfig): RsbuildConfig;
 export function defineConfig(config: RsbuildConfigSyncFn): RsbuildConfigSyncFn;
 export function defineConfig(config: RsbuildConfigAsyncFn): RsbuildConfigAsyncFn;
-export function defineConfig(config: RsbuildConfigExport): RsbuildConfigExport;
-export function defineConfig(config: RsbuildConfigExport) {
+export function defineConfig(config: RsbuildConfigDefinition): RsbuildConfigDefinition;
+export function defineConfig(config: RsbuildConfigDefinition) {
   return config;
 }
 
@@ -115,10 +115,10 @@ const resolveConfigPath = (root: string, customConfig?: string) => {
 
 export type ConfigLoader = 'auto' | 'jiti' | 'native';
 
-const getConfigExport = (module: unknown): RsbuildConfigExport =>
+const getConfigExport = (module: unknown): RsbuildConfigDefinition =>
   (module && typeof module === 'object' && 'default' in module
     ? module.default
-    : module) as RsbuildConfigExport;
+    : module) as RsbuildConfigDefinition;
 
 const tryFreshImport = async (configFileURL: string) => {
   try {
@@ -133,7 +133,7 @@ const tryFreshImport = async (configFileURL: string) => {
 const loadConfigWithNative = async (
   configFilePath: string,
 ): Promise<{
-  configExport: RsbuildConfigExport;
+  configExport: RsbuildConfigDefinition;
   dependencies: string[];
 }> => {
   const configFileURL = pathToFileURL(configFilePath).href;
@@ -179,7 +179,7 @@ export async function loadConfig({
     return config;
   };
 
-  let configExport: RsbuildConfigExport | undefined;
+  let configExport: RsbuildConfigDefinition | undefined;
 
   // Determine the loading strategy based on the config loader type
   const useNative = Boolean(
@@ -215,7 +215,7 @@ export async function loadConfig({
         nativeModules: ['typescript'],
       });
 
-      configExport = await jiti.import<RsbuildConfigExport>(configFilePath, {
+      configExport = await jiti.import<RsbuildConfigDefinition>(configFilePath, {
         default: true,
       });
     } catch (err) {


### PR DESCRIPTION
## Summary

This PR renames the config definition union type from `RsbuildConfigExport` to `RsbuildConfigDefinition` so the type better describes both config-file exports and values passed to `defineConfig`. It also exports `RsbuildConfigDefinition`, `RsbuildConfigSyncFn`, and `RsbuildConfigAsyncFn` from the `@rsbuild/core` entry point.