### PR TITLE
feat(core): support text import attributes for scripts

### DIFF
--- a/e2e/cases/assets/import-attributes-text-script/index.test.ts
+++ b/e2e/cases/assets/import-attributes-text-script/index.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { expect, test } from '@e2e/helper';
+
+const fixtures = ['js', 'jsx', 'ts', 'tsx'] as const;
+
+test('should import script files as text with import attributes', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview();
+
+  const scripts = await page.evaluate<Record<string, string>>('window.scriptText');
+  const values = await page.evaluate<Record<string, string>>('window.scriptValue');
+
+  for (const ext of fixtures) {
+    expect(scripts[ext]).toBe(readFileSync(join(import.meta.dirname, `src/text.${ext}`), 'utf-8'));
+    expect(values[ext]).toBe(`${ext} fixture`);
+  }
+});

--- a/e2e/cases/assets/import-attributes-text-script/src/index.js
+++ b/e2e/cases/assets/import-attributes-text-script/src/index.js
@@ -1,0 +1,22 @@
+import { value as jsValue } from './text.js';
+import jsText from './text.js' with { type: 'text' };
+import { value as jsxValue } from './text.jsx';
+import jsxText from './text.jsx' with { type: 'text' };
+import { value as tsValue } from './text.ts';
+import tsText from './text.ts' with { type: 'text' };
+import { value as tsxValue } from './text.tsx';
+import tsxText from './text.tsx' with { type: 'text' };
+
+window.scriptText = {
+  js: jsText,
+  jsx: jsxText,
+  ts: tsText,
+  tsx: tsxText,
+};
+
+window.scriptValue = {
+  js: jsValue,
+  jsx: jsxValue,
+  ts: tsValue,
+  tsx: tsxValue,
+};

--- a/e2e/cases/assets/import-attributes-text-script/src/text.js
+++ b/e2e/cases/assets/import-attributes-text-script/src/text.js
@@ -1,0 +1,1 @@
+export const value = 'js fixture';

--- a/e2e/cases/assets/import-attributes-text-script/src/text.jsx
+++ b/e2e/cases/assets/import-attributes-text-script/src/text.jsx
@@ -1,0 +1,1 @@
+export const value = 'jsx fixture';

--- a/e2e/cases/assets/import-attributes-text-script/src/text.ts
+++ b/e2e/cases/assets/import-attributes-text-script/src/text.ts
@@ -1,0 +1,1 @@
+export const value = 'ts fixture';

--- a/e2e/cases/assets/import-attributes-text-script/src/text.tsx
+++ b/e2e/cases/assets/import-attributes-text-script/src/text.tsx
@@ -1,0 +1,1 @@
+export const value = 'tsx fixture';

--- a/packages/core/src/configChain.ts
+++ b/packages/core/src/configChain.ts
@@ -67,6 +67,7 @@ export const CHAIN_ID = {
     JS_MAIN: 'js',
     JS_WORKER: 'js-worker',
     JS_RAW: 'js-raw',
+    JS_TEXT: 'js-text',
     /** CSS oneOf rules */
     CSS_MAIN: 'css',
     CSS_RAW: 'css-raw',

--- a/packages/core/src/plugins/swc.ts
+++ b/packages/core/src/plugins/swc.ts
@@ -110,6 +110,9 @@ export const pluginSwc = (): RsbuildPlugin => ({
           // the module should be treated as an asset module rather than a JS module.
           .dependency({ not: 'url' });
 
+        // Support for `import source from "a.js" with { type: "text" }`
+        rule.oneOf(CHAIN_ID.ONE_OF.JS_TEXT).with({ type: 'text' }).type('asset/source');
+
         // Support for `import rawJs from "a.js?raw"`
         rule.oneOf(CHAIN_ID.ONE_OF.JS_RAW).resourceQuery(RAW_QUERY_REGEX).type('asset/source');
 

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -176,6 +176,12 @@ exports[`default bundler > should use Rspack by default 1`] = `
             ],
           },
           {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
+          },
+          {
             "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/source",
           },

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -199,6 +199,12 @@ exports[`should apply default plugins correctly 1`] = `
             ],
           },
           {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
+          },
+          {
             "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/source",
           },
@@ -688,6 +694,12 @@ exports[`should apply default plugins correctly in production 1`] = `
                 "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
               },
             ],
+          },
+          {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
           },
           {
             "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
@@ -1198,6 +1210,12 @@ exports[`should apply default plugins correctly when target is node 1`] = `
             ],
           },
           {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
+          },
+          {
             "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/source",
           },
@@ -1692,6 +1710,12 @@ exports[`tools.rspack > should match snapshot 1`] = `
                 "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
               },
             ],
+          },
+          {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
           },
           {
             "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -172,6 +172,12 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
               ],
             },
             {
+              "type": "asset/source",
+              "with": {
+                "type": "text",
+              },
+            },
+            {
               "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
               "type": "asset/source",
             },
@@ -652,6 +658,12 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
                   "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
                 },
               ],
+            },
+            {
+              "type": "asset/source",
+              "with": {
+                "type": "text",
+              },
             },
             {
               "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,

--- a/packages/core/tests/__snapshots__/swc.test.ts.snap
+++ b/packages/core/tests/__snapshots__/swc.test.ts.snap
@@ -29,6 +29,12 @@ exports[`plugin-swc > should allow \`tools.swc\` to be a function 1`] = `
         ],
       },
       {
+        "type": "asset/source",
+        "with": {
+          "type": "text",
+        },
+      },
+      {
         "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
         "type": "asset/source",
       },
@@ -78,6 +84,12 @@ exports[`plugin-swc > should allow using \`tools.swc\` to configure swc-loader o
             "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
           },
         ],
+      },
+      {
+        "type": "asset/source",
+        "with": {
+          "type": "text",
+        },
       },
       {
         "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
@@ -158,6 +170,12 @@ exports[`plugin-swc > should apply decorators version 2023-11 1`] = `
               "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
             },
           ],
+        },
+        {
+          "type": "asset/source",
+          "with": {
+            "type": "text",
+          },
         },
         {
           "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
@@ -241,6 +259,12 @@ exports[`plugin-swc > should apply environment config correctly 1`] = `
             "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
           },
         ],
+      },
+      {
+        "type": "asset/source",
+        "with": {
+          "type": "text",
+        },
       },
       {
         "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
@@ -338,6 +362,12 @@ exports[`plugin-swc > should apply environment config correctly 2`] = `
         ],
       },
       {
+        "type": "asset/source",
+        "with": {
+          "type": "text",
+        },
+      },
+      {
         "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
         "type": "asset/source",
       },
@@ -420,6 +450,12 @@ exports[`plugin-swc > should apply overrideBrowserslist 1`] = `
           ],
         },
         {
+          "type": "asset/source",
+          "with": {
+            "type": "text",
+          },
+        },
+        {
           "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
           "type": "asset/source",
         },
@@ -496,6 +532,12 @@ exports[`plugin-swc > should apply pluginImport 1`] = `
               "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
             },
           ],
+        },
+        {
+          "type": "asset/source",
+          "with": {
+            "type": "text",
+          },
         },
         {
           "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
@@ -582,6 +624,12 @@ exports[`plugin-swc > should apply pluginImport correctly with ConfigChain 1`] =
               "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
             },
           ],
+        },
+        {
+          "type": "asset/source",
+          "with": {
+            "type": "text",
+          },
         },
         {
           "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
@@ -673,6 +721,12 @@ exports[`plugin-swc > should disable pluginImport when it returns undefined 1`] 
           ],
         },
         {
+          "type": "asset/source",
+          "with": {
+            "type": "text",
+          },
+        },
+        {
           "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
           "type": "asset/source",
         },
@@ -754,6 +808,12 @@ exports[`plugin-swc > should disable preset-env for non-web targets 1`] = `
           ],
         },
         {
+          "type": "asset/source",
+          "with": {
+            "type": "text",
+          },
+        },
+        {
           "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
           "type": "asset/source",
         },
@@ -830,6 +890,12 @@ exports[`plugin-swc > should disable preset-env mode 1`] = `
               "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
             },
           ],
+        },
+        {
+          "type": "asset/source",
+          "with": {
+            "type": "text",
+          },
         },
         {
           "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
@@ -911,6 +977,12 @@ exports[`plugin-swc > should enable preset-env in entry mode 1`] = `
               "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
             },
           ],
+        },
+        {
+          "type": "asset/source",
+          "with": {
+            "type": "text",
+          },
         },
         {
           "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
@@ -999,6 +1071,12 @@ exports[`plugin-swc > should enable preset-env in usage mode 1`] = `
               "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
             },
           ],
+        },
+        {
+          "type": "asset/source",
+          "with": {
+            "type": "text",
+          },
         },
         {
           "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
@@ -1090,6 +1168,12 @@ exports[`plugin-swc > should use the correct core-js version 1`] = `
           ],
         },
         {
+          "type": "asset/source",
+          "with": {
+            "type": "text",
+          },
+        },
+        {
           "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
           "type": "asset/source",
         },
@@ -1176,6 +1260,12 @@ exports[`plugin-swc > should use the correct core-js version 2`] = `
               "loader": "<ROOT>/packages/core/src/workerLoader.mjs",
             },
           ],
+        },
+        {
+          "type": "asset/source",
+          "with": {
+            "type": "text",
+          },
         },
         {
           "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,

--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -26,6 +26,12 @@ exports[`plugins/babel > babel-loader should works with builtin:swc-loader 1`] =
       ],
     },
     {
+      "type": "asset/source",
+      "with": {
+        "type": "text",
+      },
+    },
+    {
       "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
       "type": "asset/source",
     },
@@ -130,6 +136,12 @@ exports[`plugins/babel > should allow to add multiple babel rules 1`] = `
             "loader": "<ROOT>/packages/core/dist/workerLoader.mjs",
           },
         ],
+      },
+      {
+        "type": "asset/source",
+        "with": {
+          "type": "text",
+        },
       },
       {
         "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
@@ -266,6 +278,12 @@ exports[`plugins/babel > should apply decorators version 2023-11 correctly 1`] =
       ],
     },
     {
+      "type": "asset/source",
+      "with": {
+        "type": "text",
+      },
+    },
+    {
       "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
       "type": "asset/source",
     },
@@ -366,6 +384,12 @@ exports[`plugins/babel > should apply environment config correctly 1`] = `
           "loader": "<ROOT>/packages/core/dist/workerLoader.mjs",
         },
       ],
+    },
+    {
+      "type": "asset/source",
+      "with": {
+        "type": "text",
+      },
     },
     {
       "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
@@ -470,6 +494,12 @@ exports[`plugins/babel > should apply environment config correctly 2`] = `
       ],
     },
     {
+      "type": "asset/source",
+      "with": {
+        "type": "text",
+      },
+    },
+    {
       "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
       "type": "asset/source",
     },
@@ -566,6 +596,12 @@ exports[`plugins/babel > should set babel-loader 1`] = `
           "loader": "<ROOT>/packages/core/dist/workerLoader.mjs",
         },
       ],
+    },
+    {
+      "type": "asset/source",
+      "with": {
+        "type": "text",
+      },
     },
     {
       "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
@@ -665,6 +701,12 @@ exports[`plugins/babel > should set babel-loader when config is add 1`] = `
           "loader": "<ROOT>/packages/core/dist/workerLoader.mjs",
         },
       ],
+    },
+    {
+      "type": "asset/source",
+      "with": {
+        "type": "text",
+      },
     },
     {
       "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -30,6 +30,12 @@ exports[`plugins/react > should configuring \`tools.swc\` to override react runt
         ],
       },
       {
+        "type": "asset/source",
+        "with": {
+          "type": "text",
+        },
+      },
+      {
         "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
         "type": "asset/source",
       },
@@ -163,6 +169,12 @@ exports[`plugins/react > should work with swc-loader 1`] = `
             "loader": "<ROOT>/packages/core/dist/workerLoader.mjs",
           },
         ],
+      },
+      {
+        "type": "asset/source",
+        "with": {
+          "type": "text",
+        },
       },
       {
         "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,

--- a/packages/plugin-solid/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-solid/tests/__snapshots__/index.test.ts.snap
@@ -22,6 +22,12 @@ exports[`plugin-solid > should allow deprecated solidPresetOptions alias 1`] = `
       ],
     },
     {
+      "type": "asset/source",
+      "with": {
+        "type": "text",
+      },
+    },
+    {
       "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
       "type": "asset/source",
     },
@@ -130,6 +136,12 @@ exports[`plugin-solid > should allow solid options to override ssr defaults 1`] 
       ],
     },
     {
+      "type": "asset/source",
+      "with": {
+        "type": "text",
+      },
+    },
+    {
       "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
       "type": "asset/source",
     },
@@ -227,6 +239,12 @@ exports[`plugin-solid > should allow to configure solid options 1`] = `
           "loader": "<ROOT>/packages/core/dist/workerLoader.mjs",
         },
       ],
+    },
+    {
+      "type": "asset/source",
+      "with": {
+        "type": "text",
+      },
     },
     {
       "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
@@ -337,6 +355,12 @@ exports[`plugin-solid > should apply solid preset correctly 1`] = `
       ],
     },
     {
+      "type": "asset/source",
+      "with": {
+        "type": "text",
+      },
+    },
+    {
       "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
       "type": "asset/source",
     },
@@ -440,6 +464,12 @@ exports[`plugin-solid > should use hydratable dom output for ssr option on web t
           "loader": "<ROOT>/packages/core/dist/workerLoader.mjs",
         },
       ],
+    },
+    {
+      "type": "asset/source",
+      "with": {
+        "type": "text",
+      },
     },
     {
       "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
@@ -548,6 +578,12 @@ exports[`plugin-solid > should use ssr output for ssr option on node target 1`] 
           "loader": "<ROOT>/packages/core/dist/workerLoader.mjs",
         },
       ],
+    },
+    {
+      "type": "asset/source",
+      "with": {
+        "type": "text",
+      },
     },
     {
       "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,

--- a/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
@@ -33,6 +33,12 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
         ],
       },
       {
+        "type": "asset/source",
+        "with": {
+          "type": "text",
+        },
+      },
+      {
         "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
         "type": "asset/source",
       },
@@ -164,6 +170,12 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
             "loader": "<ROOT>/packages/core/dist/workerLoader.mjs",
           },
         ],
+      },
+      {
+        "type": "asset/source",
+        "with": {
+          "type": "text",
+        },
       },
       {
         "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,


### PR DESCRIPTION
## Summary

This PR adds support for importing script files as source text via `with { type: 'text' }`, covering `.js`, `.jsx`, `.ts`, and `.tsx` files without changing normal script module imports. It adds a dedicated JS rule before the existing raw/SWC handling and e2e coverage that checks both import-attribute text imports and regular named imports.

## Related Links

- TC39 Import Attributes proposal repository: https://github.com/tc39/proposal-import-attributes
- Rspack implementation reference: https://github.com/web-infra-dev/rspack/pull/12457