### PR TITLE
fix(plugin-babel): skip text import attributes in standalone rule

### DIFF
--- a/e2e/cases/plugin-babel/import-attributes-text-script/index.test.ts
+++ b/e2e/cases/plugin-babel/import-attributes-text-script/index.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { expect, test } from '@e2e/helper';
+import { pluginBabel } from '@rsbuild/plugin-babel';
+
+test('should keep text imports unchanged with Babel include', async ({ page, buildPreview }) => {
+  await buildPreview({
+    config: {
+      plugins: [pluginBabel({ include: /src/ })],
+    },
+  });
+
+  expect(await page.evaluate('window.scriptText')).toBe(
+    readFileSync(join(import.meta.dirname, 'src/text.ts'), 'utf-8'),
+  );
+  expect(await page.evaluate('window.scriptValue')).toBe('text fixture');
+});

--- a/e2e/cases/plugin-babel/import-attributes-text-script/src/index.js
+++ b/e2e/cases/plugin-babel/import-attributes-text-script/src/index.js
@@ -1,0 +1,5 @@
+import { value } from './text.ts';
+import scriptText from './text.ts' with { type: 'text' };
+
+window.scriptText = scriptText;
+window.scriptValue = value;

--- a/e2e/cases/plugin-babel/import-attributes-text-script/src/text.ts
+++ b/e2e/cases/plugin-babel/import-attributes-text-script/src/text.ts
@@ -1,0 +1,1 @@
+export const value: string = 'text fixture';

--- a/packages/plugin-babel/src/plugin.ts
+++ b/packages/plugin-babel/src/plugin.ts
@@ -141,6 +141,7 @@ export const pluginBabel = (options: PluginBabelOptions = {}): RsbuildPlugin => 
 
           const loader = rule
             .test(SCRIPT_REGEX)
+            .with({ type: { not: 'text' } })
             .use(CHAIN_ID.USE.BABEL)
             .loader(BABEL_LOADER_PATH)
             .options(babelOptions);

--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -221,6 +221,11 @@ exports[`plugins/babel > should allow to add multiple babel rules 1`] = `
         },
       },
     ],
+    "with": {
+      "type": {
+        "not": "text",
+      },
+    },
   },
   {
     "include": [
@@ -252,6 +257,11 @@ exports[`plugins/babel > should allow to add multiple babel rules 1`] = `
         },
       },
     ],
+    "with": {
+      "type": {
+        "not": "text",
+      },
+    },
   },
 ]
 `;


### PR DESCRIPTION
## Summary

This PR fixes a `@rsbuild/plugin-babel` include/exclude mode compatibility issue where its standalone script rule could still transform script imports using `with { type: 'text' }`, causing the text import to export Babel-processed content instead of the original source text. The standalone Babel rule now skips `type: 'text'` import attributes, and a focused e2e case covers the `.ts` text-import path while keeping normal named imports working.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8037
- https://github.com/web-infra-dev/rsbuild/pull/8037#discussion_r3510395463