### PR TITLE
fix(plugin-babel): skip raw query in standalone rule

### DIFF
--- a/e2e/cases/plugin-babel/raw-query/index.test.ts
+++ b/e2e/cases/plugin-babel/raw-query/index.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { expect, test } from '@e2e/helper';
+import { pluginBabel } from '@rsbuild/plugin-babel';
+
+test('should keep raw query imports unchanged with Babel include', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview({
+    config: {
+      plugins: [pluginBabel({ include: /src/ })],
+    },
+  });
+
+  expect(await page.evaluate('window.rawText')).toBe(
+    readFileSync(join(import.meta.dirname, 'src/raw.ts'), 'utf-8'),
+  );
+  expect(await page.evaluate('window.rawValue')).toBe('raw fixture');
+});

--- a/e2e/cases/plugin-babel/raw-query/src/index.js
+++ b/e2e/cases/plugin-babel/raw-query/src/index.js
@@ -1,0 +1,5 @@
+import { value } from './raw.ts';
+import rawText from './raw.ts?raw';
+
+window.rawText = rawText;
+window.rawValue = value;

--- a/e2e/cases/plugin-babel/raw-query/src/raw.ts
+++ b/e2e/cases/plugin-babel/raw-query/src/raw.ts
@@ -1,0 +1,1 @@
+export const value: string = 'raw fixture';

--- a/packages/plugin-babel/src/plugin.ts
+++ b/packages/plugin-babel/src/plugin.ts
@@ -141,6 +141,7 @@ export const pluginBabel = (options: PluginBabelOptions = {}): RsbuildPlugin => 
 
           const loader = rule
             .test(SCRIPT_REGEX)
+            .resourceQuery({ not: /[?&]raw(?:&|=|$)/ })
             .with({ type: { not: 'text' } })
             .use(CHAIN_ID.USE.BABEL)
             .loader(BABEL_LOADER_PATH)

--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -195,6 +195,9 @@ exports[`plugins/babel > should allow to add multiple babel rules 1`] = `
     "include": [
       /b\\\\\\.js\\$/,
     ],
+    "resourceQuery": {
+      "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+    },
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
     "use": [
       {
@@ -231,6 +234,9 @@ exports[`plugins/babel > should allow to add multiple babel rules 1`] = `
     "include": [
       /a\\\\\\.js\\$/,
     ],
+    "resourceQuery": {
+      "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+    },
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
     "use": [
       {


### PR DESCRIPTION
## Summary

This PR fixes another `@rsbuild/plugin-babel` include/exclude mode compatibility issue where the standalone Babel rule could transform script imports using `?raw`, causing raw script imports to export Babel-processed content instead of the original source text. The standalone Babel rule now skips raw-query script imports, and a focused e2e case verifies `.ts?raw` preserves the original source while normal named imports keep working.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8039