### PR TITLE
fix(plugin-babel): skip URL dependencies in standalone rule

### DIFF
--- a/e2e/cases/plugin-babel/url-dependency/index.test.ts
+++ b/e2e/cases/plugin-babel/url-dependency/index.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from '@e2e/helper';
+import { pluginBabel } from '@rsbuild/plugin-babel';
+
+test('should keep URL dependency assets unchanged with Babel include', async ({
+  page,
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview({
+    config: {
+      output: {
+        filenameHash: false,
+      },
+      plugins: [pluginBabel({ include: /src/ })],
+    },
+  });
+
+  const files = rsbuild.getDistFiles();
+  const asset = Object.keys(files).find((filename) =>
+    filename.includes('dist/static/assets/asset.ts'),
+  );
+
+  expect(asset).toBeDefined();
+  expect(files[asset!]).toContain(`export const value: string = 'url dependency';`);
+  expect(await page.evaluate('window.assetUrl')).toBe(
+    `http://localhost:${rsbuild.port}/static/assets/asset.ts`,
+  );
+});

--- a/e2e/cases/plugin-babel/url-dependency/src/asset.ts
+++ b/e2e/cases/plugin-babel/url-dependency/src/asset.ts
@@ -1,0 +1,1 @@
+export const value: string = 'url dependency';

--- a/e2e/cases/plugin-babel/url-dependency/src/index.js
+++ b/e2e/cases/plugin-babel/url-dependency/src/index.js
@@ -1,0 +1,1 @@
+window.assetUrl = new URL('./asset.ts', import.meta.url).href;

--- a/packages/plugin-babel/src/plugin.ts
+++ b/packages/plugin-babel/src/plugin.ts
@@ -141,6 +141,7 @@ export const pluginBabel = (options: PluginBabelOptions = {}): RsbuildPlugin => 
 
           const loader = rule
             .test(SCRIPT_REGEX)
+            .dependency({ not: 'url' })
             .resourceQuery({ not: /[?&]raw(?:&|=|$)/ })
             .with({ type: { not: 'text' } })
             .use(CHAIN_ID.USE.BABEL)

--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -192,6 +192,9 @@ exports[`plugins/babel > should allow to add multiple babel rules 1`] = `
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
   },
   {
+    "dependency": {
+      "not": "url",
+    },
     "include": [
       /b\\\\\\.js\\$/,
     ],
@@ -231,6 +234,9 @@ exports[`plugins/babel > should allow to add multiple babel rules 1`] = `
     },
   },
   {
+    "dependency": {
+      "not": "url",
+    },
     "include": [
       /a\\\\\\.js\\$/,
     ],


### PR DESCRIPTION
## Summary

This PR fixes another `@rsbuild/plugin-babel` include/exclude mode compatibility issue where the standalone Babel rule could match `dependency: 'url'` script modules from `new URL('./foo.js', import.meta.url)`. The standalone rule now mirrors the core JS rule by skipping URL dependencies, and a focused e2e case verifies script URL assets keep their original source while normal Babel include behavior remains covered.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8039#discussion_r3510847738