### PR TITLE
feat(core): support CSS text import attributes

### DIFF
--- a/e2e/cases/css/import-attributes-text/index.test.ts
+++ b/e2e/cases/css/import-attributes-text/index.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { expect, test } from '@e2e/helper';
+
+const fixtures = ['css', 'less', 'scss', 'sass'] as const;
+
+test('should import style files as text with import attributes', async ({ page, runBothServe }) => {
+  await runBothServe(async () => {
+    const styles = await page.evaluate<Record<string, string>>('window.styleText');
+
+    for (const ext of fixtures) {
+      expect(styles[ext]).toBe(
+        readFileSync(join(import.meta.dirname, `src/style.${ext}`), 'utf-8'),
+      );
+    }
+
+    expect(await page.evaluate('getComputedStyle(document.body).color')).toBe('rgb(0, 0, 255)');
+  });
+});

--- a/e2e/cases/css/import-attributes-text/rsbuild.config.ts
+++ b/e2e/cases/css/import-attributes-text/rsbuild.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginLess } from '@rsbuild/plugin-less';
+import { pluginSass } from '@rsbuild/plugin-sass';
+
+export default defineConfig({
+  plugins: [pluginLess(), pluginSass()],
+});

--- a/e2e/cases/css/import-attributes-text/src/index.js
+++ b/e2e/cases/css/import-attributes-text/src/index.js
@@ -1,0 +1,12 @@
+import './normal.css';
+import cssText from './style.css' with { type: 'text' };
+import lessText from './style.less' with { type: 'text' };
+import sassText from './style.sass' with { type: 'text' };
+import scssText from './style.scss' with { type: 'text' };
+
+window.styleText = {
+  css: cssText,
+  less: lessText,
+  sass: sassText,
+  scss: scssText,
+};

--- a/e2e/cases/css/import-attributes-text/src/normal.css
+++ b/e2e/cases/css/import-attributes-text/src/normal.css
@@ -1,0 +1,3 @@
+body {
+  color: blue;
+}

--- a/e2e/cases/css/import-attributes-text/src/style.css
+++ b/e2e/cases/css/import-attributes-text/src/style.css
@@ -1,0 +1,3 @@
+.css-text {
+  color: red;
+}

--- a/e2e/cases/css/import-attributes-text/src/style.less
+++ b/e2e/cases/css/import-attributes-text/src/style.less
@@ -1,0 +1,5 @@
+.less-text {
+  &__item {
+    color: red;
+  }
+}

--- a/e2e/cases/css/import-attributes-text/src/style.sass
+++ b/e2e/cases/css/import-attributes-text/src/style.sass
@@ -1,0 +1,2 @@
+.sass-text
+  color: red

--- a/e2e/cases/css/import-attributes-text/src/style.scss
+++ b/e2e/cases/css/import-attributes-text/src/style.scss
@@ -1,0 +1,5 @@
+.scss-text {
+  &__item {
+    color: red;
+  }
+}

--- a/packages/core/src/configChain.ts
+++ b/packages/core/src/configChain.ts
@@ -71,6 +71,7 @@ export const CHAIN_ID = {
     /** CSS oneOf rules */
     CSS_MAIN: 'css',
     CSS_RAW: 'css-raw',
+    CSS_TEXT: 'css-text',
     CSS_URL: 'css-url',
     CSS_INLINE: 'css-inline',
     /** SVG oneOf rules */

--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -273,6 +273,9 @@ export const pluginCss = (): RsbuildPlugin => ({
           // the module should be treated as an asset module rather than a JS module.
           .dependency({ not: 'url' });
 
+        // Support for `import cssText from "a.css" with { type: "text" }`
+        cssRule.oneOf(CHAIN_ID.ONE_OF.CSS_TEXT).with({ type: 'text' }).type('asset/source');
+
         // Support for `import cssUrl from "a.css?url"`
         const urlRule = cssRule.oneOf(CHAIN_ID.ONE_OF.CSS_URL).resourceQuery(URL_QUERY_REGEX);
         urlRule.use(CHAIN_ID.USE.CSS_URL).loader(path.join(LOADER_PATH, 'cssUrlLoader.mjs'));

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -39,6 +39,12 @@ exports[`default bundler > should use Rspack by default 1`] = `
         },
         "oneOf": [
           {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
+          },
+          {
             "resolve": {
               "preferRelative": true,
             },

--- a/packages/core/tests/__snapshots__/css.test.ts.snap
+++ b/packages/core/tests/__snapshots__/css.test.ts.snap
@@ -8,6 +8,12 @@ exports[`plugin-css > should use custom cssModules rule when using output.cssMod
     },
     "oneOf": [
       {
+        "type": "asset/source",
+        "with": {
+          "type": "text",
+        },
+      },
+      {
         "resolve": {
           "preferRelative": true,
         },
@@ -134,6 +140,12 @@ exports[`plugin-css injectStyles > should apply ignoreCssLoader when injectStyle
     },
     "oneOf": [
       {
+        "type": "asset/source",
+        "with": {
+          "type": "text",
+        },
+      },
+      {
         "resolve": {
           "preferRelative": true,
         },
@@ -253,6 +265,12 @@ exports[`plugin-css injectStyles > should use css-loader + style-loader when inj
       "not": "url",
     },
     "oneOf": [
+      {
+        "type": "asset/source",
+        "with": {
+          "type": "text",
+        },
+      },
       {
         "resolve": {
           "preferRelative": true,
@@ -379,6 +397,12 @@ exports[`should ensure isolation of PostCSS config objects between different bui
       "not": "url",
     },
     "oneOf": [
+      {
+        "type": "asset/source",
+        "with": {
+          "type": "text",
+        },
+      },
       {
         "resolve": {
           "preferRelative": true,
@@ -550,6 +574,12 @@ exports[`should ensure isolation of PostCSS config objects between different bui
       "not": "url",
     },
     "oneOf": [
+      {
+        "type": "asset/source",
+        "with": {
+          "type": "text",
+        },
+      },
       {
         "resolve": {
           "preferRelative": true,

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -62,6 +62,12 @@ exports[`should apply default plugins correctly 1`] = `
         },
         "oneOf": [
           {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
+          },
+          {
             "resolve": {
               "preferRelative": true,
             },
@@ -557,6 +563,12 @@ exports[`should apply default plugins correctly in production 1`] = `
           "not": "url",
         },
         "oneOf": [
+          {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
+          },
           {
             "resolve": {
               "preferRelative": true,
@@ -1080,6 +1092,12 @@ exports[`should apply default plugins correctly when target is node 1`] = `
         },
         "oneOf": [
           {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
+          },
+          {
             "resolve": {
               "preferRelative": true,
             },
@@ -1574,6 +1592,12 @@ exports[`tools.rspack > should match snapshot 1`] = `
           "not": "url",
         },
         "oneOf": [
+          {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
+          },
           {
             "resolve": {
               "preferRelative": true,

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -35,6 +35,12 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
           },
           "oneOf": [
             {
+              "type": "asset/source",
+              "with": {
+                "type": "text",
+              },
+            },
+            {
               "resolve": {
                 "preferRelative": true,
               },
@@ -523,6 +529,12 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
             "not": "url",
           },
           "oneOf": [
+            {
+              "type": "asset/source",
+              "with": {
+                "type": "text",
+              },
+            },
             {
               "resolve": {
                 "preferRelative": true,

--- a/packages/plugin-less/src/index.ts
+++ b/packages/plugin-less/src/index.ts
@@ -185,6 +185,7 @@ export const pluginLess = (pluginOptions: PluginLessOptions = {}): RsbuildPlugin
     const CSS_INLINE = 'css-inline';
     const CSS_RAW = 'css-raw';
     const LESS_MAIN = 'less';
+    const LESS_TEXT = 'less-text';
     const LESS_URL = 'less-url';
     const LESS_INLINE = 'less-inline';
     const LESS_RAW = 'less-raw';
@@ -204,6 +205,8 @@ export const pluginLess = (pluginOptions: PluginLessOptions = {}): RsbuildPlugin
       };
 
       const cssRule = chain.module.rule(CHAIN_ID.RULE.CSS);
+      const cssTextRuleId = CHAIN_ID.ONE_OF.CSS_TEXT;
+      const hasCssTextRule = cssTextRuleId && cssRule.oneOfs.has(cssTextRuleId);
       const cssUrlRuleId = CHAIN_ID.ONE_OF.CSS_URL;
       const hasCssUrlRule = cssUrlRuleId && cssRule.oneOfs.has(cssUrlRuleId);
 
@@ -215,6 +218,11 @@ export const pluginLess = (pluginOptions: PluginLessOptions = {}): RsbuildPlugin
 
       // Raw Less for `?raw` imports
       getRule(LESS_RAW).type('asset/source').resourceQuery(getRule(CSS_RAW).get('resourceQuery'));
+
+      // Less text import with import attributes.
+      if (hasCssTextRule) {
+        getRule(LESS_TEXT).type('asset/source').with(getRule(cssTextRuleId).get('with'));
+      }
 
       // Main Less transform
       const lessMainRule = getRule(LESS_MAIN);

--- a/packages/plugin-less/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-less/tests/__snapshots__/index.test.ts.snap
@@ -102,6 +102,12 @@ exports[`plugin-less > should add less-loader 1`] = `
         "type": "asset/source",
       },
       {
+        "type": "asset/source",
+        "with": {
+          "type": "text",
+        },
+      },
+      {
         "sideEffects": true,
         "use": [
           {
@@ -256,6 +262,12 @@ exports[`plugin-less > should add less-loader and css-loader when injectStyles 1
       {
         "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
         "type": "asset/source",
+      },
+      {
+        "type": "asset/source",
+        "with": {
+          "type": "text",
+        },
       },
       {
         "sideEffects": true,
@@ -420,6 +432,12 @@ exports[`plugin-less > should add less-loader with excludes 1`] = `
         "type": "asset/source",
       },
       {
+        "type": "asset/source",
+        "with": {
+          "type": "text",
+        },
+      },
+      {
         "exclude": [
           /node_modules/,
         ],
@@ -577,6 +595,12 @@ exports[`plugin-less > should add less-loader with tools.less 1`] = `
       {
         "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
         "type": "asset/source",
+      },
+      {
+        "type": "asset/source",
+        "with": {
+          "type": "text",
+        },
       },
       {
         "sideEffects": true,
@@ -747,6 +771,12 @@ exports[`plugin-less > should allow to use Less plugins 1`] = `
       {
         "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
         "type": "asset/source",
+      },
+      {
+        "type": "asset/source",
+        "with": {
+          "type": "text",
+        },
       },
       {
         "sideEffects": true,

--- a/packages/plugin-sass/src/index.ts
+++ b/packages/plugin-sass/src/index.ts
@@ -109,6 +109,7 @@ export const pluginSass = (pluginOptions: PluginSassOptions = {}): RsbuildPlugin
     const CSS_INLINE = 'css-inline';
     const CSS_RAW = 'css-raw';
     const SASS_MAIN = 'sass';
+    const SASS_TEXT = 'sass-text';
     const SASS_URL = 'sass-url';
     const SASS_INLINE = 'sass-inline';
     const SASS_RAW = 'sass-raw';
@@ -137,6 +138,8 @@ export const pluginSass = (pluginOptions: PluginSassOptions = {}): RsbuildPlugin
         .end();
 
       const cssRule = chain.module.rule(CHAIN_ID.RULE.CSS);
+      const cssTextRuleId = CHAIN_ID.ONE_OF.CSS_TEXT;
+      const hasCssTextRule = cssTextRuleId && cssRule.oneOfs.has(cssTextRuleId);
       const cssUrlRuleId = CHAIN_ID.ONE_OF.CSS_URL;
       const hasCssUrlRule = cssUrlRuleId && cssRule.oneOfs.has(cssUrlRuleId);
 
@@ -152,6 +155,11 @@ export const pluginSass = (pluginOptions: PluginSassOptions = {}): RsbuildPlugin
 
       // Raw Sass for `?raw` imports
       getRule(SASS_RAW).type('asset/source').resourceQuery(getRule(CSS_RAW).get('resourceQuery'));
+
+      // Sass text import with import attributes.
+      if (hasCssTextRule) {
+        getRule(SASS_TEXT).type('asset/source').with(getRule(cssTextRuleId).get('with'));
+      }
 
       // Main Sass transform
       const sassMainRule = getRule(SASS_MAIN);

--- a/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
@@ -120,6 +120,12 @@ exports[`plugin-sass > should add sass-loader 1`] = `
         "type": "asset/source",
       },
       {
+        "type": "asset/source",
+        "with": {
+          "type": "text",
+        },
+      },
+      {
         "sideEffects": true,
         "use": [
           {
@@ -301,6 +307,12 @@ exports[`plugin-sass > should add sass-loader and css-loader when injectStyles 1
       {
         "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
         "type": "asset/source",
+      },
+      {
+        "type": "asset/source",
+        "with": {
+          "type": "text",
+        },
       },
       {
         "sideEffects": true,
@@ -492,6 +504,12 @@ exports[`plugin-sass > should add sass-loader with excludes 1`] = `
         "type": "asset/source",
       },
       {
+        "type": "asset/source",
+        "with": {
+          "type": "text",
+        },
+      },
+      {
         "exclude": [
           /node_modules/,
         ],
@@ -678,6 +696,12 @@ exports[`plugin-sass > should allow to use legacy API and mute deprecation warni
       {
         "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
         "type": "asset/source",
+      },
+      {
+        "type": "asset/source",
+        "with": {
+          "type": "text",
+        },
       },
       {
         "sideEffects": true,

--- a/packages/plugin-tailwindcss/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-tailwindcss/tests/__snapshots__/index.test.ts.snap
@@ -8,6 +8,12 @@ exports[`plugin-tailwindcss > should add tailwindcss loader to CSS rule 1`] = `
     },
     "oneOf": [
       {
+        "type": "asset/source",
+        "with": {
+          "type": "text",
+        },
+      },
+      {
         "resolve": {
           "preferRelative": true,
         },


### PR DESCRIPTION
## Summary

This PR adds support for importing CSS as source text with import attributes (`with { type: 'text' }`). It adds a dedicated CSS rule branch and mirrors it in the Less and Sass plugins so `.css`, `.less`, `.scss`, and `.sass` files can be imported as text without entering the normal style pipeline. It also adds e2e coverage for those style formats and updates the affected unit test snapshots.