### PR TITLE
feat(core): support custom config file names

### DIFF
--- a/e2e/cases/javascript-api/load-config/custom.config.mjs
+++ b/e2e/cases/javascript-api/load-config/custom.config.mjs
@@ -1,0 +1,7 @@
+export default {
+  source: {
+    define: {
+      CONFIG_FILE_NAME: JSON.stringify('custom'),
+    },
+  },
+};

--- a/e2e/cases/javascript-api/load-config/fallback.config.mjs
+++ b/e2e/cases/javascript-api/load-config/fallback.config.mjs
@@ -1,0 +1,7 @@
+export default {
+  source: {
+    define: {
+      CONFIG_FILE_NAME: JSON.stringify('fallback'),
+    },
+  },
+};

--- a/e2e/cases/javascript-api/load-config/index.test.ts
+++ b/e2e/cases/javascript-api/load-config/index.test.ts
@@ -1,3 +1,4 @@
+import { join } from 'node:path';
 import { expect, test } from '@e2e/helper';
 import { loadConfig } from '@rsbuild/core';
 
@@ -9,5 +10,17 @@ test('should pass command to config function', async () => {
 
   expect(content.source?.define).toEqual({
     COMMAND: JSON.stringify('build'),
+  });
+});
+
+test('should load config from custom config file names', async () => {
+  const { content, filePath } = await loadConfig({
+    cwd: import.meta.dirname,
+    configFileNames: ['custom.config.mjs', 'fallback.config.mjs'],
+  });
+
+  expect(filePath).toBe(join(import.meta.dirname, 'custom.config.mjs'));
+  expect(content.source?.define).toEqual({
+    CONFIG_FILE_NAME: JSON.stringify('custom'),
   });
 });

--- a/packages/core/src/loadConfig.ts
+++ b/packages/core/src/loadConfig.ts
@@ -30,6 +30,11 @@ export type LoadConfigOptions = {
    */
   path?: string;
   /**
+   * Config file names to search in `cwd` when `path` is not provided.
+   * The list replaces the default `rsbuild.config.*` lookup order.
+   */
+  configFileNames?: string[];
+  /**
    * A custom meta object to be passed into the config function of `defineConfig`.
    */
   meta?: Record<string, unknown>;
@@ -82,7 +87,21 @@ export function defineConfig(config: RsbuildConfigDefinition) {
   return config;
 }
 
-const resolveConfigPath = (root: string, customConfig?: string) => {
+// Resolve the most commonly used config file types first to improve lookup performance.
+const DEFAULT_CONFIG_FILE_NAMES = [
+  'rsbuild.config.ts',
+  'rsbuild.config.js',
+  'rsbuild.config.mts',
+  'rsbuild.config.mjs',
+  'rsbuild.config.cts',
+  'rsbuild.config.cjs',
+];
+
+const resolveConfigPath = (
+  root: string,
+  customConfig?: string,
+  configFileNames = DEFAULT_CONFIG_FILE_NAMES,
+) => {
   if (customConfig) {
     const customConfigPath = isAbsolute(customConfig) ? customConfig : join(root, customConfig);
     if (fs.existsSync(customConfigPath)) {
@@ -91,18 +110,7 @@ const resolveConfigPath = (root: string, customConfig?: string) => {
     throw new Error(`Cannot find config file: ${color.dim(customConfigPath)}`);
   }
 
-  // Resolve the most commonly used config file types first
-  // to improve lookup performance.
-  const CONFIG_FILES = [
-    'rsbuild.config.ts',
-    'rsbuild.config.js',
-    'rsbuild.config.mts',
-    'rsbuild.config.mjs',
-    'rsbuild.config.cts',
-    'rsbuild.config.cjs',
-  ];
-
-  for (const file of CONFIG_FILES) {
+  for (const file of configFileNames) {
     const configFile = join(root, file);
 
     if (fs.existsSync(configFile)) {
@@ -156,12 +164,13 @@ const loadConfigWithNative = async (
 export async function loadConfig({
   cwd = process.cwd(),
   path,
+  configFileNames,
   envMode,
   meta,
   loader = 'auto',
   command,
 }: LoadConfigOptions = {}): Promise<LoadConfigResult> {
-  const configFilePath = resolveConfigPath(cwd, path);
+  const configFilePath = resolveConfigPath(cwd, path, configFileNames);
 
   if (!configFilePath) {
     defaultLogger.debug('no config file found.');

--- a/website/docs/en/api/javascript-api/core.mdx
+++ b/website/docs/en/api/javascript-api/core.mdx
@@ -137,6 +137,8 @@ function loadConfig(params?: {
   cwd?: string;
   // Specify the configuration file (relative or absolute path)
   path?: string;
+  // Config file names to search when path is not specified
+  configFileNames?: string[];
   meta?: Record<string, unknown>;
   envMode?: string;
   /**
@@ -186,6 +188,18 @@ When `path` is not specified, `loadConfig` searches for config files in the foll
 - `rsbuild.config.cjs`
 
 If multiple config files exist at the same time, `loadConfig` uses the first matching file in this list.
+
+### Customize config file names
+
+Use the `configFileNames` option to replace the default lookup list. The file names are resolved relative to `cwd`, and this option is ignored when `path` is specified.
+
+```ts
+import { loadConfig } from '@rsbuild/core';
+
+const { content } = await loadConfig({
+  configFileNames: ['framework.config.ts', 'framework.config.mjs'],
+});
+```
 
 ### Specify the configuration file
 

--- a/website/docs/zh/api/javascript-api/core.mdx
+++ b/website/docs/zh/api/javascript-api/core.mdx
@@ -137,6 +137,8 @@ function loadConfig(params?: {
   cwd?: string;
   // 指定配置文件路径，可以为相对路径或绝对路径
   path?: string;
+  // 未指定 path 时要查找的配置文件名列表
+  configFileNames?: string[];
   meta?: Record<string, unknown>;
   envMode?: string;
   /**
@@ -186,6 +188,18 @@ const rsbuild = await createRsbuild({
 - `rsbuild.config.cjs`
 
 如果同时存在多个配置文件，`loadConfig` 会使用这个列表中第一个匹配到的文件。
+
+### 自定义配置文件名
+
+使用 `configFileNames` 选项可以替换默认的配置文件查找列表。文件名会相对于 `cwd` 解析，且指定 `path` 时会忽略该选项。
+
+```ts
+import { loadConfig } from '@rsbuild/core';
+
+const { content } = await loadConfig({
+  configFileNames: ['framework.config.ts', 'framework.config.mjs'],
+});
+```
 
 ### 指定配置文件
 


### PR DESCRIPTION
## Summary

This PR adds a `configFileNames` option to the `loadConfig` JavaScript API so framework wrappers can replace the default `rsbuild.config.*` discovery list while preserving `path` as the explicit-file override. It also documents the option in English and Chinese docs and adds a minimal JavaScript API e2e case covering the custom lookup order.