### PR TITLE
release: @rsbuild/plugin-babel v2.0.1

### DIFF
--- a/packages/create-rsbuild/template-solid-js/package.json
+++ b/packages/create-rsbuild/template-solid-js/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "^2.1.1",
-    "@rsbuild/plugin-babel": "^2.0.0",
+    "@rsbuild/plugin-babel": "^2.0.1",
     "@rsbuild/plugin-solid": "^1.2.2"
   }
 }

--- a/packages/create-rsbuild/template-solid-ts/package.json
+++ b/packages/create-rsbuild/template-solid-ts/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "^2.1.1",
-    "@rsbuild/plugin-babel": "^2.0.0",
+    "@rsbuild/plugin-babel": "^2.0.1",
     "@rsbuild/plugin-solid": "^1.2.2",
     "@types/node": "^24.13.2",
     "typescript": "^6.0.3"

--- a/packages/plugin-babel/CHANGELOG.md
+++ b/packages/plugin-babel/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @rsbuild/plugin-babel
 
+## 2.0.1 (2026-07-02)
+
+### Bug fixes
+
+- fix(plugin-babel): skip text import attributes in standalone rule by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/8039
+- fix(plugin-babel): skip raw query in standalone rule by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/8040
+- fix(plugin-babel): skip URL dependencies in standalone rule by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/8041
+
+### Document
+
+- docs: update React Compiler guides by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/8038
+
 ## 2.0.0 (2026-06-16)
 
 ### Breaking changes

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-babel",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Babel plugin for Rsbuild",
   "homepage": "https://rsbuild.rs",
   "bugs": {


### PR DESCRIPTION
## Summary

Release `@rsbuild/plugin-babel` v2.0.1 with the latest standalone rule fixes, and sync the create-rsbuild Solid template dependencies to use the patch version.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8038
- https://github.com/web-infra-dev/rsbuild/pull/8039
- https://github.com/web-infra-dev/rsbuild/pull/8040
- https://github.com/web-infra-dev/rsbuild/pull/8041