### PR TITLE
docs: update e2e testing guidance

### DIFF
--- a/.agents/skills/write-e2e-cases/SKILL.md
+++ b/.agents/skills/write-e2e-cases/SKILL.md
@@ -25,6 +25,7 @@ description: Use when adding or updating Rsbuild end-to-end tests in `e2e/cases`
 - Prefer putting static Rsbuild configurations in `rsbuild.config.ts` to enable easier debugging via `npx rsbuild`.
 - Use inline config for dynamic values or minor per-test variations.
 - Split into multiple case directories when cases need different `src` code or different Rsbuild configs.
+- When static assets are needed, prefer reusing assets from `@e2e/assets` before adding new files.
 - For package mocks used by one case, place them under that case's `_node_modules` directory and call `copyNodeModules()` before they are resolved.
 
 ## Constraints

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,10 @@ pnpm e2e css
 pnpm e2e
 ```
 
-Run `pnpm build` once before any `pnpm e2e` command, including focused cases.
+## Testing
+
+- Prefer adding e2e tests over unit tests, unless testing single-function behavior.
+- Run `pnpm build` once before any `pnpm e2e` command, including focused cases.
 
 ## Project structure
 


### PR DESCRIPTION
## Summary

This PR updates the repository and e2e skill guidance for test selection and static asset reuse. It moves the e2e-before-unit-test preference into a dedicated Testing section in `AGENTS.md`, keeps the existing build-before-e2e rule there, and tells e2e case authors to reuse `@e2e/assets` before adding new assets.