### PR TITLE
feat(core): support asset text import attributes

### DIFF
--- a/e2e/cases/assets/import-attributes-text-static/index.test.ts
+++ b/e2e/cases/assets/import-attributes-text-static/index.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { expect, test } from '@e2e/helper';
+
+const assetsDir = join(import.meta.dirname, '../../../assets');
+
+test('should import static assets as text with import attributes', async ({
+  page,
+  runBothServe,
+}) => {
+  await runBothServe(async () => {
+    const assets = await page.evaluate<Record<string, string>>('window.assetText');
+
+    expect(assets.svg).toBe(readFileSync(join(assetsDir, 'circle.svg'), 'utf-8'));
+    expect(assets.png).toBe(readFileSync(join(assetsDir, 'icon.png'), 'utf-8'));
+  });
+});

--- a/e2e/cases/assets/import-attributes-text-static/src/index.js
+++ b/e2e/cases/assets/import-attributes-text-static/src/index.js
@@ -1,0 +1,7 @@
+import pngText from '@e2e/assets/icon.png' with { type: 'text' };
+import svgText from '@e2e/assets/circle.svg' with { type: 'text' };
+
+window.assetText = {
+  png: pngText,
+  svg: svgText,
+};

--- a/packages/core/src/plugins/asset.ts
+++ b/packages/core/src/plugins/asset.ts
@@ -46,11 +46,11 @@ const chainStaticAssetRule = ({
   // get inlined base64 content: "foo.png?inline"
   rule.oneOf(`${assetType}-asset-inline`).type('asset/inline').resourceQuery(INLINE_QUERY_REGEX);
 
-  // get raw content: "foo.png?raw"
-  rule.oneOf(`${assetType}-asset-raw`).type('asset/source').resourceQuery(RAW_QUERY_REGEX);
-
   // get asset source: `import source from "foo.png" with { type: "text" }`
   rule.oneOf(`${assetType}-asset-text`).type('asset/source').with({ type: 'text' });
+
+  // get raw content: "foo.png?raw"
+  rule.oneOf(`${assetType}-asset-raw`).type('asset/source').resourceQuery(RAW_QUERY_REGEX);
 
   rule
     .oneOf(`${assetType}-asset`)

--- a/packages/core/src/plugins/asset.ts
+++ b/packages/core/src/plugins/asset.ts
@@ -49,6 +49,9 @@ const chainStaticAssetRule = ({
   // get raw content: "foo.png?raw"
   rule.oneOf(`${assetType}-asset-raw`).type('asset/source').resourceQuery(RAW_QUERY_REGEX);
 
+  // get asset source: `import source from "foo.png" with { type: "text" }`
+  rule.oneOf(`${assetType}-asset-text`).type('asset/source').with({ type: 'text' });
+
   rule
     .oneOf(`${assetType}-asset`)
     .type('asset')

--- a/packages/core/tests/__snapshots__/asset.test.ts.snap
+++ b/packages/core/tests/__snapshots__/asset.test.ts.snap
@@ -20,6 +20,12 @@ exports[`plugin-asset > should add image rules correctly 1`] = `
         "type": "asset/source",
       },
       {
+        "type": "asset/source",
+        "with": {
+          "type": "text",
+        },
+      },
+      {
         "generator": {
           "filename": "static/image/[name].[contenthash:10][ext]",
         },
@@ -54,6 +60,12 @@ exports[`plugin-asset > should add image rules correctly 2`] = `
       {
         "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
         "type": "asset/source",
+      },
+      {
+        "type": "asset/source",
+        "with": {
+          "type": "text",
+        },
       },
       {
         "generator": {
@@ -92,6 +104,12 @@ exports[`plugin-asset > should allow using distPath.image to modify dist path 1`
         "type": "asset/source",
       },
       {
+        "type": "asset/source",
+        "with": {
+          "type": "text",
+        },
+      },
+      {
         "generator": {
           "filename": "foo/[name].[contenthash:10][ext]",
         },
@@ -126,6 +144,12 @@ exports[`plugin-asset > should allow using filename.image to modify filename 1`]
       {
         "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
         "type": "asset/source",
+      },
+      {
+        "type": "asset/source",
+        "with": {
+          "type": "text",
+        },
       },
       {
         "generator": {

--- a/packages/core/tests/__snapshots__/asset.test.ts.snap
+++ b/packages/core/tests/__snapshots__/asset.test.ts.snap
@@ -16,14 +16,14 @@ exports[`plugin-asset > should add image rules correctly 1`] = `
         "type": "asset/inline",
       },
       {
-        "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-        "type": "asset/source",
-      },
-      {
         "type": "asset/source",
         "with": {
           "type": "text",
         },
+      },
+      {
+        "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+        "type": "asset/source",
       },
       {
         "generator": {
@@ -58,14 +58,14 @@ exports[`plugin-asset > should add image rules correctly 2`] = `
         "type": "asset/inline",
       },
       {
-        "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-        "type": "asset/source",
-      },
-      {
         "type": "asset/source",
         "with": {
           "type": "text",
         },
+      },
+      {
+        "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+        "type": "asset/source",
       },
       {
         "generator": {
@@ -100,14 +100,14 @@ exports[`plugin-asset > should allow using distPath.image to modify dist path 1`
         "type": "asset/inline",
       },
       {
-        "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-        "type": "asset/source",
-      },
-      {
         "type": "asset/source",
         "with": {
           "type": "text",
         },
+      },
+      {
+        "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+        "type": "asset/source",
       },
       {
         "generator": {
@@ -142,14 +142,14 @@ exports[`plugin-asset > should allow using filename.image to modify filename 1`]
         "type": "asset/inline",
       },
       {
-        "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-        "type": "asset/source",
-      },
-      {
         "type": "asset/source",
         "with": {
           "type": "text",
         },
+      },
+      {
+        "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+        "type": "asset/source",
       },
       {
         "generator": {

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -298,14 +298,14 @@ exports[`default bundler > should use Rspack by default 1`] = `
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-            "type": "asset/source",
-          },
-          {
             "type": "asset/source",
             "with": {
               "type": "text",
             },
+          },
+          {
+            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -335,14 +335,14 @@ exports[`default bundler > should use Rspack by default 1`] = `
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-            "type": "asset/source",
-          },
-          {
             "type": "asset/source",
             "with": {
               "type": "text",
             },
+          },
+          {
+            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -372,14 +372,14 @@ exports[`default bundler > should use Rspack by default 1`] = `
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-            "type": "asset/source",
-          },
-          {
             "type": "asset/source",
             "with": {
               "type": "text",
             },
+          },
+          {
+            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -409,14 +409,14 @@ exports[`default bundler > should use Rspack by default 1`] = `
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-            "type": "asset/source",
-          },
-          {
             "type": "asset/source",
             "with": {
               "type": "text",
             },
+          },
+          {
+            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+            "type": "asset/source",
           },
           {
             "generator": {

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -302,6 +302,12 @@ exports[`default bundler > should use Rspack by default 1`] = `
             "type": "asset/source",
           },
           {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
+          },
+          {
             "generator": {
               "filename": "static/image/[name].[contenthash:10][ext]",
             },
@@ -331,6 +337,12 @@ exports[`default bundler > should use Rspack by default 1`] = `
           {
             "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/source",
+          },
+          {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
           },
           {
             "generator": {
@@ -364,6 +376,12 @@ exports[`default bundler > should use Rspack by default 1`] = `
             "type": "asset/source",
           },
           {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
+          },
+          {
             "generator": {
               "filename": "static/media/[name].[contenthash:10][ext]",
             },
@@ -393,6 +411,12 @@ exports[`default bundler > should use Rspack by default 1`] = `
           {
             "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/source",
+          },
+          {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
           },
           {
             "generator": {

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -325,6 +325,12 @@ exports[`should apply default plugins correctly 1`] = `
             "type": "asset/source",
           },
           {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
+          },
+          {
             "generator": {
               "filename": "static/image/[name].[contenthash:10][ext]",
             },
@@ -354,6 +360,12 @@ exports[`should apply default plugins correctly 1`] = `
           {
             "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/source",
+          },
+          {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
           },
           {
             "generator": {
@@ -387,6 +399,12 @@ exports[`should apply default plugins correctly 1`] = `
             "type": "asset/source",
           },
           {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
+          },
+          {
             "generator": {
               "filename": "static/media/[name].[contenthash:10][ext]",
             },
@@ -416,6 +434,12 @@ exports[`should apply default plugins correctly 1`] = `
           {
             "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/source",
+          },
+          {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
           },
           {
             "generator": {
@@ -828,6 +852,12 @@ exports[`should apply default plugins correctly in production 1`] = `
             "type": "asset/source",
           },
           {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
+          },
+          {
             "generator": {
               "filename": "static/image/[name].[contenthash:10][ext]",
             },
@@ -857,6 +887,12 @@ exports[`should apply default plugins correctly in production 1`] = `
           {
             "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/source",
+          },
+          {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
           },
           {
             "generator": {
@@ -890,6 +926,12 @@ exports[`should apply default plugins correctly in production 1`] = `
             "type": "asset/source",
           },
           {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
+          },
+          {
             "generator": {
               "filename": "static/media/[name].[contenthash:10][ext]",
             },
@@ -919,6 +961,12 @@ exports[`should apply default plugins correctly in production 1`] = `
           {
             "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/source",
+          },
+          {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
           },
           {
             "generator": {
@@ -1342,6 +1390,12 @@ exports[`should apply default plugins correctly when target is node 1`] = `
             "type": "asset/source",
           },
           {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
+          },
+          {
             "generator": {
               "filename": "static/image/[name].[contenthash:10][ext]",
             },
@@ -1371,6 +1425,12 @@ exports[`should apply default plugins correctly when target is node 1`] = `
           {
             "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/source",
+          },
+          {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
           },
           {
             "generator": {
@@ -1404,6 +1464,12 @@ exports[`should apply default plugins correctly when target is node 1`] = `
             "type": "asset/source",
           },
           {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
+          },
+          {
             "generator": {
               "filename": "static/media/[name].[contenthash:10][ext]",
             },
@@ -1433,6 +1499,12 @@ exports[`should apply default plugins correctly when target is node 1`] = `
           {
             "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/source",
+          },
+          {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
           },
           {
             "generator": {
@@ -1856,6 +1928,12 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "type": "asset/source",
           },
           {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
+          },
+          {
             "generator": {
               "filename": "static/image/[name].[contenthash:10][ext]",
             },
@@ -1885,6 +1963,12 @@ exports[`tools.rspack > should match snapshot 1`] = `
           {
             "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/source",
+          },
+          {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
           },
           {
             "generator": {
@@ -1918,6 +2002,12 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "type": "asset/source",
           },
           {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
+          },
+          {
             "generator": {
               "filename": "static/media/[name].[contenthash:10][ext]",
             },
@@ -1947,6 +2037,12 @@ exports[`tools.rspack > should match snapshot 1`] = `
           {
             "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/source",
+          },
+          {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
           },
           {
             "generator": {

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -321,14 +321,14 @@ exports[`should apply default plugins correctly 1`] = `
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-            "type": "asset/source",
-          },
-          {
             "type": "asset/source",
             "with": {
               "type": "text",
             },
+          },
+          {
+            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -358,14 +358,14 @@ exports[`should apply default plugins correctly 1`] = `
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-            "type": "asset/source",
-          },
-          {
             "type": "asset/source",
             "with": {
               "type": "text",
             },
+          },
+          {
+            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -395,14 +395,14 @@ exports[`should apply default plugins correctly 1`] = `
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-            "type": "asset/source",
-          },
-          {
             "type": "asset/source",
             "with": {
               "type": "text",
             },
+          },
+          {
+            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -432,14 +432,14 @@ exports[`should apply default plugins correctly 1`] = `
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-            "type": "asset/source",
-          },
-          {
             "type": "asset/source",
             "with": {
               "type": "text",
             },
+          },
+          {
+            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -848,14 +848,14 @@ exports[`should apply default plugins correctly in production 1`] = `
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-            "type": "asset/source",
-          },
-          {
             "type": "asset/source",
             "with": {
               "type": "text",
             },
+          },
+          {
+            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -885,14 +885,14 @@ exports[`should apply default plugins correctly in production 1`] = `
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-            "type": "asset/source",
-          },
-          {
             "type": "asset/source",
             "with": {
               "type": "text",
             },
+          },
+          {
+            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -922,14 +922,14 @@ exports[`should apply default plugins correctly in production 1`] = `
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-            "type": "asset/source",
-          },
-          {
             "type": "asset/source",
             "with": {
               "type": "text",
             },
+          },
+          {
+            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -959,14 +959,14 @@ exports[`should apply default plugins correctly in production 1`] = `
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-            "type": "asset/source",
-          },
-          {
             "type": "asset/source",
             "with": {
               "type": "text",
             },
+          },
+          {
+            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -1386,14 +1386,14 @@ exports[`should apply default plugins correctly when target is node 1`] = `
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-            "type": "asset/source",
-          },
-          {
             "type": "asset/source",
             "with": {
               "type": "text",
             },
+          },
+          {
+            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -1423,14 +1423,14 @@ exports[`should apply default plugins correctly when target is node 1`] = `
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-            "type": "asset/source",
-          },
-          {
             "type": "asset/source",
             "with": {
               "type": "text",
             },
+          },
+          {
+            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -1460,14 +1460,14 @@ exports[`should apply default plugins correctly when target is node 1`] = `
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-            "type": "asset/source",
-          },
-          {
             "type": "asset/source",
             "with": {
               "type": "text",
             },
+          },
+          {
+            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -1497,14 +1497,14 @@ exports[`should apply default plugins correctly when target is node 1`] = `
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-            "type": "asset/source",
-          },
-          {
             "type": "asset/source",
             "with": {
               "type": "text",
             },
+          },
+          {
+            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -1924,14 +1924,14 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-            "type": "asset/source",
-          },
-          {
             "type": "asset/source",
             "with": {
               "type": "text",
             },
+          },
+          {
+            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -1961,14 +1961,14 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-            "type": "asset/source",
-          },
-          {
             "type": "asset/source",
             "with": {
               "type": "text",
             },
+          },
+          {
+            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -1998,14 +1998,14 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-            "type": "asset/source",
-          },
-          {
             "type": "asset/source",
             "with": {
               "type": "text",
             },
+          },
+          {
+            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -2035,14 +2035,14 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-            "type": "asset/source",
-          },
-          {
             "type": "asset/source",
             "with": {
               "type": "text",
             },
+          },
+          {
+            "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+            "type": "asset/source",
           },
           {
             "generator": {

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -298,6 +298,12 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
               "type": "asset/source",
             },
             {
+              "type": "asset/source",
+              "with": {
+                "type": "text",
+              },
+            },
+            {
               "generator": {
                 "filename": "static/image/[name].[contenthash:10][ext]",
               },
@@ -327,6 +333,12 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
             {
               "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
               "type": "asset/source",
+            },
+            {
+              "type": "asset/source",
+              "with": {
+                "type": "text",
+              },
             },
             {
               "generator": {
@@ -360,6 +372,12 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
               "type": "asset/source",
             },
             {
+              "type": "asset/source",
+              "with": {
+                "type": "text",
+              },
+            },
+            {
               "generator": {
                 "filename": "static/media/[name].[contenthash:10][ext]",
               },
@@ -389,6 +407,12 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
             {
               "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
               "type": "asset/source",
+            },
+            {
+              "type": "asset/source",
+              "with": {
+                "type": "text",
+              },
             },
             {
               "generator": {
@@ -786,6 +810,12 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
               "type": "asset/source",
             },
             {
+              "type": "asset/source",
+              "with": {
+                "type": "text",
+              },
+            },
+            {
               "generator": {
                 "filename": "static/image/[name].[contenthash:10][ext]",
               },
@@ -815,6 +845,12 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
             {
               "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
               "type": "asset/source",
+            },
+            {
+              "type": "asset/source",
+              "with": {
+                "type": "text",
+              },
             },
             {
               "generator": {
@@ -848,6 +884,12 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
               "type": "asset/source",
             },
             {
+              "type": "asset/source",
+              "with": {
+                "type": "text",
+              },
+            },
+            {
               "generator": {
                 "filename": "static/media/[name].[contenthash:10][ext]",
               },
@@ -877,6 +919,12 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
             {
               "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
               "type": "asset/source",
+            },
+            {
+              "type": "asset/source",
+              "with": {
+                "type": "text",
+              },
             },
             {
               "generator": {

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -294,14 +294,14 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
               "type": "asset/inline",
             },
             {
-              "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-              "type": "asset/source",
-            },
-            {
               "type": "asset/source",
               "with": {
                 "type": "text",
               },
+            },
+            {
+              "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+              "type": "asset/source",
             },
             {
               "generator": {
@@ -331,14 +331,14 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
               "type": "asset/inline",
             },
             {
-              "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-              "type": "asset/source",
-            },
-            {
               "type": "asset/source",
               "with": {
                 "type": "text",
               },
+            },
+            {
+              "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+              "type": "asset/source",
             },
             {
               "generator": {
@@ -368,14 +368,14 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
               "type": "asset/inline",
             },
             {
-              "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-              "type": "asset/source",
-            },
-            {
               "type": "asset/source",
               "with": {
                 "type": "text",
               },
+            },
+            {
+              "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+              "type": "asset/source",
             },
             {
               "generator": {
@@ -405,14 +405,14 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
               "type": "asset/inline",
             },
             {
-              "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-              "type": "asset/source",
-            },
-            {
               "type": "asset/source",
               "with": {
                 "type": "text",
               },
+            },
+            {
+              "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+              "type": "asset/source",
             },
             {
               "generator": {
@@ -806,14 +806,14 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
               "type": "asset/inline",
             },
             {
-              "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-              "type": "asset/source",
-            },
-            {
               "type": "asset/source",
               "with": {
                 "type": "text",
               },
+            },
+            {
+              "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+              "type": "asset/source",
             },
             {
               "generator": {
@@ -843,14 +843,14 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
               "type": "asset/inline",
             },
             {
-              "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-              "type": "asset/source",
-            },
-            {
               "type": "asset/source",
               "with": {
                 "type": "text",
               },
+            },
+            {
+              "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+              "type": "asset/source",
             },
             {
               "generator": {
@@ -880,14 +880,14 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
               "type": "asset/inline",
             },
             {
-              "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-              "type": "asset/source",
-            },
-            {
               "type": "asset/source",
               "with": {
                 "type": "text",
               },
+            },
+            {
+              "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+              "type": "asset/source",
             },
             {
               "generator": {
@@ -917,14 +917,14 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
               "type": "asset/inline",
             },
             {
-              "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-              "type": "asset/source",
-            },
-            {
               "type": "asset/source",
               "with": {
                 "type": "text",
               },
+            },
+            {
+              "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+              "type": "asset/source",
             },
             {
               "generator": {

--- a/packages/plugin-less/src/index.ts
+++ b/packages/plugin-less/src/index.ts
@@ -216,13 +216,13 @@ export const pluginLess = (pluginOptions: PluginLessOptions = {}): RsbuildPlugin
       // Inline Less for `?inline` imports
       const lessInlineRule = getRule(LESS_INLINE);
 
-      // Raw Less for `?raw` imports
-      getRule(LESS_RAW).type('asset/source').resourceQuery(getRule(CSS_RAW).get('resourceQuery'));
-
       // Less text import with import attributes.
       if (hasCssTextRule) {
         getRule(LESS_TEXT).type('asset/source').with(getRule(cssTextRuleId).get('with'));
       }
+
+      // Raw Less for `?raw` imports
+      getRule(LESS_RAW).type('asset/source').resourceQuery(getRule(CSS_RAW).get('resourceQuery'));
 
       // Main Less transform
       const lessMainRule = getRule(LESS_MAIN);

--- a/packages/plugin-less/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-less/tests/__snapshots__/index.test.ts.snap
@@ -98,14 +98,14 @@ exports[`plugin-less > should add less-loader 1`] = `
         ],
       },
       {
-        "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-        "type": "asset/source",
-      },
-      {
         "type": "asset/source",
         "with": {
           "type": "text",
         },
+      },
+      {
+        "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+        "type": "asset/source",
       },
       {
         "sideEffects": true,
@@ -260,14 +260,14 @@ exports[`plugin-less > should add less-loader and css-loader when injectStyles 1
         ],
       },
       {
-        "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-        "type": "asset/source",
-      },
-      {
         "type": "asset/source",
         "with": {
           "type": "text",
         },
+      },
+      {
+        "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+        "type": "asset/source",
       },
       {
         "sideEffects": true,
@@ -428,14 +428,14 @@ exports[`plugin-less > should add less-loader with excludes 1`] = `
         ],
       },
       {
-        "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-        "type": "asset/source",
-      },
-      {
         "type": "asset/source",
         "with": {
           "type": "text",
         },
+      },
+      {
+        "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+        "type": "asset/source",
       },
       {
         "exclude": [
@@ -593,14 +593,14 @@ exports[`plugin-less > should add less-loader with tools.less 1`] = `
         ],
       },
       {
-        "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-        "type": "asset/source",
-      },
-      {
         "type": "asset/source",
         "with": {
           "type": "text",
         },
+      },
+      {
+        "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+        "type": "asset/source",
       },
       {
         "sideEffects": true,
@@ -769,14 +769,14 @@ exports[`plugin-less > should allow to use Less plugins 1`] = `
         ],
       },
       {
-        "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-        "type": "asset/source",
-      },
-      {
         "type": "asset/source",
         "with": {
           "type": "text",
         },
+      },
+      {
+        "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+        "type": "asset/source",
       },
       {
         "sideEffects": true,

--- a/packages/plugin-sass/src/index.ts
+++ b/packages/plugin-sass/src/index.ts
@@ -153,13 +153,13 @@ export const pluginSass = (pluginOptions: PluginSassOptions = {}): RsbuildPlugin
       // Inline Sass for `?inline` imports
       const sassInlineRule = getRule(SASS_INLINE);
 
-      // Raw Sass for `?raw` imports
-      getRule(SASS_RAW).type('asset/source').resourceQuery(getRule(CSS_RAW).get('resourceQuery'));
-
       // Sass text import with import attributes.
       if (hasCssTextRule) {
         getRule(SASS_TEXT).type('asset/source').with(getRule(cssTextRuleId).get('with'));
       }
+
+      // Raw Sass for `?raw` imports
+      getRule(SASS_RAW).type('asset/source').resourceQuery(getRule(CSS_RAW).get('resourceQuery'));
 
       // Main Sass transform
       const sassMainRule = getRule(SASS_MAIN);

--- a/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
@@ -116,14 +116,14 @@ exports[`plugin-sass > should add sass-loader 1`] = `
         ],
       },
       {
-        "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-        "type": "asset/source",
-      },
-      {
         "type": "asset/source",
         "with": {
           "type": "text",
         },
+      },
+      {
+        "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+        "type": "asset/source",
       },
       {
         "sideEffects": true,
@@ -305,14 +305,14 @@ exports[`plugin-sass > should add sass-loader and css-loader when injectStyles 1
         ],
       },
       {
-        "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-        "type": "asset/source",
-      },
-      {
         "type": "asset/source",
         "with": {
           "type": "text",
         },
+      },
+      {
+        "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+        "type": "asset/source",
       },
       {
         "sideEffects": true,
@@ -500,14 +500,14 @@ exports[`plugin-sass > should add sass-loader with excludes 1`] = `
         ],
       },
       {
-        "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-        "type": "asset/source",
-      },
-      {
         "type": "asset/source",
         "with": {
           "type": "text",
         },
+      },
+      {
+        "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+        "type": "asset/source",
       },
       {
         "exclude": [
@@ -694,14 +694,14 @@ exports[`plugin-sass > should allow to use legacy API and mute deprecation warni
         ],
       },
       {
-        "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-        "type": "asset/source",
-      },
-      {
         "type": "asset/source",
         "with": {
           "type": "text",
         },
+      },
+      {
+        "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+        "type": "asset/source",
       },
       {
         "sideEffects": true,


### PR DESCRIPTION
## Summary

This PR adds support for importing built-in static assets as source text with import attributes (`with { type: 'text' }`). It adds a dedicated asset rule branch and e2e coverage for `.svg` and `.png` assets, and normalizes the text-import oneOf branch to run before raw-query branches. Plugin-specific SVG handling such as `@rsbuild/plugin-svgr` is intentionally left for a follow-up PR.