### PR TITLE
feat(plugin-svgr): support SVG text import attributes

### DIFF
--- a/e2e/cases/plugin-svgr/import-attributes-text/index.test.ts
+++ b/e2e/cases/plugin-svgr/import-attributes-text/index.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { expect, test } from '@e2e/helper';
+
+test('should import SVG as text with import attributes when using pluginSvgr', async ({
+  page,
+  runBothServe,
+}) => {
+  await runBothServe(async () => {
+    expect(await page.evaluate('window.svgText')).toBe(
+      readFileSync(join(import.meta.dirname, '../../../assets/circle.svg'), 'utf-8'),
+    );
+  });
+});

--- a/e2e/cases/plugin-svgr/import-attributes-text/rsbuild.config.ts
+++ b/e2e/cases/plugin-svgr/import-attributes-text/rsbuild.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginSvgr } from '@rsbuild/plugin-svgr';
+
+export default defineConfig({
+  plugins: [pluginSvgr()],
+});

--- a/e2e/cases/plugin-svgr/import-attributes-text/src/index.js
+++ b/e2e/cases/plugin-svgr/import-attributes-text/src/index.js
@@ -1,0 +1,3 @@
+import svgText from '@e2e/assets/circle.svg' with { type: 'text' };
+
+window.svgText = svgText;

--- a/packages/core/src/configChain.ts
+++ b/packages/core/src/configChain.ts
@@ -77,6 +77,7 @@ export const CHAIN_ID = {
     /** SVG oneOf rules */
     SVG: 'svg',
     SVG_RAW: 'svg-asset-raw',
+    SVG_TEXT: 'svg-asset-text',
     SVG_URL: 'svg-asset-url',
     SVG_ASSET: 'svg-asset',
     SVG_REACT: 'svg-react',

--- a/packages/plugin-svgr/src/index.ts
+++ b/packages/plugin-svgr/src/index.ts
@@ -205,6 +205,11 @@ export const pluginSvgr = (options: PluginSvgrOptions = {}): RsbuildPlugin => ({
         .type('asset/inline')
         .resourceQuery(/^\?inline$/);
 
+      // get SVG source: `import source from "foo.svg" with { type: "text" }`
+      if (CHAIN_ID.ONE_OF.SVG_TEXT) {
+        rule.oneOf(CHAIN_ID.ONE_OF.SVG_TEXT).type('asset/source').with({ type: 'text' });
+      }
+
       // get raw content: "foo.svg?raw"
       if (CHAIN_ID.ONE_OF.SVG_RAW) {
         rule

--- a/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
@@ -15,6 +15,12 @@ exports[`svgr > configure SVGR options 1`] = `
       "type": "asset/inline",
     },
     {
+      "type": "asset/source",
+      "with": {
+        "type": "text",
+      },
+    },
+    {
       "resourceQuery": /\\^\\\\\\?raw\\$/,
       "type": "asset/source",
     },
@@ -115,6 +121,12 @@ exports[`svgr > exportType default / mixedImport false 1`] = `
     {
       "resourceQuery": /\\^\\\\\\?inline\\$/,
       "type": "asset/inline",
+    },
+    {
+      "type": "asset/source",
+      "with": {
+        "type": "text",
+      },
     },
     {
       "resourceQuery": /\\^\\\\\\?raw\\$/,
@@ -288,6 +300,12 @@ exports[`svgr > exportType default / mixedImport true 1`] = `
       "type": "asset/inline",
     },
     {
+      "type": "asset/source",
+      "with": {
+        "type": "text",
+      },
+    },
+    {
       "resourceQuery": /\\^\\\\\\?raw\\$/,
       "type": "asset/source",
     },
@@ -459,6 +477,12 @@ exports[`svgr > exportType named / mixedImport false 1`] = `
       "type": "asset/inline",
     },
     {
+      "type": "asset/source",
+      "with": {
+        "type": "text",
+      },
+    },
+    {
       "resourceQuery": /\\^\\\\\\?raw\\$/,
       "type": "asset/source",
     },
@@ -628,6 +652,12 @@ exports[`svgr > exportType named / mixedImport true 1`] = `
     {
       "resourceQuery": /\\^\\\\\\?inline\\$/,
       "type": "asset/inline",
+    },
+    {
+      "type": "asset/source",
+      "with": {
+        "type": "text",
+      },
     },
     {
       "resourceQuery": /\\^\\\\\\?raw\\$/,


### PR DESCRIPTION
## Summary

This PR adds `with { type: 'text' }` support for SVG imports when `@rsbuild/plugin-svgr` rebuilds the SVG rule. It preserves the built-in text-import branch before the raw-query branch, adds a `SVG_TEXT` chain id, and includes plugin-specific e2e coverage for importing an SVG as source text.