### PR TITLE
feat(core): support text import attributes for JSON

### DIFF
--- a/e2e/cases/assets/import-json-text-attributes/index.test.ts
+++ b/e2e/cases/assets/import-json-text-attributes/index.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { expect, test } from '@e2e/helper';
+
+test('should import JSON as text with import attributes', async ({ page, runBothServe }) => {
+  await runBothServe(async () => {
+    expect(await page.evaluate('window.jsonText')).toBe(
+      readFileSync(join(import.meta.dirname, './src/data.json'), 'utf-8'),
+    );
+    expect(await page.evaluate('window.jsonValue')).toBe('text attributes');
+  });
+});

--- a/e2e/cases/assets/import-json-text-attributes/src/data.json
+++ b/e2e/cases/assets/import-json-text-attributes/src/data.json
@@ -1,0 +1,4 @@
+{
+  "name": "text attributes",
+  "unused": "tree-shaking is not relevant for text imports"
+}

--- a/e2e/cases/assets/import-json-text-attributes/src/index.js
+++ b/e2e/cases/assets/import-json-text-attributes/src/index.js
@@ -1,0 +1,5 @@
+import dataText from './data.json' with { type: 'text' };
+import data from './data.json' with { type: 'json' };
+
+window.jsonText = dataText;
+window.jsonValue = data.name;

--- a/packages/core/src/plugins/asset.ts
+++ b/packages/core/src/plugins/asset.ts
@@ -134,7 +134,7 @@ export const pluginAsset = (): RsbuildPlugin => ({
       createAssetRule(CHAIN_ID.RULE.FONT, FONT_EXTENSIONS, emitAssets);
 
       // JSON
-      // Rspack has built-in rule for JSON, so we only need to handle imports with query
+      // Rspack has built-in rule for JSON, so we only need to handle imports with query or import attributes
       const rule = chain.module.rule(CHAIN_ID.RULE.JSON).test(/\.json$/i);
       // get JSON source: `import source from "foo.json" with { type: "text" }`
       rule.oneOf('json-asset-text').type('asset/source').with({ type: 'text' });

--- a/packages/core/src/plugins/asset.ts
+++ b/packages/core/src/plugins/asset.ts
@@ -135,8 +135,10 @@ export const pluginAsset = (): RsbuildPlugin => ({
 
       // JSON
       // Rspack has built-in rule for JSON, so we only need to handle imports with query
-      // get raw content: "foo.json?raw"
       const rule = chain.module.rule(CHAIN_ID.RULE.JSON).test(/\.json$/i);
+      // get JSON source: `import source from "foo.json" with { type: "text" }`
+      rule.oneOf('json-asset-text').type('asset/source').with({ type: 'text' });
+      // get raw content: "foo.json?raw"
       rule.oneOf('json-asset-raw').type('asset/source').resourceQuery(RAW_QUERY_REGEX);
 
       // assets

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -435,6 +435,12 @@ exports[`default bundler > should use Rspack by default 1`] = `
       {
         "oneOf": [
           {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
+          },
+          {
             "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/source",
           },

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -458,6 +458,12 @@ exports[`should apply default plugins correctly 1`] = `
       {
         "oneOf": [
           {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
+          },
+          {
             "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/source",
           },
@@ -984,6 +990,12 @@ exports[`should apply default plugins correctly in production 1`] = `
       },
       {
         "oneOf": [
+          {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
+          },
           {
             "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/source",
@@ -1523,6 +1535,12 @@ exports[`should apply default plugins correctly when target is node 1`] = `
       {
         "oneOf": [
           {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
+          },
+          {
             "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/source",
           },
@@ -2060,6 +2078,12 @@ exports[`tools.rspack > should match snapshot 1`] = `
       },
       {
         "oneOf": [
+          {
+            "type": "asset/source",
+            "with": {
+              "type": "text",
+            },
+          },
           {
             "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/source",

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -431,6 +431,12 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
         {
           "oneOf": [
             {
+              "type": "asset/source",
+              "with": {
+                "type": "text",
+              },
+            },
+            {
               "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
               "type": "asset/source",
             },
@@ -942,6 +948,12 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
         },
         {
           "oneOf": [
+            {
+              "type": "asset/source",
+              "with": {
+                "type": "text",
+              },
+            },
             {
               "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
               "type": "asset/source",


### PR DESCRIPTION
## Summary

This PR adds support for importing JSON files as text with import attributes, allowing `.json` files to use `with { type: 'text' }` while preserving the existing JSON object import behavior. The JSON asset rule now handles text import attributes before `?raw`, and a dedicated assets e2e case covers both text and JSON imports.