### PR TITLE
fix(core): print gzip size for script assets

### DIFF
--- a/e2e/cases/print-file-size/basic/index.test.ts
+++ b/e2e/cases/print-file-size/basic/index.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@e2e/helper';
+import type { RsbuildPlugin } from '@rsbuild/core';
 import { extractFileSizeLogs } from '../helper';
 
 test('should print file size after building by default', async ({ build }) => {
@@ -199,6 +200,35 @@ dist/static/js/index.[[hash]].js       X.X kB     X.X kB
 dist/static/image/icon.[[hash]].png    X.X kB
 dist/static/js/lib-react.[[hash]].js   X.X kB   X.X kB
                               Total:   X.X kB   X.X kB`);
+});
+
+test('should calculate gzip size for script-like assets', async ({ build }) => {
+  const emitTsAssetPlugin: RsbuildPlugin = {
+    name: 'emit-ts-asset',
+    setup(api) {
+      api.processAssets({ stage: 'additional' }, ({ compilation, sources }) => {
+        compilation.emitAsset(
+          'static/assets/script.ts',
+          new sources.RawSource("const value = 'ts';\n"),
+        );
+      });
+    },
+  };
+
+  const rsbuild = await build({
+    config: {
+      performance: {
+        printFileSize: {
+          total: false,
+        },
+      },
+      plugins: [emitTsAssetPlugin],
+    },
+  });
+
+  const logs = extractFileSizeLogs(rsbuild.logs);
+
+  expect(logs).toMatch(/dist\/static\/assets\/script\.ts\s+X\.X kB\s+X\.X kB/);
 });
 
 test('should respect a custom total function for printFileSize', async ({ build }) => {

--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -97,9 +97,9 @@ async function saveSnapshots(
   }
 }
 
-const EXCLUDE_ASSET_REGEX = /\.(?:map|LICENSE\.txt|d\.ts)$/;
+const EXCLUDE_ASSET_REGEX = /\.(?:map|LICENSE\.txt|d\.(?:ts|mts|cts))$/;
 
-/** Exclude source map and license files by default */
+/** Exclude source map, license, and type declaration files by default */
 export const excludeAsset = (asset: PrintFileSizeAsset): boolean =>
   EXCLUDE_ASSET_REGEX.test(asset.name);
 
@@ -171,7 +171,8 @@ const coloringAssetName = (assetName: string) => {
   return color.magenta(assetName);
 };
 
-const COMPRESSIBLE_REGEX = /\.(?:js|css|html|json|svg|txt|xml|xhtml|wasm|manifest|md)$/i;
+const COMPRESSIBLE_REGEX =
+  /\.(?:js|mjs|cjs|jsx|ts|tsx|mts|cts|css|html|json|svg|txt|xml|xhtml|wasm|manifest|md)$/i;
 
 /** Check if the asset is compressible. */
 const isCompressible = (assetName: string) => COMPRESSIBLE_REGEX.test(assetName);

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -709,7 +709,7 @@ export type PrintFileSizeOptions = {
   /**
    * A filter function to exclude static assets from the total size or detailed size.
    * If both `include` and `exclude` are set, `exclude` will take precedence.
-   * @default (asset) => /\.(?:map|LICENSE\.txt)$/.test(asset.name)
+   * @default (asset) => /\.(?:map|LICENSE\.txt|d\.(?:ts|mts|cts))$/.test(asset.name)
    */
   exclude?: (asset: PrintFileSizeAsset) => boolean;
   /**

--- a/packages/core/tests/fileSize.test.ts
+++ b/packages/core/tests/fileSize.test.ts
@@ -10,6 +10,8 @@ describe('plugin-file-size', () => {
     expect(excludeAsset({ name: 'dist/b.css.LICENSE.txt', size: 1000 })).toBeTruthy();
     expect(excludeAsset({ name: 'dist/a.png', size: 1000 })).toBeFalsy();
     expect(excludeAsset({ name: 'dist/a.d.ts', size: 1000 })).toBeTruthy();
+    expect(excludeAsset({ name: 'dist/a.d.mts', size: 1000 })).toBeTruthy();
+    expect(excludeAsset({ name: 'dist/a.d.cts', size: 1000 })).toBeTruthy();
   });
 
   describe('#normalizeFilePath', () => {

--- a/website/docs/en/config/performance/print-file-size.mdx
+++ b/website/docs/en/config/performance/print-file-size.mdx
@@ -213,11 +213,11 @@ export default {
 type Exclude = (asset: PrintFileSizeAsset) => boolean;
 ```
 
-- **Default:** `(asset) => /\.(?:map|LICENSE\.txt|d\.ts)$/.test(asset.name)`
+- **Default:** `(asset) => /\.(?:map|LICENSE\.txt|d\.(?:ts|mts|cts))$/.test(asset.name)`
 
 A filter function to determine which static assets to exclude. If both `include` and `exclude` are set, `exclude` will take precedence.
 
-Rsbuild defaults to excluding source map, license files, and `.d.ts` type files, as these files do not affect page load performance.
+Rsbuild defaults to excluding source map, license files, and `.d.ts`, `.d.mts`, or `.d.cts` type declaration files, as these files do not affect page load performance.
 
 For example, exclude `.html` files in addition to the default:
 
@@ -226,7 +226,7 @@ export default {
   performance: {
     printFileSize: {
       exclude: (asset) =>
-        /\.(?:map|LICENSE\.txt|d\.ts)$/.test(asset.name) || /\.html$/.test(asset.name),
+        /\.(?:map|LICENSE\.txt|d\.(?:ts|mts|cts))$/.test(asset.name) || /\.html$/.test(asset.name),
     },
   },
 };

--- a/website/docs/zh/config/performance/print-file-size.mdx
+++ b/website/docs/zh/config/performance/print-file-size.mdx
@@ -213,11 +213,11 @@ export default {
 type Exclude = (asset: PrintFileSizeAsset) => boolean;
 ```
 
-- **默认值：** `(asset) => /\.(?:map|LICENSE\.txt|d\.ts)$/.test(asset.name)`
+- **默认值：** `(asset) => /\.(?:map|LICENSE\.txt|d\.(?:ts|mts|cts))$/.test(asset.name)`
 
 一个过滤函数，用于确定哪些静态资源需要被排除。如果同时设置了 `include` 和 `exclude`，则 `exclude` 优先级更高。
 
-Rsbuild 默认排除 source map、许可证文件和 `.d.ts` 类型文件，因为这些文件不会影响页面加载的性能。
+Rsbuild 默认排除 source map、许可证文件和 `.d.ts`、`.d.mts`、`.d.cts` 类型声明文件，因为这些文件不会影响页面加载的性能。
 
 例如，额外再排除 `.html` 文件：
 
@@ -226,7 +226,7 @@ export default {
   performance: {
     printFileSize: {
       exclude: (asset) =>
-        /\.(?:map|LICENSE\.txt|d\.ts)$/.test(asset.name) || /\.html$/.test(asset.name),
+        /\.(?:map|LICENSE\.txt|d\.(?:ts|mts|cts))$/.test(asset.name) || /\.html$/.test(asset.name),
     },
   },
 };


### PR DESCRIPTION
## Summary

Rslib outputs can include script assets with extensions such as `.mjs`, `.cjs`, `.jsx`, `.ts`, `.tsx`, `.mts`, and `.cts`, but `performance.printFileSize` only treated `.js` as compressible JavaScript.

This PR includes those script-like extensions in gzip size calculation and extends the default declaration-file exclude rule to cover `.d.mts` and `.d.cts`, keeping the printed total gzip size accurate for Rslib-style outputs.