### PR TITLE
docs: update agent skill metadata

### DIFF
--- a/.agents/skills/create-draft-release-notes/SKILL.md
+++ b/.agents/skills/create-draft-release-notes/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: create-draft-release-notes
 description: Create or update draft GitHub release notes, or output organized Markdown when draft creation is unavailable. Use for release notes, draft releases, release PR checks, npm staged publishing checks, and optional highlights.
+metadata:
+  internal: true
 ---
 
 # Create Draft Release Notes

--- a/.agents/skills/pr-creator/SKILL.md
+++ b/.agents/skills/pr-creator/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: pr-creator
 description: Use when asked to create a pull request for this repository. It helps the PR follow the repository's branch safety rules, title convention, pull request template, and concise English writing style.
+metadata:
+  internal: true
 ---
 
 # Pull Request Creator
@@ -30,7 +32,7 @@ description: Use when asked to create a pull request for this repository. It hel
    - In `Summary`, explain the change context first: the user-facing problem, maintenance goal, or compatibility constraint that makes the change necessary.
    - Prioritize high-signal information: public API changes, behavior changes, breaking changes, migration notes, and important compatibility implications.
    - Then describe the main implementation change only as much as needed to understand the review.
-   - Keep it short: one compact paragraph or 2-4 bullets is usually enough.
+   - Keep the PR body concise and review-oriented: use 1-4 short standalone sentences for typical changes, covering why it matters, what changed, and any reviewer-important impact.
    - Avoid low-signal sections such as `Test plan` or `Validation`, routine verification commands, generated file lists, or obvious implementation details unless the repository template explicitly requires them or the change has unusual validation risk.
    - Good background examples:
      - `This PR adds support for custom logger injection so CLI output can be isolated per instance.`

--- a/.agents/skills/release-blog-writer/SKILL.md
+++ b/.agents/skills/release-blog-writer/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: release-blog-writer
 description: Write or revise release blog posts for product releases. Use when the user asks to draft, polish, restructure, or adapt a release announcement.
+metadata:
+  internal: true
 ---
 
 # Release blog writer

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -4,20 +4,20 @@
     "create-draft-release-notes": {
       "source": "rstackjs/agent-skills",
       "sourceType": "github",
-      "skillPath": "skills/create-draft-release-notes/SKILL.md",
-      "computedHash": "cb32485c5a35e45acba920a690a14d10f878c92fbbd2312ec3d0ce4bf2012abc"
+      "skillPath": ".agents/skills/create-draft-release-notes/SKILL.md",
+      "computedHash": "9fa7807d607c7fb7e02795ddee2560cc190d4af791320537a66ca8b2e429d858"
     },
     "pr-creator": {
       "source": "rstackjs/agent-skills",
       "sourceType": "github",
-      "skillPath": "skills/pr-creator/SKILL.md",
-      "computedHash": "065a131500e344efa79c620b4ccc8686ff375c4017f33929e4b00643e57cdc74"
+      "skillPath": ".agents/skills/pr-creator/SKILL.md",
+      "computedHash": "c49fcbba72894d08a34d054a00720610d19a2e87e25942aee05da09e87b268df"
     },
     "release-blog-writer": {
       "source": "rstackjs/agent-skills",
       "sourceType": "github",
-      "skillPath": "skills/release-blog-writer/SKILL.md",
-      "computedHash": "24bdde0407813d43e4f42336fa0d433f53e5c5c8a516f46acbc3505c557f68ea"
+      "skillPath": ".agents/skills/release-blog-writer/SKILL.md",
+      "computedHash": "982e423497efa0a1266e06e14f880264c791e22b33144ce283fcd38041a7e814"
     },
     "rspress-description-generator": {
       "source": "rstackjs/agent-skills",


### PR DESCRIPTION
## Summary

This PR updates the repo agent skill metadata so internal-only skills are marked consistently and the lockfile points at their local `.agents/skills` paths. It also tightens the PR creator guidance for concise, review-oriented PR bodies.