### PR TITLE
docs: add text import attributes usage

### DIFF
--- a/website/docs/en/guide/basic/static-assets.mdx
+++ b/website/docs/en/guide/basic/static-assets.mdx
@@ -159,33 +159,59 @@ For a more detailed introduction to asset inlining, refer to the [Static Asset I
 
 ## Importing as string
 
-Rsbuild supports using the `?raw` query parameter to import the raw content of static assets as a string in JavaScript.
+### With import attributes
+
+Rsbuild supports using import attributes with `type: 'text'` to import the original content of files as strings in JavaScript.
+
+```ts
+import svgText from './static/logo.svg' with { type: 'text' };
+import imageText from './static/image.png' with { type: 'text' };
+import jsonText from './data.json' with { type: 'text' };
+import componentText from './component.tsx' with { type: 'text' };
+import styleText from './style.css' with { type: 'text' };
+
+console.log(svgText); // The original content of the SVG file
+```
+
+The `type: 'text'` import attribute imports the original resource content as a string, without running the default asset, script, or style processing pipeline.
+
+The import attribute only affects the current import. Normal imports keep their default behavior:
+
+```ts
+import { foo } from './foo.js';
+import fooText from './foo.js' with { type: 'text' };
+
+console.log(foo); // The export from foo.js
+console.log(fooText); // The original content of foo.js
+```
+
+Dynamic imports can pass import attributes through the second argument:
+
+```ts
+const { default: fooText } = await import('./foo.js', {
+  with: { type: 'text' },
+});
+
+console.log(fooText); // The original content of foo.js
+```
+
+:::tip
+`type: 'text'` is supported in Rsbuild >= 2.1.3 and is recommended over the `?raw` query parameter.
+:::
+
+### With query parameters
+
+Rsbuild also supports using the `?raw` query parameter to import file content as a string:
 
 ```ts
 import rawSvg from './static/logo.svg?raw';
+import rawImage from './static/image.png?raw';
+import rawJson from './data.json?raw';
+import rawComponent from './component.tsx?raw';
+import rawStyle from './style.css?raw';
 
-console.log(rawSvg); // The raw content of the SVG file
+console.log(rawSvg); // The original content of the SVG file
 ```
-
-Rsbuild also supports importing the raw content of JavaScript, TypeScript, and JSX files through the `?raw` query parameter.
-
-```ts
-import rawJs from './script1.js?raw';
-import rawTs from './script2.ts?raw';
-import rawJsx from './script3.jsx?raw';
-import rawTsx from './script4.tsx?raw';
-
-console.log(rawJs); // The raw content of the JS file
-console.log(rawTs); // The raw content of the TS file
-console.log(rawJsx); // The raw content of the JSX file
-console.log(rawTsx); // The raw content of the TSX file
-```
-
-You can also use the `?raw` query parameter to import the raw content of CSS files, see [CSS](/guide/styling/css-usage#raw).
-
-:::tip
-Rsbuild >= 1.3.0 supports the `?raw` query parameter, and >= 1.4.0 supports importing the raw content of JS and TS files.
-:::
 
 ## Output files
 

--- a/website/docs/en/guide/styling/css-usage.mdx
+++ b/website/docs/en/guide/styling/css-usage.mdx
@@ -163,6 +163,26 @@ In Sass and Less files, it is also allowed to add the `~` prefix to resolve styl
 @import 'normalize.css';
 ```
 
+## Import attributes
+
+Rsbuild supports importing raw CSS source as a string in JavaScript by using import attributes with `type: 'text'`.
+
+```js title="src/index.js"
+import rawCss from './style.css' with { type: 'text' };
+
+console.log(rawCss); // Output the raw content of the CSS file
+```
+
+Using `import "*.css" with { type: 'text' }` has the following behaviors:
+
+- Get the raw text content of the CSS file, without any preprocessing or compilation
+- The content of the CSS file will be inlined into the final JavaScript bundle
+- No separate CSS file will be generated
+
+:::tip
+`type: 'text'` is supported in Rsbuild >= 2.1.3.
+:::
+
 ## Query parameters
 
 ### inline
@@ -190,9 +210,9 @@ Using `import "*.css?inline"` has the following behaviors:
 
 ### raw
 
-Rsbuild supports importing raw CSS files as strings in JavaScript by using the `?raw` query parameter.
+Rsbuild also supports importing raw CSS files as strings in JavaScript by using the `?raw` query parameter.
 
-```ts title="src/index.js"
+```js title="src/index.js"
 import rawCss from './style.css?raw';
 
 console.log(rawCss); // Output the raw content of the CSS file

--- a/website/docs/zh/guide/basic/static-assets.mdx
+++ b/website/docs/zh/guide/basic/static-assets.mdx
@@ -159,33 +159,59 @@ console.log(image); // "data:image/png;base64,iVBORw0KGgo..."
 
 ## 导入为字符串
 
-Rsbuild 支持通过 `?raw` 查询参数引用静态资源的原始内容，并将其作为字符串导入到 JavaScript 中。
+### 通过导入属性
+
+Rsbuild 支持通过 `type: 'text'` 导入属性将文件原始内容作为字符串导入到 JavaScript 中。
+
+```ts
+import svgText from './static/logo.svg' with { type: 'text' };
+import imageText from './static/image.png' with { type: 'text' };
+import jsonText from './data.json' with { type: 'text' };
+import componentText from './component.tsx' with { type: 'text' };
+import styleText from './style.css' with { type: 'text' };
+
+console.log(svgText); // 输出 SVG 文件的原始内容
+```
+
+`type: 'text'` 导入属性支持将资源的原始内容作为字符串导入，不会经过默认的资源、脚本或样式处理流程。
+
+导入属性只影响当前导入，普通导入仍会保持默认行为：
+
+```ts
+import { foo } from './foo.js';
+import fooText from './foo.js' with { type: 'text' };
+
+console.log(foo); // foo.js 导出的内容
+console.log(fooText); // foo.js 的原始内容
+```
+
+动态导入也可以通过第二个参数传入导入属性：
+
+```ts
+const { default: fooText } = await import('./foo.js', {
+  with: { type: 'text' },
+});
+
+console.log(fooText); // foo.js 的原始内容
+```
+
+:::tip
+`type: 'text'` 在 Rsbuild >= 2.1.3 中支持，推荐优先使用它，而不是 `?raw` 查询参数。
+:::
+
+### 通过查询参数
+
+Rsbuild 也支持通过 `?raw` 查询参数将文件内容作为字符串导入：
 
 ```ts
 import rawSvg from './static/logo.svg?raw';
+import rawImage from './static/image.png?raw';
+import rawJson from './data.json?raw';
+import rawComponent from './component.tsx?raw';
+import rawStyle from './style.css?raw';
 
 console.log(rawSvg); // 输出 SVG 文件的原始内容
 ```
-
-Rsbuild 还支持通过 `?raw` 查询参数引用 JavaScript、TypeScript 和 JSX 等文件的原始内容。
-
-```ts
-import rawJs from './script1.js?raw';
-import rawTs from './script2.ts?raw';
-import rawJsx from './script3.jsx?raw';
-import rawTsx from './script4.tsx?raw';
-
-console.log(rawJs); // JS 文件的原始内容
-console.log(rawTs); // TS 文件的原始内容
-console.log(rawJsx); // JSX 文件的原始内容
-console.log(rawTsx); // TSX 文件的原始内容
-```
-
-你也可以使用 `?raw` 查询参数来引用 CSS 文件的原始内容，详见 [CSS](/guide/styling/css-usage#raw)。
-
-:::tip
-Rsbuild >= 1.3.0 支持 `?raw` 查询参数，>= 1.4.0 支持引用 JS 和 TS 文件的原始内容。
-:::
 
 ## 构建产物
 

--- a/website/docs/zh/guide/styling/css-usage.mdx
+++ b/website/docs/zh/guide/styling/css-usage.mdx
@@ -163,6 +163,26 @@ body {
 @import '~normalize.css';
 ```
 
+## 导入属性
+
+Rsbuild 支持通过 `type: 'text'` 导入属性引用 CSS 文件的原始内容，并将其作为字符串导入到 JavaScript 中。
+
+```js title="src/index.js"
+import rawCss from './style.css' with { type: 'text' };
+
+console.log(rawCss); // 输出 CSS 文件的原始内容
+```
+
+使用 `import "*.css" with { type: 'text' }` 的行为如下：
+
+- 获取 CSS 文件的原始文本内容，不经过任何预处理或编译
+- 内容会作为字符串内联到最终的 JavaScript 包中
+- 不会生成单独的 CSS 文件
+
+:::tip
+`type: 'text'` 在 Rsbuild >= 2.1.3 中支持。
+:::
+
 ## 查询参数
 
 ### inline
@@ -190,9 +210,9 @@ console.log(inlineCss); // 编译后的 CSS 内容
 
 ### raw
 
-Rsbuild 支持通过 `?raw` 查询参数引用 CSS 文件的原始内容，并将其作为字符串导入到 JavaScript 中。
+Rsbuild 也支持通过 `?raw` 查询参数引用 CSS 文件的原始内容，并将其作为字符串导入到 JavaScript 中。
 
-```ts title="src/index.js"
+```js title="src/index.js"
 import rawCss from './style.css?raw';
 
 console.log(rawCss); // 输出 CSS 文件的原始内容


### PR DESCRIPTION
## Summary

Document the `type: 'text'` import attribute for importing resources as strings, including static and dynamic import examples.

This also recommends `type: 'text'` over the `?raw` query parameter and moves CSS text import usage into a dedicated import attributes section.