### PR TITLE
feat(plugin-svelte): support text import attributes

### DIFF
--- a/e2e/cases/plugin-svelte/import-attributes-text/index.test.ts
+++ b/e2e/cases/plugin-svelte/import-attributes-text/index.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { expect, test } from '@e2e/helper';
+
+test('should import Svelte files as text with import attributes', async ({
+  page,
+  runBothServe,
+}) => {
+  await runBothServe(async () => {
+    expect(await page.evaluate('window.svelteText')).toBe(
+      readFileSync(join(import.meta.dirname, './src/Text.svelte'), 'utf-8'),
+    );
+    expect(await page.evaluate('window.svelteTsText')).toBe(
+      readFileSync(join(import.meta.dirname, './src/state.svelte.ts'), 'utf-8'),
+    );
+    await expect(page.locator('#normal-svelte')).toHaveText('Normal Svelte');
+  });
+});

--- a/e2e/cases/plugin-svelte/import-attributes-text/rsbuild.config.ts
+++ b/e2e/cases/plugin-svelte/import-attributes-text/rsbuild.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginSvelte } from '@rsbuild/plugin-svelte';
+
+export default defineConfig({
+  plugins: [pluginSvelte()],
+});

--- a/e2e/cases/plugin-svelte/import-attributes-text/src/Normal.svelte
+++ b/e2e/cases/plugin-svelte/import-attributes-text/src/Normal.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import { getMessage } from './state.svelte';
+</script>
+
+<div id="normal-svelte">{getMessage()}</div>

--- a/e2e/cases/plugin-svelte/import-attributes-text/src/Normal.svelte
+++ b/e2e/cases/plugin-svelte/import-attributes-text/src/Normal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { getMessage } from './state.svelte';
+  import { getMessage } from './state.svelte.ts';
 </script>
 
 <div id="normal-svelte">{getMessage()}</div>

--- a/e2e/cases/plugin-svelte/import-attributes-text/src/Text.svelte
+++ b/e2e/cases/plugin-svelte/import-attributes-text/src/Text.svelte
@@ -1,0 +1,5 @@
+<script>
+  const message = 'raw source should keep script content';
+</script>
+
+<div class="text-source">Svelte text import</div>

--- a/e2e/cases/plugin-svelte/import-attributes-text/src/index.js
+++ b/e2e/cases/plugin-svelte/import-attributes-text/src/index.js
@@ -1,0 +1,11 @@
+import { mount } from 'svelte';
+import svelteText from './Text.svelte' with { type: 'text' };
+import svelteTsText from './state.svelte.ts' with { type: 'text' };
+import Normal from './Normal.svelte';
+
+window.svelteText = svelteText;
+window.svelteTsText = svelteTsText;
+
+mount(Normal, {
+  target: document.querySelector('#root'),
+});

--- a/e2e/cases/plugin-svelte/import-attributes-text/src/state.svelte.ts
+++ b/e2e/cases/plugin-svelte/import-attributes-text/src/state.svelte.ts
@@ -1,0 +1,5 @@
+let message = $state('Normal Svelte');
+
+export function getMessage() {
+  return message;
+}

--- a/packages/plugin-svelte/src/index.ts
+++ b/packages/plugin-svelte/src/index.ts
@@ -115,7 +115,11 @@ export function pluginSvelte(options: PluginSvelteOptions = {}): RsbuildPlugin {
         const jsMainRule = jsRule.oneOfs.get(CHAIN_ID.ONE_OF.JS_MAIN);
         const swcUse = jsMainRule.uses.get(CHAIN_ID.USE.SWC);
 
-        const svelteRule = chain.module.rule(CHAIN_ID.RULE.SVELTE).test(/\.svelte$/);
+        // TODO: Use a oneOf-based rule structure in the next major version.
+        const svelteRule = chain.module
+          .rule(CHAIN_ID.RULE.SVELTE)
+          .test(/\.svelte$/)
+          .with({ type: { not: 'text' } });
 
         svelteRule
           .use(CHAIN_ID.USE.SWC)
@@ -124,6 +128,13 @@ export function pluginSvelte(options: PluginSvelteOptions = {}): RsbuildPlugin {
 
         svelteRule.use(CHAIN_ID.USE.SVELTE).loader(loaderPath).options(svelteLoaderOptions).end();
 
+        chain.module
+          .rule('svelte-text')
+          .after(CHAIN_ID.RULE.SVELTE)
+          .test(/\.svelte$/)
+          .with({ type: 'text' })
+          .type('asset/source');
+
         const regexp = /\.(?:svelte\.js|svelte\.ts)$/;
 
         jsRule.exclude.add(regexp);
@@ -131,6 +142,7 @@ export function pluginSvelte(options: PluginSvelteOptions = {}): RsbuildPlugin {
         chain.module
           .rule('svelte-js')
           .test(regexp)
+          .with({ type: { not: 'text' } })
           .use(CHAIN_ID.USE.SVELTE)
           .loader(loaderPath)
           .options(svelteLoaderOptions)
@@ -138,6 +150,13 @@ export function pluginSvelte(options: PluginSvelteOptions = {}): RsbuildPlugin {
           .use(CHAIN_ID.USE.SWC)
           .loader(swcUse.get('loader'))
           .options(swcUse.get('options'));
+
+        chain.module
+          .rule('svelte-js-text')
+          .after('svelte-js')
+          .test(regexp)
+          .with({ type: 'text' })
+          .type('asset/source');
       });
     },
   };

--- a/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
@@ -141,6 +141,18 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
         },
       },
     ],
+    "with": {
+      "type": {
+        "not": "text",
+      },
+    },
+  },
+  {
+    "test": /\\\\\\.\\(\\?:svelte\\\\\\.js\\|svelte\\\\\\.ts\\)\\$/,
+    "type": "asset/source",
+    "with": {
+      "type": "text",
+    },
   },
 ]
 `;
@@ -280,6 +292,18 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
         },
       },
     ],
+    "with": {
+      "type": {
+        "not": "text",
+      },
+    },
+  },
+  {
+    "test": /\\\\\\.\\(\\?:svelte\\\\\\.js\\|svelte\\\\\\.ts\\)\\$/,
+    "type": "asset/source",
+    "with": {
+      "type": "text",
+    },
   },
 ]
 `;
@@ -341,6 +365,18 @@ exports[`plugin-svelte > should add svelte loader and resolve config properly 1`
         },
       },
     ],
+    "with": {
+      "type": {
+        "not": "text",
+      },
+    },
+  },
+  {
+    "test": /\\\\\\.svelte\\$/,
+    "type": "asset/source",
+    "with": {
+      "type": "text",
+    },
   },
 ]
 `;
@@ -438,6 +474,18 @@ exports[`plugin-svelte > should override default svelte-loader options throw opt
         },
       },
     ],
+    "with": {
+      "type": {
+        "not": "text",
+      },
+    },
+  },
+  {
+    "test": /\\\\\\.svelte\\$/,
+    "type": "asset/source",
+    "with": {
+      "type": "text",
+    },
   },
 ]
 `;
@@ -499,6 +547,18 @@ exports[`plugin-svelte > should set dev and hotReload to false in production mod
         },
       },
     ],
+    "with": {
+      "type": {
+        "not": "text",
+      },
+    },
+  },
+  {
+    "test": /\\\\\\.svelte\\$/,
+    "type": "asset/source",
+    "with": {
+      "type": "text",
+    },
   },
 ]
 `;
@@ -560,6 +620,18 @@ exports[`plugin-svelte > should support pass custom preprocess options 1`] = `
         },
       },
     ],
+    "with": {
+      "type": {
+        "not": "text",
+      },
+    },
+  },
+  {
+    "test": /\\\\\\.svelte\\$/,
+    "type": "asset/source",
+    "with": {
+      "type": "text",
+    },
   },
 ]
 `;
@@ -621,6 +693,18 @@ exports[`plugin-svelte > should turn off HMR by hand correctly 1`] = `
         },
       },
     ],
+    "with": {
+      "type": {
+        "not": "text",
+      },
+    },
+  },
+  {
+    "test": /\\\\\\.svelte\\$/,
+    "type": "asset/source",
+    "with": {
+      "type": "text",
+    },
   },
 ]
 `;


### PR DESCRIPTION
## Summary

This PR adds support for importing Svelte files as text with import attributes, allowing `.svelte` and `.svelte.js` / `.svelte.ts` files to use `with { type: 'text' }` and receive their original source. The Svelte loader rules now exclude text imports while separate asset/source rules handle them, preserving the current rule shape until the next major version can switch to a oneOf-based structure.