### PR TITLE
feat(core): support custom loadConfig types

### DIFF
--- a/packages/core/src/loadConfig.ts
+++ b/packages/core/src/loadConfig.ts
@@ -58,11 +58,11 @@ export type LoadConfigOptions = {
   command?: string;
 };
 
-export type LoadConfigResult = {
+export type LoadConfigResult<Config = RsbuildConfig> = {
   /**
    * The loaded configuration object.
    */
-  content: RsbuildConfig;
+  content: Config;
   /**
    * The path to the loaded configuration file.
    * Return `null` if the configuration file is not found.
@@ -161,7 +161,7 @@ const loadConfigWithNative = async (
   };
 };
 
-export async function loadConfig({
+export async function loadConfig<Config = RsbuildConfig>({
   cwd = process.cwd(),
   path,
   configFileNames,
@@ -169,13 +169,13 @@ export async function loadConfig({
   meta,
   loader = 'auto',
   command,
-}: LoadConfigOptions = {}): Promise<LoadConfigResult> {
+}: LoadConfigOptions = {}): Promise<LoadConfigResult<Config>> {
   const configFilePath = resolveConfigPath(cwd, path, configFileNames);
 
   if (!configFilePath) {
     defaultLogger.debug('no config file found.');
     return {
-      content: {},
+      content: {} as Config,
       filePath: configFilePath,
       dependencies: [],
     };
@@ -185,7 +185,7 @@ export async function loadConfig({
 
   const applyMetaInfo = (config: RsbuildConfig) => {
     config._privateMeta = { configFilePath };
-    return config;
+    return config as Config;
   };
 
   let configExport: RsbuildConfigDefinition | undefined;

--- a/website/docs/en/api/javascript-api/core.mdx
+++ b/website/docs/en/api/javascript-api/core.mdx
@@ -132,7 +132,7 @@ Load Rsbuild configuration file.
 - **Type:**
 
 ```ts
-function loadConfig(params?: {
+function loadConfig<Config = RsbuildConfig>(params?: {
   // Default is process.cwd()
   cwd?: string;
   // Specify the configuration file (relative or absolute path)
@@ -156,8 +156,9 @@ function loadConfig(params?: {
    */
   loader?: 'auto' | 'jiti' | 'native';
 }): Promise<{
-  content: RsbuildConfig;
+  content: Config;
   filePath: string | null;
+  dependencies: string[];
 }>;
 ```
 

--- a/website/docs/zh/api/javascript-api/core.mdx
+++ b/website/docs/zh/api/javascript-api/core.mdx
@@ -132,7 +132,7 @@ export const myPlugin = {
 - **类型：**
 
 ```ts
-function loadConfig(params?: {
+function loadConfig<Config = RsbuildConfig>(params?: {
   // 默认为 process.cwd()
   cwd?: string;
   // 指定配置文件路径，可以为相对路径或绝对路径
@@ -156,8 +156,9 @@ function loadConfig(params?: {
    */
   loader?: 'auto' | 'jiti' | 'native';
 }): Promise<{
-  content: RsbuildConfig;
+  content: Config;
   filePath: string | null;
+  dependencies: string[];
 }>;
 ```
 


### PR DESCRIPTION
## Summary

This PR allows `loadConfig` callers to specify a custom config type while preserving `RsbuildConfig` as the default. It updates the JavaScript API docs to show the generic signature and include the existing `dependencies` return field.