### PR TITLE
feat(core): support exportName in loadConfig

### DIFF
--- a/e2e/cases/javascript-api/load-config/index.test.ts
+++ b/e2e/cases/javascript-api/load-config/index.test.ts
@@ -24,3 +24,41 @@ test('should load config from custom config file names', async () => {
     CONFIG_FILE_NAME: JSON.stringify('custom'),
   });
 });
+
+test('should load config from named export', async () => {
+  const { content } = await loadConfig<{ name: string }>({
+    cwd: import.meta.dirname,
+    configFileNames: ['named.config.mjs'],
+    exportName: 'rsbuildConfig',
+  });
+
+  expect(content.name).toBe('rsbuildConfig');
+});
+
+test('should execute config file without reading exports', async () => {
+  const globalState = globalThis as typeof globalThis & {
+    __LOAD_CONFIG_HIT__?: string;
+  };
+  delete globalState.__LOAD_CONFIG_HIT__;
+
+  const { content, filePath } = await loadConfig({
+    cwd: import.meta.dirname,
+    configFileNames: ['side-effect.config.mjs'],
+    exportName: false,
+  });
+
+  expect(filePath).toBe(join(import.meta.dirname, 'side-effect.config.mjs'));
+  expect(content.source).toBeUndefined();
+  expect(content._privateMeta?.configFilePath).toBe(filePath);
+  expect(globalState.__LOAD_CONFIG_HIT__).toBe('loaded');
+});
+
+test('should throw when named export is missing', async () => {
+  await expect(
+    loadConfig({
+      cwd: import.meta.dirname,
+      configFileNames: ['named.config.mjs'],
+      exportName: 'missingConfig',
+    }),
+  ).rejects.toThrow(/Cannot find export .*missingConfig/);
+});

--- a/e2e/cases/javascript-api/load-config/named.config.mjs
+++ b/e2e/cases/javascript-api/load-config/named.config.mjs
@@ -1,0 +1,3 @@
+export const rsbuildConfig = {
+  name: 'rsbuildConfig',
+};

--- a/e2e/cases/javascript-api/load-config/side-effect.config.mjs
+++ b/e2e/cases/javascript-api/load-config/side-effect.config.mjs
@@ -1,0 +1,5 @@
+globalThis.__LOAD_CONFIG_HIT__ = 'loaded';
+
+export const ignoredConfig = {
+  name: 'ignoredConfig',
+};

--- a/packages/core/src/loadConfig.ts
+++ b/packages/core/src/loadConfig.ts
@@ -56,6 +56,12 @@ export type LoadConfigOptions = {
    * @default process.argv[2]
    */
   command?: string;
+  /**
+   * The export name to read from the config file.
+   * Set to `false` to execute the config file without reading exports.
+   * @default 'default'
+   */
+  exportName?: string | false;
 };
 
 export type LoadConfigResult<Config = RsbuildConfig> = {
@@ -123,10 +129,37 @@ const resolveConfigPath = (
 
 export type ConfigLoader = 'auto' | 'jiti' | 'native';
 
-const getConfigExport = (module: unknown): RsbuildConfigDefinition =>
-  (module && typeof module === 'object' && 'default' in module
-    ? module.default
-    : module) as RsbuildConfigDefinition;
+const canReadExport = (module: unknown): module is Record<string, unknown> =>
+  module !== null && (typeof module === 'object' || typeof module === 'function');
+
+const getConfigExport = (
+  configModule: unknown,
+  exportName: string | false,
+  configFilePath: string,
+): RsbuildConfigDefinition => {
+  if (exportName === false) {
+    return {};
+  }
+
+  if (exportName === 'default') {
+    return (
+      canReadExport(configModule) && 'default' in configModule ? configModule.default : configModule
+    ) as RsbuildConfigDefinition;
+  }
+
+  if (canReadExport(configModule) && Object.hasOwn(configModule, exportName)) {
+    return configModule[exportName] as RsbuildConfigDefinition;
+  }
+
+  throw new Error(
+    `Cannot find export ${color.yellow(exportName)} in config file: ${color.dim(configFilePath)}`,
+  );
+};
+
+type LoadedConfig = {
+  configExport: RsbuildConfigDefinition;
+  dependencies: string[];
+};
 
 const tryFreshImport = async (configFileURL: string) => {
   try {
@@ -141,7 +174,7 @@ const tryFreshImport = async (configFileURL: string) => {
 const loadConfigWithNative = async (
   configFilePath: string,
 ): Promise<{
-  configExport: RsbuildConfigDefinition;
+  configModule: unknown;
   dependencies: string[];
 }> => {
   const configFileURL = pathToFileURL(configFilePath).href;
@@ -149,14 +182,44 @@ const loadConfigWithNative = async (
 
   if (freshImportResult) {
     return {
-      configExport: getConfigExport(freshImportResult.result),
+      configModule: freshImportResult.result,
       dependencies: freshImportResult.dependencies.sort(),
     };
   }
 
   const exportModule = await import(`${configFileURL}?t=${Date.now()}`);
   return {
-    configExport: getConfigExport(exportModule),
+    configModule: exportModule,
+    dependencies: [],
+  };
+};
+
+const loadConfigWithJiti = async (
+  configFilePath: string,
+  exportName: string | false,
+): Promise<LoadedConfig> => {
+  const { createJiti } = await import('jiti');
+  const jiti = createJiti(import.meta.filename, {
+    // disable require cache to support restart CLI and read the new config
+    moduleCache: false,
+    interopDefault: true,
+    // Always use native `require()` for these packages,
+    // This avoids `typescript` being loaded twice.
+    nativeModules: ['typescript'],
+  });
+
+  if (exportName === 'default') {
+    return {
+      configExport: await jiti.import<RsbuildConfigDefinition>(configFilePath, {
+        default: true,
+      }),
+      dependencies: [],
+    };
+  }
+
+  const configModule = await jiti.import<unknown>(configFilePath);
+  return {
+    configExport: getConfigExport(configModule, exportName, configFilePath),
     dependencies: [],
   };
 };
@@ -169,6 +232,7 @@ export async function loadConfig<Config = RsbuildConfig>({
   meta,
   loader = 'auto',
   command,
+  exportName = 'default',
 }: LoadConfigOptions = {}): Promise<LoadConfigResult<Config>> {
   const configFilePath = resolveConfigPath(cwd, path, configFileNames);
 
@@ -181,14 +245,12 @@ export async function loadConfig<Config = RsbuildConfig>({
     };
   }
 
-  let dependencies: string[] = [];
-
   const applyMetaInfo = (config: RsbuildConfig) => {
     config._privateMeta = { configFilePath };
     return config as Config;
   };
 
-  let configExport: RsbuildConfigDefinition | undefined;
+  let loadedConfig: LoadedConfig | undefined;
 
   // Determine the loading strategy based on the config loader type
   const useNative = Boolean(
@@ -198,8 +260,9 @@ export async function loadConfig<Config = RsbuildConfig>({
   );
 
   if (useNative || /\.(?:js|mjs|cjs)$/.test(configFilePath)) {
+    let result: Awaited<ReturnType<typeof loadConfigWithNative>> | undefined;
     try {
-      ({ configExport, dependencies } = await loadConfigWithNative(configFilePath));
+      result = await loadConfigWithNative(configFilePath);
     } catch (err) {
       const errorMessage = `Failed to load file with native loader: ${color.dim(configFilePath)}`;
       if (loader === 'native') {
@@ -210,28 +273,25 @@ export async function loadConfig<Config = RsbuildConfig>({
       defaultLogger.debug(`${errorMessage}, fallback to jiti.`);
       defaultLogger.debug(err);
     }
+
+    if (result) {
+      loadedConfig = {
+        configExport: getConfigExport(result.configModule, exportName, configFilePath),
+        dependencies: result.dependencies,
+      };
+    }
   }
 
-  if (configExport === undefined) {
+  if (!loadedConfig) {
     try {
-      const { createJiti } = await import('jiti');
-      const jiti = createJiti(import.meta.filename, {
-        // disable require cache to support restart CLI and read the new config
-        moduleCache: false,
-        interopDefault: true,
-        // Always use native `require()` for these packages,
-        // This avoids `@rspack/core` being loaded twice.
-        nativeModules: ['typescript'],
-      });
-
-      configExport = await jiti.import<RsbuildConfigDefinition>(configFilePath, {
-        default: true,
-      });
+      loadedConfig = await loadConfigWithJiti(configFilePath, exportName);
     } catch (err) {
       defaultLogger.error(`Failed to load file with jiti: ${color.dim(configFilePath)}`);
       throw err;
     }
   }
+
+  const { configExport, dependencies } = loadedConfig;
 
   if (typeof configExport === 'function') {
     const nodeEnv = getNodeEnv();
@@ -245,9 +305,7 @@ export async function loadConfig<Config = RsbuildConfig>({
     const result = await configExport(configParams);
 
     if (result === undefined) {
-      throw new Error(
-        `${color.dim('[rsbuild:loadConfig]')} The config function must return a config object.`,
-      );
+      throw new Error('The config function must return a config object.');
     }
 
     return {
@@ -259,8 +317,8 @@ export async function loadConfig<Config = RsbuildConfig>({
 
   if (!isObject(configExport)) {
     throw new Error(
-      `${color.dim('[rsbuild:loadConfig]')} The config must be an object or a function that returns an object, get ${color.yellow(
-        configExport,
+      `The config must be an object or a function that returns an object, get ${color.yellow(
+        String(configExport),
       )}`,
     );
   }

--- a/website/docs/en/api/javascript-api/core.mdx
+++ b/website/docs/en/api/javascript-api/core.mdx
@@ -139,6 +139,12 @@ function loadConfig<Config = RsbuildConfig>(params?: {
   path?: string;
   // Config file names to search when path is not specified
   configFileNames?: string[];
+  /**
+   * The export name to read from the config file
+   * Set to `false` to execute the config file without reading exports
+   * @default 'default'
+   */
+  exportName?: string | false;
   meta?: Record<string, unknown>;
   envMode?: string;
   /**
@@ -212,6 +218,34 @@ import { loadConfig } from '@rsbuild/core';
 
 const { content } = await loadConfig({
   path: join(__dirname, 'my-config.ts'),
+});
+```
+
+### Specify the export name
+
+By default, `loadConfig` reads the default export from the config file. Use `exportName` to read a named export instead:
+
+```ts title="rsbuild.config.ts"
+export const rsbuildConfig = {
+  // ...
+};
+```
+
+```ts
+import { loadConfig } from '@rsbuild/core';
+
+const { content } = await loadConfig({
+  exportName: 'rsbuildConfig',
+});
+```
+
+Set `exportName` to `false` when the config file only needs to be executed and no export should be read. In this case, `content` is `{}`.
+
+```ts
+import { loadConfig } from '@rsbuild/core';
+
+const { content } = await loadConfig({
+  exportName: false,
 });
 ```
 

--- a/website/docs/zh/api/javascript-api/core.mdx
+++ b/website/docs/zh/api/javascript-api/core.mdx
@@ -139,6 +139,12 @@ function loadConfig<Config = RsbuildConfig>(params?: {
   path?: string;
   // 未指定 path 时要查找的配置文件名列表
   configFileNames?: string[];
+  /**
+   * 从配置文件中读取的导出名称
+   * 设置为 `false` 时，只执行配置文件，不读取导出
+   * @default 'default'
+   */
+  exportName?: string | false;
   meta?: Record<string, unknown>;
   envMode?: string;
   /**
@@ -212,6 +218,34 @@ import { loadConfig } from '@rsbuild/core';
 
 const { content } = await loadConfig({
   path: join(__dirname, 'my-config.ts'),
+});
+```
+
+### 指定导出名称
+
+默认情况下，`loadConfig` 会读取配置文件的默认导出。使用 `exportName` 可以读取命名导出：
+
+```ts title="rsbuild.config.ts"
+export const rsbuildConfig = {
+  // ...
+};
+```
+
+```ts
+import { loadConfig } from '@rsbuild/core';
+
+const { content } = await loadConfig({
+  exportName: 'rsbuildConfig',
+});
+```
+
+当配置文件只需要被执行、不需要读取任何导出时，可以将 `exportName` 设置为 `false`，此时 `content` 为 `{}`。
+
+```ts
+import { loadConfig } from '@rsbuild/core';
+
+const { content } = await loadConfig({
+  exportName: false,
 });
 ```
 


### PR DESCRIPTION
## Summary

This PR adds an `exportName` option to `loadConfig` so callers can read named exports or execute config files without reading exports. The default remains `default`, preserving existing default export behavior.

It also updates the JavaScript API docs and adds e2e coverage for named exports, `exportName: false`, and missing export errors.