### PR TITLE
chore: sync example tsconfigs with templates

### DIFF
--- a/examples/node/tsconfig.json
+++ b/examples/node/tsconfig.json
@@ -1,13 +1,22 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
     "lib": ["ES2022"],
-    "types": ["node"],
+    "target": "ES2022",
+    "noEmit": true,
     "skipLibCheck": true,
+    "types": ["@rsbuild/core/types", "node"],
+    "useDefineForClassFields": true,
+
+    /* modules */
+    "moduleDetection": "force",
+    "moduleResolution": "bundler",
     "verbatimModuleSyntax": true,
     "resolveJsonModule": true,
-    "moduleResolution": "bundler",
-    "useDefineForClassFields": true
+    "allowImportingTsExtensions": true,
+
+    /* type checking */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
   },
   "include": ["src"]
 }

--- a/examples/react/tsconfig.json
+++ b/examples/react/tsconfig.json
@@ -1,13 +1,23 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
-    "lib": ["DOM", "ES2022"],
+    "lib": ["DOM", "ES2020"],
     "jsx": "react-jsx",
+    "target": "ES2020",
+    "noEmit": true,
     "skipLibCheck": true,
+    "types": ["@rsbuild/core/types", "node"],
+    "useDefineForClassFields": true,
+
+    /* modules */
+    "moduleDetection": "force",
+    "moduleResolution": "bundler",
     "verbatimModuleSyntax": true,
     "resolveJsonModule": true,
-    "moduleResolution": "bundler",
-    "useDefineForClassFields": true
+    "allowImportingTsExtensions": true,
+
+    /* type checking */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
   },
   "include": ["src"]
 }

--- a/examples/vue/tsconfig.json
+++ b/examples/vue/tsconfig.json
@@ -1,14 +1,24 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
-    "lib": ["DOM", "ES2022"],
+    "lib": ["DOM", "ES2020"],
     "jsx": "preserve",
-    "jsxImportSource": "vue",
+    "target": "ES2020",
+    "noEmit": true,
     "skipLibCheck": true,
+    "types": ["@rsbuild/core/types", "node"],
+    "jsxImportSource": "vue",
+    "useDefineForClassFields": true,
+
+    /* modules */
+    "moduleDetection": "force",
+    "moduleResolution": "bundler",
     "verbatimModuleSyntax": true,
     "resolveJsonModule": true,
-    "moduleResolution": "bundler",
-    "useDefineForClassFields": true
+    "allowImportingTsExtensions": true,
+
+    /* type checking */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
   },
-  "include": ["src"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"]
 }


### PR DESCRIPTION
## Summary

This PR syncs the example TypeScript configs with the current create-rsbuild templates so generated projects and examples share the same compiler defaults.

It updates the React and Vue examples to match their TypeScript templates, and aligns the Node example with the shared template options while preserving its Node-only target settings.