### PR TITLE
fix(core): normalize jiti required browserslist

### DIFF
--- a/e2e/cases/css/jiti-require-browserslist/browserslist.cjs
+++ b/e2e/cases/css/jiti-require-browserslist/browserslist.cjs
@@ -1,0 +1,1 @@
+module.exports = ['iOS >= 9', 'Android >= 4.4'];

--- a/e2e/cases/css/jiti-require-browserslist/index.test.ts
+++ b/e2e/cases/css/jiti-require-browserslist/index.test.ts
@@ -1,0 +1,18 @@
+import path from 'node:path';
+import { expect, getFileContent, readDirContents, test } from '@e2e/helper';
+
+test('should normalize browserslist required by jiti config', async ({ execCliSync }) => {
+  // Regression for CJS arrays loaded by require() in a jiti config.
+  // https://github.com/web-infra-dev/rsbuild/issues/8063
+  execCliSync('build --config-loader jiti');
+
+  const files = await readDirContents(path.join(import.meta.dirname, 'dist'));
+  const content = getFileContent(files, '.css');
+
+  expect(content).toContain('-webkit-transform:translateZ(0)');
+  expect(content).toContain('top:0');
+  expect(content).toContain('right:0');
+  expect(content).toContain('bottom:0');
+  expect(content).toContain('left:0');
+  expect(content).not.toContain('inset:0');
+});

--- a/e2e/cases/css/jiti-require-browserslist/rsbuild.config.ts
+++ b/e2e/cases/css/jiti-require-browserslist/rsbuild.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@rsbuild/core';
+
+// rslint-disable-next-line @typescript-eslint/no-require-imports
+const browserslist = require('./browserslist.cjs');
+
+export default defineConfig({
+  output: {
+    filenameHash: false,
+    overrideBrowserslist: browserslist,
+  },
+});

--- a/e2e/cases/css/jiti-require-browserslist/src/index.css
+++ b/e2e/cases/css/jiti-require-browserslist/src/index.css
@@ -1,0 +1,8 @@
+.cover {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  transform: translateZ(0);
+}

--- a/e2e/cases/css/jiti-require-browserslist/src/index.js
+++ b/e2e/cases/css/jiti-require-browserslist/src/index.js
@@ -1,0 +1,1 @@
+import './index.css';

--- a/packages/core/src/createContext.ts
+++ b/packages/core/src/createContext.ts
@@ -50,7 +50,10 @@ export function getBrowserslistByEnvironment(
   const { target, overrideBrowserslist } = config.output;
 
   if (Array.isArray(overrideBrowserslist)) {
-    return overrideBrowserslist;
+    // CJS arrays returned by require() in a jiti-loaded config can be Proxies.
+    // Clone them before passing browserslist to native bindings.
+    // https://github.com/web-infra-dev/rsbuild/issues/8063
+    return [...overrideBrowserslist];
   }
 
   // Read project browserslist config when target is `web-like`


### PR DESCRIPTION
## Summary

This PR fixes CSS target handling when a jiti-loaded Rsbuild config reads a CJS browserslist array with `require()`. 

jiti can return a Proxy-wrapped array, which native CSS processing may not treat as a normal targets array. Rsbuild now clones `overrideBrowserslist` before exposing it through the environment browserslist.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/8063