### PR TITLE
test(types): add core preset module type coverage

### DIFF
--- a/e2e/type-tests/core-types/index.ts
+++ b/e2e/type-tests/core-types/index.ts
@@ -1,0 +1,34 @@
+// This folder checks the preset module declarations from @rsbuild/core/types.
+import styles from './style.module.css';
+import './style.css';
+import cssUrl from './style.css?url';
+import inlineCss from './style.css?inline';
+import rawCss from './style.css?raw';
+import pngUrl from './image.png?url';
+import inlinePng from './image.png?inline';
+import rawSvg from './logo.svg?raw';
+import rawJson from './data.json?raw';
+import rawTs from './module.ts?raw';
+import QueryWorker from './worker.ts?worker';
+import InlineWorker from './worker.ts?worker&inline';
+import InlineWorkerReordered from './worker.ts?inline&worker';
+
+const stringResults: string[] = [
+  styles.root,
+  cssUrl,
+  inlineCss,
+  rawCss,
+  pngUrl,
+  inlinePng,
+  rawSvg,
+  rawJson,
+  rawTs,
+];
+
+const workerResults: Worker[] = [
+  new QueryWorker({ name: 'query-worker' }),
+  new InlineWorker({ name: 'inline-worker' }),
+  new InlineWorkerReordered({ name: 'inline-worker-reordered' }),
+];
+
+export { stringResults, workerResults };

--- a/e2e/type-tests/core-types/package.json
+++ b/e2e/type-tests/core-types/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@type-tests/core-types",
+  "private": true,
+  "type": "module"
+}

--- a/e2e/type-tests/core-types/tsconfig.json
+++ b/e2e/type-tests/core-types/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@scripts/config/tsconfig",
+  "compilerOptions": {
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "skipLibCheck": false,
+    "types": ["@rsbuild/core/types", "node"]
+  },
+  "include": ["index.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -684,6 +684,8 @@ importers:
         specifier: 'catalog:'
         version: 0.3.31
 
+  e2e/type-tests/core-types: {}
+
   e2e/type-tests/resolution-bundler: {}
 
   e2e/type-tests/resolution-nodenext: {}


### PR DESCRIPTION
## Summary

Adds a dedicated type-test package for `@rsbuild/core/types` so the preset module declarations are checked under bundler resolution with `skipLibCheck` disabled.

The test covers CSS, asset, raw/inline/url query imports, and worker query constructors to guard against regressions in public ambient declarations.