### PR TITLE
fix(core): validate loadEnv prefixes

### DIFF
--- a/e2e/cases/javascript-api/load-env/index.test.ts
+++ b/e2e/cases/javascript-api/load-env/index.test.ts
@@ -1,5 +1,19 @@
+import { stripVTControlCharacters as stripAnsi } from 'node:util';
 import { expect, test } from '@e2e/helper';
 import { loadEnv } from '@rsbuild/core';
+
+function getLoadEnvError(prefixes: string[]) {
+  try {
+    loadEnv({
+      cwd: import.meta.dirname,
+      prefixes,
+    });
+  } catch (err) {
+    return err as Error;
+  }
+
+  throw new Error('Expected loadEnv to throw.');
+}
 
 test('should load env files correctly', () => {
   const env = loadEnv({
@@ -55,4 +69,21 @@ test('should not modify process.env if processEnv is provided', () => {
   env.cleanup();
   expect(process.env.REACT_NAME).toEqual(undefined);
   expect(targetEnv.REACT_NAME).toEqual(undefined);
+});
+
+test('should throw when prefixes contains empty string', () => {
+  const message = stripAnsi(getLoadEnvError(['PUBLIC_', '']).message);
+
+  expect(message).toContain('Invalid prefixes option');
+  expect(message).toContain('received ""');
+  expect(message).toContain('An empty string matches every key in processEnv');
+  expect(message).toContain('process.env.* and import.meta.env.* replacements');
+});
+
+test('should throw when prefixes contains whitespace-only string', () => {
+  const message = stripAnsi(getLoadEnvError(['PUBLIC_', '  ']).message);
+
+  expect(message).toContain('Invalid prefixes option');
+  expect(message).toContain('received "  "');
+  expect(message).toContain('A whitespace-only string is not a valid public');
 });

--- a/packages/core/src/loadEnv.ts
+++ b/packages/core/src/loadEnv.ts
@@ -55,6 +55,30 @@ function parse(src: Buffer) {
   return obj;
 }
 
+function validatePrefixes(prefixes: string[]) {
+  const invalidIndex = prefixes.findIndex((prefix) => prefix.trim() === '');
+
+  if (invalidIndex === -1) {
+    return;
+  }
+
+  const prefix = prefixes[invalidIndex];
+  const reason =
+    prefix === ''
+      ? 'An empty string matches every key in processEnv, so every environment variable would be treated as public and could be inlined into client-side code through process.env.* and import.meta.env.* replacements.'
+      : 'A whitespace-only string is not a valid public environment variable prefix because it does not contain any non-whitespace characters.';
+
+  throw new Error(
+    `${color.dim('[rsbuild:loadEnv]')} Invalid ${color.yellow(
+      'prefixes',
+    )} option: received ${color.yellow(
+      JSON.stringify(prefix),
+    )}. ${reason} Use a prefix with at least one non-whitespace character, such as ${color.yellow(
+      '"PUBLIC_"',
+    )}.`,
+  );
+}
+
 export type LoadEnvOptions = {
   /**
    * The root path to load the env file
@@ -125,6 +149,8 @@ export function loadEnv({
   prefixes = ['PUBLIC_'],
   processEnv = process.env as Record<string, string>,
 }: LoadEnvOptions = {}): LoadEnvResult {
+  validatePrefixes(prefixes);
+
   if (mode === 'local') {
     throw new Error(
       `${color.dim('[rsbuild:loadEnv]')} ${color.yellow('local')} cannot be used as a value for env mode, because ${color.yellow(


### PR DESCRIPTION
## Summary

This PR prevents invalid `loadEnv({ prefixes })` values from treating every environment variable as public. Empty string and whitespace-only prefixes now throw clear errors before env files are loaded.