### PR TITLE
docs: update agent testing guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,8 @@ pnpm e2e
 ## Testing
 
 - Prefer adding e2e tests over unit tests, unless testing single-function behavior.
-- Run `pnpm build` once before any `pnpm e2e` command, including focused cases.
+- Update all affected unit test snapshots, not just a subset.
+- Run `pnpm build` once before `pnpm test` or any `pnpm e2e` command, including focused cases.
 
 ## Project structure
 


### PR DESCRIPTION
## Summary

Update the agent instructions to prevent partial unit test snapshot updates and clarify that `pnpm build` should run before `pnpm test` as well as e2e checks.