### PR TITLE
feat(core): support txt assets

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -82,7 +82,7 @@ export const PLUGIN_CSS_NAME = 'rsbuild:css';
 
 // Extensions
 export const FONT_EXTENSIONS: string[] = ['woff', 'woff2', 'eot', 'ttf', 'otf', 'ttc'];
-export const ASSET_EXTENSIONS: string[] = ['pdf'];
+export const ASSET_EXTENSIONS: string[] = ['pdf', 'txt'];
 export const IMAGE_EXTENSIONS: string[] = [
   'png',
   'jpg',

--- a/packages/core/tests/__snapshots__/asset.test.ts.snap
+++ b/packages/core/tests/__snapshots__/asset.test.ts.snap
@@ -121,7 +121,7 @@ exports[`plugin-asset > should add other asset rules correctly 1`] = `
         "type": "asset",
       },
     ],
-    "test": /\\\\\\.pdf\\$/i,
+    "test": /\\\\\\.\\(\\?:pdf\\|txt\\)\\$/i,
   },
 ]
 `;

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -467,7 +467,7 @@ exports[`default bundler > should use Rspack by default 1`] = `
             "type": "asset",
           },
         ],
-        "test": /\\\\\\.pdf\\$/i,
+        "test": /\\\\\\.\\(\\?:pdf\\|txt\\)\\$/i,
       },
       {
         "oneOf": [

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -490,7 +490,7 @@ exports[`should apply default plugins correctly 1`] = `
             "type": "asset",
           },
         ],
-        "test": /\\\\\\.pdf\\$/i,
+        "test": /\\\\\\.\\(\\?:pdf\\|txt\\)\\$/i,
       },
       {
         "oneOf": [
@@ -1060,7 +1060,7 @@ exports[`should apply default plugins correctly in production 1`] = `
             "type": "asset",
           },
         ],
-        "test": /\\\\\\.pdf\\$/i,
+        "test": /\\\\\\.\\(\\?:pdf\\|txt\\)\\$/i,
       },
       {
         "oneOf": [
@@ -1641,7 +1641,7 @@ exports[`should apply default plugins correctly when target is node 1`] = `
             "type": "asset",
           },
         ],
-        "test": /\\\\\\.pdf\\$/i,
+        "test": /\\\\\\.\\(\\?:pdf\\|txt\\)\\$/i,
       },
       {
         "oneOf": [
@@ -2222,7 +2222,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "type": "asset",
           },
         ],
-        "test": /\\\\\\.pdf\\$/i,
+        "test": /\\\\\\.\\(\\?:pdf\\|txt\\)\\$/i,
       },
       {
         "oneOf": [

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -463,7 +463,7 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
               "type": "asset",
             },
           ],
-          "test": /\\\\\\.pdf\\$/i,
+          "test": /\\\\\\.\\(\\?:pdf\\|txt\\)\\$/i,
         },
         {
           "oneOf": [
@@ -1018,7 +1018,7 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
               "type": "asset",
             },
           ],
-          "test": /\\\\\\.pdf\\$/i,
+          "test": /\\\\\\.\\(\\?:pdf\\|txt\\)\\$/i,
         },
         {
           "oneOf": [

--- a/packages/core/tests/asset.test.ts
+++ b/packages/core/tests/asset.test.ts
@@ -68,6 +68,8 @@ describe('plugin-asset', () => {
     const rsbuild = await createRsbuild();
 
     const config = (await rsbuild.initConfigs())[0];
-    expect(matchRules(config, 'a.pdf')).toMatchSnapshot();
+    const rules = matchRules(config, 'a.pdf');
+    expect(rules).toMatchSnapshot();
+    expect(matchRules(config, 'a.txt')).toEqual(rules);
   });
 });

--- a/packages/core/types.d.ts
+++ b/packages/core/types.d.ts
@@ -232,6 +232,10 @@ declare module '*.pdf' {
   const src: string;
   export default src;
 }
+declare module '*.txt' {
+  const src: string;
+  export default src;
+}
 
 /**
  * @requires [@rsbuild/plugin-yaml](https://npmjs.com/package/@rsbuild/plugin-yaml)

--- a/website/docs/en/guide/basic/static-assets.mdx
+++ b/website/docs/en/guide/basic/static-assets.mdx
@@ -18,7 +18,7 @@ Rsbuild supports these formats by default:
 - **Fonts**: woff, woff2, eot, ttf, otf, ttc.
 - **Audio**: mp3, wav, flac, aac, m4a, opus.
 - **Video**: mp4, webm, ogg, mov.
-- **Other**: pdf.
+- **Other**: pdf, txt.
 
 To import assets in other formats, refer to [Extend Asset Types](#extend-asset-types).
 

--- a/website/docs/zh/guide/basic/static-assets.mdx
+++ b/website/docs/zh/guide/basic/static-assets.mdx
@@ -18,7 +18,7 @@ Rsbuild 支持在代码中引用图片、字体、媒体和其他类型文件等
 - **字体**：woff、woff2、eot、ttf、otf、ttc。
 - **音频**：mp3、wav、flac、aac、m4a、opus。
 - **视频**：mp4、webm、ogg、mov。
-- **其他**：pdf。
+- **其他**：pdf、txt。
 
 如果你需要引用其他格式的静态资源，请参考 [扩展静态资源类型](#extend-asset-types)。
 


### PR DESCRIPTION
## Summary

This PR adds `.txt` to Rsbuild's built-in static asset formats, so text files can be imported without configuring `source.assetsInclude`.

It updates the asset extension list, TypeScript declarations, related config snapshots, and the English/Chinese static assets docs.

Resource hints preload classification is intentionally left unchanged in this PR so it can be evaluated separately.
