### PR TITLE
fix(core): exclude generic assets from resource hints

### DIFF
--- a/e2e/cases/performance/resource-hints-prefetch/index.test.ts
+++ b/e2e/cases/performance/resource-hints-prefetch/index.test.ts
@@ -41,6 +41,34 @@ test('should generate prefetch link when prefetch is defined', async ({ build })
   ).toBeTruthy();
 });
 
+test('should allow prefetch.exclude to override default asset excludes', async ({ build }) => {
+  const rsbuild = await build({
+    config: {
+      plugins: [pluginReact()],
+      source: {
+        entry: {
+          main: join(fixtures, 'src/page1/index.ts'),
+        },
+      },
+      performance: {
+        prefetch: {
+          exclude: /\.css$/,
+        },
+      },
+    },
+  });
+
+  const files = rsbuild.getDistFiles();
+
+  const textFileName = findFile(files, /\/static\/assets\/.+\.txt$/);
+  const content = getFileContent(files, '.html');
+  const textHref = textFileName.slice(textFileName.indexOf('/static/assets/'));
+
+  // test.js, image.png, file.txt
+  expect(content.match(/rel="prefetch"/g)?.length).toBe(3);
+  expect(content).toContain(`<link href="${textHref}" rel="prefetch">`);
+});
+
 test('should generate prefetch link correctly when assetPrefix do not have a protocol', async ({
   build,
 }) => {
@@ -216,10 +244,12 @@ test('should generate prefetch link with exclude array', async ({ build }) => {
   const files = rsbuild.getDistFiles();
 
   const asyncFileName = findFile(files, 'image.png');
+  const textFileName = findFile(files, /\/static\/assets\/.+\.txt$/);
   const content = getFileContent(files, '.html');
+  const textHref = textFileName.slice(textFileName.indexOf('/static/assets/'));
 
-  // image.png
-  expect(content.match(/rel="prefetch"/g)?.length).toBe(1);
+  // image.png, file.txt
+  expect(content.match(/rel="prefetch"/g)?.length).toBe(2);
 
   expect(
     content.includes(
@@ -228,6 +258,7 @@ test('should generate prefetch link with exclude array', async ({ build }) => {
       )}" rel="prefetch">`,
     ),
   ).toBeTruthy();
+  expect(content).toContain(`<link href="${textHref}" rel="prefetch">`);
 });
 
 test('should generate prefetch link by config (distinguish html)', async ({ build }) => {

--- a/e2e/cases/performance/resource-hints-prefetch/index.test.ts
+++ b/e2e/cases/performance/resource-hints-prefetch/index.test.ts
@@ -25,10 +25,12 @@ test('should generate prefetch link when prefetch is defined', async ({ build })
   const files = rsbuild.getDistFiles();
 
   const asyncFileName = findFile(files, /\/static\/js\/async\/.+\.js$/);
+  const textFileName = findFile(files, /\/static\/assets\/.+\.txt$/);
   const content = getFileContent(files, '.html');
 
   // test.js, test.css, image.png
   expect(content.match(/rel="prefetch"/g)?.length).toBe(3);
+  expect(content).not.toContain(textFileName.slice(textFileName.indexOf('/static/assets/')));
 
   expect(
     content.includes(

--- a/e2e/cases/performance/resource-hints-prefetch/src/file.txt
+++ b/e2e/cases/performance/resource-hints-prefetch/src/file.txt
@@ -1,0 +1,1 @@
+plain text asset

--- a/e2e/cases/performance/resource-hints-prefetch/src/test.ts
+++ b/e2e/cases/performance/resource-hints-prefetch/src/test.ts
@@ -1,5 +1,6 @@
+import text from './file.txt?url';
 import png from '@e2e/assets/image.png?url';
 import './test.css';
 
-export { png };
+export { png, text };
 export const a = '1111';

--- a/e2e/cases/performance/resource-hints-preload/index.test.ts
+++ b/e2e/cases/performance/resource-hints-preload/index.test.ts
@@ -38,6 +38,34 @@ test('should generate preload link when preload is defined', async ({ build }) =
   ).toBeTruthy();
 });
 
+test('should allow preload.exclude to override default asset excludes', async ({ build }) => {
+  const rsbuild = await build({
+    config: {
+      plugins: [pluginReact()],
+      source: {
+        entry: {
+          main: join(fixtures, 'src/page1/index.ts'),
+        },
+      },
+      performance: {
+        preload: {
+          exclude: /\.css$/,
+        },
+      },
+    },
+  });
+
+  const files = rsbuild.getDistFiles();
+
+  const textFileName = findFile(files, /\/static\/assets\/.+\.txt$/);
+  const content = getFileContent(files, '.html');
+  const textHref = textFileName.slice(textFileName.indexOf('/static/assets/'));
+
+  // test.js, image.png, file.txt
+  expect(content.match(/rel="preload"/g)?.length).toBe(3);
+  expect(content).toContain(textHref);
+});
+
 test('should generate preload link with duplicate', async ({ build }) => {
   const rsbuild = await build({
     config: {

--- a/e2e/cases/performance/resource-hints-preload/index.test.ts
+++ b/e2e/cases/performance/resource-hints-preload/index.test.ts
@@ -22,10 +22,12 @@ test('should generate preload link when preload is defined', async ({ build }) =
   const files = rsbuild.getDistFiles();
 
   const asyncFileName = findFile(files, /\/static\/js\/async\/.+\.js$/);
+  const textFileName = findFile(files, /\/static\/assets\/.+\.txt$/);
   const content = getFileContent(files, '.html');
 
   // test.js, test.css, image.png
   expect(content.match(/rel="preload"/g)?.length).toBe(3);
+  expect(content).not.toContain(textFileName.slice(textFileName.indexOf('/static/assets/')));
 
   expect(
     content.includes(

--- a/e2e/cases/performance/resource-hints-preload/src/file.txt
+++ b/e2e/cases/performance/resource-hints-preload/src/file.txt
@@ -1,0 +1,1 @@
+plain text asset

--- a/e2e/cases/performance/resource-hints-preload/src/test.ts
+++ b/e2e/cases/performance/resource-hints-preload/src/test.ts
@@ -1,5 +1,6 @@
+import text from './file.txt?url';
 import png from '@e2e/assets/image.png?url';
 import './test.css';
 
-export { png };
+export { png, text };
 export const a = '1111';

--- a/packages/core/src/plugins/resourceHints.ts
+++ b/packages/core/src/plugins/resourceHints.ts
@@ -1,4 +1,5 @@
 import { isRegExp } from 'node:util/types';
+import { ASSET_EXTENSIONS } from '../constants';
 import { castArray } from '../helpers';
 import { getHTMLPlugin } from '../pluginHelper';
 import { HtmlResourceHintsPlugin } from '../rspack-plugins/resource-hints/HtmlResourceHintsPlugin';
@@ -10,6 +11,7 @@ import type {
   PreloadOptions,
   RsbuildPlugin,
 } from '../types';
+import { getRegExpForExts } from './asset';
 import { getInlineTests } from './inlineChunk';
 
 const generateLinks = (
@@ -95,11 +97,13 @@ export const pluginResourceHints = (): RsbuildPlugin => ({
 
       const HTMLCount = chain.entryPoints.values().length;
       const excludes = getInlineExcludes(config);
+      const assetExclude = getRegExpForExts(ASSET_EXTENSIONS);
+      const resourceHintExcludes = [...excludes, assetExclude];
 
       if (prefetch) {
         const options = appendExcludes<PrefetchOptions>(
           prefetch === true ? {} : prefetch,
-          excludes,
+          resourceHintExcludes,
         );
 
         chain
@@ -114,7 +118,10 @@ export const pluginResourceHints = (): RsbuildPlugin => ({
       }
 
       if (preload) {
-        const options = appendExcludes<PreloadOptions>(preload === true ? {} : preload, excludes);
+        const options = appendExcludes<PreloadOptions>(
+          preload === true ? {} : preload,
+          resourceHintExcludes,
+        );
 
         chain
           .plugin(CHAIN_ID.PLUGIN.HTML_PRELOAD)

--- a/packages/core/src/plugins/resourceHints.ts
+++ b/packages/core/src/plugins/resourceHints.ts
@@ -37,18 +37,23 @@ const getInlineExcludes = (config: NormalizedEnvironmentConfig): RegExp[] => {
   return [...scriptTests, ...styleTests].filter((item) => isRegExp(item));
 };
 
-const appendExcludes = <T extends PrefetchOptions | PreloadOptions>(
+const applyExcludes = <T extends PrefetchOptions | PreloadOptions>(
   options: T | T[],
+  defaultExclude: RegExp,
   excludes: RegExp[],
 ): T | T[] => {
-  if (!excludes.length) {
-    return options;
-  }
+  const optionsList = castArray(options).map((option): T => {
+    const exclude = option.exclude ?? defaultExclude;
 
-  const optionsList = castArray(options).map((option) => ({
-    ...option,
-    exclude: option.exclude ? [...castArray(option.exclude), ...excludes] : excludes,
-  }));
+    if (!excludes.length && option.exclude !== undefined) {
+      return option;
+    }
+
+    return {
+      ...option,
+      exclude: excludes.length ? [...castArray(exclude), ...excludes] : exclude,
+    } as T;
+  });
 
   return Array.isArray(options) ? optionsList : optionsList[0];
 };
@@ -98,12 +103,12 @@ export const pluginResourceHints = (): RsbuildPlugin => ({
       const HTMLCount = chain.entryPoints.values().length;
       const excludes = getInlineExcludes(config);
       const assetExclude = getRegExpForExts(ASSET_EXTENSIONS);
-      const resourceHintExcludes = [...excludes, assetExclude];
 
       if (prefetch) {
-        const options = appendExcludes<PrefetchOptions>(
+        const options = applyExcludes<PrefetchOptions>(
           prefetch === true ? {} : prefetch,
-          resourceHintExcludes,
+          assetExclude,
+          excludes,
         );
 
         chain
@@ -118,9 +123,10 @@ export const pluginResourceHints = (): RsbuildPlugin => ({
       }
 
       if (preload) {
-        const options = appendExcludes<PreloadOptions>(
+        const options = applyExcludes<PreloadOptions>(
           preload === true ? {} : preload,
-          resourceHintExcludes,
+          assetExclude,
+          excludes,
         );
 
         chain

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -755,11 +755,13 @@ export interface ResourceHintsOptions {
    */
   type?: ResourceHintsIncludeType;
   /**
-   * A extra filter to determine which resources to include.
+   * An extra filter to determine which resources to include.
    */
   include?: ResourceHintsFilter;
   /**
-   * A extra filter to determine which resources to exclude.
+   * An extra filter to determine which resources to exclude.
+   *
+   * @default /\.(?:pdf|txt)$/i
    */
   exclude?: ResourceHintsFilter;
   /**

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -747,7 +747,7 @@ export interface ResourceHintsOptions {
   /**
    * Specifies which types of resources will be included.
    * - `async-chunks`: Includes all async resources on the current page, such as async JS
-   * chunks, and its associated CSS, images, fonts, and other static resources.
+   * chunks, and its associated CSS, images, and fonts.
    * - `initial`: Includes all non-async resources on the current page.
    * - `all-chunks`: Includes all async and non-async resources on the current page.
    * - `all-assets`: Includes all resources from all pages.
@@ -822,7 +822,7 @@ export interface PerformanceConfig {
    *
    * When `performance.preload` is set to `true`, Rsbuild will use the following default
    * options to preload resources. This means preloading all async resources on the current
-   * page, including async JS and its associated CSS, image, font, and other resources.
+   * page, including async JS and its associated CSS, image, and font resources.
    *
    * ```js
    * const defaultOptions = {
@@ -840,7 +840,7 @@ export interface PerformanceConfig {
    *
    * When `performance.prefetch` is set to `true`, Rsbuild will use the following default
    * options to prefetch resources. This means prefetching all async resources on the current
-   * page, including async JS and its associated CSS, image, font, and other resources.
+   * page, including async JS and its associated CSS, image, and font resources.
    *
    * ```js
    * const defaultOptions = {

--- a/website/docs/en/config/performance/prefetch.mdx
+++ b/website/docs/en/config/performance/prefetch.mdx
@@ -26,7 +26,7 @@ The prefetch keyword for the rel attribute of the `<link>` element provides a hi
 
 ## Enable prefetch
 
-When `performance.prefetch` is set to `true`, Rsbuild will use the following default options to prefetch resources. This means prefetching all async resources on the current page, including async JS and its associated CSS, image, font, and other resources.
+When `performance.prefetch` is set to `true`, Rsbuild will use the following default options to prefetch resources. This means prefetching all async resources on the current page, including async JS and its associated CSS, image, and font resources.
 
 ```js
 const defaultOptions = {
@@ -107,10 +107,12 @@ type ResourceHintsIncludeType = 'async-chunks' | 'initial' | 'all-assets' | 'all
 
 Specify which types of resources will be included. Currently supported values are as follows:
 
-- `async-chunks`: Includes all async resources on the current page, such as async JS chunks, and its associated CSS, images, fonts, and other static resources.
+- `async-chunks`: Includes all async resources on the current page, such as async JS chunks, and its associated CSS, images, and fonts.
 - `initial`: Includes all non-async resources on the current page.
 - `all-chunks`: Includes all async and non-async resources on the current page.
 - `all-assets`: Includes all resources from all pages.
+
+Generic built-in assets such as `.pdf` and `.txt` are excluded from prefetch generation by default. If you need to prefetch them, you can manually add prefetch tags through [html.tags](/config/html/tags).
 
 For example, to include all png images on the current page, configure it as follows:
 

--- a/website/docs/en/config/performance/prefetch.mdx
+++ b/website/docs/en/config/performance/prefetch.mdx
@@ -112,8 +112,6 @@ Specify which types of resources will be included. Currently supported values ar
 - `all-chunks`: Includes all async and non-async resources on the current page.
 - `all-assets`: Includes all resources from all pages.
 
-Generic built-in assets such as `.pdf` and `.txt` are excluded from prefetch generation by default. If you need to prefetch them, you can manually add prefetch tags through [html.tags](/config/html/tags).
-
 For example, to include all png images on the current page, configure it as follows:
 
 ```ts title="rsbuild.config.ts"
@@ -226,7 +224,7 @@ type ResourceHintsFilter =
   | Array<string | RegExp | ((filename: string) => boolean)>;
 ```
 
-- **Default:** `undefined`
+- **Default:** `/\.(?:pdf|txt)$/i`
 
 An extra filter to determine which resources to exclude. The usage is similar to `include`.
 
@@ -234,4 +232,5 @@ An extra filter to determine which resources to exclude. The usage is similar to
 
 | Version | Changes                                                      |
 | ------- | ------------------------------------------------------------ |
+| v2.1.5  | Excluded `.pdf` and `.txt` assets by default                 |
 | v2.0.12 | Added support for setting `performance.prefetch` to an array |

--- a/website/docs/en/config/performance/preload.mdx
+++ b/website/docs/en/config/performance/preload.mdx
@@ -106,8 +106,6 @@ Specify which types of resources will be included. Currently supported values ar
 - `all-chunks`: Includes all async and non-async resources on the current page.
 - `all-assets`: Includes all resources from all pages.
 
-Generic built-in assets such as `.pdf` and `.txt` are excluded from preload generation by default. If you need to preload them, you can manually add preload tags through [html.tags](/config/html/tags).
-
 For example, to include all png images on the current page, configure it as follows:
 
 ```ts title="rsbuild.config.ts"
@@ -216,7 +214,7 @@ type ResourceHintsFilter =
   | Array<string | RegExp | ((filename: string) => boolean)>;
 ```
 
-- **Default:** `undefined`
+- **Default:** `/\.(?:pdf|txt)$/i`
 
 An extra filter to determine which resources to exclude. The usage is similar to `include`.
 
@@ -243,4 +241,5 @@ export default {
 
 | Version | Changes                                                     |
 | ------- | ----------------------------------------------------------- |
+| v2.1.5  | Excluded `.pdf` and `.txt` assets by default                |
 | v2.0.12 | Added support for setting `performance.preload` to an array |

--- a/website/docs/en/config/performance/preload.mdx
+++ b/website/docs/en/config/performance/preload.mdx
@@ -29,7 +29,7 @@ This ensures they are available earlier and are less likely to block the page's 
 
 ## Enable preload
 
-When `performance.preload` is set to `true`, Rsbuild will use the following default options to preload resources. This means preloading all async resources on the current page, including async JS and its associated CSS, image, font, and other resources.
+When `performance.preload` is set to `true`, Rsbuild will use the following default options to preload resources. This means preloading all async resources on the current page, including async JS and its associated CSS, image, and font resources.
 
 ```js
 const defaultOptions = {
@@ -101,10 +101,12 @@ type ResourceHintsIncludeType = 'async-chunks' | 'initial' | 'all-assets' | 'all
 
 Specify which types of resources will be included. Currently supported values are as follows:
 
-- `async-chunks`: Includes all async resources on the current page, such as async JS chunks, and its associated CSS, images, fonts, and other static resources.
+- `async-chunks`: Includes all async resources on the current page, such as async JS chunks, and its associated CSS, images, and fonts.
 - `initial`: Includes all non-async resources on the current page.
 - `all-chunks`: Includes all async and non-async resources on the current page.
 - `all-assets`: Includes all resources from all pages.
+
+Generic built-in assets such as `.pdf` and `.txt` are excluded from preload generation by default. If you need to preload them, you can manually add preload tags through [html.tags](/config/html/tags).
 
 For example, to include all png images on the current page, configure it as follows:
 

--- a/website/docs/zh/config/performance/prefetch.mdx
+++ b/website/docs/zh/config/performance/prefetch.mdx
@@ -26,7 +26,7 @@ interface PrefetchOptions {
 
 ## 启用 prefetch
 
-当设置 `performance.prefetch` 为 `true` 时，Rsbuild 将使用以下默认选项，对资源进行预获取，这表示 prefetch 当前页面的所有异步资源，包含异步 JS 及其关联的 CSS、image、font 等资源。
+当设置 `performance.prefetch` 为 `true` 时，Rsbuild 将使用以下默认选项，对资源进行预获取，这表示 prefetch 当前页面的所有异步资源，包含异步 JS 及其关联的 CSS、image、font 资源。
 
 ```js
 const defaultOptions = {
@@ -107,10 +107,12 @@ type ResourceHintsIncludeType = 'async-chunks' | 'initial' | 'all-assets' | 'all
 
 指定哪些类型的资源会被包含，目前支持的值如下：
 
-- `async-chunks`: 包含当前页面的所有异步资源，比如异步的 JS chunks，以及它关联的 CSS、image、font 等静态资源。
+- `async-chunks`: 包含当前页面的所有异步资源，比如异步的 JS chunks，以及它关联的 CSS、image、font 资源。
 - `initial`: 包含当前页面的所有非异步资源。
 - `all-chunks`: 包含当前页面的所有异步和非异步资源。
 - `all-assets`: 包含所有页面的所有资源。
+
+`.pdf`、`.txt` 等通用内置资源默认不会生成 prefetch 标签。如果你需要 prefetch 这些资源，可以通过 [html.tags](/config/html/tags) 手动添加标签。
 
 例如，为了包含当前页面中所有 png 图片，可以配置为：
 

--- a/website/docs/zh/config/performance/prefetch.mdx
+++ b/website/docs/zh/config/performance/prefetch.mdx
@@ -112,8 +112,6 @@ type ResourceHintsIncludeType = 'async-chunks' | 'initial' | 'all-assets' | 'all
 - `all-chunks`: 包含当前页面的所有异步和非异步资源。
 - `all-assets`: 包含所有页面的所有资源。
 
-`.pdf`、`.txt` 等通用内置资源默认不会生成 prefetch 标签。如果你需要 prefetch 这些资源，可以通过 [html.tags](/config/html/tags) 手动添加标签。
-
 例如，为了包含当前页面中所有 png 图片，可以配置为：
 
 ```ts title="rsbuild.config.ts"
@@ -226,7 +224,7 @@ type ResourceHintsFilter =
   | Array<string | RegExp | ((filename: string) => boolean)>;
 ```
 
-- **默认值：** `undefined`
+- **默认值：** `/\.(?:pdf|txt)$/i`
 
 一个额外的过滤器，用于指定哪些资源会被排除，用法与 `include` 类似。
 
@@ -234,4 +232,5 @@ type ResourceHintsFilter =
 
 | 版本    | 变更内容                                 |
 | ------- | ---------------------------------------- |
+| v2.1.5  | 默认排除 `.pdf` 和 `.txt` 资源           |
 | v2.0.12 | 支持将 `performance.prefetch` 设置为数组 |

--- a/website/docs/zh/config/performance/preload.mdx
+++ b/website/docs/zh/config/performance/preload.mdx
@@ -106,8 +106,6 @@ type ResourceHintsIncludeType = 'async-chunks' | 'initial' | 'all-assets' | 'all
 - `all-chunks`: 包含当前页面的所有异步和非异步资源。
 - `all-assets`: 包含所有页面的所有资源。
 
-`.pdf`、`.txt` 等通用内置资源默认不会生成 preload 标签。如果你需要 preload 这些资源，可以通过 [html.tags](/config/html/tags) 手动添加标签。
-
 例如，为了包含当前页面中所有 png 图片，可以配置为：
 
 ```ts title="rsbuild.config.ts"
@@ -216,7 +214,7 @@ type ResourceHintsFilter =
   | Array<string | RegExp | ((filename: string) => boolean)>;
 ```
 
-- **默认值：** `undefined`
+- **默认值：** `/\.(?:pdf|txt)$/i`
 
 一个额外的过滤器，用于指定哪些资源会被排除，用法与 `include` 类似。
 
@@ -243,4 +241,5 @@ export default {
 
 | 版本    | 变更内容                                |
 | ------- | --------------------------------------- |
+| v2.1.5  | 默认排除 `.pdf` 和 `.txt` 资源          |
 | v2.0.12 | 支持将 `performance.preload` 设置为数组 |

--- a/website/docs/zh/config/performance/preload.mdx
+++ b/website/docs/zh/config/performance/preload.mdx
@@ -29,7 +29,7 @@ interface PreloadOptions {
 
 ## 启用 preload
 
-当设置 `performance.preload` 为 `true` 时，Rsbuild 将使用以下默认选项，对资源进行预获取，这表示 preload 当前页面的所有异步资源，包含异步 JS 及其关联的 CSS、image、font 等资源。
+当设置 `performance.preload` 为 `true` 时，Rsbuild 将使用以下默认选项，对资源进行预获取，这表示 preload 当前页面的所有异步资源，包含异步 JS 及其关联的 CSS、image、font 资源。
 
 ```js
 const defaultOptions = {
@@ -101,10 +101,12 @@ type ResourceHintsIncludeType = 'async-chunks' | 'initial' | 'all-assets' | 'all
 
 指定哪些类型的资源会被包含，目前支持的值如下：
 
-- `async-chunks`: 包含当前页面的所有异步资源，比如异步的 JS chunks，以及它关联的 CSS、image、font 等静态资源。
+- `async-chunks`: 包含当前页面的所有异步资源，比如异步的 JS chunks，以及它关联的 CSS、image、font 资源。
 - `initial`: 包含当前页面的所有非异步资源。
 - `all-chunks`: 包含当前页面的所有异步和非异步资源。
 - `all-assets`: 包含所有页面的所有资源。
+
+`.pdf`、`.txt` 等通用内置资源默认不会生成 preload 标签。如果你需要 preload 这些资源，可以通过 [html.tags](/config/html/tags) 手动添加标签。
 
 例如，为了包含当前页面中所有 png 图片，可以配置为：
 


### PR DESCRIPTION
## Summary

This PR narrows the default `performance.preload` and `performance.prefetch` behavior so generic built-in assets such as `.pdf` and `.txt` are not hinted automatically.

It keeps resource hints focused on async JS and associated CSS, image, and font resources, avoiding incorrect or overly aggressive hints for files whose runtime usage is unclear.

The docs and e2e coverage are updated for both preload and prefetch.
