### PR TITLE
chore: enable Rspack native watcher

### DIFF
--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -126,6 +126,13 @@ export default defineConfig({
   output: {
     externals,
   },
+  tools: {
+    rspack: {
+      experiments: {
+        nativeWatcher: true,
+      },
+    },
+  },
   lib: [
     // Build client modules and copy dependencies to compiled folder
     {

--- a/scripts/config/rslib.config.ts
+++ b/scripts/config/rslib.config.ts
@@ -40,6 +40,9 @@ export const pureEsmPackage = defineConfig({
   lib: [esmConfig],
   tools: {
     rspack: {
+      experiments: {
+        nativeWatcher: true,
+      },
       externals: commonExternals,
     },
   },
@@ -58,6 +61,9 @@ export const dualPackage = defineConfig({
   lib: [esmConfig, cjsConfig],
   tools: {
     rspack: {
+      experiments: {
+        nativeWatcher: true,
+      },
       externals: commonExternals,
     },
   },

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -244,6 +244,13 @@ export default defineConfig({
     server: {
       open: true,
     },
+    tools: {
+      rspack: {
+        experiments: {
+          nativeWatcher: true,
+        },
+      },
+    },
     html: {
       tags: [
         // for baidu SEO verification


### PR DESCRIPTION
## Summary

This PR enables Rspack's `experiments.nativeWatcher` in the Rslib and Rspress configs so the repo can exercise the native watcher in everyday development workflows. The goal is to try this feature in real project usage and surface any compatibility or stability issues early.

## Related Links

https://rspack.rs/config/experiments#experimentsnativewatcher