### PR TITLE
feat(core): support webmanifest assets

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -82,7 +82,7 @@ export const PLUGIN_CSS_NAME = 'rsbuild:css';
 
 // Extensions
 export const FONT_EXTENSIONS: string[] = ['woff', 'woff2', 'eot', 'ttf', 'otf', 'ttc'];
-export const ASSET_EXTENSIONS: string[] = ['pdf', 'txt'];
+export const ASSET_EXTENSIONS: string[] = ['webmanifest', 'pdf', 'txt'];
 export const IMAGE_EXTENSIONS: string[] = [
   'png',
   'jpg',

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -761,7 +761,7 @@ export interface ResourceHintsOptions {
   /**
    * An extra filter to determine which resources to exclude.
    *
-   * @default /\.(?:pdf|txt)$/i
+   * @default /\.(?:webmanifest|pdf|txt)$/i
    */
   exclude?: ResourceHintsFilter;
   /**

--- a/packages/core/tests/__snapshots__/asset.test.ts.snap
+++ b/packages/core/tests/__snapshots__/asset.test.ts.snap
@@ -121,7 +121,7 @@ exports[`plugin-asset > should add other asset rules correctly 1`] = `
         "type": "asset",
       },
     ],
-    "test": /\\\\\\.\\(\\?:pdf\\|txt\\)\\$/i,
+    "test": /\\\\\\.\\(\\?:webmanifest\\|pdf\\|txt\\)\\$/i,
   },
 ]
 `;

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -467,7 +467,7 @@ exports[`default bundler > should use Rspack by default 1`] = `
             "type": "asset",
           },
         ],
-        "test": /\\\\\\.\\(\\?:pdf\\|txt\\)\\$/i,
+        "test": /\\\\\\.\\(\\?:webmanifest\\|pdf\\|txt\\)\\$/i,
       },
       {
         "oneOf": [

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -490,7 +490,7 @@ exports[`should apply default plugins correctly 1`] = `
             "type": "asset",
           },
         ],
-        "test": /\\\\\\.\\(\\?:pdf\\|txt\\)\\$/i,
+        "test": /\\\\\\.\\(\\?:webmanifest\\|pdf\\|txt\\)\\$/i,
       },
       {
         "oneOf": [
@@ -1060,7 +1060,7 @@ exports[`should apply default plugins correctly in production 1`] = `
             "type": "asset",
           },
         ],
-        "test": /\\\\\\.\\(\\?:pdf\\|txt\\)\\$/i,
+        "test": /\\\\\\.\\(\\?:webmanifest\\|pdf\\|txt\\)\\$/i,
       },
       {
         "oneOf": [
@@ -1641,7 +1641,7 @@ exports[`should apply default plugins correctly when target is node 1`] = `
             "type": "asset",
           },
         ],
-        "test": /\\\\\\.\\(\\?:pdf\\|txt\\)\\$/i,
+        "test": /\\\\\\.\\(\\?:webmanifest\\|pdf\\|txt\\)\\$/i,
       },
       {
         "oneOf": [
@@ -2222,7 +2222,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "type": "asset",
           },
         ],
-        "test": /\\\\\\.\\(\\?:pdf\\|txt\\)\\$/i,
+        "test": /\\\\\\.\\(\\?:webmanifest\\|pdf\\|txt\\)\\$/i,
       },
       {
         "oneOf": [

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -463,7 +463,7 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
               "type": "asset",
             },
           ],
-          "test": /\\\\\\.\\(\\?:pdf\\|txt\\)\\$/i,
+          "test": /\\\\\\.\\(\\?:webmanifest\\|pdf\\|txt\\)\\$/i,
         },
         {
           "oneOf": [
@@ -1018,7 +1018,7 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
               "type": "asset",
             },
           ],
-          "test": /\\\\\\.\\(\\?:pdf\\|txt\\)\\$/i,
+          "test": /\\\\\\.\\(\\?:webmanifest\\|pdf\\|txt\\)\\$/i,
         },
         {
           "oneOf": [

--- a/packages/core/tests/asset.test.ts
+++ b/packages/core/tests/asset.test.ts
@@ -68,8 +68,9 @@ describe('plugin-asset', () => {
     const rsbuild = await createRsbuild();
 
     const config = (await rsbuild.initConfigs())[0];
-    const rules = matchRules(config, 'a.pdf');
+    const rules = matchRules(config, 'a.webmanifest');
     expect(rules).toMatchSnapshot();
+    expect(matchRules(config, 'a.pdf')).toEqual(rules);
     expect(matchRules(config, 'a.txt')).toEqual(rules);
   });
 });

--- a/packages/core/types.d.ts
+++ b/packages/core/types.d.ts
@@ -228,6 +228,10 @@ declare module '*.opus' {
 /**
  * Other assets
  */
+declare module '*.webmanifest' {
+  const src: string;
+  export default src;
+}
 declare module '*.pdf' {
   const src: string;
   export default src;

--- a/website/docs/en/config/performance/prefetch.mdx
+++ b/website/docs/en/config/performance/prefetch.mdx
@@ -224,13 +224,13 @@ type ResourceHintsFilter =
   | Array<string | RegExp | ((filename: string) => boolean)>;
 ```
 
-- **Default:** `/\.(?:pdf|txt)$/i`
+- **Default:** `/\.(?:webmanifest|pdf|txt)$/i`
 
 An extra filter to determine which resources to exclude. The usage is similar to `include`.
 
 ## Version history
 
-| Version | Changes                                                      |
-| ------- | ------------------------------------------------------------ |
-| v2.1.5  | Excluded `.pdf` and `.txt` assets by default                 |
-| v2.0.12 | Added support for setting `performance.prefetch` to an array |
+| Version | Changes                                                       |
+| ------- | ------------------------------------------------------------- |
+| v2.1.5  | Excluded `.webmanifest`, `.pdf`, and `.txt` assets by default |
+| v2.0.12 | Added support for setting `performance.prefetch` to an array  |

--- a/website/docs/en/config/performance/preload.mdx
+++ b/website/docs/en/config/performance/preload.mdx
@@ -214,7 +214,7 @@ type ResourceHintsFilter =
   | Array<string | RegExp | ((filename: string) => boolean)>;
 ```
 
-- **Default:** `/\.(?:pdf|txt)$/i`
+- **Default:** `/\.(?:webmanifest|pdf|txt)$/i`
 
 An extra filter to determine which resources to exclude. The usage is similar to `include`.
 
@@ -239,7 +239,7 @@ export default {
 
 ## Version history
 
-| Version | Changes                                                     |
-| ------- | ----------------------------------------------------------- |
-| v2.1.5  | Excluded `.pdf` and `.txt` assets by default                |
-| v2.0.12 | Added support for setting `performance.preload` to an array |
+| Version | Changes                                                       |
+| ------- | ------------------------------------------------------------- |
+| v2.1.5  | Excluded `.webmanifest`, `.pdf`, and `.txt` assets by default |
+| v2.0.12 | Added support for setting `performance.preload` to an array   |

--- a/website/docs/en/guide/basic/static-assets.mdx
+++ b/website/docs/en/guide/basic/static-assets.mdx
@@ -18,7 +18,7 @@ Rsbuild supports these formats by default:
 - **Fonts**: woff, woff2, eot, ttf, otf, ttc.
 - **Audio**: mp3, wav, flac, aac, m4a, opus.
 - **Video**: mp4, webm, ogg, mov.
-- **Other**: pdf, txt.
+- **Other**: webmanifest, pdf, txt.
 
 To import assets in other formats, refer to [Extend Asset Types](#extend-asset-types).
 

--- a/website/docs/zh/config/performance/prefetch.mdx
+++ b/website/docs/zh/config/performance/prefetch.mdx
@@ -224,13 +224,13 @@ type ResourceHintsFilter =
   | Array<string | RegExp | ((filename: string) => boolean)>;
 ```
 
-- **默认值：** `/\.(?:pdf|txt)$/i`
+- **默认值：** `/\.(?:webmanifest|pdf|txt)$/i`
 
 一个额外的过滤器，用于指定哪些资源会被排除，用法与 `include` 类似。
 
 ## 版本历史
 
-| 版本    | 变更内容                                 |
-| ------- | ---------------------------------------- |
-| v2.1.5  | 默认排除 `.pdf` 和 `.txt` 资源           |
-| v2.0.12 | 支持将 `performance.prefetch` 设置为数组 |
+| 版本    | 变更内容                                       |
+| ------- | ---------------------------------------------- |
+| v2.1.5  | 默认排除 `.webmanifest`、`.pdf` 和 `.txt` 资源 |
+| v2.0.12 | 支持将 `performance.prefetch` 设置为数组       |

--- a/website/docs/zh/config/performance/preload.mdx
+++ b/website/docs/zh/config/performance/preload.mdx
@@ -214,7 +214,7 @@ type ResourceHintsFilter =
   | Array<string | RegExp | ((filename: string) => boolean)>;
 ```
 
-- **默认值：** `/\.(?:pdf|txt)$/i`
+- **默认值：** `/\.(?:webmanifest|pdf|txt)$/i`
 
 一个额外的过滤器，用于指定哪些资源会被排除，用法与 `include` 类似。
 
@@ -239,7 +239,7 @@ export default {
 
 ## 版本历史
 
-| 版本    | 变更内容                                |
-| ------- | --------------------------------------- |
-| v2.1.5  | 默认排除 `.pdf` 和 `.txt` 资源          |
-| v2.0.12 | 支持将 `performance.preload` 设置为数组 |
+| 版本    | 变更内容                                       |
+| ------- | ---------------------------------------------- |
+| v2.1.5  | 默认排除 `.webmanifest`、`.pdf` 和 `.txt` 资源 |
+| v2.0.12 | 支持将 `performance.preload` 设置为数组        |

--- a/website/docs/zh/guide/basic/static-assets.mdx
+++ b/website/docs/zh/guide/basic/static-assets.mdx
@@ -18,7 +18,7 @@ Rsbuild 支持在代码中引用图片、字体、媒体和其他类型文件等
 - **字体**：woff、woff2、eot、ttf、otf、ttc。
 - **音频**：mp3、wav、flac、aac、m4a、opus。
 - **视频**：mp4、webm、ogg、mov。
-- **其他**：pdf、txt。
+- **其他**：webmanifest、pdf、txt。
 
 如果你需要引用其他格式的静态资源，请参考 [扩展静态资源类型](#extend-asset-types)。
 


### PR DESCRIPTION
## Summary

This PR adds `.webmanifest` to Rsbuild's built-in asset handling so web app manifest files can be imported as asset URLs without custom rules.

It also adds the matching TypeScript declaration, updates the static asset documentation, and keeps the resource-hint default exclusions aligned for generic asset files.