### PR TITLE
feat(core): support vtt assets

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -102,6 +102,7 @@ export const IMAGE_EXTENSIONS: string[] = [
 ];
 export const VIDEO_EXTENSIONS: string[] = ['mp4', 'webm', 'ogg', 'mov'];
 export const AUDIO_EXTENSIONS: string[] = ['mp3', 'wav', 'flac', 'aac', 'm4a', 'opus'];
+export const TRACK_EXTENSIONS: string[] = ['vtt'];
 
 export const LAZY_COMPILATION_IDENTIFIER = 'lazy-compilation-proxy';
 

--- a/packages/core/src/plugins/asset.ts
+++ b/packages/core/src/plugins/asset.ts
@@ -8,6 +8,7 @@ import {
   IMAGE_EXTENSIONS,
   INLINE_QUERY_REGEX,
   RAW_QUERY_REGEX,
+  TRACK_EXTENSIONS,
   URL_QUERY_REGEX,
   VIDEO_EXTENSIONS,
 } from '../constants';
@@ -129,7 +130,11 @@ export const pluginAsset = (): RsbuildPlugin => ({
       createAssetRule(CHAIN_ID.RULE.SVG, ['svg'], emitAssets);
 
       // media
-      createAssetRule(CHAIN_ID.RULE.MEDIA, [...VIDEO_EXTENSIONS, ...AUDIO_EXTENSIONS], emitAssets);
+      createAssetRule(
+        CHAIN_ID.RULE.MEDIA,
+        [...VIDEO_EXTENSIONS, ...AUDIO_EXTENSIONS, ...TRACK_EXTENSIONS],
+        emitAssets,
+      );
 
       // font
       createAssetRule(CHAIN_ID.RULE.FONT, FONT_EXTENSIONS, emitAssets);

--- a/packages/core/src/rspack-plugins/resource-hints/getResourceType.ts
+++ b/packages/core/src/rspack-plugins/resource-hints/getResourceType.ts
@@ -22,6 +22,7 @@ import {
   AUDIO_EXTENSIONS,
   FONT_EXTENSIONS,
   IMAGE_EXTENSIONS,
+  TRACK_EXTENSIONS,
   VIDEO_EXTENSIONS,
 } from '../../constants';
 
@@ -69,7 +70,7 @@ export function getResourceType({ href, file }: { href: string; file: string }):
     return 'font';
   }
 
-  if (['vtt'].includes(extension)) {
+  if (TRACK_EXTENSIONS.includes(extension)) {
     return 'track';
   }
 

--- a/packages/core/tests/__snapshots__/asset.test.ts.snap
+++ b/packages/core/tests/__snapshots__/asset.test.ts.snap
@@ -84,6 +84,48 @@ exports[`plugin-asset > should add image rules correctly 2`] = `
 ]
 `;
 
+exports[`plugin-asset > should add media rules correctly 1`] = `
+[
+  {
+    "oneOf": [
+      {
+        "generator": {
+          "filename": "static/media/[name].[contenthash:10][ext]",
+        },
+        "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
+        "type": "asset/resource",
+      },
+      {
+        "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
+        "type": "asset/inline",
+      },
+      {
+        "type": "asset/source",
+        "with": {
+          "type": "text",
+        },
+      },
+      {
+        "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+        "type": "asset/source",
+      },
+      {
+        "generator": {
+          "filename": "static/media/[name].[contenthash:10][ext]",
+        },
+        "parser": {
+          "dataUrlCondition": {
+            "maxSize": 4096,
+          },
+        },
+        "type": "asset",
+      },
+    ],
+    "test": /\\\\\\.\\(\\?:mp4\\|webm\\|ogg\\|mov\\|mp3\\|wav\\|flac\\|aac\\|m4a\\|opus\\|vtt\\)\\$/i,
+  },
+]
+`;
+
 exports[`plugin-asset > should add other asset rules correctly 1`] = `
 [
   {

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -393,7 +393,7 @@ exports[`default bundler > should use Rspack by default 1`] = `
             "type": "asset",
           },
         ],
-        "test": /\\\\\\.\\(\\?:mp4\\|webm\\|ogg\\|mov\\|mp3\\|wav\\|flac\\|aac\\|m4a\\|opus\\)\\$/i,
+        "test": /\\\\\\.\\(\\?:mp4\\|webm\\|ogg\\|mov\\|mp3\\|wav\\|flac\\|aac\\|m4a\\|opus\\|vtt\\)\\$/i,
       },
       {
         "oneOf": [

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -416,7 +416,7 @@ exports[`should apply default plugins correctly 1`] = `
             "type": "asset",
           },
         ],
-        "test": /\\\\\\.\\(\\?:mp4\\|webm\\|ogg\\|mov\\|mp3\\|wav\\|flac\\|aac\\|m4a\\|opus\\)\\$/i,
+        "test": /\\\\\\.\\(\\?:mp4\\|webm\\|ogg\\|mov\\|mp3\\|wav\\|flac\\|aac\\|m4a\\|opus\\|vtt\\)\\$/i,
       },
       {
         "oneOf": [
@@ -986,7 +986,7 @@ exports[`should apply default plugins correctly in production 1`] = `
             "type": "asset",
           },
         ],
-        "test": /\\\\\\.\\(\\?:mp4\\|webm\\|ogg\\|mov\\|mp3\\|wav\\|flac\\|aac\\|m4a\\|opus\\)\\$/i,
+        "test": /\\\\\\.\\(\\?:mp4\\|webm\\|ogg\\|mov\\|mp3\\|wav\\|flac\\|aac\\|m4a\\|opus\\|vtt\\)\\$/i,
       },
       {
         "oneOf": [
@@ -1567,7 +1567,7 @@ exports[`should apply default plugins correctly when target is node 1`] = `
             "type": "asset",
           },
         ],
-        "test": /\\\\\\.\\(\\?:mp4\\|webm\\|ogg\\|mov\\|mp3\\|wav\\|flac\\|aac\\|m4a\\|opus\\)\\$/i,
+        "test": /\\\\\\.\\(\\?:mp4\\|webm\\|ogg\\|mov\\|mp3\\|wav\\|flac\\|aac\\|m4a\\|opus\\|vtt\\)\\$/i,
       },
       {
         "oneOf": [
@@ -2148,7 +2148,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "type": "asset",
           },
         ],
-        "test": /\\\\\\.\\(\\?:mp4\\|webm\\|ogg\\|mov\\|mp3\\|wav\\|flac\\|aac\\|m4a\\|opus\\)\\$/i,
+        "test": /\\\\\\.\\(\\?:mp4\\|webm\\|ogg\\|mov\\|mp3\\|wav\\|flac\\|aac\\|m4a\\|opus\\|vtt\\)\\$/i,
       },
       {
         "oneOf": [

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -389,7 +389,7 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
               "type": "asset",
             },
           ],
-          "test": /\\\\\\.\\(\\?:mp4\\|webm\\|ogg\\|mov\\|mp3\\|wav\\|flac\\|aac\\|m4a\\|opus\\)\\$/i,
+          "test": /\\\\\\.\\(\\?:mp4\\|webm\\|ogg\\|mov\\|mp3\\|wav\\|flac\\|aac\\|m4a\\|opus\\|vtt\\)\\$/i,
         },
         {
           "oneOf": [
@@ -944,7 +944,7 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
               "type": "asset",
             },
           ],
-          "test": /\\\\\\.\\(\\?:mp4\\|webm\\|ogg\\|mov\\|mp3\\|wav\\|flac\\|aac\\|m4a\\|opus\\)\\$/i,
+          "test": /\\\\\\.\\(\\?:mp4\\|webm\\|ogg\\|mov\\|mp3\\|wav\\|flac\\|aac\\|m4a\\|opus\\|vtt\\)\\$/i,
         },
         {
           "oneOf": [

--- a/packages/core/tests/asset.test.ts
+++ b/packages/core/tests/asset.test.ts
@@ -64,6 +64,15 @@ describe('plugin-asset', () => {
     expect(matchRules(config, 'a.png')).toMatchSnapshot();
   });
 
+  test('should add media rules correctly', async () => {
+    const rsbuild = await createRsbuild();
+
+    const config = (await rsbuild.initConfigs())[0];
+    const rules = matchRules(config, 'a.mp4');
+    expect(rules).toMatchSnapshot();
+    expect(matchRules(config, 'a.vtt')).toEqual(rules);
+  });
+
   test('should add other asset rules correctly', async () => {
     const rsbuild = await createRsbuild();
 

--- a/packages/core/tests/resourceHints.test.ts
+++ b/packages/core/tests/resourceHints.test.ts
@@ -18,4 +18,13 @@ describe('getResourceType', () => {
       }),
     ).toBe('image');
   });
+
+  it('should return track for WebVTT files', () => {
+    expect(
+      getResourceType({
+        href: '/media/subtitles.vtt',
+        file: 'media/subtitles.vtt',
+      }),
+    ).toBe('track');
+  });
 });

--- a/packages/core/types.d.ts
+++ b/packages/core/types.d.ts
@@ -224,6 +224,10 @@ declare module '*.opus' {
   const src: string;
   export default src;
 }
+declare module '*.vtt' {
+  const src: string;
+  export default src;
+}
 
 /**
  * Other assets

--- a/website/docs/en/guide/basic/static-assets.mdx
+++ b/website/docs/en/guide/basic/static-assets.mdx
@@ -17,7 +17,7 @@ Rsbuild supports these formats by default:
 - **Images**: png, jpg, jpeg, gif, svg, bmp, webp, ico, apng, avif, tif, tiff, jfif, pjpeg, pjp, cur.
 - **Fonts**: woff, woff2, eot, ttf, otf, ttc.
 - **Audio**: mp3, wav, flac, aac, m4a, opus.
-- **Video**: mp4, webm, ogg, mov.
+- **Video**: mp4, webm, ogg, mov, vtt.
 - **Other**: webmanifest, pdf, txt.
 
 To import assets in other formats, refer to [Extend Asset Types](#extend-asset-types).

--- a/website/docs/en/guide/basic/static-assets.mdx
+++ b/website/docs/en/guide/basic/static-assets.mdx
@@ -17,8 +17,8 @@ Rsbuild supports these formats by default:
 - **Images**: png, jpg, jpeg, gif, svg, bmp, webp, ico, apng, avif, tif, tiff, jfif, pjpeg, pjp, cur.
 - **Fonts**: woff, woff2, eot, ttf, otf, ttc.
 - **Audio**: mp3, wav, flac, aac, m4a, opus.
-- **Video**: mp4, webm, ogg, mov, vtt.
-- **Other**: webmanifest, pdf, txt.
+- **Video**: mp4, webm, ogg, mov.
+- **Other**: webmanifest, pdf, txt, vtt.
 
 To import assets in other formats, refer to [Extend Asset Types](#extend-asset-types).
 

--- a/website/docs/zh/guide/basic/static-assets.mdx
+++ b/website/docs/zh/guide/basic/static-assets.mdx
@@ -17,8 +17,8 @@ Rsbuild 支持在代码中引用图片、字体、媒体和其他类型文件等
 - **图片**：png、jpg、jpeg、gif、svg、bmp、webp、ico、apng、avif、tif、tiff、jfif、pjpeg、pjp、cur。
 - **字体**：woff、woff2、eot、ttf、otf、ttc。
 - **音频**：mp3、wav、flac、aac、m4a、opus。
-- **视频**：mp4、webm、ogg、mov、vtt。
-- **其他**：webmanifest、pdf、txt。
+- **视频**：mp4、webm、ogg、mov。
+- **其他**：webmanifest、pdf、txt、vtt。
 
 如果你需要引用其他格式的静态资源，请参考 [扩展静态资源类型](#extend-asset-types)。
 

--- a/website/docs/zh/guide/basic/static-assets.mdx
+++ b/website/docs/zh/guide/basic/static-assets.mdx
@@ -17,7 +17,7 @@ Rsbuild 支持在代码中引用图片、字体、媒体和其他类型文件等
 - **图片**：png、jpg、jpeg、gif、svg、bmp、webp、ico、apng、avif、tif、tiff、jfif、pjpeg、pjp、cur。
 - **字体**：woff、woff2、eot、ttf、otf、ttc。
 - **音频**：mp3、wav、flac、aac、m4a、opus。
-- **视频**：mp4、webm、ogg、mov。
+- **视频**：mp4、webm、ogg、mov、vtt。
 - **其他**：webmanifest、pdf、txt。
 
 如果你需要引用其他格式的静态资源，请参考 [扩展静态资源类型](#extend-asset-types)。


### PR DESCRIPTION
## Summary

This PR adds WebVTT (`.vtt`) to Rsbuild's built-in static asset handling so subtitle and text-track files can be imported without custom asset rules.

It emits `.vtt` through the existing media asset rule, adds the TypeScript module declaration, documents the supported format, and keeps resource hints classified as `track`.