### PR TITLE
fix(create-rsbuild): preserve test template types

### DIFF
--- a/packages/create-rsbuild/template-rstest/react-ts/tests/tsconfig.json
+++ b/packages/create-rsbuild/template-rstest/react-ts/tests/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "types": ["@testing-library/jest-dom"]
+    "types": ["@rsbuild/core/types", "node", "@testing-library/jest-dom"]
   },
   "include": ["./"]
 }

--- a/packages/create-rsbuild/template-rstest/vanilla-ts/tests/tsconfig.json
+++ b/packages/create-rsbuild/template-rstest/vanilla-ts/tests/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "types": ["@testing-library/jest-dom"]
+    "types": ["@rsbuild/core/types", "node", "@testing-library/jest-dom"]
   },
   "include": ["./"]
 }

--- a/packages/create-rsbuild/template-rstest/vue-ts/tests/tsconfig.json
+++ b/packages/create-rsbuild/template-rstest/vue-ts/tests/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "types": ["@testing-library/jest-dom"]
+    "types": ["@rsbuild/core/types", "node", "@testing-library/jest-dom"]
   },
   "include": ["./"]
 }


### PR DESCRIPTION
## Summary

This PR keeps the generated Rstest TypeScript template configs aligned with their parent `tsconfig.json` files. Since `compilerOptions.types` is not merged from extended configs, the test tsconfigs now include the parent `@rsbuild/core/types` and `node` entries alongside `@testing-library/jest-dom`.
