### PR TITLE
refactor(core): use shared load config package

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,6 +52,7 @@
     "@jridgewell/remapping": "catalog:",
     "@jridgewell/trace-mapping": "catalog:",
     "@rslib/core": "catalog:",
+    "@rstackjs/load-config": "catalog:",
     "@types/cors": "catalog:",
     "@types/node": "catalog:",
     "@types/on-finished": "catalog:",

--- a/packages/core/prebundle.config.ts
+++ b/packages/core/prebundle.config.ts
@@ -19,6 +19,10 @@ export default {
   dependencies: [
     'html-rspack-plugin',
     {
+      name: '@rstackjs/load-config',
+      dtsOnly: true,
+    },
+    {
       name: 'chokidar',
       dtsOnly: true,
     },

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -196,6 +196,7 @@ export default defineConfig({
           postcss: './compiled/postcss',
           chokidar: './compiled/chokidar',
           'connect-next': './compiled/connect-next',
+          '@rstackjs/load-config': './compiled/@rstackjs/load-config',
           'rspack-chain': './compiled/rspack-chain/types',
           'html-rspack-plugin': './compiled/html-rspack-plugin',
           'http-proxy-middleware': './compiled/http-proxy-middleware',

--- a/packages/core/src/loadConfig.ts
+++ b/packages/core/src/loadConfig.ts
@@ -1,9 +1,13 @@
-import fs from 'node:fs';
-import { isAbsolute, join } from 'node:path';
-import { pathToFileURL } from 'node:url';
+import {
+  loadConfig as baseImpl,
+  type LoadConfigOptions as BaseOptions,
+  type LoadConfigResult as BaseResult,
+} from '@rstackjs/load-config';
 import { color, getNodeEnv, isObject } from './helpers';
 import { defaultLogger } from './logger';
 import type { RsbuildConfig } from './types';
+
+export type { ConfigLoader } from '@rstackjs/load-config';
 
 export type ConfigParams = {
   env: string;
@@ -18,22 +22,10 @@ export type RsbuildConfigSyncFn = (env: ConfigParams) => RsbuildConfig;
 
 export type RsbuildConfigDefinition = RsbuildConfig | RsbuildConfigSyncFn | RsbuildConfigAsyncFn;
 
-export type LoadConfigOptions = {
-  /**
-   * The root path to resolve the config file.
-   * @default process.cwd()
-   */
-  cwd?: string;
-  /**
-   * The path to the config file, can be a relative or absolute path.
-   * If `path` is not provided, the function will search for the config file in the `cwd`.
-   */
-  path?: string;
-  /**
-   * Config file names to search in `cwd` when `path` is not provided.
-   * The list replaces the default `rsbuild.config.*` lookup order.
-   */
-  configFileNames?: string[];
+export type LoadConfigOptions = Pick<
+  BaseOptions<[ConfigParams]>,
+  'cwd' | 'path' | 'loader' | 'exportName' | 'configFileNames'
+> & {
   /**
    * A custom meta object to be passed into the config function of `defineConfig`.
    */
@@ -44,42 +36,16 @@ export type LoadConfigOptions = {
    */
   envMode?: string;
   /**
-   * Specify the config loader, can be `auto`, `jiti` or `native`.
-   * - 'auto': Use native Node.js loader first, fallback to jiti if failed
-   * - 'jiti': Use `jiti` as loader, which supports TypeScript and ESM out of the box
-   * - 'native': Use native Node.js loader, requires TypeScript support in Node.js >= 22.6
-   * @default 'auto'
-   */
-  loader?: ConfigLoader;
-  /**
    * The command passed to the config function.
    * @default process.argv[2]
    */
   command?: string;
-  /**
-   * The export name to read from the config file.
-   * Set to `false` to execute the config file without reading exports.
-   * @default 'default'
-   */
-  exportName?: string | false;
 };
 
-export type LoadConfigResult<Config = RsbuildConfig> = {
-  /**
-   * The loaded configuration object.
-   */
-  content: Config;
-  /**
-   * The path to the loaded configuration file.
-   * Return `null` if the configuration file is not found.
-   */
-  filePath: string | null;
-  /**
-   * Absolute file paths of statically imported (relative) dependencies of the
-   * config file.
-   */
-  dependencies: string[];
-};
+export type LoadConfigResult<Config = RsbuildConfig> = Pick<
+  BaseResult<Config>,
+  'content' | 'filePath' | 'dependencies'
+>;
 
 /**
  * This function helps you to autocomplete configuration types.
@@ -103,231 +69,52 @@ const DEFAULT_CONFIG_FILE_NAMES = [
   'rsbuild.config.cjs',
 ];
 
-const resolveConfigPath = (
-  root: string,
-  customConfig?: string,
-  configFileNames = DEFAULT_CONFIG_FILE_NAMES,
-) => {
-  if (customConfig) {
-    const customConfigPath = isAbsolute(customConfig) ? customConfig : join(root, customConfig);
-    if (fs.existsSync(customConfigPath)) {
-      return customConfigPath;
-    }
-    throw new Error(`Cannot find config file: ${color.dim(customConfigPath)}`);
-  }
-
-  for (const file of configFileNames) {
-    const configFile = join(root, file);
-
-    if (fs.existsSync(configFile)) {
-      return configFile;
-    }
-  }
-
-  return null;
-};
-
-export type ConfigLoader = 'auto' | 'jiti' | 'native';
-
-const canReadExport = (module: unknown): module is Record<string, unknown> =>
-  module !== null && (typeof module === 'object' || typeof module === 'function');
-
-const getConfigExport = (
-  configModule: unknown,
-  exportName: string | false,
-  configFilePath: string,
-): RsbuildConfigDefinition => {
-  if (exportName === false) {
-    return {};
-  }
-
-  if (exportName === 'default') {
-    return (
-      canReadExport(configModule) && 'default' in configModule ? configModule.default : configModule
-    ) as RsbuildConfigDefinition;
-  }
-
-  if (canReadExport(configModule) && Object.hasOwn(configModule, exportName)) {
-    return configModule[exportName] as RsbuildConfigDefinition;
-  }
-
-  throw new Error(
-    `Cannot find export ${color.yellow(exportName)} in config file: ${color.dim(configFilePath)}`,
-  );
-};
-
-type LoadedConfig = {
-  configExport: RsbuildConfigDefinition;
-  dependencies: string[];
-};
-
-const tryFreshImport = async (configFileURL: string) => {
-  try {
-    const { freshImport } = await import('fresh-import');
-    return await freshImport(configFileURL);
-  } catch (err) {
-    defaultLogger.debug('failed to initialize fresh-import, fallback to dynamic import.');
-    defaultLogger.debug(err);
-  }
-};
-
-const loadConfigWithNative = async (
-  configFilePath: string,
-): Promise<{
-  configModule: unknown;
-  dependencies: string[];
-}> => {
-  const configFileURL = pathToFileURL(configFilePath).href;
-  const freshImportResult = await tryFreshImport(configFileURL);
-
-  if (freshImportResult) {
-    return {
-      configModule: freshImportResult.result,
-      dependencies: freshImportResult.dependencies.sort(),
-    };
-  }
-
-  const exportModule = await import(`${configFileURL}?t=${Date.now()}`);
-  return {
-    configModule: exportModule,
-    dependencies: [],
-  };
-};
-
-const loadConfigWithJiti = async (
-  configFilePath: string,
-  exportName: string | false,
-): Promise<LoadedConfig> => {
-  const { createJiti } = await import('jiti');
-  const jiti = createJiti(import.meta.filename, {
-    // disable require cache to support restart CLI and read the new config
-    moduleCache: false,
-    interopDefault: true,
-    // Always use native `require()` for these packages,
-    // This avoids `typescript` being loaded twice.
-    nativeModules: ['typescript'],
-  });
-
-  if (exportName === 'default') {
-    return {
-      configExport: await jiti.import<RsbuildConfigDefinition>(configFilePath, {
-        default: true,
-      }),
-      dependencies: [],
-    };
-  }
-
-  const configModule = await jiti.import<unknown>(configFilePath);
-  return {
-    configExport: getConfigExport(configModule, exportName, configFilePath),
-    dependencies: [],
-  };
-};
-
 export async function loadConfig<Config = RsbuildConfig>({
   cwd = process.cwd(),
   path,
-  configFileNames,
+  configFileNames = DEFAULT_CONFIG_FILE_NAMES,
   envMode,
   meta,
   loader = 'auto',
   command,
   exportName = 'default',
 }: LoadConfigOptions = {}): Promise<LoadConfigResult<Config>> {
-  const configFilePath = resolveConfigPath(cwd, path, configFileNames);
-
-  if (!configFilePath) {
-    defaultLogger.debug('no config file found.');
-    return {
-      content: {} as Config,
-      filePath: configFilePath,
-      dependencies: [],
-    };
-  }
-
-  const applyMetaInfo = (config: RsbuildConfig) => {
-    config._privateMeta = { configFilePath };
-    return config as Config;
+  const nodeEnv = getNodeEnv();
+  const configParams: ConfigParams = {
+    env: nodeEnv,
+    command: command ?? process.argv[2],
+    envMode: envMode || nodeEnv,
+    meta,
   };
 
-  let loadedConfig: LoadedConfig | undefined;
+  const result = await baseImpl<Config, [ConfigParams]>({
+    cwd,
+    path,
+    configFileNames,
+    loader,
+    exportName,
+    configParams: [configParams],
+    fresh: true,
+  });
 
-  // Determine the loading strategy based on the config loader type
-  const useNative = Boolean(
-    loader === 'native' ||
-    (loader === 'auto' &&
-      (process.features.typescript || process.versions.bun || process.versions.deno)),
-  );
-
-  if (useNative || /\.(?:js|mjs|cjs)$/.test(configFilePath)) {
-    let result: Awaited<ReturnType<typeof loadConfigWithNative>> | undefined;
-    try {
-      result = await loadConfigWithNative(configFilePath);
-    } catch (err) {
-      const errorMessage = `Failed to load file with native loader: ${color.dim(configFilePath)}`;
-      if (loader === 'native') {
-        defaultLogger.error(errorMessage);
-        throw err;
-      }
-
-      defaultLogger.debug(`${errorMessage}, fallback to jiti.`);
-      defaultLogger.debug(err);
-    }
-
-    if (result) {
-      loadedConfig = {
-        configExport: getConfigExport(result.configModule, exportName, configFilePath),
-        dependencies: result.dependencies,
-      };
-    }
+  if (!result.filePath) {
+    defaultLogger.debug('no config file found.');
+    return result as LoadConfigResult<Config>;
   }
 
-  if (!loadedConfig) {
-    try {
-      loadedConfig = await loadConfigWithJiti(configFilePath, exportName);
-    } catch (err) {
-      defaultLogger.error(`Failed to load file with jiti: ${color.dim(configFilePath)}`);
-      throw err;
-    }
-  }
-
-  const { configExport, dependencies } = loadedConfig;
-
-  if (typeof configExport === 'function') {
-    const nodeEnv = getNodeEnv();
-    const configParams: ConfigParams = {
-      env: nodeEnv,
-      command: command ?? process.argv[2],
-      envMode: envMode || nodeEnv,
-      meta,
-    };
-
-    const result = await configExport(configParams);
-
-    if (result === undefined) {
-      throw new Error('The config function must return a config object.');
-    }
-
-    return {
-      content: applyMetaInfo(result),
-      filePath: configFilePath,
-      dependencies,
-    };
-  }
-
-  if (!isObject(configExport)) {
+  if (!isObject(result.content)) {
     throw new Error(
       `The config must be an object or a function that returns an object, get ${color.yellow(
-        String(configExport),
+        String(result.content),
       )}`,
     );
   }
 
-  defaultLogger.debug('configuration loaded from:', configFilePath);
-
-  return {
-    content: applyMetaInfo(configExport),
-    filePath: configFilePath,
-    dependencies,
+  (result.content as RsbuildConfig)._privateMeta = {
+    configFilePath: result.filePath,
   };
+
+  defaultLogger.debug('configuration loaded from:', result.filePath);
+
+  return result;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ catalogs:
     '@rstack-dev/doc-ui':
       specifier: 1.14.5
       version: 1.14.5
+    '@rstackjs/load-config':
+      specifier: ^0.1.1
+      version: 0.1.1
     '@rstest/adapter-rslib':
       specifier: ^0.11.0
       version: 0.11.0
@@ -906,6 +909,9 @@ importers:
       '@rslib/core':
         specifier: 'catalog:'
         version: 0.23.2(@module-federation/runtime-tools@2.6.0)(core-js@3.49.0)(typescript@6.0.3)
+      '@rstackjs/load-config':
+        specifier: 'catalog:'
+        version: 0.1.1(jiti@2.7.0)
       '@types/cors':
         specifier: 'catalog:'
         version: 2.8.19
@@ -1235,7 +1241,7 @@ importers:
         version: 5.0.0
       sass-loader:
         specifier: 'catalog:'
-        version: 16.0.8(@rspack/core@2.1.3)(sass-embedded@1.100.0)(sass@1.100.0)
+        version: 16.0.8(@rspack/core@2.1.3)(sass-embedded@1.100.0)(sass@1.101.0)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1275,7 +1281,7 @@ importers:
         version: 3.2.4(svelte@5.56.4)
       svelte-preprocess:
         specifier: 'catalog:'
-        version: 6.0.5(@babel/core@7.29.7)(less@4.6.7)(postcss-load-config@6.0.1)(postcss@8.5.15)(sass@1.100.0)(svelte@5.56.4)(typescript@6.0.3)
+        version: 6.0.5(@babel/core@7.29.7)(less@4.6.7)(postcss-load-config@6.0.1)(postcss@8.5.16)(sass@1.101.0)(svelte@5.56.4)(typescript@6.0.3)
     devDependencies:
       '@rsbuild/core':
         specifier: workspace:*
@@ -1562,16 +1568,8 @@ packages:
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.29.3':
-    resolution: {integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/compat-data@7.29.7':
     resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/core@7.29.0':
-    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/core@7.29.7':
@@ -1584,10 +1582,6 @@ packages:
 
   '@babel/helper-annotate-as-pure@7.29.7':
     resolution: {integrity: sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-compilation-targets@7.28.6':
-    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-compilation-targets@7.29.7':
@@ -1640,16 +1634,8 @@ packages:
     resolution: {integrity: sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.29.7':
@@ -1660,18 +1646,9 @@ packages:
     resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.29.2':
-    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helpers@7.29.7':
     resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.29.3':
-    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
@@ -1686,12 +1663,6 @@ packages:
 
   '@babel/plugin-syntax-decorators@7.29.7':
     resolution: {integrity: sha512-9MTTLbF39X6sqM92JPEsoI7++26hjZvzkxKZy64aMhWLH2mPkJ/Q3AV4QLmls3R14FpSpkOwQQfUh962JGQxxg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-jsx@7.28.6':
-    resolution: {integrity: sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1738,10 +1709,6 @@ packages:
 
   '@babel/traverse@7.29.7':
     resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.29.0':
-    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
@@ -2469,16 +2436,6 @@ packages:
     engines: {node: '>=18.12.0'}
     hasBin: true
 
-  '@rsbuild/core@2.1.4':
-    resolution: {integrity: sha512-kdubx/qB6tXduCdqaW78OULLZJ3ludpuA4mOkDko18THsI1rUy9U34DsaDSnotE8GAvTeme+FX9MnqLEUlg8kQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      core-js: '>= 3.0.0'
-    peerDependenciesMeta:
-      core-js:
-        optional: true
-
   '@rsbuild/core@2.1.5':
     resolution: {integrity: sha512-7TW4U1SH7VxQZzSTIOzvwj5lo9uNTmGpsmTXFr4axQAE4giLDKP3kVUA1ZW4P3/Mz4QQJJyvZP29mVcb8kZCfg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2811,6 +2768,14 @@ packages:
       '@rspress/core':
         optional: true
 
+  '@rstackjs/load-config@0.1.1':
+    resolution: {integrity: sha512-YYtqGoM5DrrmZLGaYSUAC66qhhfjAfwXVvBScGJIfPXGa878rK0SJeO6b44W2pYfikm8yefzyV0OeedWO/PKkw==}
+    peerDependencies:
+      jiti: ^2.0.0
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
   '@rstest/adapter-rslib@0.11.0':
     resolution: {integrity: sha512-xouLiDYOd79jWORVMcyhFcIOtaqgfFGDHNjLab6+Ni6uzXmi47VuB3zgxV2rZHPBtOvTg50DGuc//qZUhs7Dng==}
     peerDependencies:
@@ -3079,9 +3044,6 @@ packages:
       webpack:
         optional: true
 
-  '@tybys/wasm-util@0.10.2':
-    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
-
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
@@ -3241,11 +3203,6 @@ packages:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-
-  acorn@8.16.0:
-    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
 
   acorn@8.17.0:
     resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
@@ -4696,10 +4653,6 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.16:
     resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -5356,11 +5309,6 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
-  terser@5.47.1:
-    resolution: {integrity: sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   terser@5.48.0:
     resolution: {integrity: sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==}
     engines: {node: '>=10'}
@@ -5626,29 +5574,7 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.29.3': {}
-
   '@babel/compat-data@7.29.7': {}
-
-  '@babel/core@7.29.0':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@babel/generator': 7.29.7
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0)
-      '@babel/helpers': 7.29.2
-      '@babel/parser': 7.29.7
-      '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
-      '@babel/types': 7.29.7
-      '@jridgewell/remapping': 2.3.5
-      convert-source-map: 2.0.0
-      debug: 4.4.3
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/core@7.29.7':
     dependencies:
@@ -5681,14 +5607,6 @@ snapshots:
   '@babel/helper-annotate-as-pure@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
-
-  '@babel/helper-compilation-targets@7.28.6':
-    dependencies:
-      '@babel/compat-data': 7.29.3
-      '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.28.2
-      lru-cache: 5.1.1
-      semver: 6.3.1
 
   '@babel/helper-compilation-targets@7.29.7':
     dependencies:
@@ -5731,15 +5649,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.29.7
-      '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -5771,28 +5680,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-string-parser@7.27.1': {}
-
   '@babel/helper-string-parser@7.29.7': {}
-
-  '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/helper-validator-option@7.29.7': {}
 
-  '@babel/helpers@7.29.2':
-    dependencies:
-      '@babel/template': 7.29.7
-      '@babel/types': 7.29.7
-
   '@babel/helpers@7.29.7':
     dependencies:
       '@babel/template': 7.29.7
-      '@babel/types': 7.29.7
-
-  '@babel/parser@7.29.3':
-    dependencies:
       '@babel/types': 7.29.7
 
   '@babel/parser@7.29.7':
@@ -5809,11 +5705,6 @@ snapshots:
       - supports-color
 
   '@babel/plugin-syntax-decorators@7.29.7(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
@@ -5883,11 +5774,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.29.0':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.29.7':
     dependencies:
@@ -6348,7 +6234,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.11.2
       '@emnapi/runtime': 1.11.2
-      '@tybys/wasm-util': 0.10.2
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
@@ -6578,19 +6464,10 @@ snapshots:
   '@rsbuild/core@1.7.5':
     dependencies:
       '@rspack/core': 1.7.12(@swc/helpers@0.5.23)
-      '@rspack/lite-tapable': 1.1.0
+      '@rspack/lite-tapable': 1.1.2
       '@swc/helpers': 0.5.23
       core-js: 3.47.0
       jiti: 2.7.0
-
-  '@rsbuild/core@2.1.4(@module-federation/runtime-tools@2.6.0)(core-js@3.49.0)':
-    dependencies:
-      '@rspack/core': 2.1.3(@module-federation/runtime-tools@2.6.0)(@swc/helpers@0.5.23)
-      '@swc/helpers': 0.5.23
-    optionalDependencies:
-      core-js: 3.49.0
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
 
   '@rsbuild/core@2.1.5(@module-federation/runtime-tools@2.6.0)(core-js@3.49.0)':
     dependencies:
@@ -6600,11 +6477,10 @@ snapshots:
       core-js: 3.49.0
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
-    optional: true
 
   '@rsbuild/plugin-check-syntax@2.0.0(@rsbuild/core@packages+core)':
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
       browserslist-to-es-version: 1.4.1
       htmlparser2: 12.0.0
       picocolors: 1.1.1
@@ -6612,12 +6488,12 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': link:packages/core
 
-  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.1.4)(@rspack/core@2.1.3)':
+  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)':
     dependencies:
       '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.1.3)(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.4(@module-federation/runtime-tools@2.6.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.6.0)(core-js@3.49.0)
     transitivePeerDependencies:
       - '@rspack/core'
 
@@ -6642,8 +6518,8 @@ snapshots:
 
   '@rslib/core@0.23.2(@module-federation/runtime-tools@2.6.0)(core-js@3.49.0)(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/core': 2.1.4(@module-federation/runtime-tools@2.6.0)(core-js@3.49.0)
-      rsbuild-plugin-dts: 0.23.2(@rsbuild/core@2.1.4)(typescript@6.0.3)
+      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.6.0)(core-js@3.49.0)
+      rsbuild-plugin-dts: 0.23.2(@rsbuild/core@2.1.5)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -6831,8 +6707,8 @@ snapshots:
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.7)
-      '@rsbuild/core': 2.1.4(@module-federation/runtime-tools@2.6.0)(core-js@3.49.0)
-      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.1.4)(@rspack/core@2.1.3)
+      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.6.0)(core-js@3.49.0)
+      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)
       '@rspress/shared': 2.0.16(@module-federation/runtime-tools@2.6.0)(core-js@3.49.0)
       '@shikijs/rehype': 4.3.0
       '@types/unist': 3.0.3
@@ -6905,7 +6781,7 @@ snapshots:
 
   '@rspress/shared@2.0.16(@module-federation/runtime-tools@2.6.0)(core-js@3.49.0)':
     dependencies:
-      '@rsbuild/core': 2.1.4(@module-federation/runtime-tools@2.6.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.6.0)(core-js@3.49.0)
       '@shikijs/rehype': 4.3.0
       unified: 11.0.5
     transitivePeerDependencies:
@@ -6916,6 +6792,10 @@ snapshots:
     optionalDependencies:
       '@rspress/core': 2.0.16(@module-federation/runtime-tools@2.6.0)(@rspack/core@2.1.3)(@types/mdast@4.0.4)(@types/react@19.2.17)(core-js@3.49.0)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
+  '@rstackjs/load-config@0.1.1(jiti@2.7.0)':
+    optionalDependencies:
+      jiti: 2.7.0
+
   '@rstest/adapter-rslib@0.11.0(@rslib/core@0.23.2)(@rstest/core@0.11.0)(typescript@6.0.3)':
     dependencies:
       '@rslib/core': 0.23.2(@module-federation/runtime-tools@2.6.0)(core-js@3.49.0)(typescript@6.0.3)
@@ -6925,7 +6805,7 @@ snapshots:
 
   '@rstest/core@0.11.0(@module-federation/runtime-tools@2.6.0)(core-js@3.49.0)':
     dependencies:
-      '@rsbuild/core': 2.1.4(@module-federation/runtime-tools@2.6.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.6.0)(core-js@3.49.0)
       '@types/chai': 5.2.3
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
@@ -7008,54 +6888,54 @@ snapshots:
     dependencies:
       acorn: 8.17.0
 
-  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
 
-  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
 
-  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
 
-  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
 
-  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
 
-  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
 
-  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
 
-  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
 
-  '@svgr/babel-preset@8.1.0(@babel/core@7.29.0)':
+  '@svgr/babel-preset@8.1.0(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.29.7)
+      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.29.7)
+      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.29.7)
+      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.29.7)
+      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.29.7)
+      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.29.7)
+      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.7)
+      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.7)
 
   '@svgr/core@8.1.0(typescript@6.0.3)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.7)
       camelcase: 6.3.0
       cosmiconfig: 8.3.6(typescript@6.0.3)
       snake-case: 3.0.4
@@ -7070,8 +6950,8 @@ snapshots:
 
   '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.7)
       '@svgr/core': 8.1.0(typescript@6.0.3)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
@@ -7167,7 +7047,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.2
       '@tailwindcss/oxide': 4.3.2
-      postcss: 8.5.15
+      postcss: 8.5.16
       tailwindcss: 4.3.2
 
   '@tailwindcss/webpack@4.3.2(@rspack/core@2.1.3)':
@@ -7179,11 +7059,6 @@ snapshots:
     optionalDependencies:
       '@rspack/core': 2.1.3(@module-federation/runtime-tools@2.6.0)(@swc/helpers@0.5.23)
 
-  '@tybys/wasm-util@0.10.2':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
@@ -7191,8 +7066,8 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.28.0
@@ -7285,7 +7160,7 @@ snapshots:
       '@types/node': 24.13.2
       '@types/node-sass': 4.11.8
       '@types/webpack': 4.41.40
-      sass: 1.100.0
+      sass: 1.101.0
 
   '@types/semver@7.5.8': {}
 
@@ -7353,7 +7228,7 @@ snapshots:
       '@vue/shared': 3.5.39
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.15
+      postcss: 8.5.16
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.39':
@@ -7388,8 +7263,6 @@ snapshots:
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
       acorn: 8.17.0
-
-  acorn@8.16.0: {}
 
   acorn@8.17.0: {}
 
@@ -7448,7 +7321,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
       '@babel/types': 7.29.7
       html-entities: 2.3.3
       parse5: 7.3.0
@@ -8084,11 +7957,11 @@ snapshots:
       entities: 4.5.0
       param-case: 3.0.4
       relateurl: 0.2.7
-      terser: 5.47.1
+      terser: 5.48.0
 
   html-rspack-plugin@6.1.9(@rspack/core@2.1.3):
     dependencies:
-      '@rspack/lite-tapable': 1.1.0
+      '@rspack/lite-tapable': 1.1.2
     optionalDependencies:
       '@rspack/core': 2.1.3(@module-federation/runtime-tools@2.6.0)(@swc/helpers@0.5.23)
 
@@ -9081,12 +8954,6 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.15:
-    dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
   postcss@8.5.16:
     dependencies:
       nanoid: 3.3.12
@@ -9367,10 +9234,10 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.6.0)(core-js@3.49.0)
 
-  rsbuild-plugin-dts@0.23.2(@rsbuild/core@2.1.4)(typescript@6.0.3):
+  rsbuild-plugin-dts@0.23.2(@rsbuild/core@2.1.5)(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.1.4(@module-federation/runtime-tools@2.6.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.6.0)(core-js@3.49.0)
     optionalDependencies:
       typescript: 6.0.3
 
@@ -9390,7 +9257,7 @@ snapshots:
 
   rspack-manifest-plugin@5.2.2(@rspack/core@2.1.3):
     dependencies:
-      '@rspack/lite-tapable': 1.1.0
+      '@rspack/lite-tapable': 1.1.2
     optionalDependencies:
       '@rspack/core': 2.1.3(@module-federation/runtime-tools@2.6.0)(@swc/helpers@0.5.23)
 
@@ -9398,7 +9265,7 @@ snapshots:
 
   rspack-vue-loader@17.5.1(@rspack/core@2.1.3)(vue@3.5.39):
     dependencies:
-      '@rspack/lite-tapable': 1.1.0
+      '@rspack/lite-tapable': 1.1.2
       chalk: 4.1.2
     optionalDependencies:
       '@rspack/core': 2.1.3(@module-federation/runtime-tools@2.6.0)(@swc/helpers@0.5.23)
@@ -9507,12 +9374,12 @@ snapshots:
       sass-embedded-win32-arm64: 1.100.0
       sass-embedded-win32-x64: 1.100.0
 
-  sass-loader@16.0.8(@rspack/core@2.1.3)(sass-embedded@1.100.0)(sass@1.100.0):
+  sass-loader@16.0.8(@rspack/core@2.1.3)(sass-embedded@1.100.0)(sass@1.101.0):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
       '@rspack/core': 2.1.3(@module-federation/runtime-tools@2.6.0)(@swc/helpers@0.5.23)
-      sass: 1.100.0
+      sass: 1.101.0
       sass-embedded: 1.100.0
 
   sass@1.100.0:
@@ -9522,6 +9389,7 @@ snapshots:
       source-map-js: 1.2.1
     optionalDependencies:
       '@parcel/watcher': 2.5.6
+    optional: true
 
   sass@1.101.0:
     dependencies:
@@ -9664,15 +9532,15 @@ snapshots:
       svelte-dev-helper: 1.1.9
       svelte-hmr: 0.14.12(svelte@5.56.4)
 
-  svelte-preprocess@6.0.5(@babel/core@7.29.7)(less@4.6.7)(postcss-load-config@6.0.1)(postcss@8.5.15)(sass@1.100.0)(svelte@5.56.4)(typescript@6.0.3):
+  svelte-preprocess@6.0.5(@babel/core@7.29.7)(less@4.6.7)(postcss-load-config@6.0.1)(postcss@8.5.16)(sass@1.101.0)(svelte@5.56.4)(typescript@6.0.3):
     dependencies:
       svelte: 5.56.4
     optionalDependencies:
       '@babel/core': 7.29.7
       less: 4.6.7
-      postcss: 8.5.15
+      postcss: 8.5.16
       postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.16)
-      sass: 1.100.0
+      sass: 1.101.0
       typescript: 6.0.3
 
   svelte@5.56.4:
@@ -9720,17 +9588,10 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  terser@5.47.1:
-    dependencies:
-      '@jridgewell/source-map': 0.3.11
-      acorn: 8.17.0
-      commander: 2.20.3
-      source-map-support: 0.5.21
-
   terser@5.48.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.16.0
+      acorn: 8.17.0
       commander: 2.20.3
       source-map-support: 0.5.21
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -44,6 +44,7 @@ catalog:
   '@rspress/plugin-rss': '^2.0.16'
   '@rspress/plugin-sitemap': '^2.0.16'
   '@rstack-dev/doc-ui': '1.14.5'
+  '@rstackjs/load-config': '^0.1.1'
   '@rstest/adapter-rslib': '^0.11.0'
   '@rstest/core': '^0.11.0'
   '@shikijs/transformers': '^4.3.1'
@@ -179,12 +180,11 @@ minimumReleaseAgeExclude:
   - '@tailwindcss/*'
   - 'tailwindcss'
   - 'reduce-configs'
-  - '@rstack-dev/doc-ui'
+  - '@rstack-dev/*'
+  - '@rstackjs/*'
   - 'rsbuild-plugin-*'
   - '@swc/*'
   - 'heading-case'
-  # Renovate security update: http-proxy-middleware@4.1.1
-  - http-proxy-middleware@4.1.1
 
 patchedDependencies:
   css-loader@7.1.4: patches/css-loader@7.1.4.patch


### PR DESCRIPTION
## Summary

This PR moves Rsbuild's config loading implementation onto `@rstackjs/load-config` while keeping Rsbuild-specific defaults, config params, and validation in `@rsbuild/core`.

## Related Links

https://github.com/rstackjs/load-config