### PR TITLE
test: restore stubbed environment variables

### DIFF
--- a/packages/core/tests/builder.test.ts
+++ b/packages/core/tests/builder.test.ts
@@ -1,10 +1,6 @@
 import { createRsbuild } from '../src';
 
 describe('default bundler', () => {
-  afterEach(() => {
-    rs.unstubAllEnvs();
-  });
-
   it('should use Rspack by default', async () => {
     rs.stubEnv('NODE_ENV', 'development');
     const rsbuild = await createRsbuild({

--- a/packages/core/tests/css.test.ts
+++ b/packages/core/tests/css.test.ts
@@ -35,10 +35,6 @@ describe('normalizeCssLoaderOptions', () => {
 });
 
 describe('plugin-css', () => {
-  afterEach(() => {
-    rs.unstubAllEnvs();
-  });
-
   it('should enable source map when output.sourceMap.css is true', async () => {
     const rsbuild = await createRsbuild({
       config: {

--- a/packages/core/tests/default.test.ts
+++ b/packages/core/tests/default.test.ts
@@ -1,10 +1,6 @@
 import { matchRules } from '@scripts/test-helper';
 import { createRsbuild, type RsbuildPlugin } from '../src';
 
-afterEach(() => {
-  rs.unstubAllEnvs();
-});
-
 it('should apply default plugins correctly', async () => {
   rs.stubEnv('NODE_ENV', 'development');
   const rsbuild = await createRsbuild();

--- a/packages/core/tests/environments.test.ts
+++ b/packages/core/tests/environments.test.ts
@@ -3,10 +3,6 @@ import { matchPlugin } from '@scripts/test-helper';
 import { createRsbuild, type RsbuildPlugin } from '../src';
 
 describe('environment config', () => {
-  afterEach(() => {
-    rs.unstubAllEnvs();
-  });
-
   it('should normalize context correctly', async () => {
     rs.stubEnv('NODE_ENV', 'development');
     const cwd = process.cwd();

--- a/packages/core/tests/html.test.ts
+++ b/packages/core/tests/html.test.ts
@@ -10,10 +10,6 @@ describe('plugin-html', () => {
     },
   };
 
-  afterEach(() => {
-    rs.unstubAllEnvs();
-  });
-
   it('should register html plugin correctly', async () => {
     const rsbuild = await createRsbuild({
       config: defaultEntryConfig,

--- a/packages/core/tests/logger.test.ts
+++ b/packages/core/tests/logger.test.ts
@@ -3,7 +3,6 @@ import { createLogger, createRsbuild, logger, type Logger, type RsbuildPlugin } 
 const initialGlobalLogLevel = logger.level;
 
 afterEach(() => {
-  rs.unstubAllEnvs();
   logger.level = initialGlobalLogLevel;
 });
 

--- a/packages/core/tests/minimize.test.ts
+++ b/packages/core/tests/minimize.test.ts
@@ -1,10 +1,6 @@
 import { createRsbuild } from '../src';
 
 describe('plugin-minimize', () => {
-  afterEach(() => {
-    rs.unstubAllEnvs();
-  });
-
   it('should not apply minimizer in development', async () => {
     rs.stubEnv('NODE_ENV', 'development');
 

--- a/packages/core/tests/output.test.ts
+++ b/packages/core/tests/output.test.ts
@@ -2,10 +2,6 @@ import { matchPlugin } from '@scripts/test-helper';
 import { createRsbuild } from '../src';
 
 describe('plugin-output', () => {
-  afterEach(() => {
-    rs.unstubAllEnvs();
-  });
-
   it('should set output correctly', async () => {
     const rsbuild = await createRsbuild();
 

--- a/packages/plugin-react/tests/index.test.ts
+++ b/packages/plugin-react/tests/index.test.ts
@@ -4,10 +4,6 @@ import { matchPlugin, matchRules } from '@scripts/test-helper';
 import { pluginReact } from '../src';
 
 describe('plugins/react', () => {
-  afterEach(() => {
-    rs.unstubAllEnvs();
-  });
-
   it('should work with swc-loader', async () => {
     const rsbuild = await createRsbuild({
       config: {

--- a/packages/plugin-svelte/tests/index.test.ts
+++ b/packages/plugin-svelte/tests/index.test.ts
@@ -3,10 +3,6 @@ import { matchRules } from '@scripts/test-helper';
 import { pluginSvelte } from '../src';
 
 describe('plugin-svelte', () => {
-  afterEach(() => {
-    rs.unstubAllEnvs();
-  });
-
   it('should add svelte loader and resolve config properly', async () => {
     const rsbuild = await createRsbuild({
       cwd: __dirname,

--- a/rstest.config.ts
+++ b/rstest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
   name: 'node',
   globals: true,
   restoreMocks: true,
+  unstubEnvs: true,
   include: ['packages/**/*.test.ts'],
   exclude: ['packages/create-rsbuild/template-rstest'],
   setupFiles: ['./scripts/test-helper/rstest.setup.ts'],


### PR DESCRIPTION
## Summary

This PR prevents environment variables stubbed by one test from leaking into subsequent tests by enabling Rstest's `unstubEnvs` option. It also removes the now-redundant per-file `rs.unstubAllEnvs()` cleanup hooks.

## Related Links

https://rstest.rs/config/test/unstub-envs