### PR TITLE
test(e2e): improve random port allocation

### DIFF
--- a/e2e/helper/utils.ts
+++ b/e2e/helper/utils.ts
@@ -39,15 +39,16 @@ function isPortAvailable(port: number) {
     const server = net.createServer().listen(port);
     return new Promise((resolve) => {
       server.on('listening', () => {
-        server.close();
-        resolve(true);
+        server.close(() => {
+          resolve(true);
+        });
       });
       server.on('error', () => {
         resolve(false);
       });
     });
   } catch {
-    return false;
+    return Promise.resolve(false);
   }
 }
 
@@ -61,13 +62,14 @@ const portMap = new Map();
  */
 export async function getRandomPort(defaultPort = Math.ceil(Math.random() * 30000) + 15000) {
   let port = defaultPort;
-  while (true) {
+  while (port <= 65535) {
     if (!portMap.get(port) && (await isPortAvailable(port))) {
       portMap.set(port, 1);
       return port;
     }
     port++;
   }
+  throw new Error('No available ports found in the valid range.');
 }
 
 // fast-glob only accepts posix path


### PR DESCRIPTION
## Summary

This PR prevents intermittent e2e port conflicts by waiting for the availability probe server to close before returning a port. It also stops scanning at the maximum valid port and throws a clear error when no port is available.