### PR TITLE
test(e2e): stream command output with spawn

### DIFF
--- a/e2e/helper/fixture.ts
+++ b/e2e/helper/fixture.ts
@@ -1,9 +1,9 @@
 import {
   type ChildProcess,
-  type ExecOptions,
   type ExecSyncOptions,
   execSync,
-  exec as nodeExec,
+  type SpawnOptions,
+  spawn as nodeSpawn,
 } from 'node:child_process';
 import { constants as fsConstants, promises } from 'node:fs';
 import path from 'node:path';
@@ -35,7 +35,7 @@ type EditFile = (filename: string, replacer: (code: string) => string) => Promis
 
 type Exec = (
   command: string,
-  options?: ExecOptions,
+  options?: SpawnOptions,
 ) => {
   childProcess: ChildProcess;
 };
@@ -166,7 +166,7 @@ type RsbuildFixture = {
 
 type Close = DevResult['close'];
 
-const setupExecOptions = <T extends ExecOptions | ExecSyncOptions>(options: T, cwd: string): T => {
+const setupExecOptions = <T extends SpawnOptions | ExecSyncOptions>(options: T, cwd: string): T => {
   // inherit process.env from current process
   const { NODE_ENV: _, ...restEnv } = process.env;
   options.env ||= {};
@@ -296,10 +296,10 @@ export const test = base.extend<RsbuildFixture>({
   },
 
   exec: async ({ cwd, logHelper }, use) => {
-    let close: (() => void) | undefined;
+    const closes: Array<() => void> = [];
 
     const exec: Exec = (command, options = {}) => {
-      const childProcess = nodeExec(command, setupExecOptions(options, cwd));
+      const childProcess = nodeSpawn(command, setupExecOptions({ shell: true, ...options }, cwd));
 
       const onData = (data: Buffer) => {
         logHelper.addLog(data.toString());
@@ -308,22 +308,27 @@ export const test = base.extend<RsbuildFixture>({
       childProcess.stdout?.on('data', onData);
       childProcess.stderr?.on('data', onData);
 
-      close = () => {
+      closes.push(() => {
         childProcess.stdout?.off('data', onData);
         childProcess.stderr?.off('data', onData);
         childProcess.kill();
-      };
+      });
 
       return { childProcess };
     };
 
-    await use(exec);
-    close?.();
+    try {
+      await use(exec);
+    } finally {
+      for (const close of closes) {
+        close();
+      }
+    }
   },
 
   execCli: async ({ exec }, use) => {
     const execCli: Exec = (command, options = {}) => {
-      return exec(`node ${RSBUILD_BIN_PATH} ${command}`, options);
+      return exec(`node "${RSBUILD_BIN_PATH}" ${command}`, options);
     };
     await use(execCli);
   },

--- a/website/theme/rsbuildPluginOverview.ts
+++ b/website/theme/rsbuildPluginOverview.ts
@@ -9,7 +9,7 @@ export const rsbuildPluginOverview: RsbuildPlugin = {
   name: 'rsbuild-doc:overview',
 
   async setup(api) {
-    const root = path.join(__dirname, '../docs/en/config/');
+    const root = path.join(import.meta.dirname, '../docs/en/config/');
     const globPath = path.join(root, '**/*.{mdx,md}');
 
     const files = await glob(globPath);


### PR DESCRIPTION
## Summary

The E2E command fixture starts long-running build and watch processes whose output can exceed `exec`'s buffered output limit. This PR uses `spawn` to stream stdout and stderr into the log helper while preserving shell command behavior and cleaning up every started process.

It also uses `import.meta.dirname` for ESM-native path resolution in the documentation plugin.