### PR TITLE
test(e2e): add prepareDist fixture

### DIFF
--- a/e2e/cases/cli/config-loader-native-deps/index.test.ts
+++ b/e2e/cases/cli/config-loader-native-deps/index.test.ts
@@ -4,12 +4,11 @@ import { expect, getRandomPort, gotoPage, test } from '@e2e/helper';
 
 const tempConfig = path.join(import.meta.dirname, 'test-temp.config.mjs');
 const tempConfigDep = path.join(import.meta.dirname, 'test-temp-dep.mjs');
-const distDir = path.join(import.meta.dirname, 'dist');
 
-test.afterEach(() => {
+test.afterEach(async ({ prepareDist }) => {
+  await prepareDist();
   fs.rmSync(tempConfig, { force: true });
   fs.rmSync(tempConfigDep, { force: true });
-  fs.rmSync(distDir, { recursive: true, force: true });
 });
 
 test('should restart dev server when native config dependency changed', async ({

--- a/e2e/cases/cli/function-config/index.test.ts
+++ b/e2e/cases/cli/function-config/index.test.ts
@@ -1,19 +1,18 @@
-import path from 'node:path';
 import { expect, getFileContent, readDirContents, test } from '@e2e/helper';
-import fse from 'fs-extra';
 
-const distDir = path.join(import.meta.dirname, 'dist');
-
-test('should support exporting a function from the config file', async ({ execCliSync }) => {
-  await fse.remove(distDir);
+test('should support exporting a function from the config file', async ({
+  prepareDist,
+  execCliSync,
+}) => {
+  const distDir = await prepareDist();
   execCliSync('build');
   const files = await readDirContents(distDir);
   const content = getFileContent(files, 'index.js');
   expect(content.includes('production-production-build')).toBeTruthy();
 });
 
-test('should specify env as expected', async ({ execCliSync }) => {
-  await fse.remove(distDir);
+test('should specify env as expected', async ({ prepareDist, execCliSync }) => {
+  const distDir = await prepareDist();
   execCliSync('build', {
     env: {
       ...process.env,
@@ -25,16 +24,19 @@ test('should specify env as expected', async ({ execCliSync }) => {
   expect(content.includes('development-development-build')).toBeTruthy();
 });
 
-test('should specify env mode as expected', async ({ execCliSync }) => {
-  await fse.remove(distDir);
+test('should specify env mode as expected', async ({ prepareDist, execCliSync }) => {
+  const distDir = await prepareDist();
   execCliSync('build --env-mode staging');
   const files = await readDirContents(distDir);
   const content = getFileContent(files, 'index.js');
   expect(content.includes('production-staging-build')).toBeTruthy();
 });
 
-test('should parse build command after global option values', async ({ execCliSync }) => {
-  await fse.remove(distDir);
+test('should parse build command after global option values', async ({
+  prepareDist,
+  execCliSync,
+}) => {
+  const distDir = await prepareDist();
   execCliSync('--env-mode inspect build');
   const files = await readDirContents(distDir);
   const content = getFileContent(files, 'index.js');

--- a/e2e/cases/cli/inspect/index.test.ts
+++ b/e2e/cases/cli/inspect/index.test.ts
@@ -1,17 +1,11 @@
 import path from 'node:path';
 import { expect, readDirContents, test } from '@e2e/helper';
-import fse from 'fs-extra';
 
-const clean = () => {
-  fse.removeSync(path.join(import.meta.dirname, 'dist'));
-};
-
-test('should run inspect command correctly', async ({ execCliSync }) => {
-  clean();
-
+test('should run inspect command correctly', async ({ prepareDist, execCliSync }) => {
+  const distPath = await prepareDist();
   execCliSync('inspect');
 
-  const files = await readDirContents(path.join(import.meta.dirname, 'dist/.rsbuild'));
+  const files = await readDirContents(path.join(distPath, '.rsbuild'));
   const fileNames = Object.keys(files);
 
   const config = fileNames.find((item) => item.includes('rsbuild.config.mjs'));
@@ -25,12 +19,14 @@ test('should run inspect command correctly', async ({ execCliSync }) => {
   expect(files[rspackConfig!]).toContain("mode: 'development'");
 });
 
-test('should run inspect command with mode option correctly', async ({ execCliSync }) => {
-  clean();
-
+test('should run inspect command with mode option correctly', async ({
+  prepareDist,
+  execCliSync,
+}) => {
+  const distPath = await prepareDist();
   execCliSync('inspect --mode production');
 
-  const files = await readDirContents(path.join(import.meta.dirname, 'dist/.rsbuild'));
+  const files = await readDirContents(path.join(distPath, '.rsbuild'));
   const fileNames = Object.keys(files);
 
   const config = fileNames.find((item) => item.includes('rsbuild.config.mjs'));
@@ -41,12 +37,14 @@ test('should run inspect command with mode option correctly', async ({ execCliSy
   expect(files[rspackConfig!]).toContain("mode: 'production'");
 });
 
-test('should run inspect command with output option correctly', async ({ execCliSync }) => {
-  clean();
-
+test('should run inspect command with output option correctly', async ({
+  prepareDist,
+  execCliSync,
+}) => {
+  const distPath = await prepareDist();
   execCliSync('inspect --output foo');
 
-  const outputs = await readDirContents(path.join(import.meta.dirname, 'dist/foo'));
+  const outputs = await readDirContents(path.join(distPath, 'foo'));
   const outputFiles = Object.keys(outputs);
 
   expect(outputFiles.find((item) => item.includes('rsbuild.config.mjs'))).toBeTruthy();

--- a/e2e/cases/cli/output-dist-path/index.test.ts
+++ b/e2e/cases/cli/output-dist-path/index.test.ts
@@ -2,15 +2,16 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { expect, expectFile, readDirContents, test } from '@e2e/helper';
 
-test('should set output dist path from CLI', async ({ execCliSync }) => {
+test('should set output dist path from CLI', async ({ prepareDist, execCliSync }) => {
+  const distPath = await prepareDist();
+  const distCustom = await prepareDist('dist-custom');
   execCliSync('build --dist-path dist-custom');
 
-  const distCustom = path.join(import.meta.dirname, 'dist-custom');
   await expectFile(path.join(distCustom, 'index.html'));
 
   const outputs = await readDirContents(distCustom);
   const outputFiles = Object.keys(outputs);
 
   expect(outputFiles.find((item) => item.includes('static/js/index.'))).toBeTruthy();
-  expect(fs.existsSync(path.join(import.meta.dirname, 'dist'))).toBeFalsy();
+  expect(fs.existsSync(distPath)).toBeFalsy();
 });

--- a/e2e/cases/cli/reload-config/index.test.ts
+++ b/e2e/cases/cli/reload-config/index.test.ts
@@ -4,14 +4,13 @@ import { expectFile, getRandomPort, test } from '@e2e/helper';
 import fse from 'fs-extra';
 
 test('should restart dev server and reload config when config file changed', async ({
+  prepareDist,
   execCli,
 }) => {
-  const dist1 = path.join(import.meta.dirname, 'dist');
-  const dist2 = path.join(import.meta.dirname, 'dist-2');
   const configFile = path.join(import.meta.dirname, 'rsbuild.config.mjs');
 
-  await fse.remove(dist1);
-  await fse.remove(dist2);
+  const dist1 = await prepareDist();
+  const dist2 = await prepareDist('dist-2');
   await fse.remove(configFile);
 
   fs.writeFileSync(

--- a/e2e/cases/cli/source-map/index.test.ts
+++ b/e2e/cases/cli/source-map/index.test.ts
@@ -1,14 +1,7 @@
-import fs from 'node:fs';
-import path from 'node:path';
 import { expect, readDirContents, test } from '@e2e/helper';
 
-const distPath = path.join(import.meta.dirname, 'dist');
-
-test.beforeEach(() => {
-  fs.rmSync(distPath, { recursive: true, force: true });
-});
-
-test('should enable source map from CLI', async ({ execCliSync }) => {
+test('should enable source map from CLI', async ({ prepareDist, execCliSync }) => {
+  const distPath = await prepareDist();
   execCliSync('build --source-map');
 
   const outputs = await readDirContents(distPath);
@@ -17,7 +10,8 @@ test('should enable source map from CLI', async ({ execCliSync }) => {
   expect(outputFiles.some((file) => file.endsWith('.js.map'))).toBeTruthy();
 });
 
-test('should disable source map from CLI', async ({ execCliSync }) => {
+test('should disable source map from CLI', async ({ prepareDist, execCliSync }) => {
+  const distPath = await prepareDist();
   execCliSync('build --config source-map.config.ts --no-source-map');
 
   const outputs = await readDirContents(distPath);

--- a/e2e/cases/cli/specified-environment/index.test.ts
+++ b/e2e/cases/cli/specified-environment/index.test.ts
@@ -1,16 +1,10 @@
-import { join } from 'node:path';
 import { expect, readDirContents, test } from '@e2e/helper';
-import fse from 'fs-extra';
-
-const distPath = join(import.meta.dirname, 'dist');
-
-test.beforeEach(async () => {
-  await fse.remove(distPath);
-});
 
 test('should only build specified environment when using --environment option', async ({
+  prepareDist,
   execCliSync,
 }) => {
+  const distPath = await prepareDist();
   execCliSync('build --environment web2');
 
   const files = await readDirContents(distPath);
@@ -21,8 +15,10 @@ test('should only build specified environment when using --environment option', 
 });
 
 test('should build specified environments when using --environment shorten option', async ({
+  prepareDist,
   execCliSync,
 }) => {
+  const distPath = await prepareDist();
   execCliSync('build --environment web1,web2');
 
   const files = await readDirContents(distPath);

--- a/e2e/cases/config/debug-mode/index.test.ts
+++ b/e2e/cases/config/debug-mode/index.test.ts
@@ -2,15 +2,15 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { enableDebugMode, expect, test } from '@e2e/helper';
 
-const getRsbuildConfig = (dist: string) =>
-  path.resolve(import.meta.dirname, `./${dist}/.rsbuild/rsbuild.config.mjs`);
+const getRsbuildConfig = (distPath: string) => path.join(distPath, '.rsbuild/rsbuild.config.mjs');
 
-const getBundlerConfig = (dist: string) =>
-  path.resolve(import.meta.dirname, `./${dist}/.rsbuild/rspack.config.web.mjs`);
+const getBundlerConfig = (distPath: string) =>
+  path.join(distPath, '.rsbuild/rspack.config.web.mjs');
 
-test('should generate config files in debug mode when build', async ({ build }) => {
+test('should generate config files in debug mode when build', async ({ build, prepareDist }) => {
   const restore = enableDebugMode();
   const distRoot = 'dist-1';
+  const distPath = await prepareDist(distRoot);
   const rsbuild = await build({
     config: {
       output: {
@@ -19,17 +19,18 @@ test('should generate config files in debug mode when build', async ({ build }) 
     },
   });
 
-  expect(fs.existsSync(getRsbuildConfig(distRoot))).toBeTruthy();
-  expect(fs.existsSync(getBundlerConfig(distRoot))).toBeTruthy();
+  expect(fs.existsSync(getRsbuildConfig(distPath))).toBeTruthy();
+  expect(fs.existsSync(getBundlerConfig(distPath))).toBeTruthy();
 
   await rsbuild.expectLog('config inspection completed');
   await rsbuild.expectLog('creating compiler');
   restore();
 });
 
-test('should generate config files in debug mode when dev', async ({ page, dev }) => {
+test('should generate config files in debug mode when dev', async ({ prepareDist, page, dev }) => {
   const restore = enableDebugMode();
   const distRoot = 'dist-2';
+  const distPath = await prepareDist(distRoot);
   const rsbuild = await dev({
     config: {
       output: {
@@ -39,8 +40,8 @@ test('should generate config files in debug mode when dev', async ({ page, dev }
     page,
   });
 
-  expect(fs.existsSync(getRsbuildConfig(distRoot))).toBeTruthy();
-  expect(fs.existsSync(getBundlerConfig(distRoot))).toBeTruthy();
+  expect(fs.existsSync(getRsbuildConfig(distPath))).toBeTruthy();
+  expect(fs.existsSync(getBundlerConfig(distPath))).toBeTruthy();
 
   await rsbuild.expectLog('config inspection completed');
   await rsbuild.expectLog('creating compiler');

--- a/e2e/cases/config/inspect-config/index.test.ts
+++ b/e2e/cases/config/inspect-config/index.test.ts
@@ -1,17 +1,12 @@
 import fs from 'node:fs';
-import path, { join } from 'node:path';
+import path from 'node:path';
 import { expect, test } from '@e2e/helper';
 import type { RsbuildPlugin } from '@rsbuild/core';
 import { createRsbuild } from '@rsbuild/core';
-import fse from 'fs-extra';
 
-test.afterAll(() => {
-  const files = fs.readdirSync(import.meta.dirname);
-  for (const file of files) {
-    if (file.startsWith('test-temp') || file.startsWith('dist')) {
-      fse.removeSync(join(import.meta.dirname, file));
-    }
-  }
+test.afterEach(async ({ prepareDist }) => {
+  await prepareDist();
+  await prepareDist('test-temp-output');
 });
 
 const rsbuildConfig = path.resolve(import.meta.dirname, './dist/.rsbuild/rsbuild.config.mjs');
@@ -41,9 +36,6 @@ test('should generate config files when writeToDisk is true', async ({ logHelper
   expect(fs.existsSync(rspackConfig)).toBeTruthy();
   expect(fs.existsSync(rsbuildConfig)).toBeTruthy();
   await expectLog(INSPECT_LOG);
-
-  await fse.remove(rsbuildConfig);
-  await fse.remove(rspackConfig);
 });
 
 test('should generate config files correctly when output is specified', async ({ logHelper }) => {
@@ -64,9 +56,6 @@ test('should generate config files correctly when output is specified', async ({
   expect(fs.existsSync(rspackConfig)).toBeTruthy();
   expect(fs.existsSync(rsbuildConfig)).toBeTruthy();
   await expectLog(INSPECT_LOG);
-
-  await fse.remove(rsbuildConfig);
-  await fse.remove(rspackConfig);
 });
 
 test('should generate bundler config for node when target contains node', async ({ logHelper }) => {
@@ -93,11 +82,6 @@ test('should generate bundler config for node when target contains node', async 
   expect(fs.existsSync(rspackConfig)).toBeTruthy();
   expect(fs.existsSync(bundlerNodeConfig)).toBeTruthy();
   await expectLog(INSPECT_LOG);
-
-  await fse.remove(rsbuildConfig);
-  await fse.remove(rsbuildNodeConfig);
-  await fse.remove(rspackConfig);
-  await fse.remove(bundlerNodeConfig);
 });
 
 test('should not generate config files when writeToDisk is false', async () => {
@@ -128,8 +112,6 @@ test('should allow to specify absolute output path', async ({ logHelper }) => {
   await expectLog(INSPECT_LOG);
 
   expect(fs.existsSync(path.join(outputPath, 'rspack.config.web.mjs'))).toBeTruthy();
-
-  await fse.remove(rsbuildConfig);
 });
 
 test('should generate extra config files', async ({ logHelper }) => {
@@ -151,7 +133,6 @@ test('should generate extra config files', async ({ logHelper }) => {
 
   expect(fs.existsSync(rstestConfig)).toBeTruthy();
   await expectLog('Rstest Config:');
-  await fse.remove(rstestConfig);
 });
 
 test('should apply plugin correctly', async () => {

--- a/e2e/cases/resolve/tsconfig-paths-reload/index.test.ts
+++ b/e2e/cases/resolve/tsconfig-paths-reload/index.test.ts
@@ -4,13 +4,12 @@ import fse from 'fs-extra';
 import { tempConfig } from './rsbuild.config';
 
 test('should watch tsconfig.json and reload the server when it changes', async ({
+  prepareDist,
   page,
   editFile,
   execCli,
 }) => {
-  const dist = join(import.meta.dirname, 'dist');
-
-  await fse.remove(dist);
+  const dist = await prepareDist();
   await fse.remove(tempConfig);
   await fse.copy(join(import.meta.dirname, 'tsconfig.json'), tempConfig);
 

--- a/e2e/cases/server/public-dir/publicDir.test.ts
+++ b/e2e/cases/server/public-dir/publicDir.test.ts
@@ -191,9 +191,10 @@ test('should copy publicDir to the node distDir when copyOnBuild is specified as
 
 test('should copy publicDir to root dist when environment dist path has a parent-child relationship', async ({
   build,
+  prepareDist,
 }) => {
   await fse.outputFile(join(import.meta.dirname, 'public', 'test-temp-file.txt'), 'a');
-  fse.removeSync(join(import.meta.dirname, 'dist-build-web'));
+  await prepareDist('dist-build-web');
 
   const rsbuild = await build({
     config: {

--- a/e2e/cases/server/write-to-disk-environments/index.test.ts
+++ b/e2e/cases/server/write-to-disk-environments/index.test.ts
@@ -1,16 +1,12 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
 import { expect, test } from '@e2e/helper';
-import fse from 'fs-extra';
 
 const cwd = import.meta.dirname;
 
-test.beforeEach(() => {
-  const dirs = ['dist', 'dist-1', 'dist-2', 'dist-same', 'dist-same-1'];
-  for (const dir of dirs) {
-    const target = join(cwd, dir);
-    fse.removeSync(target);
-  }
+test.beforeEach(async ({ prepareDist }) => {
+  const distFolderNames = ['dist', 'dist-1', 'dist-2', 'dist-same', 'dist-same-1'];
+  await Promise.all(distFolderNames.map((distFolderName) => prepareDist(distFolderName)));
 });
 
 test('should handle writeToDisk correctly across multiple environments', async ({ page, dev }) => {

--- a/e2e/helper/fixture.ts
+++ b/e2e/helper/fixture.ts
@@ -59,6 +59,8 @@ type RunBoth = (
 
 type CopyNodeModules = () => Promise<string>;
 
+type PrepareDist = (distFolderName?: string) => Promise<string>;
+
 type RsbuildFixture = {
   /**
    * Absolute working directory of the current test file.
@@ -89,6 +91,15 @@ type RsbuildFixture = {
    * The fixture auto-closes after the test.
    */
   buildPreview: Build;
+  /**
+   * Prepare a dist folder by removing it from the test file's cwd.
+   * @param distFolderName The dist folder name. Defaults to `dist`.
+   * @returns The absolute path of the removed dist folder.
+   * @example
+   * const distPath = await prepareDist();
+   * const distWebPath = await prepareDist('dist-web');
+   */
+  prepareDist: PrepareDist;
   /**
    * Copies the source directory to a temporary directory for testing purposes.
    */
@@ -232,6 +243,15 @@ export const test = base.extend<RsbuildFixture>({
         await close();
       }
     }
+  },
+
+  prepareDist: async ({ cwd }, use) => {
+    const prepareDist: PrepareDist = async (distFolderName = 'dist') => {
+      const distPath = path.join(cwd, distFolderName);
+      await fse.remove(distPath);
+      return distPath;
+    };
+    await use(prepareDist);
   },
 
   dev: async ({ cwd, page, logHelper }, use) => {


### PR DESCRIPTION
## Summary

This PR reduces duplicated output-directory cleanup across e2e tests by adding a `prepareDist` fixture. The helper removes `dist`, or a custom folder name, relative to the test cwd and returns its absolute path, and existing test cases now use it for setup and cleanup.