### PR TITLE
test(e2e): import shared test utils directly

### DIFF
--- a/.agents/skills/write-e2e-cases/SKILL.md
+++ b/.agents/skills/write-e2e-cases/SKILL.md
@@ -11,7 +11,7 @@ description: Use when adding or updating Rsbuild end-to-end tests in `e2e/cases`
 
 2. Read `e2e/README.md` and follow its conventions.
 
-3. Prefer `@e2e/helper` methods (for example `dev`, `build`, `getDistFiles`, `findFile`, `getFileContent`, `expectFile`, and `expectFileWithContent`) to keep tests minimal, including file and file-content assertions.
+3. Use `@e2e/helper` for Rsbuild-specific fixtures and helpers, such as `test`, `dev`, and `build`. Import generic test utilities, such as `getDistFiles`, `findFile`, and `getFileContent`, directly from `@rstackjs/test-utils`.
 
 4. Add Playwright cases under `e2e/cases`, following existing directory patterns.
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -32,11 +32,14 @@ npx rsbuild build
 ## Add test cases
 
 ```ts
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@e2e/helper';
+import { toPosixPath } from '@rstackjs/test-utils';
 
-test('test 1 + 1', () => {
-  expect(1 + 1).toBe(2);
+test('normalize path', () => {
+  expect(toPosixPath('foo\\bar')).toBe('foo/bar');
 });
 ```
+
+Use `@e2e/helper` for Rsbuild-specific fixtures and helpers. Import generic test utilities directly from `@rstackjs/test-utils`.
 
 You can use the local skill at [`write-e2e-cases`](../.agents/skills/write-e2e-cases/SKILL.md) to add new test cases.

--- a/e2e/cases/assets/asset-prefix/index.test.ts
+++ b/e2e/cases/assets/asset-prefix/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should allow dev.assetPrefix to be `auto`', async ({ page, dev }) => {
   await dev({

--- a/e2e/cases/browser-logs/custom-source-map/index.test.ts
+++ b/e2e/cases/browser-logs/custom-source-map/index.test.ts
@@ -1,5 +1,6 @@
 import { join, relative } from 'node:path';
-import { test, toPosixPath } from '@e2e/helper';
+import { test } from '@e2e/helper';
+import { toPosixPath } from '@rstackjs/test-utils';
 
 const EXPECTED_LOG = 'error   [browser] Uncaught Error: test (src/index.js:1:0)';
 

--- a/e2e/cases/browserslist/extends-browserslist/index.test.ts
+++ b/e2e/cases/browserslist/extends-browserslist/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should extend browserslist and downgrade syntax', async ({ build }) => {
   const originalCwd = process.cwd();

--- a/e2e/cases/browserslist/package-config-array/index.test.ts
+++ b/e2e/cases/browserslist/package-config-array/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should read browserslist array from package.json', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/browserslist/package-config-object/index.test.ts
+++ b/e2e/cases/browserslist/package-config-object/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should read browserslist string from package.json', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/browserslist/package-config-string/index.test.ts
+++ b/e2e/cases/browserslist/package-config-string/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should read browserslist string from package.json', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/cache/cache-directory/index.test.ts
+++ b/e2e/cases/cache/cache-directory/index.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { expect, test, waitForFile } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { waitForFile } from '@rstackjs/test-utils';
 import fse from 'fs-extra';
 
 const cacheDirectory = path.resolve(import.meta.dirname, './node_modules/.cache');

--- a/e2e/cases/cli/base/index.test.ts
+++ b/e2e/cases/cli/base/index.test.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
-import { expect, readDirContents, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { readDirContents } from '@rstackjs/test-utils';
 
 test('should run allow to specify base path', async ({ execCliSync }) => {
   execCliSync('build --base /test');

--- a/e2e/cases/cli/build-watch-options/index.test.ts
+++ b/e2e/cases/cli/build-watch-options/index.test.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
-import { test, waitForFileContent } from '@e2e/helper';
+import { test } from '@e2e/helper';
+import { waitForFileContent } from '@rstackjs/test-utils';
 import fse from 'fs-extra';
 
 test('should allow to custom watch options for build watch', async ({

--- a/e2e/cases/cli/build-watch-restart/index.test.ts
+++ b/e2e/cases/cli/build-watch-restart/index.test.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
-import { test, waitForFileContent } from '@e2e/helper';
+import { test } from '@e2e/helper';
+import { waitForFileContent } from '@rstackjs/test-utils';
 import fse from 'fs-extra';
 
 test('should support restart build when config changed', async ({ execCli, logHelper }) => {

--- a/e2e/cases/cli/build-watch/index.test.ts
+++ b/e2e/cases/cli/build-watch/index.test.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
-import { test, waitForFileContent } from '@e2e/helper';
+import { test } from '@e2e/helper';
+import { waitForFileContent } from '@rstackjs/test-utils';
 import fse from 'fs-extra';
 
 test('should support watch mode for build command', async ({ execCli, logHelper }) => {

--- a/e2e/cases/cli/build/index.test.ts
+++ b/e2e/cases/cli/build/index.test.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
-import { expect, readDirContents, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { readDirContents } from '@rstackjs/test-utils';
 
 test('should run build command correctly', async ({ execCliSync }) => {
   execCliSync('build');

--- a/e2e/cases/cli/config-loader-native-deps/index.test.ts
+++ b/e2e/cases/cli/config-loader-native-deps/index.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { expect, getRandomPort, gotoPage, test } from '@e2e/helper';
+import { expect, gotoPage, test } from '@e2e/helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 
 const tempConfig = path.join(import.meta.dirname, 'test-temp.config.mjs');
 const tempConfigDep = path.join(import.meta.dirname, 'test-temp-dep.mjs');

--- a/e2e/cases/cli/config-loader/index.test.ts
+++ b/e2e/cases/cli/config-loader/index.test.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
-import { expect, readDirContents, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { readDirContents } from '@rstackjs/test-utils';
 
 test('should use Node.js native loader to load config', async ({ execCliSync }) => {
   if (!process.features.typescript) {

--- a/e2e/cases/cli/custom-config/index.test.ts
+++ b/e2e/cases/cli/custom-config/index.test.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
-import { expect, readDirContents, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { readDirContents } from '@rstackjs/test-utils';
 
 test('should use custom config when using --config option', async ({ execCliSync }) => {
   execCliSync('build --config ./custom.config.js');

--- a/e2e/cases/cli/dev/index.test.ts
+++ b/e2e/cases/cli/dev/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getRandomPort, gotoPage, test } from '@e2e/helper';
+import { expect, gotoPage, test } from '@e2e/helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 
 test('should run dev server via `dev` command', async ({ page, execCli, logHelper }) => {
   const port = await getRandomPort();

--- a/e2e/cases/cli/falsy-plugins/index.test.ts
+++ b/e2e/cases/cli/falsy-plugins/index.test.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
-import { expect, readDirContents, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { readDirContents } from '@rstackjs/test-utils';
 
 test('should run build command correctly', async ({ execCliSync }) => {
   execCliSync('build');

--- a/e2e/cases/cli/function-config/index.test.ts
+++ b/e2e/cases/cli/function-config/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, readDirContents, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent, readDirContents } from '@rstackjs/test-utils';
 
 test('should support exporting a function from the config file', async ({
   prepareDist,

--- a/e2e/cases/cli/host/index.test.ts
+++ b/e2e/cases/cli/host/index.test.ts
@@ -1,4 +1,5 @@
-import { getRandomPort, NETWORK_LOG_REGEX, test } from '@e2e/helper';
+import { NETWORK_LOG_REGEX, test } from '@e2e/helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 
 test('should listen on localhost by default', async ({ execCli, logHelper }) => {
   const port = await getRandomPort();

--- a/e2e/cases/cli/inspect/index.test.ts
+++ b/e2e/cases/cli/inspect/index.test.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
-import { expect, readDirContents, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { readDirContents } from '@rstackjs/test-utils';
 
 test('should run inspect command correctly', async ({ prepareDist, execCliSync }) => {
   const distPath = await prepareDist();

--- a/e2e/cases/cli/mode/index.test.ts
+++ b/e2e/cases/cli/mode/index.test.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
-import { expect, readDirContents, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { readDirContents } from '@rstackjs/test-utils';
 
 test('should run build command with --mode option correctly', async ({ execCliSync }) => {
   execCliSync('build --mode development');

--- a/e2e/cases/cli/node-env/index.test.ts
+++ b/e2e/cases/cli/node-env/index.test.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
-import { expect, readDirContents, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { readDirContents } from '@rstackjs/test-utils';
 
 test('should set NODE_ENV correctly when running build command', async ({ execCliSync }) => {
   delete process.env.NODE_ENV;

--- a/e2e/cases/cli/output-dist-path/index.test.ts
+++ b/e2e/cases/cli/output-dist-path/index.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { expect, readDirContents, test, waitForFile } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { readDirContents, waitForFile } from '@rstackjs/test-utils';
 
 test('should set output dist path from CLI', async ({ prepareDist, execCliSync }) => {
   const distPath = await prepareDist();

--- a/e2e/cases/cli/reload-config/index.test.ts
+++ b/e2e/cases/cli/reload-config/index.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { getRandomPort, test, waitForFile } from '@e2e/helper';
+import { test } from '@e2e/helper';
+import { getRandomPort, waitForFile } from '@rstackjs/test-utils';
 import fse from 'fs-extra';
 
 test('should restart dev server and reload config when config file changed', async ({

--- a/e2e/cases/cli/reload-env/index.test.ts
+++ b/e2e/cases/cli/reload-env/index.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { getRandomPort, test, waitForFileContent } from '@e2e/helper';
+import { test } from '@e2e/helper';
+import { getRandomPort, waitForFileContent } from '@rstackjs/test-utils';
 
 test('should restart dev server when .env file is changed', async ({ execCli, logHelper }) => {
   const dist = path.join(import.meta.dirname, 'dist');

--- a/e2e/cases/cli/root/index.test.ts
+++ b/e2e/cases/cli/root/index.test.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
-import { expect, readDirContents, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { readDirContents } from '@rstackjs/test-utils';
 
 test('should run build command with --root option correctly', async ({ execCliSync }) => {
   execCliSync('build --root test');

--- a/e2e/cases/cli/source-map/index.test.ts
+++ b/e2e/cases/cli/source-map/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, readDirContents, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { readDirContents } from '@rstackjs/test-utils';
 
 test('should enable source map from CLI', async ({ prepareDist, execCliSync }) => {
   const distPath = await prepareDist();

--- a/e2e/cases/cli/specified-environment/index.test.ts
+++ b/e2e/cases/cli/specified-environment/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, readDirContents, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { readDirContents } from '@rstackjs/test-utils';
 
 test('should only build specified environment when using --environment option', async ({
   prepareDist,

--- a/e2e/cases/cli/strict-port/index.test.ts
+++ b/e2e/cases/cli/strict-port/index.test.ts
@@ -1,6 +1,7 @@
 import net from 'node:net';
 import { stripVTControlCharacters as stripAnsi } from 'node:util';
-import { expect, getRandomPort, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 
 const HOST = '0.0.0.0';
 

--- a/e2e/cases/cli/vue/index.test.ts
+++ b/e2e/cases/cli/vue/index.test.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
-import { expect, readDirContents, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { readDirContents } from '@rstackjs/test-utils';
 
 test('should build Vue SFC correctly', async ({ execCliSync }) => {
   execCliSync('build');

--- a/e2e/cases/cli/watch-files-array/index.test.ts
+++ b/e2e/cases/cli/watch-files-array/index.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { expect, getRandomPort, gotoPage, test } from '@e2e/helper';
+import { expect, gotoPage, test } from '@e2e/helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 
 const tempConfig = path.join(import.meta.dirname, 'test-temp-config.ts');
 

--- a/e2e/cases/cli/watch-files/index.test.ts
+++ b/e2e/cases/cli/watch-files/index.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { expect, getRandomPort, gotoPage, test } from '@e2e/helper';
+import { expect, gotoPage, test } from '@e2e/helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 
 const tempConfig = path.join(import.meta.dirname, 'test-temp-config.ts');
 

--- a/e2e/cases/css/configure-css-extract/index.test.ts
+++ b/e2e/cases/css/configure-css-extract/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should allow to configure options of CSSExtractPlugin', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/css/css-layers/index.test.ts
+++ b/e2e/cases/css/css-layers/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should bundle CSS layers as expected', async ({ runBoth }) => {
   await runBoth(async ({ mode, result }) => {

--- a/e2e/cases/css/css-modules-composes/index.test.ts
+++ b/e2e/cases/css/css-modules-composes/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should compile CSS Modules composes correctly', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/css/css-modules-dom/index.test.ts
+++ b/e2e/cases/css/css-modules-dom/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, findFile, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { findFile } from '@rstackjs/test-utils';
 
 test('should inject styles and not emit CSS files when output.injectStyles is true', async ({
   page,

--- a/e2e/cases/css/css-modules-export-locals/index.test.ts
+++ b/e2e/cases/css/css-modules-export-locals/index.test.ts
@@ -1,4 +1,5 @@
-import { type BuildResult, expect, getFileContent, test } from '@e2e/helper';
+import { type BuildResult, expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 declare global {
   interface Window {

--- a/e2e/cases/css/css-modules-exports-global/index.test.ts
+++ b/e2e/cases/css/css-modules-exports-global/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should export globals in CSS Modules correctly', async ({ page, runBothServe }) => {
   await runBothServe(async ({ mode, result }) => {

--- a/e2e/cases/css/css-modules-global/index.test.ts
+++ b/e2e/cases/css/css-modules-global/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should compile CSS Modules with :global() correctly', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/css/css-modules-mode/index.test.ts
+++ b/e2e/cases/css/css-modules-mode/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should compile CSS Modules global mode correctly', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/css/css-modules-named-export/index.test.ts
+++ b/e2e/cases/css/css-modules-named-export/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should compile CSS Modules with named exports correctly', async ({ page, buildPreview }) => {
   const rsbuild = await buildPreview();

--- a/e2e/cases/css/css-modules/index.test.ts
+++ b/e2e/cases/css/css-modules/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should compile CSS Modules with default configuration', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/css/emit-css/index.test.ts
+++ b/e2e/cases/css/emit-css/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should not emit CSS files when build node target', async ({ build }) => {
   const rsbuild = await build({

--- a/e2e/cases/css/enable-experiments-css/index.test.ts
+++ b/e2e/cases/css/enable-experiments-css/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 const COMPILE_WARNING = 'Compile Warning';
 

--- a/e2e/cases/css/import-common-css/index.test.ts
+++ b/e2e/cases/css/import-common-css/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should compile common CSS import correctly', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/css/import-loaders/index.test.ts
+++ b/e2e/cases/css/import-loaders/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should compile CSS Modules which depends on importLoaders correctly', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/css/inject-styles-lightningcss/index.test.ts
+++ b/e2e/cases/css/inject-styles-lightningcss/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should use lightningcss-loader to transform and minify CSS when injectStyles is true', async ({
   build,

--- a/e2e/cases/css/inject-styles/index.test.ts
+++ b/e2e/cases/css/inject-styles/index.test.ts
@@ -1,5 +1,6 @@
 import { join } from 'node:path';
-import { expect, findFile, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { findFile, getFileContent } from '@rstackjs/test-utils';
 
 test('should inline style when `injectStyles` is enabled', async ({ page, buildPreview }) => {
   const rsbuild = await buildPreview();

--- a/e2e/cases/css/jiti-require-browserslist/index.test.ts
+++ b/e2e/cases/css/jiti-require-browserslist/index.test.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
-import { expect, getFileContent, readDirContents, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent, readDirContents } from '@rstackjs/test-utils';
 
 test('should normalize browserslist required by jiti config', async ({ execCliSync }) => {
   // Regression for CJS arrays loaded by require() in a jiti config.

--- a/e2e/cases/css/lightningcss-disabled/index.test.ts
+++ b/e2e/cases/css/lightningcss-disabled/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should allow to disable the built-in lightningcss loader', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/css/lightningcss-prefixes/index.test.ts
+++ b/e2e/cases/css/lightningcss-prefixes/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should add vendor prefixes by current browserslist', async ({ runBoth }) => {
   await runBoth(async ({ mode, result }) => {

--- a/e2e/cases/css/multi-css/index.test.ts
+++ b/e2e/cases/css/multi-css/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should emit multiple CSS files correctly', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/css/nested-npm-import/index.test.ts
+++ b/e2e/cases/css/nested-npm-import/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should compile nested npm import correctly', async ({ build, copyNodeModules }) => {
   await copyNodeModules();

--- a/e2e/cases/css/postcss-add-plugins/index.test.ts
+++ b/e2e/cases/css/postcss-add-plugins/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should call `addPlugins` helper with `order` options', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/css/postcss-config-ts/index.test.ts
+++ b/e2e/cases/css/postcss-config-ts/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should load postcss.config.ts correctly', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/css/postcss-function-options-merge/index.test.ts
+++ b/e2e/cases/css/postcss-function-options-merge/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should merge `postcssOptions` function with `postcss.config.ts` as expected', async ({
   build,

--- a/e2e/cases/css/postcss-function-options/index.test.ts
+++ b/e2e/cases/css/postcss-function-options/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should allow to use `postcssOptions` function to apply different postcss config for different files', async ({
   build,

--- a/e2e/cases/css/relative-import/index.test.ts
+++ b/e2e/cases/css/relative-import/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should compile CSS relative imports correctly', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/css/resolve-alias/index.test.ts
+++ b/e2e/cases/css/resolve-alias/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should compile CSS with alias correctly', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/css/resolve-ts-paths/index.test.ts
+++ b/e2e/cases/css/resolve-ts-paths/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should resolve ts paths correctly in SCSS file', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/css/resolve-url-loader/index.test.ts
+++ b/e2e/cases/css/resolve-url-loader/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should resolve relative asset correctly in SCSS file', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/css/url-query-css-modules/index.test.ts
+++ b/e2e/cases/css/url-query-css-modules/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 const EXPECTED_ERROR = 'CSS Modules do not support the ?url query';
 

--- a/e2e/cases/css/url-query/index.test.ts
+++ b/e2e/cases/css/url-query/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, findFile, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { findFile, getFileContent } from '@rstackjs/test-utils';
 
 type CssUrlResult = {
   aStyleContent: string;

--- a/e2e/cases/environments/import-meta-env-ssr/index.test.ts
+++ b/e2e/cases/environments/import-meta-env-ssr/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should define import.meta.env.SSR based on environment target', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/html/app-icon-public-manifest/index.test.ts
+++ b/e2e/cases/html/app-icon-public-manifest/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getDistFiles, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getDistFiles, getFileContent } from '@rstackjs/test-utils';
 
 test('should use public manifest for additional manifest fields', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/html/app-icon/index.test.ts
+++ b/e2e/cases/html/app-icon/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, findFile, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { findFile, getFileContent } from '@rstackjs/test-utils';
 
 test('should emit apple-touch-icon to dist path', async ({ build }) => {
   const rsbuild = await build({

--- a/e2e/cases/html/cross-origin/index.test.ts
+++ b/e2e/cases/html/cross-origin/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should not apply crossOrigin by default', async ({ build }) => {
   const rsbuild = await build({

--- a/e2e/cases/html/custom-filename/index.test.ts
+++ b/e2e/cases/html/custom-filename/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, findFile, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { findFile } from '@rstackjs/test-utils';
 
 test('should allow to custom HTML filename', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/html/favicon/index.test.ts
+++ b/e2e/cases/html/favicon/index.test.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
-import { expect, findFile, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { findFile, getFileContent } from '@rstackjs/test-utils';
 import fse from 'fs-extra';
 
 test('should emit local favicon to dist path', async ({ build }) => {

--- a/e2e/cases/html/filename-hash/index.test.ts
+++ b/e2e/cases/html/filename-hash/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, findFile, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { findFile } from '@rstackjs/test-utils';
 
 test('should allow to generate HTML with filename hash using filename.html', async ({ build }) => {
   const rsbuild = await build({

--- a/e2e/cases/html/html-tags/basic/index.test.ts
+++ b/e2e/cases/html/html-tags/basic/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should inject tags correctly', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/html/html-tags/function-usage/index.test.ts
+++ b/e2e/cases/html/html-tags/function-usage/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, normalizeEol, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent, normalizeEol } from '@rstackjs/test-utils';
 
 test('should inject tags with function usage correctly', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/html/html-tags/modify-by-entry/index.test.ts
+++ b/e2e/cases/html/html-tags/modify-by-entry/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should allow to inject tags by entry name', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/html/html-tags/relative-path-multi-entry/index.test.ts
+++ b/e2e/cases/html/html-tags/relative-path-multi-entry/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, gotoPage, test } from '@e2e/helper';
+import { expect, gotoPage, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should handle relative paths correctly for multiple entries in subdirectories', async ({
   page,

--- a/e2e/cases/html/inject/index.test.ts
+++ b/e2e/cases/html/inject/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, normalizeEol, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent, normalizeEol } from '@rstackjs/test-utils';
 import { pluginRem } from '@rsbuild/plugin-rem';
 
 test('should preserve the expected script injection order', async ({ build }) => {

--- a/e2e/cases/html/meta/index.test.ts
+++ b/e2e/cases/html/meta/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, normalizeEol, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent, normalizeEol } from '@rstackjs/test-utils';
 
 test('should not inject charset meta if template already contains it', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/html/minify/index.test.ts
+++ b/e2e/cases/html/minify/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should minify template success when inlineScripts & inlineStyles', async ({
   buildPreview,

--- a/e2e/cases/html/script-loading/index.test.ts
+++ b/e2e/cases/html/script-loading/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should apply defer by default', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/html/template-conditional-statement/index.test.ts
+++ b/e2e/cases/html/template-conditional-statement/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should render conditional statement correctly', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/html/template-escape/index.test.ts
+++ b/e2e/cases/html/template-escape/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should escape template parameters correctly', async ({ build }) => {
   const rsbuild = await build({

--- a/e2e/cases/html/template-loop-statement/index.test.ts
+++ b/e2e/cases/html/template-loop-statement/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should render loop statements correctly', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/html/template-no-head/index.test.ts
+++ b/e2e/cases/html/template-no-head/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 // https://github.com/web-infra-dev/rsbuild/issues/4924
 test('should inject tags to HTML template without <head> tag', async ({ build }) => {

--- a/e2e/cases/html/template-with-script/index.test.ts
+++ b/e2e/cases/html/template-with-script/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 // see: https://github.com/rstackjs/html-rspack-plugin/issues/14
 test('should compile template with es template correctly', async ({ build }) => {

--- a/e2e/cases/html/template/index.test.ts
+++ b/e2e/cases/html/template/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should set template via function correctly', async ({ build }) => {
   const rsbuild = await build({

--- a/e2e/cases/html/title/index.test.ts
+++ b/e2e/cases/html/title/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should generate default title correctly', async ({ build }) => {
   const rsbuild = await build({

--- a/e2e/cases/javascript-api/environment-hot-send/index.test.ts
+++ b/e2e/cases/javascript-api/environment-hot-send/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getRandomPort, HMR_CONNECTED_LOG, test } from '@e2e/helper';
+import { expect, HMR_CONNECTED_LOG, test } from '@e2e/helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 import { createRsbuild } from '@rsbuild/core';
 
 test('should send HMR messages to the matched environment only', async ({ page, context }) => {

--- a/e2e/cases/javascript-api/register-plugin/index.test.ts
+++ b/e2e/cases/javascript-api/register-plugin/index.test.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
-import { expect, readDirContents, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { readDirContents } from '@rstackjs/test-utils';
 import { pluginVue } from '@rsbuild/plugin-vue';
 
 test('should register plugins correctly when using JavaScript API', async ({ build }) => {

--- a/e2e/cases/lazy-compilation/client-url/index.test.ts
+++ b/e2e/cases/lazy-compilation/client-url/index.test.ts
@@ -1,5 +1,6 @@
 import { createServer, type Server } from 'node:http';
-import { expect, getRandomPort, gotoPage, test } from '@e2e/helper';
+import { expect, gotoPage, test } from '@e2e/helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 
 const listen = (server: Server, port: number) =>
   new Promise<void>((resolve, reject) => {

--- a/e2e/cases/manifest/async-chunks/index.test.ts
+++ b/e2e/cases/manifest/async-chunks/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should generate manifest for async chunks correctly', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/manifest/basic/index.test.ts
+++ b/e2e/cases/manifest/basic/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should generate manifest file in output', async ({ build }) => {
   const rsbuild = await build({

--- a/e2e/cases/manifest/entry-assets-prefix/index.test.ts
+++ b/e2e/cases/manifest/entry-assets-prefix/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should apply assetPrefix to assets in manifest entries', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/manifest/filter/index.test.ts
+++ b/e2e/cases/manifest/filter/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should allow to filter files in manifest', async ({ build }) => {
   const rsbuild = await build({

--- a/e2e/cases/manifest/generate/index.test.ts
+++ b/e2e/cases/manifest/generate/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 import type { RsbuildConfig } from '@rsbuild/core';
 
 const config: RsbuildConfig = {

--- a/e2e/cases/manifest/integrity/index.test.ts
+++ b/e2e/cases/manifest/integrity/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 import type { ManifestData } from '@rsbuild/core';
 
 const checkManifestIntegrity = (rsbuild: { getDistFiles: () => Record<string, string> }) => {

--- a/e2e/cases/manifest/node/index.test.ts
+++ b/e2e/cases/manifest/node/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should generate manifest file when target is node', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/manifest/remove-prefix/index.test.ts
+++ b/e2e/cases/manifest/remove-prefix/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should remove prefix from manifest', async ({ build }) => {
   const rsbuild = await build({

--- a/e2e/cases/manifest/single-vendor/index.test.ts
+++ b/e2e/cases/manifest/single-vendor/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should generate manifest with single vendor as expected', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/mode/basic/index.test.ts
+++ b/e2e/cases/mode/basic/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should allow to set development mode when building', async ({ build }) => {
   const rsbuild = await build({

--- a/e2e/cases/module-federation/v1-basic/index.test.ts
+++ b/e2e/cases/module-federation/v1-basic/index.test.ts
@@ -1,6 +1,7 @@
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { expect, getRandomPort, gotoPage, test } from '@e2e/helper';
+import { expect, gotoPage, test } from '@e2e/helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 import type { RsbuildConfig } from '@rsbuild/core';
 import { pluginCheckSyntax } from '@rsbuild/plugin-check-syntax';
 

--- a/e2e/cases/module-federation/v2-basic/index.test.ts
+++ b/e2e/cases/module-federation/v2-basic/index.test.ts
@@ -1,6 +1,7 @@
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { expect, getRandomPort, gotoPage, test } from '@e2e/helper';
+import { expect, gotoPage, test } from '@e2e/helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 import type { RsbuildConfig } from '@rsbuild/core';
 import { pluginCheckSyntax } from '@rsbuild/plugin-check-syntax';
 

--- a/e2e/cases/node-addons/cjs/index.test.ts
+++ b/e2e/cases/node-addons/cjs/index.test.ts
@@ -1,7 +1,8 @@
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import { join } from 'node:path';
-import { expect, findFile, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { findFile } from '@rstackjs/test-utils';
 import fse from 'fs-extra';
 
 const require = createRequire(import.meta.url);

--- a/e2e/cases/node-addons/esm/index.test.ts
+++ b/e2e/cases/node-addons/esm/index.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
-import { expect, findFile, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { findFile } from '@rstackjs/test-utils';
 import fse from 'fs-extra';
 
 test('should compile Node addons correctly for ESM output', async ({ build }) => {

--- a/e2e/cases/optimization/css-minify-always/index.test.ts
+++ b/e2e/cases/optimization/css-minify-always/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should minimize CSS correctly by default', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/optimization/css-minify-options/index.test.ts
+++ b/e2e/cases/optimization/css-minify-options/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should allow to custom CSS minify options', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/optimization/css-minify/index.test.ts
+++ b/e2e/cases/optimization/css-minify/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should allow to minify CSS in dev', async ({ dev }) => {
   const rsbuild = await dev();

--- a/e2e/cases/optimization/js-minify-always/index.test.ts
+++ b/e2e/cases/optimization/js-minify-always/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should allow to minify JS in dev', async ({ dev }) => {
   const rsbuild = await dev();

--- a/e2e/cases/output/auto-external-node/index.test.ts
+++ b/e2e/cases/output/auto-external-node/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 const expectBundledExport = (content: string, exportName: 'dep' | 'dev' | 'peer') => {
   expect(content).toContain(JSON.stringify(exportName));

--- a/e2e/cases/output/auto-external-web/index.test.ts
+++ b/e2e/cases/output/auto-external-web/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should auto externalize dependencies for web CommonJS library output', async ({ build }) => {
   const rsbuild = await build({

--- a/e2e/cases/output/charset/index.test.ts
+++ b/e2e/cases/output/charset/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 const utf8Str = `你好 world! I'm 🦀`;
 const asciiStr = `\\u{4F60}\\u{597D} world! I'm \\u{1F980}`;

--- a/e2e/cases/output/externals/index.test.ts
+++ b/e2e/cases/output/externals/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 test('should treat specified modules as externals', async ({ page, buildPreview }) => {

--- a/e2e/cases/output/filename-hash-development/index.test.ts
+++ b/e2e/cases/output/filename-hash-development/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should allow to force filename hash in development mode', async ({ build }) => {
   const rsbuild = await build({

--- a/e2e/cases/output/filename-hash-node-target/index.test.ts
+++ b/e2e/cases/output/filename-hash-node-target/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should allow to force filename hash for node target', async ({ build }) => {
   const rsbuild = await build({

--- a/e2e/cases/output/inline-chunk/index.test.ts
+++ b/e2e/cases/output/inline-chunk/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 import type { RspackChain } from '@rsbuild/core';
 
 // use source-map for easy to test. By default, Rsbuild use hidden-source-map

--- a/e2e/cases/output/legal-comments/index.test.ts
+++ b/e2e/cases/output/legal-comments/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, findFile, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { findFile, getFileContent } from '@rstackjs/test-utils';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 test('legalComments linked (default)', async ({ page, buildPreview }) => {

--- a/e2e/cases/performance/dns-prefetch/index.test.ts
+++ b/e2e/cases/performance/dns-prefetch/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should generate dnsPrefetch link when dnsPrefetch is defined', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/performance/external-helpers/index.test.ts
+++ b/e2e/cases/performance/external-helpers/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should externalHelpers by default', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/performance/preconnect/index.test.ts
+++ b/e2e/cases/performance/preconnect/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should generate preconnect link when preconnect is defined', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/performance/remove-console/index.test.ts
+++ b/e2e/cases/performance/remove-console/index.test.ts
@@ -1,5 +1,6 @@
 import type { BuildResult } from '@e2e/helper';
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 const expectConsoleType = async (
   rsbuild: Awaited<BuildResult>,

--- a/e2e/cases/performance/resource-hints-prefetch/index.test.ts
+++ b/e2e/cases/performance/resource-hints-prefetch/index.test.ts
@@ -1,5 +1,6 @@
 import { join } from 'node:path';
-import { expect, findFile, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { findFile, getFileContent } from '@rstackjs/test-utils';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 const fixtures = import.meta.dirname;

--- a/e2e/cases/performance/resource-hints-preload/index.test.ts
+++ b/e2e/cases/performance/resource-hints-preload/index.test.ts
@@ -1,5 +1,6 @@
 import { join } from 'node:path';
-import { expect, findFile, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { findFile, getFileContent } from '@rstackjs/test-utils';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 const fixtures = import.meta.dirname;

--- a/e2e/cases/plugin-api/plugin-modify-html/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-modify-html/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 import type { RsbuildPlugin } from '@rsbuild/core';
 
 test('should allow plugin to modify HTML content', async ({ build }) => {

--- a/e2e/cases/plugin-api/plugin-modify-tags-meta/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-modify-tags-meta/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should allow plugin to modify HTML tags with metadata', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/plugin-api/plugin-modify-tags/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-modify-tags/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should allow plugin to modify HTML tags', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/plugin-api/plugin-process-assets-by-targets/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-process-assets-by-targets/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, findFile, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { findFile } from '@rstackjs/test-utils';
 
 test('should process assets when target is web', async ({ build }) => {
   const rsbuild = await build({

--- a/e2e/cases/plugin-api/plugin-process-assets-with-html-child-compiler/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-process-assets-with-html-child-compiler/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, findFile, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { findFile } from '@rstackjs/test-utils';
 
 test('should allow plugin to process assets', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/plugin-api/plugin-process-assets/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-process-assets/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, findFile, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { findFile } from '@rstackjs/test-utils';
 
 test('should allow plugin to process assets', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/plugin-api/plugin-transform-buffer/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-transform-buffer/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should allow plugin to transform code with Buffer return', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/plugin-api/plugin-transform-by-environments/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-transform-by-environments/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should allow plugin to transform code by environments', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/plugin-api/plugin-transform-by-targets/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-transform-by-targets/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should allow plugin to transform code by targets', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/plugin-api/plugin-transform-import-module/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-transform-import-module/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should allow plugin to transform code and call `importModule`', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/plugin-api/plugin-transform-merge-source-map/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-transform-merge-source-map/index.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
-import { expect, getDistFiles, getFileContent, mapSourceMapPositions, test } from '@e2e/helper';
+import { expect, mapSourceMapPositions, test } from '@e2e/helper';
+import { getDistFiles, getFileContent } from '@rstackjs/test-utils';
 
 const expectSourceMap = async (files: Record<string, string>) => {
   const sourceCode = readFileSync(path.join(import.meta.dirname, 'src/index.ts'), 'utf-8');

--- a/e2e/cases/plugin-api/plugin-transform/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-transform/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should allow plugin to transform code', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/plugin-less/import/index.test.ts
+++ b/e2e/cases/plugin-less/import/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should compile less import correctly', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/plugin-less/inline-js/index.test.ts
+++ b/e2e/cases/plugin-less/inline-js/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should compile less inline js correctly', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/plugin-less/npm-import/index.test.ts
+++ b/e2e/cases/plugin-less/npm-import/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should compile less npm import correctly', async ({ build, copyNodeModules }) => {
   await copyNodeModules();

--- a/e2e/cases/plugin-less/parallel/index.test.ts
+++ b/e2e/cases/plugin-less/parallel/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should compile less with `parallel` option', async ({ page, runBothServe }) => {
   await runBothServe(async ({ mode, result }) => {

--- a/e2e/cases/plugin-less/url-query/index.test.ts
+++ b/e2e/cases/plugin-less/url-query/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 type LessUrlResult = {
   styleContent: string;

--- a/e2e/cases/plugin-sass/url-query/index.test.ts
+++ b/e2e/cases/plugin-sass/url-query/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 type SassUrlResult = {
   styleContent: string;

--- a/e2e/cases/plugin-svgr/svgo-minify-id-prefix/index.test.ts
+++ b/e2e/cases/plugin-svgr/svgo-minify-id-prefix/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should add id prefix after svgo minification', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/plugin-svgr/svgo-minify-view-box/index.test.ts
+++ b/e2e/cases/plugin-svgr/svgo-minify-view-box/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should preserve viewBox after svgo minification', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/plugin-tailwindcss/basic/index.test.ts
+++ b/e2e/cases/plugin-tailwindcss/basic/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should generate tailwindcss utilities correctly with plugin', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/plugin-tailwindcss/inject-styles/index.test.ts
+++ b/e2e/cases/plugin-tailwindcss/inject-styles/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should inject transformed Tailwind CSS when injectStyles is enabled', async ({
   page,

--- a/e2e/cases/plugin-tailwindcss/optimize/index.test.ts
+++ b/e2e/cases/plugin-tailwindcss/optimize/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 import { pluginTailwindcss } from '@rsbuild/plugin-tailwindcss';
 
 const commonConfig = {

--- a/e2e/cases/plugin-tailwindcss/source-directive/index.test.ts
+++ b/e2e/cases/plugin-tailwindcss/source-directive/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should generate Tailwind utilities from @source files', async ({ runBoth }) => {
   await runBoth(async ({ result }) => {

--- a/e2e/cases/plugin-tailwindcss/source-function/index.test.ts
+++ b/e2e/cases/plugin-tailwindcss/source-function/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should generate Tailwind utilities from source() files', async ({ runBoth }) => {
   await runBoth(async ({ result }) => {

--- a/e2e/cases/plugin-vue/sfc-css-modules-multi-target/index.test.ts
+++ b/e2e/cases/plugin-vue/sfc-css-modules-multi-target/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 const getClassName = (content: string, localName: string) => {
   const matched = content.match(new RegExp(`${localName}-[\\w-]{6}`));

--- a/e2e/cases/plugin-vue/sfc-css-modules-ssr/index.test.ts
+++ b/e2e/cases/plugin-vue/sfc-css-modules-ssr/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should build Vue SFC with CSS Modules correctly in dev build for node target', async ({
   dev,

--- a/e2e/cases/polyfill/helper.ts
+++ b/e2e/cases/polyfill/helper.ts
@@ -1,4 +1,4 @@
-import { findFile } from '@e2e/helper';
+import { findFile } from '@rstackjs/test-utils';
 
 export const getPolyfillContent = (files: Record<string, string>) => {
   let polyfillFileName: string | undefined;

--- a/e2e/cases/postcss-tailwindcss/basic/index.test.ts
+++ b/e2e/cases/postcss-tailwindcss/basic/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should generate tailwindcss utilities correctly', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/postcss-tailwindcss/mjs/index.test.ts
+++ b/e2e/cases/postcss-tailwindcss/mjs/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should generate tailwindcss utilities with mjs config correctly', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/postcss-tailwindcss/vendor-prefix/index.test.ts
+++ b/e2e/cases/postcss-tailwindcss/vendor-prefix/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should generate tailwindcss utilities with vendor prefixes correctly', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/print-file-size/helper.ts
+++ b/e2e/cases/print-file-size/helper.ts
@@ -1,4 +1,4 @@
-import { toPosixPath } from '@e2e/helper';
+import { toPosixPath } from '@rstackjs/test-utils';
 
 export function extractFileSizeLogs(logs: string[]) {
   const result: string[] = [];

--- a/e2e/cases/resolve/tsconfig-paths-reload/index.test.ts
+++ b/e2e/cases/resolve/tsconfig-paths-reload/index.test.ts
@@ -1,5 +1,6 @@
 import { join } from 'node:path';
-import { expect, getRandomPort, gotoPage, test, waitForFile } from '@e2e/helper';
+import { expect, gotoPage, test } from '@e2e/helper';
+import { getRandomPort, waitForFile } from '@rstackjs/test-utils';
 import fse from 'fs-extra';
 import { tempConfig } from './rsbuild.config';
 

--- a/e2e/cases/security/nonce-basic/index.test.ts
+++ b/e2e/cases/security/nonce-basic/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should apply nonce to script and style tags', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/security/nonce-dynamic-chunk/index.test.ts
+++ b/e2e/cases/security/nonce-dynamic-chunk/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 declare global {
   interface Window {

--- a/e2e/cases/security/nonce-with-rem/index.test.ts
+++ b/e2e/cases/security/nonce-with-rem/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should inject rem runtime code with nonce', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/security/sri-algotithm-multiple/index.test.ts
+++ b/e2e/cases/security/sri-algotithm-multiple/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('generate integrity using multiple algorithms', async ({ page, buildPreview }) => {
   const rsbuild = await buildPreview();

--- a/e2e/cases/security/sri-algotithm/index.test.ts
+++ b/e2e/cases/security/sri-algotithm/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('generate integrity using sha512 algorithm', async ({ page, buildPreview }) => {
   const rsbuild = await buildPreview();

--- a/e2e/cases/security/sri-basic/index.test.ts
+++ b/e2e/cases/security/sri-basic/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should generate integrity attributes for script and style tags in build', async ({
   page,

--- a/e2e/cases/security/sri-native-html-plugin/index.test.ts
+++ b/e2e/cases/security/sri-native-html-plugin/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should generate integrity attributes in build with native html plugin', async ({
   page,

--- a/e2e/cases/security/sri-preload/index.test.ts
+++ b/e2e/cases/security/sri-preload/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('generate integrity for preload tags in build', async ({ page, buildPreview }) => {
   const rsbuild = await buildPreview();

--- a/e2e/cases/server/custom-server/scripts/pureServer.js
+++ b/e2e/cases/server/custom-server/scripts/pureServer.js
@@ -1,5 +1,5 @@
 import { createConnectHandler } from '@e2e/helper/server';
-import { getRandomPort } from '@e2e/helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 import { createAdaptorServer } from '@hono/node-server';
 import { createRsbuild } from '@rsbuild/core';
 import { Hono } from 'hono';

--- a/e2e/cases/server/custom-server/scripts/server.js
+++ b/e2e/cases/server/custom-server/scripts/server.js
@@ -1,5 +1,5 @@
 import { createConnectHandler } from '@e2e/helper/server';
-import { getRandomPort } from '@e2e/helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 import { createAdaptorServer } from '@hono/node-server';
 import { createRsbuild } from '@rsbuild/core';
 import { Hono } from 'hono';

--- a/e2e/cases/server/html-fallback/index.test.ts
+++ b/e2e/cases/server/html-fallback/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should access / success and htmlFallback success by default', async ({ page, devOnly }) => {
   const rsbuild = await devOnly();

--- a/e2e/cases/server/multi-server/index.test.ts
+++ b/e2e/cases/server/multi-server/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getRandomPort, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 import { createConnectHandler } from '@e2e/helper/server';
 import { createAdaptorServer } from '@hono/node-server';
 import { createRsbuild } from '@rsbuild/core';

--- a/e2e/cases/server/port/index.test.ts
+++ b/e2e/cases/server/port/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getRandomPort, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 
 test('should set the port via server.port', async ({ page, dev }) => {
   const errors: string[] = [];

--- a/e2e/cases/server/preview/index.test.ts
+++ b/e2e/cases/server/preview/index.test.ts
@@ -1,5 +1,6 @@
 import { basename } from 'node:path';
-import { expect, findFile, getRandomPort, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { findFile, getRandomPort } from '@rstackjs/test-utils';
 import type { RsbuildPlugin } from '@rsbuild/core';
 
 test('should preview dist files correctly', async ({ page, buildPreview }) => {

--- a/e2e/cases/server/prod-server/index.test.ts
+++ b/e2e/cases/server/prod-server/index.test.ts
@@ -1,5 +1,6 @@
 import { join } from 'node:path';
-import { expect, getRandomPort, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 
 const fixtures = import.meta.dirname;
 

--- a/e2e/cases/server/proxy-sse/index.test.ts
+++ b/e2e/cases/server/proxy-sse/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getRandomPort, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 import { createAdaptorServer } from '@hono/node-server';
 import { Hono } from 'hono';
 

--- a/e2e/cases/server/public-dir/publicDir.test.ts
+++ b/e2e/cases/server/public-dir/publicDir.test.ts
@@ -1,5 +1,6 @@
 import path, { join } from 'node:path';
-import { expect, getDistFiles, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getDistFiles } from '@rstackjs/test-utils';
 import fse from 'fs-extra';
 
 test('should serve publicDir for dev server correctly', async ({ page, devOnly }) => {

--- a/e2e/cases/server/ssr/index.test.ts
+++ b/e2e/cases/server/ssr/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('support SSR', async ({ page, devOnly }) => {
   const rsbuild = await devOnly();

--- a/e2e/cases/server/strict-port/index.test.ts
+++ b/e2e/cases/server/strict-port/index.test.ts
@@ -1,6 +1,7 @@
 import net from 'node:net';
 import { stripVTControlCharacters as stripAnsi } from 'node:util';
-import { expect, getRandomPort, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 
 const HOST = '0.0.0.0';
 

--- a/e2e/cases/source-map/basic/index.test.ts
+++ b/e2e/cases/source-map/basic/index.test.ts
@@ -1,13 +1,7 @@
 import { readFileSync } from 'node:fs';
 import path, { join } from 'node:path';
-import {
-  type Build,
-  expect,
-  findFile,
-  getFileContent,
-  mapSourceMapPositions,
-  test,
-} from '@e2e/helper';
+import { type Build, expect, mapSourceMapPositions, test } from '@e2e/helper';
+import { findFile, getFileContent } from '@rstackjs/test-utils';
 import type { Rspack } from '@rsbuild/core';
 
 const cwd = import.meta.dirname;

--- a/e2e/cases/source-map/extract/index.test.ts
+++ b/e2e/cases/source-map/extract/index.test.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
-import { type Build, expect, getFileContent, mapSourceMapPositions, test } from '@e2e/helper';
+import { type Build, expect, mapSourceMapPositions, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 import type { SourceMapExtract } from '@rsbuild/core';
 import fse from 'fs-extra';
 

--- a/e2e/cases/source-map/inline/index.test.ts
+++ b/e2e/cases/source-map/inline/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 const parseInlineSourceMap = (code: string): { sources: string[] } => {
   const match = code.match(

--- a/e2e/cases/source-map/less-import/index.test.ts
+++ b/e2e/cases/source-map/less-import/index.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { expect, findFile, mapSourceMapPositions, normalizeEol, test } from '@e2e/helper';
+import { expect, mapSourceMapPositions, test } from '@e2e/helper';
+import { findFile, normalizeEol } from '@rstackjs/test-utils';
 
 const normalizePath = (source: string | null) => source?.replace(/\\/g, '/') ?? '';
 

--- a/e2e/cases/source-map/multi-environments/index.test.ts
+++ b/e2e/cases/source-map/multi-environments/index.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { expect, findFile, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { findFile } from '@rstackjs/test-utils';
 
 test('should generate source map for multiple environments', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/source/source-exclude/index.test.ts
+++ b/e2e/cases/source/source-exclude/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, test, toPosixPath } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { toPosixPath } from '@rstackjs/test-utils';
 
 test('should not compile specified file when source.exclude', async ({ build }) => {
   const rsbuild = await build({

--- a/e2e/cases/split-chunks/legacy-by-module/index.test.ts
+++ b/e2e/cases/split-chunks/legacy-by-module/index.test.ts
@@ -1,5 +1,6 @@
 import { basename } from 'node:path';
-import { expect, findFile, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { findFile } from '@rstackjs/test-utils';
 
 test('should generate module chunks when chunkSplit is "split-by-module"', async ({ build }) => {
   const rsbuild = await build({

--- a/e2e/cases/split-chunks/legacy-single-vendor/index.test.ts
+++ b/e2e/cases/split-chunks/legacy-single-vendor/index.test.ts
@@ -1,5 +1,6 @@
 import { basename } from 'node:path';
-import { expect, findFile, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { findFile } from '@rstackjs/test-utils';
 
 test('should generate vendor chunk when chunkSplit is "single-vendor"', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/split-chunks/preset-per-package/index.test.ts
+++ b/e2e/cases/split-chunks/preset-per-package/index.test.ts
@@ -1,5 +1,6 @@
 import { basename } from 'node:path';
-import { expect, findFile, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { findFile } from '@rstackjs/test-utils';
 
 test('should generate chunks for each package when preset is "per-package"', async ({ build }) => {
   const rsbuild = await build({

--- a/e2e/cases/split-chunks/preset-single-vendor-node/index.test.ts
+++ b/e2e/cases/split-chunks/preset-single-vendor-node/index.test.ts
@@ -1,5 +1,6 @@
 import { basename } from 'node:path';
-import { expect, findFile, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { findFile } from '@rstackjs/test-utils';
 
 test('should generate a vendor chunk when preset is "single-vendor" and target is "node"', async ({
   build,

--- a/e2e/cases/split-chunks/preset-single-vendor/index.test.ts
+++ b/e2e/cases/split-chunks/preset-single-vendor/index.test.ts
@@ -1,5 +1,6 @@
 import { basename } from 'node:path';
-import { expect, findFile, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { findFile } from '@rstackjs/test-utils';
 
 test('should generate a vendor chunk when preset is "single-vendor"', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/swc/jsc-target/index.test.ts
+++ b/e2e/cases/swc/jsc-target/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, getFileContent, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
 
 test('should configure jsc.target correctly', async ({ runBoth }) => {
   await runBoth(async ({ result }) => {

--- a/e2e/cases/wasm/wasm-async/index.test.ts
+++ b/e2e/cases/wasm/wasm-async/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, findFile, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { findFile } from '@rstackjs/test-utils';
 
 test('should allow to dynamic import a Wasm file', async ({ build }) => {
   const rsbuild = await build();

--- a/e2e/cases/wasm/wasm-basic/index.test.ts
+++ b/e2e/cases/wasm/wasm-basic/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, findFile, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { findFile } from '@rstackjs/test-utils';
 
 test('should allow to import a Wasm file', async ({ page, buildPreview }) => {
   const rsbuild = await buildPreview();

--- a/e2e/cases/wasm/wasm-filename-hash-disabled/index.test.ts
+++ b/e2e/cases/wasm/wasm-filename-hash-disabled/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, findFile, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { findFile } from '@rstackjs/test-utils';
 
 test('should not allow to disable filename hash of Wasm files', async ({ buildPreview }) => {
   const rsbuild = await buildPreview();

--- a/e2e/cases/wasm/wasm-filename-hash/index.test.ts
+++ b/e2e/cases/wasm/wasm-filename-hash/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, findFile, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { findFile } from '@rstackjs/test-utils';
 
 test('should allow to custom the filename hash of Wasm files', async ({ buildPreview }) => {
   const rsbuild = await buildPreview();

--- a/e2e/cases/wasm/wasm-filename/index.test.ts
+++ b/e2e/cases/wasm/wasm-filename/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, findFile, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { findFile } from '@rstackjs/test-utils';
 
 test('should allow to custom the filename of Wasm files', async ({ buildPreview }) => {
   const rsbuild = await buildPreview();

--- a/e2e/cases/wasm/wasm-source-import/index.test.ts
+++ b/e2e/cases/wasm/wasm-source-import/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, findFile, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { findFile } from '@rstackjs/test-utils';
 
 test('should allow to import a Wasm module with source phase import', async ({
   page,

--- a/e2e/cases/wasm/wasm-url/index.test.ts
+++ b/e2e/cases/wasm/wasm-url/index.test.ts
@@ -1,4 +1,5 @@
-import { expect, findFile, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
+import { findFile } from '@rstackjs/test-utils';
 
 test('should allow to use new URL to get path of a Wasm file', async ({ page, buildPreview }) => {
   const rsbuild = await buildPreview();

--- a/e2e/helper/jsApi.ts
+++ b/e2e/helper/jsApi.ts
@@ -9,9 +9,10 @@ import {
   type RsbuildDevServer,
   type RsbuildInstance,
 } from '@rsbuild/core';
+import { getRandomPort, toPosixPath } from '@rstackjs/test-utils';
 import type { Page } from 'playwright';
 import type { LogHelper } from './logs.ts';
-import { getRandomPort, gotoPage, noop, toPosixPath } from './utils.ts';
+import { gotoPage, noop } from './utils.ts';
 
 const updateConfigForTest = async (originalConfig: RsbuildConfig, cwd: string = process.cwd()) => {
   const { loadConfig, mergeRsbuildConfig } = await import('@rsbuild/core');

--- a/e2e/helper/utils.ts
+++ b/e2e/helper/utils.ts
@@ -4,22 +4,6 @@ import { logger, type RsbuildPlugin } from '@rsbuild/core';
 import type { Page } from 'playwright';
 import { expect } from './fixture.ts';
 
-export {
-  type FileMatcher,
-  findFile,
-  type FindFileOptions,
-  getDistFiles,
-  getFileContent,
-  getRandomPort,
-  isPortAvailable,
-  normalizeEol,
-  readDirContents,
-  toPosixPath,
-  waitFor,
-  waitForFile,
-  waitForFileContent,
-} from '@rstackjs/test-utils';
-
 /**
  * Build an URL based on the entry name and port
  */

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -38,6 +38,7 @@
     "@rsbuild/plugin-tailwindcss": "workspace:*",
     "@rsbuild/plugin-type-check": "catalog:",
     "@rsbuild/plugin-vue": "workspace:*",
+    "@rstackjs/test-utils": "catalog:",
     "@scripts/test-helper": "workspace:*",
     "@tailwindcss/postcss": "catalog:",
     "@tailwindcss/webpack": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -526,6 +526,9 @@ importers:
       '@rsbuild/plugin-vue':
         specifier: workspace:*
         version: link:../packages/plugin-vue
+      '@rstackjs/test-utils':
+        specifier: 'catalog:'
+        version: 0.2.0
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../scripts/test-helper


### PR DESCRIPTION
## Summary

Imports shared e2e utilities directly from `@rstackjs/test-utils` instead of re-exporting them through `@e2e/helper`. This keeps the local helper entry focused on Rsbuild-specific fixtures and makes API ownership explicit.