### PR TITLE
perf(core): deduplicate concurrent loadBundle calls

### DIFF
--- a/packages/core/src/server/environment.ts
+++ b/packages/core/src/server/environment.ts
@@ -89,20 +89,30 @@ export const getTransformedHtml = (entryName: string, utils: ServerUtils): strin
 export const createCacheableFunction = <T>(
   getter: (stats: Rspack.Stats, entryName: string, utils: ServerUtils) => Promise<T> | T,
 ) => {
-  const cache = new WeakMap<Rspack.Stats, Record<string, T>>();
+  const cache = new WeakMap<Rspack.Stats, Map<string, Promise<T>>>();
 
-  return async (stats: Rspack.Stats, entryName: string, utils: ServerUtils): Promise<T> => {
-    const cachedEntries = cache.get(stats);
-    if (cachedEntries?.[entryName]) {
-      return cachedEntries[entryName];
+  return (stats: Rspack.Stats, entryName: string, utils: ServerUtils): Promise<T> => {
+    let cachedEntries = cache.get(stats);
+    if (!cachedEntries) {
+      cachedEntries = new Map();
+      cache.set(stats, cachedEntries);
     }
 
-    const res = await getter(stats, entryName, utils);
+    const cachedPromise = cachedEntries.get(entryName);
+    if (cachedPromise) {
+      return cachedPromise;
+    }
 
-    cache.set(stats, {
-      ...(cachedEntries || {}),
-      [entryName]: res,
-    });
-    return res;
+    // Cache the pending promise so concurrent calls share the same execution.
+    const promise = Promise.resolve()
+      .then(() => getter(stats, entryName, utils))
+      .catch((error) => {
+        // Do not cache failures, allowing the next call to retry.
+        cachedEntries.delete(entryName);
+        throw error;
+      });
+
+    cachedEntries.set(entryName, promise);
+    return promise;
   };
 };

--- a/packages/core/tests/environment.test.ts
+++ b/packages/core/tests/environment.test.ts
@@ -1,0 +1,43 @@
+import { createCacheableFunction, type ServerUtils } from '../src/server/environment';
+import type { Rspack } from '../src/types';
+
+const stats = {} as Rspack.Stats;
+const utils = {} as ServerUtils;
+
+test('should cache pending calls for the same compilation and entry', async () => {
+  let resolveGetter: ((value: string) => void) | undefined;
+  const getter = rstest.fn(
+    () =>
+      new Promise<string>((resolve) => {
+        resolveGetter = resolve;
+      }),
+  );
+  const cacheableGetter = createCacheableFunction(getter);
+
+  const first = cacheableGetter(stats, 'index', utils);
+  const second = cacheableGetter(stats, 'index', utils);
+
+  expect(first).toBe(second);
+  await Promise.resolve();
+  expect(getter).toHaveBeenCalledTimes(1);
+
+  resolveGetter?.('result');
+  await expect(first).resolves.toBe('result');
+  await expect(second).resolves.toBe('result');
+  await expect(cacheableGetter(stats, 'index', utils)).resolves.toBe('result');
+  expect(getter).toHaveBeenCalledTimes(1);
+});
+
+test('should retry after a pending call rejects', async () => {
+  const error = new Error('failed');
+  const getter = rstest.fn().mockRejectedValueOnce(error).mockResolvedValueOnce('result');
+  const cacheableGetter = createCacheableFunction<string>(getter);
+
+  const first = cacheableGetter(stats, 'index', utils);
+  const second = cacheableGetter(stats, 'index', utils);
+
+  expect(first).toBe(second);
+  await expect(first).rejects.toBe(error);
+  await expect(cacheableGetter(stats, 'index', utils)).resolves.toBe('result');
+  expect(getter).toHaveBeenCalledTimes(2);
+});


### PR DESCRIPTION
## Summary

Concurrent calls to `loadBundle` for the same compilation currently evaluate the server bundle more than once because the cache is populated only after evaluation completes.

This PR caches the pending promise per compilation and entry, while evicting rejected promises so later calls can retry.