### PR TITLE
feat(core): add HMR settlement API

### DIFF
--- a/e2e/cases/javascript-api/environment-hot-wait-until-settled/index.test.ts
+++ b/e2e/cases/javascript-api/environment-hot-wait-until-settled/index.test.ts
@@ -1,0 +1,53 @@
+import { join } from 'node:path';
+import { expect, HMR_CONNECTED_LOG, test } from '@e2e/helper';
+import type { HmrSettlement } from '@rsbuild/core';
+
+test('should wait until the matching HMR update is settled', async ({
+  page,
+  dev,
+  editFile,
+  copySrcDir,
+}) => {
+  const tempSrc = await copySrcDir();
+  const entryPath = join(tempSrc, 'index.ts');
+  const hmrConnected = page.waitForEvent('console', {
+    predicate: (message) => message.text() === HMR_CONNECTED_LOG,
+  });
+
+  const { instance, server } = await dev({
+    config: {
+      source: {
+        entry: {
+          index: entryPath,
+        },
+      },
+    },
+  });
+  await hmrConnected;
+
+  if (!server) {
+    throw new Error('Expected dev server');
+  }
+
+  let handled = false;
+  const settlementPromise = new Promise<HmrSettlement>((resolve) => {
+    instance.onAfterEnvironmentCompile(async ({ environment, stats }) => {
+      const hash = stats?.compilation.hash;
+      if (handled || environment.name !== 'web' || !hash) {
+        return;
+      }
+
+      handled = true;
+      resolve(await server.environments.web.hot.waitUntilSettled(hash));
+    });
+  });
+
+  await expect(page.locator('#title')).toHaveText('before');
+
+  await editFile(entryPath, (code) => code.replace('before', 'after'));
+  await expect(settlementPromise).resolves.toEqual({
+    hash: expect.any(String),
+    status: 'applied',
+  });
+  await expect(page.locator('#title')).toHaveText('after');
+});

--- a/e2e/cases/javascript-api/environment-hot-wait-until-settled/src/index.ts
+++ b/e2e/cases/javascript-api/environment-hot-wait-until-settled/src/index.ts
@@ -1,0 +1,5 @@
+/// <reference types="@rsbuild/core/types" />
+
+document.body.innerHTML = '<div id="title">before</div>';
+
+import.meta.webpackHot?.accept();

--- a/packages/core/src/client/hmr.ts
+++ b/packages/core/src/client/hmr.ts
@@ -1,6 +1,7 @@
 import type {
   ClientMessage,
   ClientMessageError,
+  ClientMessageHmrSettled,
   ServerMessage,
   ServerMessageErrors,
   ServerMessageFullReload,
@@ -211,15 +212,22 @@ export function init(
   // then resolved to the current compilation hash.
   const shouldUpdate = () => lastHash !== BUILD_HASH;
 
-  const handleApplyUpdates = (err: unknown, updatedModules: (string | number)[] | null) => {
+  const handleApplyUpdates = (
+    hash: string,
+    err: unknown,
+    updatedModules: (string | number)[] | null,
+  ) => {
     const forcedReload = err || !updatedModules;
     if (forcedReload) {
       if (err) {
         logger.error('[rsbuild] HMR update failed, performing full reload:', err);
       }
+      sendHmrSettled(hash, 'skipped');
       fullReload();
       return;
     }
+
+    sendHmrSettled(hash, 'applied');
 
     // While we were updating, there was a new update! Do it again.
     tryApplyUpdates();
@@ -238,20 +246,32 @@ export function init(
         return;
       }
 
+      const hash = lastHash;
+      if (!hash) {
+        return;
+      }
+
       // https://rspack.rs/api/runtime-api/module-variables#importmetawebpackhot
-      import.meta.webpackHot.check(true).then(
-        (updatedModules) => {
-          handleApplyUpdates(null, updatedModules);
-        },
-        (err: unknown) => {
-          handleApplyUpdates(err, null);
-        },
-      );
+      try {
+        import.meta.webpackHot.check(true).then(
+          (updatedModules) => {
+            handleApplyUpdates(hash, null, updatedModules);
+          },
+          (err: unknown) => {
+            handleApplyUpdates(hash, err, null);
+          },
+        );
+      } catch (err) {
+        handleApplyUpdates(hash, err, null);
+      }
       return;
     }
 
     // HotModuleReplacementPlugin is not registered in Rspack configuration
     // fallback to reload page
+    if (lastHash) {
+      sendHmrSettled(lastHash, 'skipped');
+    }
     fullReload();
   }
 
@@ -264,6 +284,13 @@ export function init(
     if (isSocketReady()) {
       socket!.send(JSON.stringify(data));
     }
+  };
+
+  const sendHmrSettled = (hash: string, status: ClientMessageHmrSettled['data']['status']) => {
+    socketSend({
+      type: 'hmr-settled',
+      data: { hash, status },
+    });
   };
 
   function onOpen() {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -80,6 +80,7 @@ export type {
   FilenameHash,
   HistoryApiFallbackContext,
   HistoryApiFallbackOptions,
+  HmrSettlement,
   HtmlBasicTag,
   HtmlConfig,
   HtmlFallback,

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -135,6 +135,7 @@ export async function createDevServer<
       compiler.compilers.forEach((compiler, index) => {
         compiler.hooks.watchRun.tap(hookOptions, () => {
           compileState.reset(index);
+          context.socketServer?.onBuildStart(context.environmentList[index].webSocketToken);
         });
         compiler.hooks.done.tap(hookOptions, (stats) => {
           compileState.done(index, stats);
@@ -143,6 +144,7 @@ export async function createDevServer<
     } else {
       compiler.hooks.watchRun.tap(hookOptions, () => {
         compileState.reset(0);
+        context.socketServer?.onBuildStart(context.environmentList[0].webSocketToken);
       });
       compiler.hooks.done.tap(hookOptions, (stats) => {
         compileState.done(0, stats);
@@ -269,6 +271,12 @@ export async function createDevServer<
       context: environment,
       hot: {
         send: createHotSend(environment.webSocketToken),
+        waitUntilSettled: async (hash) => {
+          if (!state.buildManager) {
+            throw new Error(getErrorMsg('hot.waitUntilSettled'));
+          }
+          return state.buildManager.socketServer.waitUntilSettled(environment.webSocketToken, hash);
+        },
       },
       getStats: async () => {
         if (!state.buildManager) {

--- a/packages/core/src/server/hmrTracker.ts
+++ b/packages/core/src/server/hmrTracker.ts
@@ -1,0 +1,210 @@
+import type { HmrSettlement } from '../types';
+
+type HmrSettlementStatus = HmrSettlement['status'];
+
+type UpdateRecord<Client> = {
+  clients: Set<Client>;
+  generation: number;
+  hash: string;
+  promise?: Promise<HmrSettlement>;
+  resolve?: (result: HmrSettlement) => void;
+  started: boolean;
+  status?: HmrSettlementStatus;
+  timeout?: NodeJS.Timeout;
+};
+
+type EnvironmentState<Client> = {
+  generation: number;
+  record?: UpdateRecord<Client>;
+};
+
+const HMR_SETTLEMENT_TIMEOUT = 2000;
+
+export class HmrTracker<Client> {
+  private readonly states = new Map<string, EnvironmentState<Client>>();
+
+  private readonly timeout: number;
+
+  constructor(timeout: number = HMR_SETTLEMENT_TIMEOUT) {
+    this.timeout = timeout;
+  }
+
+  public waitUntilSettled(
+    token: string,
+    hash: string,
+    clients?: ReadonlySet<Client>,
+  ): Promise<HmrSettlement> {
+    if (!clients?.size) {
+      return Promise.resolve({ hash, status: 'skipped' });
+    }
+
+    const state = this.getState(token);
+    const current = state.record;
+
+    if (current?.generation === state.generation) {
+      if (current.hash === hash) {
+        return this.waitFor(current);
+      }
+      if (current.started) {
+        return Promise.resolve({ hash, status: 'skipped' });
+      }
+    }
+
+    if (current) {
+      this.settle(current, 'skipped');
+    }
+
+    const record = this.createRecord(state.generation, hash, clients, false);
+    state.record = record;
+    return this.waitFor(record);
+  }
+
+  /** Start tracking the clients that can acknowledge this HMR update. */
+  public startUpdate(token: string, hash: string, clients?: ReadonlySet<Client>): void {
+    const state = this.getState(token);
+    let record = state.record;
+
+    if (record?.generation !== state.generation || record.hash !== hash) {
+      if (record) {
+        this.settle(record, 'skipped');
+      }
+      record = this.createRecord(state.generation, hash, clients, true);
+      state.record = record;
+    } else if (record.status === undefined) {
+      record.started = true;
+      record.clients = new Set(clients);
+    }
+
+    if (record.status === undefined && record.clients.size === 0) {
+      this.settle(record, 'skipped');
+    }
+  }
+
+  /** Mark an update as skipped when the build does not require or allow HMR. */
+  public skipUpdate(token: string, hash: string): void {
+    const state = this.getState(token);
+    let record = state.record;
+
+    if (record?.generation !== state.generation || record.hash !== hash) {
+      if (record) {
+        this.settle(record, 'skipped');
+      }
+      record = this.createRecord(state.generation, hash, undefined, true);
+      state.record = record;
+    } else {
+      record.started = true;
+    }
+
+    this.settle(record, 'skipped');
+  }
+
+  /** Settle active updates for one environment, or all environments, as skipped. */
+  public skipActive(token?: string): void {
+    if (token) {
+      const record = this.states.get(token)?.record;
+      if (record) {
+        this.settle(record, 'skipped');
+      }
+      return;
+    }
+
+    for (const { record } of this.states.values()) {
+      if (record) {
+        this.settle(record, 'skipped');
+      }
+    }
+  }
+
+  /** Invalidate the previous record so a repeated hash belongs to the new build. */
+  public onBuildStart(token: string): void {
+    const state = this.getState(token);
+    if (state.record) {
+      this.settle(state.record, 'skipped');
+    }
+    state.generation++;
+  }
+
+  public onClientSettled(
+    token: string,
+    client: Client,
+    hash: string,
+    status: HmrSettlementStatus,
+  ): void {
+    const record = this.states.get(token)?.record;
+    if (record?.hash === hash && record.clients.has(client)) {
+      this.settle(record, status);
+    }
+  }
+
+  public onDisconnect(token: string, client: Client): void {
+    const record = this.states.get(token)?.record;
+    if (record?.clients.delete(client) && record.clients.size === 0) {
+      this.settle(record, 'skipped');
+    }
+  }
+
+  public close(): void {
+    this.skipActive();
+    this.states.clear();
+  }
+
+  private createRecord(
+    generation: number,
+    hash: string,
+    clients: ReadonlySet<Client> | undefined,
+    started: boolean,
+  ): UpdateRecord<Client> {
+    return {
+      clients: new Set(clients),
+      generation,
+      hash,
+      started,
+    };
+  }
+
+  private getState(token: string): EnvironmentState<Client> {
+    let state = this.states.get(token);
+    if (!state) {
+      state = { generation: 0 };
+      this.states.set(token, state);
+    }
+    return state;
+  }
+
+  private settle(record: UpdateRecord<Client>, status: HmrSettlementStatus): void {
+    if (record.status !== undefined) {
+      return;
+    }
+
+    record.status = status;
+    record.clients.clear();
+    if (record.timeout) {
+      clearTimeout(record.timeout);
+      record.timeout = undefined;
+    }
+    record.resolve?.({ hash: record.hash, status });
+    record.promise = undefined;
+    record.resolve = undefined;
+  }
+
+  private waitFor(record: UpdateRecord<Client>): Promise<HmrSettlement> {
+    if (record.status !== undefined) {
+      return Promise.resolve({ hash: record.hash, status: record.status });
+    }
+    if (record.promise) {
+      return record.promise;
+    }
+
+    let resolve!: NonNullable<UpdateRecord<Client>['resolve']>;
+    const promise = new Promise<HmrSettlement>((resolver) => {
+      resolve = resolver;
+    });
+    record.promise = promise;
+    record.resolve = resolve;
+    record.timeout = setTimeout(() => {
+      record.timeout = undefined;
+      this.settle(record, 'timeout');
+    }, this.timeout).unref();
+    return promise;
+  }
+}

--- a/packages/core/src/server/hmrTracker.ts
+++ b/packages/core/src/server/hmrTracker.ts
@@ -18,6 +18,11 @@ type EnvironmentState<Client> = {
   record?: UpdateRecord<Client>;
 };
 
+type HmrBuildResult<Client> = {
+  clients?: ReadonlySet<Client>;
+  hash?: string;
+};
+
 const HMR_SETTLEMENT_TIMEOUT = 2000;
 
 export class HmrTracker<Client> {
@@ -59,8 +64,13 @@ export class HmrTracker<Client> {
     return this.waitFor(record);
   }
 
-  /** Start tracking the clients that can acknowledge this HMR update. */
-  public startUpdate(token: string, hash: string, clients?: ReadonlySet<Client>): void {
+  /** Track the clients of an HMR update, or skip it when no clients are provided. */
+  public onBuildResult(token: string, { clients, hash }: HmrBuildResult<Client>): void {
+    if (!hash) {
+      this.abortActive(token);
+      return;
+    }
+
     const state = this.getState(token);
     let record = state.record;
 
@@ -75,31 +85,13 @@ export class HmrTracker<Client> {
       record.clients = new Set(clients);
     }
 
-    if (record.status === undefined && record.clients.size === 0) {
+    if (!clients?.size) {
       this.settle(record, 'skipped');
     }
   }
 
-  /** Mark an update as skipped when the build does not require or allow HMR. */
-  public skipUpdate(token: string, hash: string): void {
-    const state = this.getState(token);
-    let record = state.record;
-
-    if (record?.generation !== state.generation || record.hash !== hash) {
-      if (record) {
-        this.settle(record, 'skipped');
-      }
-      record = this.createRecord(state.generation, hash, undefined, true);
-      state.record = record;
-    } else {
-      record.started = true;
-    }
-
-    this.settle(record, 'skipped');
-  }
-
-  /** Settle active updates for one environment, or all environments, as skipped. */
-  public skipActive(token?: string): void {
+  /** Abort active updates interrupted outside the build lifecycle. */
+  public abortActive(token?: string): void {
     if (token) {
       const record = this.states.get(token)?.record;
       if (record) {
@@ -144,7 +136,7 @@ export class HmrTracker<Client> {
   }
 
   public close(): void {
-    this.skipActive();
+    this.abortActive();
     this.states.clear();
   }
 

--- a/packages/core/src/server/hmrTracker.ts
+++ b/packages/core/src/server/hmrTracker.ts
@@ -3,13 +3,21 @@ import type { HmrSettlement } from '../types';
 type HmrSettlementStatus = HmrSettlement['status'];
 
 type UpdateRecord<Client> = {
+  /** Connected clients eligible to settle this update. */
   clients: Set<Client>;
+  /** Build generation used to distinguish repeated hashes. */
   generation: number;
+  /** Compilation hash for this update. */
   hash: string;
+  /** Shared settlement promise for all waiters. */
   promise?: Promise<HmrSettlement>;
+  /** Resolver for the shared settlement promise. */
   resolve?: (result: HmrSettlement) => void;
+  /** Whether onBuildResult has reported this update. */
   started: boolean;
+  /** Final status, or undefined while pending. */
   status?: HmrSettlementStatus;
+  /** Timer that settles this update with the timeout status. */
   timeout?: NodeJS.Timeout;
 };
 
@@ -44,7 +52,7 @@ export class HmrTracker<Client> {
     }
 
     const state = this.getState(token);
-    const current = state.record;
+    const { record: current } = state;
 
     if (current?.generation === state.generation) {
       if (current.hash === hash) {
@@ -59,7 +67,12 @@ export class HmrTracker<Client> {
       this.settle(current, 'skipped');
     }
 
-    const record = this.createRecord(state.generation, hash, clients, false);
+    const record: UpdateRecord<Client> = {
+      clients: new Set(clients),
+      generation: state.generation,
+      hash,
+      started: false,
+    };
     state.record = record;
     return this.waitFor(record);
   }
@@ -72,13 +85,18 @@ export class HmrTracker<Client> {
     }
 
     const state = this.getState(token);
-    let record = state.record;
+    let { record } = state;
 
     if (record?.generation !== state.generation || record.hash !== hash) {
       if (record) {
         this.settle(record, 'skipped');
       }
-      record = this.createRecord(state.generation, hash, clients, true);
+      record = {
+        clients: new Set(clients),
+        generation: state.generation,
+        hash,
+        started: true,
+      };
       state.record = record;
     } else if (record.status === undefined) {
       record.started = true;
@@ -138,20 +156,6 @@ export class HmrTracker<Client> {
   public close(): void {
     this.abortActive();
     this.states.clear();
-  }
-
-  private createRecord(
-    generation: number,
-    hash: string,
-    clients: ReadonlySet<Client> | undefined,
-    started: boolean,
-  ): UpdateRecord<Client> {
-    return {
-      clients: new Set(clients),
-      generation,
-      hash,
-      started,
-    };
   }
 
   private getState(token: string): EnvironmentState<Client> {

--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -341,9 +341,14 @@ export class SocketServer {
    */
   public sendMessage(message: ServerMessage, token?: string): void {
     if (message.type === 'full-reload' || message.type === 'static-changed') {
-      this.hmrTracker.skipActive(token);
+      this.hmrTracker.abortActive(token);
     }
 
+    this.broadcastMessage(message, token);
+  }
+
+  /** Broadcast without changing HMR settlement state. */
+  private broadcastMessage(message: ServerMessage, token?: string): void {
     const messageStr = JSON.stringify(message);
 
     const sendToSockets = (sockets: Set<WebSocket>) => {
@@ -615,29 +620,27 @@ export class SocketServer {
 
     this.initialChunksMap.set(token, newInitialChunks);
 
+    const prevHash = stats.hash ? this.currentHash.get(token) : undefined;
+    if (!force) {
+      const clients =
+        stats.hash && !shouldReload && errors.length === 0 && prevHash && prevHash !== stats.hash
+          ? this.socketsMap.get(token)
+          : undefined;
+
+      this.hmrTracker.onBuildResult(token, { clients, hash: stats.hash });
+    }
+
     if (shouldReload) {
-      if (stats.hash) {
-        this.hmrTracker.skipUpdate(token, stats.hash);
+      if (force) {
+        this.sendMessage({ type: 'full-reload' }, token);
       } else {
-        this.hmrTracker.skipActive(token);
+        this.broadcastMessage({ type: 'full-reload' }, token);
       }
-      this.sendMessage({ type: 'full-reload' }, token);
       return;
     }
 
     if (stats.hash) {
-      const prevHash = this.currentHash.get(token);
       this.currentHash.set(token, stats.hash);
-
-      if (!force) {
-        if (errors.length > 0) {
-          this.hmrTracker.skipUpdate(token, stats.hash);
-        } else if (!prevHash || prevHash === stats.hash) {
-          this.hmrTracker.skipUpdate(token, stats.hash);
-        } else {
-          this.hmrTracker.startUpdate(token, stats.hash, this.socketsMap.get(token));
-        }
-      }
 
       // If build hash is not changed and there is no error or warning,
       // skip the other messages
@@ -653,8 +656,6 @@ export class SocketServer {
         },
         token,
       );
-    } else if (!force) {
-      this.hmrTracker.skipActive(token);
     }
 
     if (errors.length > 0) {

--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -7,8 +7,16 @@ import { color, isObject } from '../helpers';
 import { formatStatsError } from '../helpers/format';
 import { isRuntimeOverlayEnabled } from '../helpers/overlayConfig';
 import { getStatsErrors, getStatsWarnings } from '../helpers/stats';
-import type { ClientConfig, DevConfig, InternalContext, RsbuildStatsItem, Rspack } from '../types';
+import type {
+  ClientConfig,
+  DevConfig,
+  HmrSettlement,
+  InternalContext,
+  RsbuildStatsItem,
+  Rspack,
+} from '../types';
 import { type CachedTraceMap, formatBrowserErrorLog } from './browserLogs';
+import { HmrTracker } from './hmrTracker';
 import { renderErrorToHtml } from './overlay';
 
 interface ExtWebSocket extends WebSocket {
@@ -108,7 +116,15 @@ export type ClientMessagePing = {
   type: 'ping';
 };
 
-export type ClientMessage = ClientMessagePing | ClientMessageError;
+export type ClientMessageHmrSettled = {
+  type: 'hmr-settled';
+  data: {
+    hash: string;
+    status: 'applied' | 'skipped';
+  };
+};
+
+export type ClientMessage = ClientMessagePing | ClientMessageError | ClientMessageHmrSettled;
 
 const parseQueryString = (req: IncomingMessage) => {
   const queryStr = req.url ? req.url.split('?')[1] : '';
@@ -159,6 +175,8 @@ export class SocketServer {
   private reportedBrowserLogs = new Set<string>();
 
   private currentHash = new Map<string, string>();
+
+  private readonly hmrTracker = new HmrTracker<WebSocket>();
 
   constructor(
     context: InternalContext,
@@ -256,6 +274,14 @@ export class SocketServer {
     }
   }
 
+  public onBuildStart(token: string): void {
+    this.hmrTracker.onBuildStart(token);
+  }
+
+  public waitUntilSettled(token: string, hash: string): Promise<HmrSettlement> {
+    return this.hmrTracker.waitUntilSettled(token, hash, this.socketsMap.get(token));
+  }
+
   /**
    * Send error messages to the client.
    */
@@ -314,6 +340,10 @@ export class SocketServer {
    * if not provided, the message will be sent to all sockets
    */
   public sendMessage(message: ServerMessage, token?: string): void {
+    if (message.type === 'full-reload' || message.type === 'static-changed') {
+      this.hmrTracker.skipActive(token);
+    }
+
     const messageStr = JSON.stringify(message);
 
     const sendToSockets = (sockets: Set<WebSocket>) => {
@@ -336,6 +366,7 @@ export class SocketServer {
 
   public async close(): Promise<void> {
     this.clearHeartbeatTimer();
+    this.hmrTracker.close();
 
     // Remove all event listeners
     this.wsServer.removeAllListeners();
@@ -390,6 +421,15 @@ export class SocketServer {
 
         const environment = this.getEnvironmentByToken(token);
         if (!environment) {
+          return;
+        }
+
+        if (
+          payload.type === 'hmr-settled' &&
+          typeof payload.data?.hash === 'string' &&
+          (payload.data.status === 'applied' || payload.data.status === 'skipped')
+        ) {
+          this.hmrTracker.onClientSettled(token, socket, payload.data.hash, payload.data.status);
           return;
         }
 
@@ -462,6 +502,8 @@ export class SocketServer {
     sockets.add(socket);
 
     socket.on('close', () => {
+      this.hmrTracker.onDisconnect(token, socket);
+
       const sockets = this.socketsMap.get(token);
       if (!sockets) {
         return;
@@ -574,6 +616,11 @@ export class SocketServer {
     this.initialChunksMap.set(token, newInitialChunks);
 
     if (shouldReload) {
+      if (stats.hash) {
+        this.hmrTracker.skipUpdate(token, stats.hash);
+      } else {
+        this.hmrTracker.skipActive(token);
+      }
       this.sendMessage({ type: 'full-reload' }, token);
       return;
     }
@@ -581,6 +628,16 @@ export class SocketServer {
     if (stats.hash) {
       const prevHash = this.currentHash.get(token);
       this.currentHash.set(token, stats.hash);
+
+      if (!force) {
+        if (errors.length > 0) {
+          this.hmrTracker.skipUpdate(token, stats.hash);
+        } else if (!prevHash || prevHash === stats.hash) {
+          this.hmrTracker.skipUpdate(token, stats.hash);
+        } else {
+          this.hmrTracker.startUpdate(token, stats.hash, this.socketsMap.get(token));
+        }
+      }
 
       // If build hash is not changed and there is no error or warning,
       // skip the other messages
@@ -596,6 +653,8 @@ export class SocketServer {
         },
         token,
       );
+    } else if (!force) {
+      this.hmrTracker.skipActive(token);
     }
 
     if (errors.length > 0) {

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1831,6 +1831,11 @@ export type ProgressBarConfig = {
 
 export type RequestHandler = Connect.NextHandleFunction;
 
+export type HmrSettlement = {
+  hash: string;
+  status: 'applied' | 'skipped' | 'timeout';
+};
+
 export type EnvironmentAPI = Record<
   string,
   {
@@ -1857,6 +1862,13 @@ export type EnvironmentAPI = Record<
      */
     hot: {
       send: HotSend;
+      /**
+       * Wait until the matching HMR update is settled by a connected client.
+       *
+       * The promise also resolves when the update does not require HMR, can no
+       * longer settle, or reaches the internal timeout.
+       */
+      waitUntilSettled: (hash: string) => Promise<HmrSettlement>;
     };
 
     /**

--- a/packages/core/tests/hmrTracker.test.ts
+++ b/packages/core/tests/hmrTracker.test.ts
@@ -1,17 +1,18 @@
 import { HmrTracker } from '../src/server/hmrTracker';
 
 const token = 'web';
+const hash = 'hash-1';
 
 test('should settle an update when wait is registered before broadcast', async () => {
   const tracker = new HmrTracker<object>();
   const client = {};
-  const promise = tracker.waitUntilSettled(token, 'hash-1', new Set([client]));
+  const promise = tracker.waitUntilSettled(token, hash, new Set([client]));
 
-  tracker.startUpdate(token, 'hash-1', new Set([client]));
-  tracker.onClientSettled(token, client, 'hash-1', 'applied');
+  tracker.onBuildResult(token, { clients: new Set([client]), hash });
+  tracker.onClientSettled(token, client, hash, 'applied');
 
   await expect(promise).resolves.toEqual({
-    hash: 'hash-1',
+    hash,
     status: 'applied',
   });
 });
@@ -20,11 +21,11 @@ test('should retain a settlement that arrives before wait is registered', async 
   const tracker = new HmrTracker<object>();
   const client = {};
 
-  tracker.startUpdate(token, 'hash-1', new Set([client]));
-  tracker.onClientSettled(token, client, 'hash-1', 'applied');
+  tracker.onBuildResult(token, { clients: new Set([client]), hash });
+  tracker.onClientSettled(token, client, hash, 'applied');
 
-  await expect(tracker.waitUntilSettled(token, 'hash-1', new Set([client]))).resolves.toEqual({
-    hash: 'hash-1',
+  await expect(tracker.waitUntilSettled(token, hash, new Set([client]))).resolves.toEqual({
+    hash,
     status: 'applied',
   });
 });
@@ -33,22 +34,22 @@ test('should ignore stale acknowledgements and acknowledgements from other clien
   const tracker = new HmrTracker<object>();
   const client = {};
   const otherClient = {};
-  const promise = tracker.waitUntilSettled(token, 'hash-1', new Set([client]));
+  const promise = tracker.waitUntilSettled(token, hash, new Set([client]));
   let result: string | undefined;
   promise.then((settlement) => {
     result = settlement.status;
   });
 
-  tracker.startUpdate(token, 'hash-1', new Set([client]));
+  tracker.onBuildResult(token, { clients: new Set([client]), hash });
   tracker.onClientSettled(token, client, 'stale-hash', 'applied');
-  tracker.onClientSettled(token, otherClient, 'hash-1', 'applied');
+  tracker.onClientSettled(token, otherClient, hash, 'applied');
 
   await Promise.resolve();
   expect(result).toBeUndefined();
 
-  tracker.onClientSettled(token, client, 'hash-1', 'skipped');
+  tracker.onClientSettled(token, client, hash, 'skipped');
   await expect(promise).resolves.toEqual({
-    hash: 'hash-1',
+    hash,
     status: 'skipped',
   });
 });
@@ -57,20 +58,34 @@ test('should resolve when all relevant clients disconnect', async () => {
   const tracker = new HmrTracker<object>();
   const clientA = {};
   const clientB = {};
-  const promise = tracker.waitUntilSettled(token, 'hash-1', new Set([clientA, clientB]));
+  const promise = tracker.waitUntilSettled(token, hash, new Set([clientA, clientB]));
   let resolved = false;
   promise.then(() => {
     resolved = true;
   });
 
-  tracker.startUpdate(token, 'hash-1', new Set([clientA, clientB]));
+  tracker.onBuildResult(token, { clients: new Set([clientA, clientB]), hash });
   tracker.onDisconnect(token, clientA);
   await Promise.resolve();
   expect(resolved).toBe(false);
 
   tracker.onDisconnect(token, clientB);
   await expect(promise).resolves.toEqual({
-    hash: 'hash-1',
+    hash,
+    status: 'skipped',
+  });
+});
+
+test('should abort an active update', async () => {
+  const tracker = new HmrTracker<object>();
+  const client = {};
+  const promise = tracker.waitUntilSettled(token, hash, new Set([client]));
+
+  tracker.onBuildResult(token, { clients: new Set([client]), hash });
+  tracker.abortActive(token);
+
+  await expect(promise).resolves.toEqual({
+    hash,
     status: 'skipped',
   });
 });
@@ -78,13 +93,13 @@ test('should resolve when all relevant clients disconnect', async () => {
 test('should resolve an older update when a new build starts', async () => {
   const tracker = new HmrTracker<object>();
   const client = {};
-  const promise = tracker.waitUntilSettled(token, 'hash-1', new Set([client]));
+  const promise = tracker.waitUntilSettled(token, hash, new Set([client]));
 
-  tracker.startUpdate(token, 'hash-1', new Set([client]));
+  tracker.onBuildResult(token, { clients: new Set([client]), hash });
   tracker.onBuildStart(token);
 
   await expect(promise).resolves.toEqual({
-    hash: 'hash-1',
+    hash,
     status: 'skipped',
   });
 });
@@ -93,15 +108,15 @@ test('should track a new build separately when its hash is unchanged', async () 
   const tracker = new HmrTracker<object>();
   const client = {};
 
-  tracker.startUpdate(token, 'hash-1', new Set([client]));
-  tracker.onClientSettled(token, client, 'hash-1', 'applied');
+  tracker.onBuildResult(token, { clients: new Set([client]), hash });
+  tracker.onClientSettled(token, client, hash, 'applied');
   tracker.onBuildStart(token);
 
-  const promise = tracker.waitUntilSettled(token, 'hash-1', new Set([client]));
-  tracker.skipUpdate(token, 'hash-1');
+  const promise = tracker.waitUntilSettled(token, hash, new Set([client]));
+  tracker.onBuildResult(token, { hash });
 
   await expect(promise).resolves.toEqual({
-    hash: 'hash-1',
+    hash,
     status: 'skipped',
   });
 });
@@ -110,10 +125,23 @@ test('should retain a skipped result for a later waiter', async () => {
   const tracker = new HmrTracker<object>();
   const client = {};
 
-  tracker.skipUpdate(token, 'hash-1');
+  tracker.onBuildResult(token, { hash });
 
-  await expect(tracker.waitUntilSettled(token, 'hash-1', new Set([client]))).resolves.toEqual({
-    hash: 'hash-1',
+  await expect(tracker.waitUntilSettled(token, hash, new Set([client]))).resolves.toEqual({
+    hash,
+    status: 'skipped',
+  });
+});
+
+test('should skip an active waiter when the build has no hash', async () => {
+  const tracker = new HmrTracker<object>();
+  const client = {};
+  const promise = tracker.waitUntilSettled(token, hash, new Set([client]));
+
+  tracker.onBuildResult(token, {});
+
+  await expect(promise).resolves.toEqual({
+    hash,
     status: 'skipped',
   });
 });
@@ -121,8 +149,8 @@ test('should retain a skipped result for a later waiter', async () => {
 test('should resolve immediately when no client is connected', async () => {
   const tracker = new HmrTracker<object>();
 
-  await expect(tracker.waitUntilSettled(token, 'hash-1')).resolves.toEqual({
-    hash: 'hash-1',
+  await expect(tracker.waitUntilSettled(token, hash)).resolves.toEqual({
+    hash,
     status: 'skipped',
   });
 });
@@ -131,8 +159,8 @@ test('should time out when no settlement arrives', async () => {
   const tracker = new HmrTracker<object>(1);
   const client = {};
 
-  await expect(tracker.waitUntilSettled(token, 'hash-1', new Set([client]))).resolves.toEqual({
-    hash: 'hash-1',
+  await expect(tracker.waitUntilSettled(token, hash, new Set([client]))).resolves.toEqual({
+    hash,
     status: 'timeout',
   });
 });

--- a/packages/core/tests/hmrTracker.test.ts
+++ b/packages/core/tests/hmrTracker.test.ts
@@ -1,0 +1,138 @@
+import { HmrTracker } from '../src/server/hmrTracker';
+
+const token = 'web';
+
+test('should settle an update when wait is registered before broadcast', async () => {
+  const tracker = new HmrTracker<object>();
+  const client = {};
+  const promise = tracker.waitUntilSettled(token, 'hash-1', new Set([client]));
+
+  tracker.startUpdate(token, 'hash-1', new Set([client]));
+  tracker.onClientSettled(token, client, 'hash-1', 'applied');
+
+  await expect(promise).resolves.toEqual({
+    hash: 'hash-1',
+    status: 'applied',
+  });
+});
+
+test('should retain a settlement that arrives before wait is registered', async () => {
+  const tracker = new HmrTracker<object>();
+  const client = {};
+
+  tracker.startUpdate(token, 'hash-1', new Set([client]));
+  tracker.onClientSettled(token, client, 'hash-1', 'applied');
+
+  await expect(tracker.waitUntilSettled(token, 'hash-1', new Set([client]))).resolves.toEqual({
+    hash: 'hash-1',
+    status: 'applied',
+  });
+});
+
+test('should ignore stale acknowledgements and acknowledgements from other clients', async () => {
+  const tracker = new HmrTracker<object>();
+  const client = {};
+  const otherClient = {};
+  const promise = tracker.waitUntilSettled(token, 'hash-1', new Set([client]));
+  let result: string | undefined;
+  promise.then((settlement) => {
+    result = settlement.status;
+  });
+
+  tracker.startUpdate(token, 'hash-1', new Set([client]));
+  tracker.onClientSettled(token, client, 'stale-hash', 'applied');
+  tracker.onClientSettled(token, otherClient, 'hash-1', 'applied');
+
+  await Promise.resolve();
+  expect(result).toBeUndefined();
+
+  tracker.onClientSettled(token, client, 'hash-1', 'skipped');
+  await expect(promise).resolves.toEqual({
+    hash: 'hash-1',
+    status: 'skipped',
+  });
+});
+
+test('should resolve when all relevant clients disconnect', async () => {
+  const tracker = new HmrTracker<object>();
+  const clientA = {};
+  const clientB = {};
+  const promise = tracker.waitUntilSettled(token, 'hash-1', new Set([clientA, clientB]));
+  let resolved = false;
+  promise.then(() => {
+    resolved = true;
+  });
+
+  tracker.startUpdate(token, 'hash-1', new Set([clientA, clientB]));
+  tracker.onDisconnect(token, clientA);
+  await Promise.resolve();
+  expect(resolved).toBe(false);
+
+  tracker.onDisconnect(token, clientB);
+  await expect(promise).resolves.toEqual({
+    hash: 'hash-1',
+    status: 'skipped',
+  });
+});
+
+test('should resolve an older update when a new build starts', async () => {
+  const tracker = new HmrTracker<object>();
+  const client = {};
+  const promise = tracker.waitUntilSettled(token, 'hash-1', new Set([client]));
+
+  tracker.startUpdate(token, 'hash-1', new Set([client]));
+  tracker.onBuildStart(token);
+
+  await expect(promise).resolves.toEqual({
+    hash: 'hash-1',
+    status: 'skipped',
+  });
+});
+
+test('should track a new build separately when its hash is unchanged', async () => {
+  const tracker = new HmrTracker<object>();
+  const client = {};
+
+  tracker.startUpdate(token, 'hash-1', new Set([client]));
+  tracker.onClientSettled(token, client, 'hash-1', 'applied');
+  tracker.onBuildStart(token);
+
+  const promise = tracker.waitUntilSettled(token, 'hash-1', new Set([client]));
+  tracker.skipUpdate(token, 'hash-1');
+
+  await expect(promise).resolves.toEqual({
+    hash: 'hash-1',
+    status: 'skipped',
+  });
+});
+
+test('should retain a skipped result for a later waiter', async () => {
+  const tracker = new HmrTracker<object>();
+  const client = {};
+
+  tracker.skipUpdate(token, 'hash-1');
+
+  await expect(tracker.waitUntilSettled(token, 'hash-1', new Set([client]))).resolves.toEqual({
+    hash: 'hash-1',
+    status: 'skipped',
+  });
+});
+
+test('should resolve immediately when no client is connected', async () => {
+  const tracker = new HmrTracker<object>();
+
+  await expect(tracker.waitUntilSettled(token, 'hash-1')).resolves.toEqual({
+    hash: 'hash-1',
+    status: 'skipped',
+  });
+});
+
+test('should time out when no settlement arrives', async () => {
+  const tracker = new HmrTracker<object>(1);
+  const client = {};
+
+  await expect(tracker.waitUntilSettled(token, 'hash-1', new Set([client]))).resolves.toEqual({
+    hash: 'hash-1',
+    status: 'timeout',
+  });
+});

--- a/website/docs/en/api/javascript-api/environment-api.mdx
+++ b/website/docs/en/api/javascript-api/environment-api.mdx
@@ -230,6 +230,7 @@ type EnvironmentAPI = {
     getTransformedHtml: (entryName: string) => Promise<string>;
     hot: {
       send: HotSend;
+      waitUntilSettled: (hash: string) => Promise<HmrSettlement>;
     };
   };
 };
@@ -307,6 +308,41 @@ const html = await environments.web.getTransformedHtml('main');
 ```
 
 This method returns the complete HTML string, including all resources and content injected through HTML plugins.
+
+### hot.waitUntilSettled
+
+Wait for the current environment's HMR update to finish in the browser. Get the current compilation hash from `compilation.hash`.
+
+This method is useful when a server integration needs to defer synchronous work that would otherwise block the dev server from delivering HMR assets.
+
+- **Type:**
+
+```ts
+type HmrSettlement = {
+  hash: string;
+  status: 'applied' | 'skipped' | 'timeout';
+};
+
+type WaitUntilSettled = (hash: string) => Promise<HmrSettlement>;
+```
+
+- **Example:**
+
+```ts
+const result = await environments.web.hot.waitUntilSettled(webCompilation.hash);
+
+if (result.status === 'applied') {
+  // The browser has finished applying this HMR update.
+}
+```
+
+The promise also resolves without waiting for a browser acknowledgement when HMR is unnecessary or cannot continue:
+
+| Status    | Meaning                                                                                                       |
+| --------- | ------------------------------------------------------------------------------------------------------------- |
+| `applied` | A browser applied the HMR update.                                                                             |
+| `skipped` | HMR did not need to run or could not continue, such as an unchanged hash, failed build, reload, or no client. |
+| `timeout` | The browser did not settle the update before timeout.                                                         |
 
 ### hot.send
 

--- a/website/docs/zh/api/javascript-api/environment-api.mdx
+++ b/website/docs/zh/api/javascript-api/environment-api.mdx
@@ -231,6 +231,7 @@ type EnvironmentAPI = {
     getTransformedHtml: (entryName: string) => Promise<string>;
     hot: {
       send: HotSend;
+      waitUntilSettled: (hash: string) => Promise<HmrSettlement>;
     };
   };
 };
@@ -308,6 +309,41 @@ const html = await environments.web.getTransformedHtml('main');
 ```
 
 该方法会返回完整的 HTML 字符串，包含了所有通过 HTML 插件注入的资源和内容。
+
+### hot.waitUntilSettled
+
+等待当前 environment 当前的 HMR 更新在浏览器中完成。`hash` 为本次编译的 hash，可以通过 `compilation.hash` 获取。
+
+当服务端集成需要延后可能阻塞 dev server 发送 HMR 资源的同步任务时，可以使用该方法。
+
+- **类型：**
+
+```ts
+type HmrSettlement = {
+  hash: string;
+  status: 'applied' | 'skipped' | 'timeout';
+};
+
+type WaitUntilSettled = (hash: string) => Promise<HmrSettlement>;
+```
+
+- **示例：**
+
+```ts
+const result = await environments.web.hot.waitUntilSettled(webCompilation.hash);
+
+if (result.status === 'applied') {
+  // 浏览器已完成此次 HMR 更新。
+}
+```
+
+当 HMR 无需执行或无法继续时，该 Promise 也会直接返回，无需等待浏览器确认：
+
+| 状态      | 含义                                                                               |
+| --------- | ---------------------------------------------------------------------------------- |
+| `applied` | 浏览器已应用 HMR 更新。                                                            |
+| `skipped` | HMR 无需执行或无法继续，例如 hash 未变化、构建失败、整页刷新或没有已连接的客户端。 |
+| `timeout` | 浏览器未能在超时前完成此次更新。                                                   |
 
 ### hot.send
 


### PR DESCRIPTION
## Summary

This PR adds `environment.hot.waitUntilSettled` so SSR integrations can wait for browser HMR to settle before continuing dependent work.

It adds browser acknowledgements, server-side settlement tracking with `applied`, `skipped`, and `timeout` results, focused unit and e2e coverage, and API documentation.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/8104