### PR TITLE
fix(core): handle relative asset prefix for lazy compilation

### DIFF
--- a/e2e/cases/lazy-compilation/client-url/index.test.ts
+++ b/e2e/cases/lazy-compilation/client-url/index.test.ts
@@ -1,4 +1,4 @@
-import { createServer, type Server } from 'node:http';
+import { createServer, request, type Server } from 'node:http';
 import { expect, gotoPage, test } from '@e2e/helper';
 import { getRandomPort } from '@rstackjs/test-utils';
 
@@ -81,6 +81,80 @@ test('should use dev.client URL for lazy compilation trigger requests', async ({
 
     await expect(page.locator('#result')).toHaveText('lazy loaded');
     expect(lazyTriggerRequests).toContain(`http://localhost:${rsbuildPort}/_rspack/lazy/trigger`);
+  } finally {
+    await close(backendServer);
+  }
+});
+
+test('should use current page URL when dev.assetPrefix is relative', async ({ page, devOnly }) => {
+  const rsbuildPort = await getRandomPort();
+  const backendPort = await getRandomPort();
+  const lazyTriggerRequests: string[] = [];
+
+  page.on('request', (request) => {
+    if (request.url().includes('/_rspack/lazy/trigger')) {
+      lazyTriggerRequests.push(request.url());
+    }
+  });
+
+  const rsbuild = await devOnly({
+    config: {
+      server: {
+        port: rsbuildPort,
+      },
+      dev: {
+        assetPrefix: '/dev-platform',
+        client: {
+          host: '127.0.0.1',
+          port: rsbuildPort,
+        },
+      },
+    },
+  });
+
+  const htmlResponse = await fetch(`http://localhost:${rsbuild.port}/index.html`);
+  expect(htmlResponse.ok).toBeTruthy();
+
+  const html = await htmlResponse.text();
+  const backendServer = createServer((req, res) => {
+    if (req.url === '/' || req.url === '/index.html') {
+      res.setHeader('Content-Type', 'text/html');
+      res.end(html);
+      return;
+    }
+
+    const proxyRequest = request(
+      {
+        hostname: 'localhost',
+        port: rsbuildPort,
+        path: req.url,
+        method: req.method,
+        headers: req.headers,
+      },
+      (proxyResponse) => {
+        res.writeHead(proxyResponse.statusCode ?? 500, proxyResponse.headers);
+        proxyResponse.pipe(res);
+      },
+    );
+    proxyRequest.on('error', (error) => {
+      res.statusCode = 502;
+      res.end(error.message);
+    });
+    req.pipe(proxyRequest);
+  });
+
+  await listen(backendServer, backendPort);
+
+  try {
+    await page.goto(`http://localhost:${backendPort}`);
+    await expect(page.locator('#result')).toHaveText('initial');
+
+    await page.locator('#load').click();
+    await rsbuild.expectLog('building src/lazy.js', { posix: true });
+    await rsbuild.expectBuildEnd();
+
+    await expect(page.locator('#result')).toHaveText('lazy loaded');
+    expect(lazyTriggerRequests).toContain(`http://localhost:${backendPort}/_rspack/lazy/trigger`);
   } finally {
     await close(backendServer);
   }

--- a/packages/core/src/plugins/lazyCompilation.ts
+++ b/packages/core/src/plugins/lazyCompilation.ts
@@ -1,3 +1,4 @@
+import { isURL } from '../helpers/url';
 import { getHostInUrl } from '../server/helper';
 import { replacePortPlaceholder } from '../server/open';
 import type { NormalizedEnvironmentConfig, RsbuildContext, RsbuildPlugin } from '../types';
@@ -6,6 +7,16 @@ const getServerUrlFromClientConfig = async (
   config: NormalizedEnvironmentConfig,
   context: RsbuildContext,
 ): Promise<string | undefined> => {
+  const { assetPrefix } = config.dev;
+  const hasAbsoluteAssetPrefix =
+    assetPrefix === true || (typeof assetPrefix === 'string' && isURL(assetPrefix));
+
+  // A relative asset prefix indicates that page requests are routed through the
+  // current origin, so the lazy compilation endpoint should follow the same route.
+  if (!hasAbsoluteAssetPrefix) {
+    return;
+  }
+
   const { devServer } = context;
   if (!devServer) {
     return;

--- a/website/docs/en/config/dev/lazy-compilation.mdx
+++ b/website/docs/en/config/dev/lazy-compilation.mdx
@@ -142,7 +142,12 @@ When the `imports` option is enabled, all async modules will only be compiled wh
 
 Use [lazyCompilation.serverUrl](https://rspack.rs/config/lazy-compilation#lazycompilationserverurl) to tell the client the server URL that needs to be requested.
 
-If `lazyCompilation.serverUrl` is not configured and `dev.client.host` or `dev.client.port` is specified, Rsbuild will use the `dev.client` URL as the default `serverUrl`.
+If `lazyCompilation.serverUrl` is not configured, Rsbuild will use the `dev.client` URL as the default `serverUrl` when both of the following conditions are met:
+
+- `dev.assetPrefix` is `true` or an absolute URL.
+- `dev.client.host` or `dev.client.port` is specified.
+
+When `dev.assetPrefix` is a relative URL, the lazy compilation request stays relative to the current page so that it can be forwarded by a proxy server.
 
 An explicitly configured `lazyCompilation.serverUrl` always takes priority over the default value inferred from `dev.client`.
 

--- a/website/docs/zh/config/dev/lazy-compilation.mdx
+++ b/website/docs/zh/config/dev/lazy-compilation.mdx
@@ -142,7 +142,12 @@ export default {
 
 通过 [lazyCompilation.serverUrl](https://rspack.rs/zh/config/lazy-compilation#lazycompilationserverurl) 可以指定 client 需要请求的 server URL。
 
-如果未配置 `lazyCompilation.serverUrl`，并且设置了 `dev.client.host` 或 `dev.client.port`，Rsbuild 会将 `dev.client` 对应的 URL 作为默认的 `serverUrl`。
+如果未配置 `lazyCompilation.serverUrl`，并且同时满足以下条件，Rsbuild 会将 `dev.client` 对应的 URL 作为默认的 `serverUrl`：
+
+- `dev.assetPrefix` 为 `true` 或绝对 URL。
+- 设置了 `dev.client.host` 或 `dev.client.port`。
+
+当 `dev.assetPrefix` 为相对 URL 时，懒编译请求会保持相对于当前页面，以便由代理服务器转发。
 
 如果显式配置了 `lazyCompilation.serverUrl`，该配置始终优先于从 `dev.client` 推导出的默认值。
 


### PR DESCRIPTION
## Summary
When an application is served through a reverse proxy with a relative `dev.assetPrefix`, `dev.client` may still point directly to the local Rsbuild server for HMR. Rsbuild previously reused the `dev.client` URL as `lazyCompilation.serverUrl`, causing lazy compilation requests to bypass the page proxy and potentially fail because of cross-origin restrictions.

This PR only infers `lazyCompilation.serverUrl` from `dev.client` when `dev.assetPrefix` is `true` or an absolute URL. For relative asset prefixes, lazy compilation requests remain relative to the current page origin. It also adds reverse-proxy E2E coverage and updates the related documentation.

### Resolution Rules

The `serverUrl` is resolved according to the following priority:

1. If `lazyCompilation.serverUrl` is explicitly configured, the user-provided value is used.
2. Otherwise, if `dev.assetPrefix` is `true` or an absolute URL and `dev.client` specifies a host or port, `serverUrl` is inferred from `dev.client`.
3. If `dev.assetPrefix` is relative, `serverUrl` remains `undefined`.
4. An explicitly configured `lazyCompilation.prefix` is preserved independently of `serverUrl`.

Rspack constructs the final lazy compilation request URL as follows:

```ts
const requestUrl = serverUrl ? serverUrl + prefix : prefix;
```

## Related Links

<!--- Provide links of related issues or pages -->
