### PR TITLE
fix(core): correct CLI subcommand help

### DIFF
--- a/e2e/cases/cli/help/index.test.ts
+++ b/e2e/cases/cli/help/index.test.ts
@@ -1,0 +1,28 @@
+import { stripVTControlCharacters as stripAnsi } from 'node:util';
+import { expect, test } from '@e2e/helper';
+
+test('should show the root help', ({ execCliSync }) => {
+  const output = stripAnsi(execCliSync('-h'));
+
+  expect(output).toContain('Usage:\n  $ rsbuild [command] [options]');
+  expect(output).toContain('Commands:');
+  expect(output).toContain('For details on a sub-command, run:');
+});
+
+test('should show the dev command help', ({ execCliSync }) => {
+  for (const args of ['dev -h', '-h dev']) {
+    const output = stripAnsi(execCliSync(args));
+
+    expect(output).toContain('Usage:\n  $ rsbuild dev [options]');
+    expect(output).not.toContain('Commands:');
+    expect(output).not.toContain('For details on a sub-command, run:');
+  }
+});
+
+test('should show the build command help', ({ execCliSync }) => {
+  const output = stripAnsi(execCliSync('build -h'));
+
+  expect(output).toContain('Usage:\n  $ rsbuild build [options]');
+  expect(output).not.toContain('Commands:');
+  expect(output).not.toContain('For details on a sub-command, run:');
+});

--- a/e2e/cases/cli/help/src/index.ts
+++ b/e2e/cases/cli/help/src/index.ts
@@ -1,0 +1,1 @@
+console.log('hello');

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -195,12 +195,14 @@ export function setupCommands(argv: string[]): void {
     // remove the default version log as we already log it in greeting
     sections.shift();
 
+    const commandName = cli.matchedCommandName;
+    sections = sections.filter(
+      ({ title }) => !commandName || (title !== 'Commands' && !title?.startsWith('For more info')),
+    );
+
     for (const section of sections) {
       if (section.title === 'Usage') {
-        section.body = section.body.replace(
-          '$ rsbuild',
-          color.yellow(`$ rsbuild [command] [options]`),
-        );
+        section.body = `  ${color.yellow(`$ rsbuild ${commandName || '[command]'} [options]`)}`;
       }
 
       // Fix the dev command name
@@ -211,7 +213,7 @@ export function setupCommands(argv: string[]): void {
         );
       }
 
-      // Simplify the help output for sub-commands
+      // Simplify the root help instructions for sub-commands
       if (section.title?.startsWith('For more info')) {
         section.title = color.dim('  For details on a sub-command, run');
         section.body = color.dim('  $ rsbuild <command> -h');
@@ -219,6 +221,8 @@ export function setupCommands(argv: string[]): void {
         section.title = color.cyan(section.title);
       }
     }
+
+    return sections;
   });
 
   cli.parse(argv);


### PR DESCRIPTION
## Summary

`rsbuild dev -h` currently renders the root command list because `dev` is also registered as the default command. This PR makes help output command-aware so subcommand help uses the correct usage and omits root-only sections, with end-to-end coverage.