### PR TITLE
feat(core): add restart type to dev.watchFiles

### DIFF
--- a/e2e/cases/cli/watch-files/rsbuild.config.ts
+++ b/e2e/cases/cli/watch-files/rsbuild.config.ts
@@ -6,7 +6,7 @@ import content from './test-temp-config';
 export default defineConfig({
   dev: {
     watchFiles: {
-      type: 'reload-server',
+      type: 'restart',
       paths: ['./test-temp-config.ts'],
     },
   },

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -121,7 +121,7 @@ const loadConfig = async (root: string) => {
       ...(config.dev.watchFiles ? castArray(config.dev.watchFiles) : []),
       {
         paths: [filePath, ...dependencies],
-        type: 'reload-server',
+        type: 'restart',
       },
     ];
   }
@@ -168,7 +168,7 @@ export async function init({
 
       if (config.dev.watchFiles) {
         for (const watchConfig of config.dev.watchFiles) {
-          if (watchConfig.type !== 'reload-server') {
+          if (watchConfig.type !== 'restart' && watchConfig.type !== 'reload-server') {
             continue;
           }
 

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -125,7 +125,7 @@ function applyEnvsToConfig(config: RsbuildConfig, envs: LoadEnvResult | null) {
     ...(config.dev.watchFiles ? castArray(config.dev.watchFiles) : []),
     {
       paths: envs.filePaths,
-      type: 'reload-server',
+      type: 'restart',
     },
   ];
 

--- a/packages/core/src/initConfigs.ts
+++ b/packages/core/src/initConfigs.ts
@@ -275,12 +275,12 @@ export async function initRsbuildConfig({
     environments[name] = normalizedEnvironmentConfig;
   }
 
-  // watch tsconfig files and restart server when tsconfig files changed
-  // to ensure `paths` alias can be updated
+  // Watch tsconfig files and restart the dev server or watch build when they change
+  // to ensure that `paths` aliases can be updated.
   if (tsconfigPaths.size && normalizedBaseConfig.resolve.aliasStrategy === 'prefer-tsconfig') {
     normalizedBaseConfig.dev.watchFiles.push({
       paths: Array.from(tsconfigPaths),
-      type: 'reload-server',
+      type: 'restart',
     });
   }
 

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1955,10 +1955,13 @@ export type WatchFiles = {
    */
   options?: ChokidarOptions;
   /**
-   * Specifies whether to reload the page or restart the dev server when files change.
+   * Specifies the action to take when files change.
+   * - `reload-page`: Reload the page.
+   * - `restart`: Restart the dev server or watch build.
+   * - `reload-server`: Deprecated alias for `restart`.
    * @default 'reload-page'
    */
-  type?: 'reload-page' | 'reload-server';
+  type?: 'reload-page' | 'restart' | 'reload-server';
 };
 
 export type CliShortcut = {
@@ -2072,7 +2075,7 @@ export interface DevConfig {
   writeToDisk?: WriteToDisk;
   /**
    * Watch specified files and directories for changes. When a file change is detected,
-   * it can trigger a page reload or restart the dev server.
+   * it can trigger a page reload or restart the dev server or watch build.
    * @default undefined
    */
   watchFiles?: WatchFiles | WatchFiles[];

--- a/website/docs/en/config/dev/watch-files.mdx
+++ b/website/docs/en/config/dev/watch-files.mdx
@@ -1,5 +1,5 @@
 ---
-description: 'Watch specified files and directories for changes. When a change is detected, it can trigger a page reload or restart the dev server.'
+description: 'Watch specified files and directories for changes. When a change is detected, it can trigger a page reload or restart the dev server or watch build.'
 ---
 
 # dev.watchFiles
@@ -9,7 +9,7 @@ description: 'Watch specified files and directories for changes. When a change i
 ```ts
 type WatchFiles = {
   paths: string | string[];
-  type?: 'reload-page' | 'reload-server';
+  type?: 'reload-page' | 'restart' | 'reload-server';
   // watch options for chokidar
   options?: ChokidarOptions;
 };
@@ -19,7 +19,7 @@ type WatchFilesConfig = WatchFiles | WatchFiles[];
 
 - **Default:** `undefined`
 
-Watch specified files and directories for changes. When a change is detected, it can trigger a page reload or restart the dev server.
+Watch specified files and directories for changes. When a change is detected, it can trigger a page reload or restart the dev server or watch build.
 
 ## paths
 
@@ -66,10 +66,10 @@ export default {
 
 ## type
 
-- **Type:** `'reload-page' | 'reload-server'`
+- **Type:** `'reload-page' | 'restart' | 'reload-server'`
 - **Default:** `'reload-page'`
 
-Specifies whether to trigger a page reload or restart the dev server when a file changes.
+Specifies whether to trigger a page reload or restart the dev server or watch build when a file changes.
 
 ### reload-page
 
@@ -90,11 +90,13 @@ export default {
 
 > If both [dev.hmr](/config/dev/hmr) and [dev.liveReload](/config/dev/live-reload) are set to `false`, the page will not automatically reload.
 
-### reload-server
+### restart
 
-`reload-server` means that the dev server will automatically restart when a file changes. This can be used to watch changes to configuration files, such as modules imported by your `rsbuild.config.ts` file.
+`restart` restarts the dev server when running `rsbuild dev`, or restarts the watch build when running `rsbuild build --watch`.
 
-For example, if you maintain some common configuration files in the `config` directory, such as `common.ts`, you may want the dev server to automatically restart when these files change. Example configuration:
+This can be used to watch configuration files whose changes require Rsbuild to be reinitialized.
+
+For example, if you maintain some common configuration files in the `config` directory, such as `common.ts`, you may want changes to these files to restart the dev server or watch build:
 
 ```ts title="rsbuild.config.ts"
 import { commonConfig } from './config/common';
@@ -103,14 +105,18 @@ export default {
   ...commonConfig,
   dev: {
     watchFiles: {
-      type: 'reload-server',
+      type: 'restart',
       paths: ['./config/*.ts'],
     },
   },
 };
 ```
 
-Note that the reload-server functionality is provided by Rsbuild CLI. If you are using a custom server or a framework built on top of Rsbuild, this configuration is currently not supported.
+The `restart` functionality is provided by Rsbuild CLI. It is currently not supported by custom servers or frameworks that invoke Rsbuild through the JavaScript API.
+
+### reload-server
+
+`reload-server` is a deprecated alias for `restart`. It remains supported for backward compatibility.
 
 ## options
 
@@ -139,3 +145,9 @@ export default {
 If you want to prevent some files from triggering a rebuild when they change, you can use Rspack's [watchOptions.ignored](https://rspack.rs/config/watch#watchoptionsignored) configuration item.
 
 > See [HMR - File Watching](/guide/advanced/hmr#file-watching) for details.
+
+## Version history
+
+| Version | Changes                                              |
+| ------- | ---------------------------------------------------- |
+| v2.1.7  | Added the `restart` type; deprecated `reload-server` |

--- a/website/docs/zh/config/dev/watch-files.mdx
+++ b/website/docs/zh/config/dev/watch-files.mdx
@@ -1,5 +1,5 @@
 ---
-description: '监听指定文件和目录的变化。当文件发生变化时，可以触发页面的重新加载，或者触发 dev server 重新启动。'
+description: '监听指定文件和目录的变化。当文件发生变化时，可以触发页面重新加载，也可以重启 dev server 或监听构建。'
 ---
 
 # dev.watchFiles
@@ -9,7 +9,7 @@ description: '监听指定文件和目录的变化。当文件发生变化时，
 ```ts
 type WatchFilesOptions = {
   paths: string | string[];
-  type?: 'reload-page' | 'reload-server';
+  type?: 'reload-page' | 'restart' | 'reload-server';
   //  chokidar 选项
   options?: ChokidarOptions;
 };
@@ -19,7 +19,7 @@ type WatchFilesConfig = WatchFiles | WatchFiles[];
 
 - **默认值：** `undefined`
 
-监听指定文件和目录的变化。当文件发生变化时，可以触发页面的重新加载，或者触发 dev server 重新启动。
+监听指定文件和目录的变化。当文件发生变化时，可以触发页面重新加载，也可以重启 dev server 或监听构建。
 
 ## paths
 
@@ -66,10 +66,10 @@ export default {
 
 ## type
 
-- **类型：** `'reload-page' | 'reload-server'`
+- **类型：** `'reload-page' | 'restart' | 'reload-server'`
 - **默认值：** `'reload-page'`
 
-指定当文件发生变化时，是触发页面重新加载，还是触发 dev server 重新启动。
+指定当文件发生变化时，是触发页面重新加载，还是重启 dev server 或监听构建。
 
 ### reload-page
 
@@ -90,11 +90,13 @@ export default {
 
 > 如果 [dev.hmr](/config/dev/hmr) 和 [dev.liveReload](/config/dev/live-reload) 都设置为 `false`，则页面将不会自动重新加载。
 
-### reload-server
+### restart
 
-reload-server 表示当文件发生变化时，dev server 会自动重新启动。这可以用于监听一些配置文件的变化，例如被 `rsbuild.config.ts` 文件 import 的模块。
+`restart` 会在执行 `rsbuild dev` 时重启 dev server，在执行 `rsbuild build --watch` 时重启监听构建。
 
-例如，你在 `config` 目录下维护了一些公共配置文件，例如 `common.ts`，你希望当这些文件发生变化时，dev server 可以自动重新启动。示例配置：
+这可以用于监听一些变更后需要重新初始化 Rsbuild 的配置文件。
+
+例如，你在 `config` 目录下维护了一些公共配置文件，例如 `common.ts`，你希望这些文件发生变化时重启 dev server 或监听构建：
 
 ```ts title="rsbuild.config.ts"
 import { commonConfig } from './config/common';
@@ -103,14 +105,18 @@ export default {
   ...commonConfig,
   dev: {
     watchFiles: {
-      type: 'reload-server',
+      type: 'restart',
       paths: ['./config/*.ts'],
     },
   },
 };
 ```
 
-需要注意的是，reload-server 功能由 Rsbuild CLI 提供。如果你使用的是自定义 server 或基于 Rsbuild 封装的上层框架，目前暂不支持此配置。
+`restart` 功能由 Rsbuild CLI 提供。如果你使用自定义 server，或者上层框架通过 JavaScript API 调用 Rsbuild，目前暂不支持此配置。
+
+### reload-server
+
+`reload-server` 是 `restart` 的废弃别名，为保证向后兼容，目前仍然支持。
 
 ## options
 
@@ -145,7 +151,7 @@ export default {
         paths: 'public/**/*',
       },
       {
-        type: 'reload-server',
+        type: 'restart',
         paths: ['./config/*.ts'],
       },
     ],
@@ -160,3 +166,9 @@ export default {
 如果你希望当某些文件变化时，不触发重新构建，可以使用 Rspack 的 [watchOptions.ignored](https://rspack.rs/zh/config/watch#watchoptionsignored) 配置项。
 
 > 详见 [模块热更新 - 文件监听](/guide/advanced/hmr#file-watching)。
+
+## 版本历史
+
+| 版本   | 变更内容                                  |
+| ------ | ----------------------------------------- |
+| v2.1.7 | 新增 `restart` 类型，废弃 `reload-server` |


### PR DESCRIPTION
## Summary

`reload-server` can also restart a watch build, so its name does not describe all supported behavior.

This PR adds `restart` as the canonical `dev.watchFiles` type for dev servers and watch builds while retaining `reload-server` as a deprecated alias for backward compatibility.