### PR TITLE
feat(core): add onRestart plugin hook

### DIFF
--- a/e2e/cases/plugin-api/plugin-on-restart-hook/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-on-restart-hook/index.test.ts
@@ -1,0 +1,21 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { test } from '@e2e/helper';
+
+const watchedFile = path.join(import.meta.dirname, 'test-temp-watch.txt');
+
+test.beforeEach(() => {
+  fs.writeFileSync(watchedFile, '1');
+});
+
+test('should call onRestart before restarting a watch build', async ({ execCli, logHelper }) => {
+  execCli('build --watch');
+
+  const { clearLogs, expectBuildEnd, expectLog } = logHelper;
+  await expectBuildEnd();
+
+  clearLogs();
+  fs.writeFileSync(watchedFile, '2');
+  await expectLog('onRestart hook called');
+  await expectBuildEnd();
+});

--- a/e2e/cases/plugin-api/plugin-on-restart-hook/rsbuild.config.ts
+++ b/e2e/cases/plugin-api/plugin-on-restart-hook/rsbuild.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  dev: {
+    watchFiles: {
+      paths: './test-temp-watch.txt',
+      type: 'restart',
+    },
+  },
+  plugins: [
+    {
+      name: 'test-on-restart',
+      setup(api) {
+        api.onRestart(async () => {
+          await Promise.resolve();
+          api.logger.info('onRestart hook called');
+        });
+      },
+    },
+  ],
+});

--- a/e2e/cases/plugin-api/plugin-on-restart-hook/src/index.js
+++ b/e2e/cases/plugin-api/plugin-on-restart-hook/src/index.js
@@ -1,0 +1,1 @@
+console.log('Hello Rsbuild!');

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -1,9 +1,9 @@
 import cac, { type CAC, type Command } from 'cac';
 import { RSPACK_BUILD_ERROR } from '../build';
 import { color } from '../helpers';
+import { restartHook } from '../helpers/restartHook';
 import type { ConfigLoader } from '../loadConfig';
 import { defaultLogger } from '../logger';
-import { onBeforeRestartServer } from '../restart';
 import type { LogLevel, RsbuildMode } from '../types';
 import { init, initCliAction } from './init';
 
@@ -132,7 +132,7 @@ export function setupCommands(argv: string[]): void {
 
         if (buildResult) {
           if (options.watch) {
-            onBeforeRestartServer(buildResult.close);
+            restartHook(buildResult.close);
           } else {
             await buildResult.close();
           }

--- a/packages/core/src/helpers/restartHook.ts
+++ b/packages/core/src/helpers/restartHook.ts
@@ -1,0 +1,14 @@
+type Callback = () => unknown;
+
+let callbacks: Callback[] = [];
+
+export const restartHook = (callback: Callback): void => {
+  callbacks.push(callback);
+};
+
+export const callRestartHook = async (): Promise<void> => {
+  for (const callback of callbacks) {
+    await callback();
+  }
+  callbacks = [];
+};

--- a/packages/core/src/hooks.ts
+++ b/packages/core/src/hooks.ts
@@ -26,6 +26,7 @@ import type {
   OnCloseBuildFn,
   OnCloseDevServerFn,
   OnExitFn,
+  OnRestartFn,
   Rspack,
 } from './types';
 
@@ -187,6 +188,7 @@ export function createAsyncHook<Callback extends (...args: any[]) => any>(): Asy
 export function initHooks(): {
   /** The following hooks are global hooks */
   onExit: AsyncHook<OnExitFn>;
+  onRestart: AsyncHook<OnRestartFn>;
   onAfterBuild: AsyncHook<OnAfterBuildFn>;
   onCloseBuild: AsyncHook<OnCloseBuildFn>;
   onBeforeBuild: AsyncHook<OnBeforeBuildFn>;
@@ -211,6 +213,7 @@ export function initHooks(): {
 } {
   return {
     onExit: createAsyncHook<OnExitFn>(),
+    onRestart: createAsyncHook<OnRestartFn>(),
     onCloseBuild: createAsyncHook<OnCloseBuildFn>(),
     onAfterBuild: createAsyncHook<OnAfterBuildFn>(),
     onBeforeBuild: createAsyncHook<OnBeforeBuildFn>(),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -147,6 +147,7 @@ export type {
   OnCloseDevServerFn,
   OnDevCompileDoneFn,
   OnExitFn,
+  OnRestartFn,
   OutputConfig,
   OverlayOptions,
   OutputStructure,

--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -4,6 +4,7 @@ import { LOADER_PATH } from './constants';
 import { createPublicContext } from './createContext';
 import { color, getFilename } from './helpers';
 import { exitHook } from './helpers/exitHook';
+import { restartHook } from './helpers/restartHook';
 import { removeLeadingSlash } from './helpers/url';
 import type { TransformLoaderOptions } from './loader/transformLoader';
 import type { Logger } from './logger';
@@ -331,6 +332,16 @@ export function initPluginAPI({
     hooks.onExit.tap(cb);
   };
 
+  let onRestartListened = false;
+
+  const onRestart: typeof hooks.onRestart.tap = (cb) => {
+    if (!onRestartListened) {
+      restartHook(() => hooks.onRestart.callBatch());
+      onRestartListened = true;
+    }
+    hooks.onRestart.tap(cb);
+  };
+
   // Each plugin returns different APIs depending on the registered environment info.
   return (environment?: string) => ({
     context: publicContext,
@@ -346,6 +357,7 @@ export function initPluginAPI({
 
     // Hooks
     onExit,
+    onRestart,
     onAfterBuild: hooks.onAfterBuild.tap,
     onCloseBuild: hooks.onCloseBuild.tap,
     onBeforeBuild: hooks.onBeforeBuild.tap,

--- a/packages/core/src/restart.ts
+++ b/packages/core/src/restart.ts
@@ -2,20 +2,10 @@ import path from 'node:path';
 import type { ChokidarOptions } from 'chokidar';
 import { init } from './cli/init';
 import { color, isTTY } from './helpers';
+import { callRestartHook, restartHook } from './helpers/restartHook';
 import type { Logger } from './logger';
 import { createChokidar } from './server/watchFiles';
 import type { RsbuildInstance } from './types';
-
-type Cleaner = () => unknown;
-
-let cleaners: Cleaner[] = [];
-
-/**
- * Add a cleaner to handle side effects
- */
-export const onBeforeRestartServer = (cleaner: Cleaner): void => {
-  cleaners.push(cleaner);
-};
 
 const clearConsole = () => {
   if (isTTY() && !process.env.DEBUG) {
@@ -45,10 +35,7 @@ const beforeRestart = async ({
     logger.info(`restarting ${id}...\n`);
   }
 
-  for (const cleaner of cleaners) {
-    await cleaner();
-  }
-  cleaners = [];
+  await callRestartHook();
 };
 
 export const restartDevServer = async ({
@@ -94,7 +81,7 @@ const restartBuild = async ({
   }
 
   const buildInstance = await rsbuild.build({ watch: true });
-  onBeforeRestartServer(buildInstance.close);
+  restartHook(buildInstance.close);
   return true;
 };
 

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -2,7 +2,8 @@ import type { Server } from 'node:http';
 import type { Http2SecureServer } from 'node:http2';
 import { color } from '../helpers';
 import { getPublicPathFromCompiler, isMultiCompiler } from '../helpers/compiler';
-import { onBeforeRestartServer, restartDevServer } from '../restart';
+import { restartHook } from '../helpers/restartHook';
+import { restartDevServer } from '../restart';
 import type {
   CreateCompiler,
   CreateDevServerOptions,
@@ -357,7 +358,7 @@ export async function createDevServer<
 
             await devServer.afterListen();
 
-            onBeforeRestartServer(devServer.close);
+            restartHook(devServer.close);
 
             resolve({
               port,

--- a/packages/core/src/types/hooks.ts
+++ b/packages/core/src/types/hooks.ts
@@ -149,6 +149,8 @@ export type OnAfterCreateCompilerFn<Compiler = Rspack.Compiler | Rspack.MultiCom
 
 export type OnExitFn = (context: { exitCode: number }) => void;
 
+export type OnRestartFn = () => MaybePromise<void>;
+
 export type ModifyHTMLContext = {
   /**
    * The Compilation object of Rspack.

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -29,6 +29,7 @@ import type {
   OnCloseBuildFn,
   OnCloseDevServerFn,
   OnExitFn,
+  OnRestartFn,
 } from './hooks';
 import type { AddPluginsOptions, RsbuildInstance, RsbuildTarget } from './rsbuild';
 import type { Rspack } from './rspack';
@@ -649,6 +650,10 @@ export type RsbuildPluginAPI = Readonly<{
    * synchronous code.
    */
   onExit: PluginHook<OnExitFn>;
+  /**
+   * Called before Rsbuild CLI restarts the dev server or watch build.
+   */
+  onRestart: PluginHook<OnRestartFn>;
   /**
    * Modify assets before emitting, the same as Rspack's
    * [compilation.hooks.processAssets](https://rspack.rs/api/plugin-api/compilation-hooks#processassets) hook.

--- a/packages/core/tests/__snapshots__/hooks.test.ts.snap
+++ b/packages/core/tests/__snapshots__/hooks.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`initHooks > should initialize hooks correctly 1`] = `
 [
   "onExit",
+  "onRestart",
   "onCloseBuild",
   "onAfterBuild",
   "onBeforeBuild",

--- a/website/docs/en/plugins/dev/hooks.mdx
+++ b/website/docs/en/plugins/dev/hooks.mdx
@@ -20,6 +20,7 @@ This page outlines the plugin hooks available for Rsbuild plugins.
 - [onAfterCreateCompiler](#onaftercreatecompiler): Called after creating a compiler instance and before building.
 - [onBeforeEnvironmentCompile](#onbeforeenvironmentcompile): Called before the compilation of a single environment.
 - [onAfterEnvironmentCompile](#onafterenvironmentcompile): Called after the compilation of a single environment. You can get the build result information.
+- [onRestart](#onrestart): Called before Rsbuild CLI restarts the dev server or watch build.
 - [onExit](#onexit): Called when the process is about to exit.
 
 ### Dev hooks
@@ -141,6 +142,7 @@ Correspondingly, there are some plugin hooks that are related to the current env
 - [onCloseBuild](#onclosebuild)
 - [onBeforeStartPreviewServer](#onbeforestartpreviewserver)
 - [onAfterStartPreviewServer](#onafterstartpreviewserver)
+- [onRestart](#onrestart)
 - [onExit](#onexit)
 
 ### Environment hooks
@@ -961,6 +963,24 @@ const myPlugin = () => ({
 ```
 
 ## Other hooks
+
+### onRestart
+
+import OnRestart from '@en/shared/onRestart.mdx';
+
+<OnRestart />
+
+- **Example:**
+
+```ts
+const myPlugin = () => ({
+  setup(api) {
+    api.onRestart(async () => {
+      console.log('restart!');
+    });
+  },
+});
+```
 
 ### onExit
 

--- a/website/docs/en/shared/onRestart.mdx
+++ b/website/docs/en/shared/onRestart.mdx
@@ -1,0 +1,11 @@
+Called before Rsbuild CLI restarts the dev server or watch build.
+
+This hook is only available through the plugin API. It is not triggered for regular rebuilds.
+
+- **Type:**
+
+```ts
+function OnRestart(callback: () => Promise<void> | void): void;
+```
+
+- **Version:** Added in v2.1.7

--- a/website/docs/zh/plugins/dev/hooks.mdx
+++ b/website/docs/zh/plugins/dev/hooks.mdx
@@ -20,6 +20,7 @@ description: '本章节介绍 Rsbuild 插件可用的 hooks。'
 - [onAfterCreateCompiler](#onaftercreatecompiler)：在创建 compiler 实例后、执行构建前调用。
 - [onBeforeEnvironmentCompile](#onbeforeenvironmentcompile): 在每次执行单个 environment 的构建前调用。
 - [onAfterEnvironmentCompile](#onafterenvironmentcompile): 在每次单个 environment 的构建结束后调用。
+- [onRestart](#onrestart)：在 Rsbuild CLI 重启 dev server 或监听构建前调用。
 - [onExit](#onexit)：在进程即将退出时调用。
 
 ### Dev hooks
@@ -141,6 +142,7 @@ description: '本章节介绍 Rsbuild 插件可用的 hooks。'
 - [onCloseBuild](#onclosebuild)
 - [onBeforeStartPreviewServer](#onbeforestartpreviewserver)
 - [onAfterStartPreviewServer](#onafterstartpreviewserver)
+- [onRestart](#onrestart)
 - [onExit](#onexit)
 
 ### Environment hooks
@@ -957,6 +959,24 @@ const myPlugin = () => ({
 ```
 
 ## Other hooks
+
+### onRestart
+
+import OnRestart from '@zh/shared/onRestart.mdx';
+
+<OnRestart />
+
+- **示例：**
+
+```ts
+const myPlugin = () => ({
+  setup(api) {
+    api.onRestart(async () => {
+      console.log('restart!');
+    });
+  },
+});
+```
 
 ### onExit
 

--- a/website/docs/zh/shared/onRestart.mdx
+++ b/website/docs/zh/shared/onRestart.mdx
@@ -1,0 +1,11 @@
+在 Rsbuild CLI 重启 dev server 或监听构建前调用。
+
+该 hook 仅在插件 API 中提供，普通的重新构建不会触发该 hook。
+
+- **类型：**
+
+```ts
+function OnRestart(callback: () => Promise<void> | void): void;
+```
+
+- **版本：** 新增于 v2.1.7


### PR DESCRIPTION
## Summary

This PR adds an `api.onRestart` plugin hook that runs before Rsbuild CLI restarts a dev server or watch build.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8118