### PR TITLE
fix(core): ensure restart cleanup hooks run

### DIFF
--- a/packages/core/src/helpers/restartHook.ts
+++ b/packages/core/src/helpers/restartHook.ts
@@ -7,8 +7,24 @@ export const restartHook = (callback: Callback): void => {
 };
 
 export const callRestartHook = async (): Promise<void> => {
-  for (const callback of callbacks) {
-    await callback();
-  }
+  const currentCallbacks = callbacks;
   callbacks = [];
+
+  let hasError = false;
+  let firstError: unknown;
+
+  for (const callback of currentCallbacks) {
+    try {
+      await callback();
+    } catch (error) {
+      if (!hasError) {
+        hasError = true;
+        firstError = error;
+      }
+    }
+  }
+
+  if (hasError) {
+    throw firstError;
+  }
 };

--- a/packages/core/tests/restartHook.test.ts
+++ b/packages/core/tests/restartHook.test.ts
@@ -12,9 +12,11 @@ describe('restartHook', () => {
       calls.push('second');
     });
 
+    // A thrown value should not prevent subsequent callbacks from running.
     await expect(callRestartHook()).rejects.toBeNull();
     expect(calls).toEqual(['first', 'second']);
 
+    // The callback registry should be cleared after the first invocation.
     await expect(callRestartHook()).resolves.toBeUndefined();
     expect(calls).toEqual(['first', 'second']);
   });

--- a/packages/core/tests/restartHook.test.ts
+++ b/packages/core/tests/restartHook.test.ts
@@ -1,0 +1,21 @@
+import { callRestartHook, restartHook } from '../src/helpers/restartHook';
+
+describe('restartHook', () => {
+  test('should execute all callbacks and clear the registry when one throws', async () => {
+    const calls: string[] = [];
+
+    restartHook(() => {
+      calls.push('first');
+      throw null;
+    });
+    restartHook(() => {
+      calls.push('second');
+    });
+
+    await expect(callRestartHook()).rejects.toBeNull();
+    expect(calls).toEqual(['first', 'second']);
+
+    await expect(callRestartHook()).resolves.toBeUndefined();
+    expect(calls).toEqual(['first', 'second']);
+  });
+});


### PR DESCRIPTION
## Summary

This PR ensures restart cleanup callbacks still run when an earlier `onRestart` callback throws. It clears the callback registry before execution, preserves callback order, and rethrows the first error after all callbacks finish.

## Related Links

- Follow-up to https://github.com/web-infra-dev/rsbuild/pull/8119
- Review comment: https://github.com/web-infra-dev/rsbuild/pull/8119#discussion_r3603635975
