### PR TITLE
feat(core): add onRestart to Rsbuild instance

### DIFF
--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -370,6 +370,7 @@ export async function createRsbuild(options: CreateRsbuildOptions = {}): Promise
       'onCloseDevServer',
       'onDevCompileDone',
       'onExit',
+      'onRestart',
     ]),
   };
 

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -296,6 +296,7 @@ export type RsbuildInstance = {
   | 'onCloseDevServer'
   | 'onDevCompileDone'
   | 'onExit'
+  | 'onRestart'
 >;
 
 export type RsbuildTarget = 'web' | 'node' | 'web-worker';

--- a/packages/core/tests/restartHook.test.ts
+++ b/packages/core/tests/restartHook.test.ts
@@ -1,3 +1,4 @@
+import { createRsbuild } from '../src';
 import { callRestartHook, restartHook } from '../src/helpers/restartHook';
 
 describe('restartHook', () => {
@@ -19,5 +20,15 @@ describe('restartHook', () => {
     // The callback registry should be cleared after the first invocation.
     await expect(callRestartHook()).resolves.toBeUndefined();
     expect(calls).toEqual(['first', 'second']);
+  });
+
+  test('should support onRestart on Rsbuild instance', async () => {
+    const onRestart = rstest.fn();
+    const rsbuild = await createRsbuild();
+
+    rsbuild.onRestart(onRestart);
+    await callRestartHook();
+
+    expect(onRestart).toHaveBeenCalledTimes(1);
   });
 });

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -992,6 +992,22 @@ rsbuild.onAfterEnvironmentCompile(({ isFirstCompile, stats }) => {
 });
 ```
 
+## rsbuild.onRestart
+
+> Provides the same functionality as the [onRestart](/plugins/dev/hooks#onrestart) plugin hook.
+
+import OnRestart from '@en/shared/onRestart.mdx';
+
+<OnRestart />
+
+- **Example:**
+
+```ts
+rsbuild.onRestart(async () => {
+  console.log('restart!');
+});
+```
+
 ## rsbuild.onExit
 
 > Provides the same functionality as the [onExit](/plugins/dev/hooks#onexit) plugin hook.

--- a/website/docs/en/shared/onRestart.mdx
+++ b/website/docs/en/shared/onRestart.mdx
@@ -1,6 +1,6 @@
 Called before Rsbuild CLI restarts the dev server or watch build.
 
-This hook is only available through the plugin API. It is not triggered for regular rebuilds.
+> This hook is not triggered for regular rebuilds.
 
 - **Type:**
 

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -992,6 +992,22 @@ rsbuild.onAfterEnvironmentCompile(({ isFirstCompile, stats }) => {
 });
 ```
 
+## rsbuild.onRestart
+
+> 功能与 [onRestart](/plugins/dev/hooks#onrestart) 插件 hook 一致。
+
+import OnRestart from '@zh/shared/onRestart.mdx';
+
+<OnRestart />
+
+- **示例：**
+
+```ts
+rsbuild.onRestart(async () => {
+  console.log('restart!');
+});
+```
+
 ## rsbuild.onExit
 
 > 功能与 [onExit](/plugins/dev/hooks#onexit) 插件 hook 一致。

--- a/website/docs/zh/shared/onRestart.mdx
+++ b/website/docs/zh/shared/onRestart.mdx
@@ -1,6 +1,6 @@
 在 Rsbuild CLI 重启 dev server 或监听构建前调用。
 
-该 hook 仅在插件 API 中提供，普通的重新构建不会触发该 hook。
+> 普通的重新构建不会触发该 hook。
 
 - **类型：**
 


### PR DESCRIPTION
## Summary

This PR exposes the existing `onRestart` hook on `RsbuildInstance`, allowing JavaScript API consumers to register restart callbacks without creating a plugin. It reuses the existing restart lifecycle and updates the public types, documentation, and focused coverage.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8119
