### PR TITLE
feat(core): add context to onRestart hook

### DIFF
--- a/e2e/cases/plugin-api/plugin-on-restart-hook/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-on-restart-hook/index.test.ts
@@ -16,6 +16,6 @@ test('should call onRestart before restarting a watch build', async ({ execCli, 
 
   clearLogs();
   fs.writeFileSync(watchedFile, '2');
-  await expectLog('onRestart hook called');
+  await expectLog(`onRestart hook called: build, ${watchedFile}`);
   await expectBuildEnd();
 });

--- a/e2e/cases/plugin-api/plugin-on-restart-hook/rsbuild.config.ts
+++ b/e2e/cases/plugin-api/plugin-on-restart-hook/rsbuild.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from '@rsbuild/core';
+import { defineConfig, type RestartContext } from '@rsbuild/core';
 
 export default defineConfig({
   dev: {
@@ -11,9 +11,9 @@ export default defineConfig({
     {
       name: 'test-on-restart',
       setup(api) {
-        api.onRestart(async () => {
+        api.onRestart(async ({ action, filePath }: RestartContext) => {
           await Promise.resolve();
-          api.logger.info('onRestart hook called');
+          api.logger.info(`onRestart hook called: ${action}, ${filePath}`);
         });
       },
     },

--- a/packages/core/src/helpers/restartHook.ts
+++ b/packages/core/src/helpers/restartHook.ts
@@ -1,4 +1,6 @@
-type Callback = () => unknown;
+import type { RestartContext } from '../types/hooks';
+
+type Callback = (context: RestartContext) => unknown;
 
 let callbacks: Callback[] = [];
 
@@ -6,7 +8,7 @@ export const restartHook = (callback: Callback): void => {
   callbacks.push(callback);
 };
 
-export const callRestartHook = async (): Promise<void> => {
+export const callRestartHook = async (context: RestartContext): Promise<void> => {
   const currentCallbacks = callbacks;
   callbacks = [];
 
@@ -15,7 +17,7 @@ export const callRestartHook = async (): Promise<void> => {
 
   for (const callback of currentCallbacks) {
     try {
-      await callback();
+      await callback(context);
     } catch (error) {
       if (!hasError) {
         hasError = true;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -176,6 +176,7 @@ export type {
   ResolveHandler,
   ResolveHook,
   ResourceHintsIncludeType,
+  RestartContext,
   RsbuildConfig,
   RsbuildContext,
   RsbuildEntry,

--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -336,7 +336,7 @@ export function initPluginAPI({
 
   const onRestart: typeof hooks.onRestart.tap = (cb) => {
     if (!onRestartListened) {
-      restartHook(() => hooks.onRestart.callBatch());
+      restartHook((context) => hooks.onRestart.callBatch(context));
       onRestartListened = true;
     }
     hooks.onRestart.tap(cb);

--- a/packages/core/src/restart.ts
+++ b/packages/core/src/restart.ts
@@ -5,7 +5,7 @@ import { color, isTTY } from './helpers';
 import { callRestartHook, restartHook } from './helpers/restartHook';
 import type { Logger } from './logger';
 import { createChokidar } from './server/watchFiles';
-import type { RsbuildInstance } from './types';
+import type { RestartContext, RsbuildInstance } from './types';
 
 const clearConsole = () => {
   if (isTTY() && !process.env.DEBUG) {
@@ -16,17 +16,17 @@ const clearConsole = () => {
 const beforeRestart = async ({
   filePath,
   clear = true,
-  id,
+  action,
   logger,
-}: {
-  filePath?: string;
+}: RestartContext & {
   clear?: boolean;
-  id: string;
   logger: Logger;
 }): Promise<void> => {
   if (clear) {
     clearConsole();
   }
+
+  const id = action === 'dev' ? 'server' : 'build';
 
   if (filePath) {
     const filename = path.basename(filePath);
@@ -35,7 +35,7 @@ const beforeRestart = async ({
     logger.info(`restarting ${id}...\n`);
   }
 
-  await callRestartHook();
+  await callRestartHook({ action, filePath });
 };
 
 export const restartDevServer = async ({
@@ -47,7 +47,7 @@ export const restartDevServer = async ({
   clear?: boolean;
   logger: Logger;
 }): Promise<boolean> => {
-  await beforeRestart({ filePath, clear, id: 'server', logger });
+  await beforeRestart({ action: 'dev', filePath, clear, logger });
 
   const rsbuild = await init({ isRestart: true });
 
@@ -70,7 +70,7 @@ const restartBuild = async ({
   clear?: boolean;
   logger: Logger;
 }): Promise<boolean> => {
-  await beforeRestart({ filePath, clear, id: 'build', logger });
+  await beforeRestart({ action: 'build', filePath, clear, logger });
 
   const rsbuild = await init({ isRestart: true, isBuildWatch: true });
 
@@ -117,9 +117,11 @@ export async function watchFilesForRestart({
     }
     restarting = true;
 
+    const absoluteFilePath = path.resolve(root, filePath);
+
     const restarted = isBuildWatch
-      ? await restartBuild({ filePath, logger: rsbuild.logger })
-      : await restartDevServer({ filePath, logger: rsbuild.logger });
+      ? await restartBuild({ filePath: absoluteFilePath, logger: rsbuild.logger })
+      : await restartDevServer({ filePath: absoluteFilePath, logger: rsbuild.logger });
 
     if (restarted) {
       await watcher.close();

--- a/packages/core/src/types/hooks.ts
+++ b/packages/core/src/types/hooks.ts
@@ -149,7 +149,19 @@ export type OnAfterCreateCompilerFn<Compiler = Rspack.Compiler | Rspack.MultiCom
 
 export type OnExitFn = (context: { exitCode: number }) => void;
 
-export type OnRestartFn = () => MaybePromise<void>;
+export type RestartContext = {
+  /**
+   * The current Rsbuild action being restarted.
+   */
+  action: 'dev' | 'build';
+  /**
+   * The absolute path of the file that triggered the restart.
+   * It is undefined when the restart is manually triggered.
+   */
+  filePath?: string;
+};
+
+export type OnRestartFn = (context: RestartContext) => MaybePromise<void>;
 
 export type ModifyHTMLContext = {
   /**

--- a/packages/core/tests/restartHook.test.ts
+++ b/packages/core/tests/restartHook.test.ts
@@ -4,6 +4,7 @@ import { callRestartHook, restartHook } from '../src/helpers/restartHook';
 describe('restartHook', () => {
   test('should execute all callbacks and clear the registry when one throws', async () => {
     const calls: string[] = [];
+    const context = { action: 'build' } as const;
 
     restartHook(() => {
       calls.push('first');
@@ -14,21 +15,22 @@ describe('restartHook', () => {
     });
 
     // A thrown value should not prevent subsequent callbacks from running.
-    await expect(callRestartHook()).rejects.toBeNull();
+    await expect(callRestartHook(context)).rejects.toBeNull();
     expect(calls).toEqual(['first', 'second']);
 
     // The callback registry should be cleared after the first invocation.
-    await expect(callRestartHook()).resolves.toBeUndefined();
+    await expect(callRestartHook(context)).resolves.toBeUndefined();
     expect(calls).toEqual(['first', 'second']);
   });
 
   test('should support onRestart on Rsbuild instance', async () => {
     const onRestart = rstest.fn();
     const rsbuild = await createRsbuild();
+    const context = { action: 'dev' } as const;
 
     rsbuild.onRestart(onRestart);
-    await callRestartHook();
+    await callRestartHook(context);
 
-    expect(onRestart).toHaveBeenCalledTimes(1);
+    expect(onRestart).toHaveBeenCalledWith(context);
   });
 });

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -1003,8 +1003,8 @@ import OnRestart from '@en/shared/onRestart.mdx';
 - **Example:**
 
 ```ts
-rsbuild.onRestart(async () => {
-  console.log('restart!');
+rsbuild.onRestart(async ({ action, filePath }) => {
+  console.log('restart!', action, filePath);
 });
 ```
 

--- a/website/docs/en/plugins/dev/hooks.mdx
+++ b/website/docs/en/plugins/dev/hooks.mdx
@@ -975,8 +975,8 @@ import OnRestart from '@en/shared/onRestart.mdx';
 ```ts
 const myPlugin = () => ({
   setup(api) {
-    api.onRestart(async () => {
-      console.log('restart!');
+    api.onRestart(async ({ action, filePath }) => {
+      console.log('restart!', action, filePath);
     });
   },
 });

--- a/website/docs/en/shared/onRestart.mdx
+++ b/website/docs/en/shared/onRestart.mdx
@@ -5,7 +5,15 @@ Called before Rsbuild CLI restarts the dev server or watch build.
 - **Type:**
 
 ```ts
-function OnRestart(callback: () => Promise<void> | void): void;
+type RestartContext = {
+  action: 'dev' | 'build';
+  filePath?: string;
+};
+
+function OnRestart(callback: (context: RestartContext) => Promise<void> | void): void;
 ```
+
+- `action`: The current Rsbuild action being restarted.
+- `filePath`: The absolute path of the file that triggered the restart. It is `undefined` when the restart is manually triggered.
 
 - **Version:** Added in v2.1.7

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -1003,8 +1003,8 @@ import OnRestart from '@zh/shared/onRestart.mdx';
 - **示例：**
 
 ```ts
-rsbuild.onRestart(async () => {
-  console.log('restart!');
+rsbuild.onRestart(async ({ action, filePath }) => {
+  console.log('restart!', action, filePath);
 });
 ```
 

--- a/website/docs/zh/plugins/dev/hooks.mdx
+++ b/website/docs/zh/plugins/dev/hooks.mdx
@@ -971,8 +971,8 @@ import OnRestart from '@zh/shared/onRestart.mdx';
 ```ts
 const myPlugin = () => ({
   setup(api) {
-    api.onRestart(async () => {
-      console.log('restart!');
+    api.onRestart(async ({ action, filePath }) => {
+      console.log('restart!', action, filePath);
     });
   },
 });

--- a/website/docs/zh/shared/onRestart.mdx
+++ b/website/docs/zh/shared/onRestart.mdx
@@ -5,7 +5,15 @@
 - **类型：**
 
 ```ts
-function OnRestart(callback: () => Promise<void> | void): void;
+type RestartContext = {
+  action: 'dev' | 'build';
+  filePath?: string;
+};
+
+function OnRestart(callback: (context: RestartContext) => Promise<void> | void): void;
 ```
+
+- `action`：当前正在重启的 Rsbuild 操作类型。
+- `filePath`：触发重启的文件绝对路径，手动触发重启时为 `undefined`。
 
 - **版本：** 新增于 v2.1.7


### PR DESCRIPTION
## Summary

This PR adds `RestartContext` to `onRestart` callbacks so plugins and Rsbuild instance consumers can distinguish dev server and watch build restarts and inspect the file that triggered them. Watched file paths are normalized to absolute paths, while manual restarts leave `filePath` undefined.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8119
- https://github.com/web-infra-dev/rsbuild/pull/8121
