### PR TITLE
fix(core): resolve restart paths from watcher cwd

### DIFF
--- a/e2e/cases/plugin-api/plugin-on-restart-hook-cwd/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-on-restart-hook-cwd/index.test.ts
@@ -4,11 +4,8 @@ import { test } from '@e2e/helper';
 
 const watchedFile = path.join(import.meta.dirname, 'test-temp-watch.txt');
 
-test.beforeEach(() => {
-  fs.writeFileSync(watchedFile, '1');
-});
-
 test('should resolve restart file path from custom watch cwd', async ({ execCli, logHelper }) => {
+  fs.writeFileSync(watchedFile, '1');
   execCli('build --watch');
 
   const { clearLogs, expectBuildEnd, expectLog } = logHelper;

--- a/e2e/cases/plugin-api/plugin-on-restart-hook-cwd/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-on-restart-hook-cwd/index.test.ts
@@ -1,0 +1,21 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { test } from '@e2e/helper';
+
+const watchedFile = path.join(import.meta.dirname, 'test-temp-watch.txt');
+
+test.beforeEach(() => {
+  fs.writeFileSync(watchedFile, '1');
+});
+
+test('should resolve restart file path from custom watch cwd', async ({ execCli, logHelper }) => {
+  execCli('build --watch');
+
+  const { clearLogs, expectBuildEnd, expectLog } = logHelper;
+  await expectBuildEnd();
+
+  clearLogs();
+  fs.writeFileSync(watchedFile, '2');
+  await expectLog(`onRestart hook called: build, ${watchedFile}`);
+  await expectBuildEnd();
+});

--- a/e2e/cases/plugin-api/plugin-on-restart-hook-cwd/rsbuild.config.ts
+++ b/e2e/cases/plugin-api/plugin-on-restart-hook-cwd/rsbuild.config.ts
@@ -3,8 +3,11 @@ import { defineConfig, type RestartContext } from '@rsbuild/core';
 export default defineConfig({
   dev: {
     watchFiles: {
-      paths: './test-temp-watch.txt',
+      paths: './plugin-on-restart-hook-cwd/test-temp-watch.txt',
       type: 'restart',
+      options: {
+        cwd: '..',
+      },
     },
   },
   plugins: [

--- a/e2e/cases/plugin-api/plugin-on-restart-hook-cwd/src/index.js
+++ b/e2e/cases/plugin-api/plugin-on-restart-hook-cwd/src/index.js
@@ -1,0 +1,1 @@
+console.log('Hello Rsbuild!');

--- a/e2e/cases/plugin-api/plugin-on-restart-hook/rsbuild.config.ts
+++ b/e2e/cases/plugin-api/plugin-on-restart-hook/rsbuild.config.ts
@@ -3,8 +3,11 @@ import { defineConfig, type RestartContext } from '@rsbuild/core';
 export default defineConfig({
   dev: {
     watchFiles: {
-      paths: './test-temp-watch.txt',
+      paths: './plugin-on-restart-hook/test-temp-watch.txt',
       type: 'restart',
+      options: {
+        cwd: '..',
+      },
     },
   },
   plugins: [

--- a/packages/core/src/restart.ts
+++ b/packages/core/src/restart.ts
@@ -101,6 +101,8 @@ export async function watchFilesForRestart({
   }
 
   const root = rsbuild.context.rootPath;
+  // Chokidar reports event paths relative to `cwd` when it is configured.
+  const watchCwd = watchOptions?.cwd || root;
   const watcher = await createChokidar(files, root, {
     // do not trigger add for initial files
     ignoreInitial: true,
@@ -117,7 +119,7 @@ export async function watchFilesForRestart({
     }
     restarting = true;
 
-    const absoluteFilePath = path.resolve(root, filePath);
+    const absoluteFilePath = path.resolve(watchCwd, filePath);
 
     const restarted = isBuildWatch
       ? await restartBuild({ filePath: absoluteFilePath, logger: rsbuild.logger })


### PR DESCRIPTION
## Summary

This PR fixes incorrect absolute paths passed to `onRestart` when `dev.watchFiles.options.cwd` is configured. Restart event paths are now resolved from the same cwd used by Chokidar, including relative cwd values, while keeping the existing Rsbuild root fallback.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8122#discussion_r3607494865