### PR TITLE
perf(plugin-babel): avoid redundant path join

### DIFF
--- a/packages/plugin-babel/src/plugin.ts
+++ b/packages/plugin-babel/src/plugin.ts
@@ -43,7 +43,7 @@ function getCacheDirectory(context: RsbuildContext, cacheDirectory?: string) {
   if (cacheDirectory) {
     return isAbsolute(cacheDirectory) ? cacheDirectory : join(context.rootPath, cacheDirectory);
   }
-  return join(context.cachePath);
+  return context.cachePath;
 }
 
 async function getCacheIdentifier(options: BabelLoaderOptions) {


### PR DESCRIPTION
## Summary

Rsbuild already stores `context.cachePath` as an absolute normalized path, so calling `path.join` with this single argument adds unnecessary work for every environment. This PR returns the existing cache path directly while preserving custom cache directory resolution and the resulting Babel loader path. The full workspace build and plugin-babel test suite pass.