### PR TITLE
test(e2e): clean up Rstest configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 - Use repo Node.js/pnpm versions (`package.json`, `.node-version`)
 - `pnpm` workspace; shared deps in `pnpm-workspace.yaml` catalogs
 - TypeScript strict, Rspack/Rsbuild
-- Tests: Rstest; e2e: Playwright
+- Unit tests: Rstest; e2e: Rstest with Playwright browser automation
 
 ## Commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ pnpm test core
 
 ### Run E2E tests
 
-Run end-to-end tests powered by [Playwright](https://github.com/microsoft/playwright):
+Run end-to-end tests with [Rstest](https://rstest.rs/) as the test runner and [Playwright](https://github.com/microsoft/playwright) for browser automation:
 
 ```sh
 pnpm run e2e

--- a/e2e/rstest.config.ts
+++ b/e2e/rstest.config.ts
@@ -18,9 +18,6 @@ export default defineConfig({
   retry: isCI ? 3 : 0,
   testTimeout: 30_000,
   hookTimeout: 30_000,
-  source: {
-    tsconfigPath: './tsconfig.json',
-  },
   output: {
     externals: ['@rsbuild/core'],
   },


### PR DESCRIPTION
## Summary

The e2e suite now relies on Rstest's default detection of `e2e/tsconfig.json`, making the explicit path redundant.

This PR removes the extra configuration and updates contributor guidance to clarify that Rstest is the test runner while Playwright handles browser automation.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/7776