### PR TITLE
test(e2e): cover onRestart hook in dev

### DIFF
--- a/e2e/cases/plugin-api/plugin-on-restart-hook/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-on-restart-hook/index.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { test } from '@e2e/helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 
 const watchedFile = path.join(import.meta.dirname, 'test-temp-watch.txt');
 
@@ -17,5 +18,17 @@ test('should call onRestart before restarting a watch build', async ({ execCli, 
   clearLogs();
   fs.writeFileSync(watchedFile, '2');
   await expectLog(`onRestart hook called: build, ${watchedFile}`);
+  await expectBuildEnd();
+});
+
+test('should call onRestart before restarting a dev server', async ({ execCli, logHelper }) => {
+  execCli(`dev --port ${await getRandomPort()}`);
+
+  const { clearLogs, expectBuildEnd, expectLog } = logHelper;
+  await expectBuildEnd();
+
+  clearLogs();
+  fs.writeFileSync(watchedFile, '2');
+  await expectLog(`onRestart hook called: dev, ${watchedFile}`);
   await expectBuildEnd();
 });


### PR DESCRIPTION
## Summary

This PR adds E2E coverage for the `onRestart` plugin hook when restarting the dev server. The test triggers a restart through `dev.watchFiles` and verifies that the hook receives the `dev` action and the triggering file path.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8119