### PR TITLE
test(e2e): use snapshots for stable outputs

### DIFF
--- a/e2e/cases/cli/help/__snapshots__/index.test.ts.snap
+++ b/e2e/cases/cli/help/__snapshots__/index.test.ts.snap
@@ -1,0 +1,87 @@
+// Rstest Snapshot v1
+
+exports[`should show the build command help 1`] = `
+"Rsbuild v<version>
+
+Usage:
+  $ rsbuild build [options]
+
+Options:
+  -w, --watch               Enable watch mode to automatically rebuild on file changes
+  --base <base>             Set the base path of the server
+  -c, --config <config>     Set the configuration file (relative or absolute path)
+  --config-loader <loader>  Set the config file loader (auto | jiti | native) (default: auto)
+  --dist-path <dir>         Set the root directory of output files
+  --source-map              Enable source map
+  --env-dir <dir>           Set the directory for loading \`.env\` files
+  --env-mode <mode>         Set the env mode to load the \`.env.[mode]\` file
+  --environment <name>      Set the environment name(s) to build (default: )
+  --log-level <level>       Set the log level (info | warn | error | silent)
+  -m, --mode <mode>         Set the build mode (development | production | none)
+  -r, --root <root>         Set the project root directory (absolute path or relative to cwd)
+  --no-env                  Disable loading of \`.env\` files (default: true)
+  -h, --help                Display this message"
+`;
+
+exports[`should show the dev command help 1`] = `
+"Rsbuild v<version>
+
+Usage:
+  $ rsbuild dev [options]
+
+Options:
+  -o, --open [url]          Open the page in browser on startup
+  --port <port>             Set the port number for the server
+  --strict-port             Exit if the specified port is already in use
+  --host [host]             Set the host that the server listens to
+  -v, --version             Display version number
+  --base <base>             Set the base path of the server
+  -c, --config <config>     Set the configuration file (relative or absolute path)
+  --config-loader <loader>  Set the config file loader (auto | jiti | native) (default: auto)
+  --dist-path <dir>         Set the root directory of output files
+  --source-map              Enable source map
+  --env-dir <dir>           Set the directory for loading \`.env\` files
+  --env-mode <mode>         Set the env mode to load the \`.env.[mode]\` file
+  --environment <name>      Set the environment name(s) to build (default: )
+  --log-level <level>       Set the log level (info | warn | error | silent)
+  -m, --mode <mode>         Set the build mode (development | production | none)
+  -r, --root <root>         Set the project root directory (absolute path or relative to cwd)
+  --no-env                  Disable loading of \`.env\` files (default: true)
+  -h, --help                Display this message"
+`;
+
+exports[`should show the root help 1`] = `
+"Rsbuild v<version>
+
+Usage:
+  $ rsbuild [command] [options]
+
+Commands:
+  dev      Start the dev server (default if no command is given)
+  build    Build the app for production
+  preview  Preview the production build locally
+  inspect  Inspect the Rspack and Rsbuild configs
+
+  For details on a sub-command, run:
+  $ rsbuild <command> -h
+
+Options:
+  -o, --open [url]          Open the page in browser on startup
+  --port <port>             Set the port number for the server
+  --strict-port             Exit if the specified port is already in use
+  --host [host]             Set the host that the server listens to
+  -v, --version             Display version number
+  --base <base>             Set the base path of the server
+  -c, --config <config>     Set the configuration file (relative or absolute path)
+  --config-loader <loader>  Set the config file loader (auto | jiti | native) (default: auto)
+  --dist-path <dir>         Set the root directory of output files
+  --source-map              Enable source map
+  --env-dir <dir>           Set the directory for loading \`.env\` files
+  --env-mode <mode>         Set the env mode to load the \`.env.[mode]\` file
+  --environment <name>      Set the environment name(s) to build (default: )
+  --log-level <level>       Set the log level (info | warn | error | silent)
+  -m, --mode <mode>         Set the build mode (development | production | none)
+  -r, --root <root>         Set the project root directory (absolute path or relative to cwd)
+  --no-env                  Disable loading of \`.env\` files (default: true)
+  -h, --help                Display this message"
+`;

--- a/e2e/cases/cli/help/index.test.ts
+++ b/e2e/cases/cli/help/index.test.ts
@@ -1,28 +1,25 @@
 import { stripVTControlCharacters as stripAnsi } from 'node:util';
 import { expect, test } from '@e2e/helper';
+import { normalizeEol } from '@rstackjs/test-utils';
+
+const normalizeHelpOutput = (output: string) =>
+  normalizeEol(stripAnsi(output))
+    // Package versions and terminal padding are unrelated to the help contract.
+    .replace(/^Rsbuild v.+$/m, 'Rsbuild v<version>')
+    .replace(/[ \t]+$/gm, '')
+    .trimEnd();
 
 test('should show the root help', ({ execCliSync }) => {
-  const output = stripAnsi(execCliSync('-h'));
-
-  expect(output).toContain('Usage:\n  $ rsbuild [command] [options]');
-  expect(output).toContain('Commands:');
-  expect(output).toContain('For details on a sub-command, run:');
+  expect(normalizeHelpOutput(execCliSync('-h'))).toMatchSnapshot();
 });
 
 test('should show the dev command help', ({ execCliSync }) => {
-  for (const args of ['dev -h', '-h dev']) {
-    const output = stripAnsi(execCliSync(args));
+  const output = normalizeHelpOutput(execCliSync('dev -h'));
 
-    expect(output).toContain('Usage:\n  $ rsbuild dev [options]');
-    expect(output).not.toContain('Commands:');
-    expect(output).not.toContain('For details on a sub-command, run:');
-  }
+  expect(output).toMatchSnapshot();
+  expect(normalizeHelpOutput(execCliSync('-h dev'))).toBe(output);
 });
 
 test('should show the build command help', ({ execCliSync }) => {
-  const output = stripAnsi(execCliSync('build -h'));
-
-  expect(output).toContain('Usage:\n  $ rsbuild build [options]');
-  expect(output).not.toContain('Commands:');
-  expect(output).not.toContain('For details on a sub-command, run:');
+  expect(normalizeHelpOutput(execCliSync('build -h'))).toMatchSnapshot();
 });

--- a/e2e/cases/cli/help/index.test.ts
+++ b/e2e/cases/cli/help/index.test.ts
@@ -4,10 +4,10 @@ import { normalizeEol } from '@rstackjs/test-utils';
 
 const normalizeHelpOutput = (output: string) =>
   normalizeEol(stripAnsi(output))
-    // Package versions and terminal padding are unrelated to the help contract.
+    // Package versions and terminal whitespace are unrelated to the help contract.
     .replace(/^Rsbuild v.+$/m, 'Rsbuild v<version>')
     .replace(/[ \t]+$/gm, '')
-    .trimEnd();
+    .trim();
 
 test('should show the root help', ({ execCliSync }) => {
   expect(normalizeHelpOutput(execCliSync('-h'))).toMatchSnapshot();

--- a/e2e/cases/css/jiti-require-browserslist/__snapshots__/index.test.ts.snap
+++ b/e2e/cases/css/jiti-require-browserslist/__snapshots__/index.test.ts.snap
@@ -1,0 +1,3 @@
+// Rstest Snapshot v1
+
+exports[`should normalize browserslist required by jiti config 1`] = `".cover{position:absolute;top:0;bottom:0;left:0;right:0;-webkit-transform:translateZ(0);transform:translateZ(0)}"`;

--- a/e2e/cases/css/jiti-require-browserslist/index.test.ts
+++ b/e2e/cases/css/jiti-require-browserslist/index.test.ts
@@ -10,10 +10,5 @@ test('should normalize browserslist required by jiti config', async ({ execCliSy
   const files = await readDirContents(path.join(import.meta.dirname, 'dist'));
   const content = getFileContent(files, '.css');
 
-  expect(content).toContain('-webkit-transform:translateZ(0)');
-  expect(content).toContain('top:0');
-  expect(content).toContain('right:0');
-  expect(content).toContain('bottom:0');
-  expect(content).toContain('left:0');
-  expect(content).not.toContain('inset:0');
+  expect(content).toMatchSnapshot();
 });

--- a/e2e/cases/html/template-conditional-statement/__snapshots__/index.test.ts.snap
+++ b/e2e/cases/html/template-conditional-statement/__snapshots__/index.test.ts.snap
@@ -1,0 +1,27 @@
+// Rstest Snapshot v1
+
+exports[`should render conditional statement correctly 1`] = `
+"<body>
+<!-- Basic if statement -->
+<div id="basic-if">
+<p>Basic if true</p>
+</div>
+<!-- if/else statement -->
+<div id="if-else">
+<p>Condition false</p>
+</div>
+<!-- if/else if/else statement -->
+<div id="if-elseif-else">
+<p>Value > 5</p>
+</div>
+<!-- Nested if statements -->
+<div id="nested-if">
+<p>Outer true</p>
+<p>Inner true</p>
+</div>
+<!-- Conditional expression -->
+<div id="conditional-expression">
+<p>Result: Success</p>
+</div>
+</body>"
+`;

--- a/e2e/cases/html/template-conditional-statement/index.test.ts
+++ b/e2e/cases/html/template-conditional-statement/index.test.ts
@@ -6,8 +6,7 @@ test('should render conditional statement correctly', async ({ build }) => {
   const files = rsbuild.getDistFiles();
 
   const indexHtml = getFileContent(files, 'index.html');
-  const body = normalizeEol(indexHtml)
-    .match(/<body>[\s\S]*<\/body>/)?.[0]
+  const body = (normalizeEol(indexHtml).match(/<body>[\s\S]*<\/body>/)?.[0] ?? '')
     .split('\n')
     .map((line) => line.trim())
     .filter(Boolean)

--- a/e2e/cases/html/template-conditional-statement/index.test.ts
+++ b/e2e/cases/html/template-conditional-statement/index.test.ts
@@ -1,29 +1,17 @@
 import { expect, test } from '@e2e/helper';
-import { getFileContent } from '@rstackjs/test-utils';
+import { getFileContent, normalizeEol } from '@rstackjs/test-utils';
 
 test('should render conditional statement correctly', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
 
   const indexHtml = getFileContent(files, 'index.html');
+  const body = normalizeEol(indexHtml)
+    .match(/<body>[\s\S]*<\/body>/)?.[0]
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join('\n');
 
-  // Basic if statement (showBasic: true)
-  expect(indexHtml).toContain('Basic if true');
-
-  // if/else statement (condition: false)
-  expect(indexHtml).toContain('Condition false');
-  expect(indexHtml).not.toContain('Condition true');
-
-  // if/else if/else statement (value: 7)
-  expect(indexHtml).toContain('Value > 5');
-  expect(indexHtml).not.toContain('Value > 10');
-  expect(indexHtml).not.toContain('Value ≤ 5');
-
-  // Nested if statements (outer: true, inner: true)
-  expect(indexHtml).toContain('Outer true');
-  expect(indexHtml).toContain('Inner true');
-
-  // Conditional expression (showResult: true, result: 'Success')
-  expect(indexHtml).toContain('Result: Success');
-  expect(indexHtml).not.toContain('Result: N/A');
+  expect(body).toMatchSnapshot();
 });

--- a/e2e/cases/html/template-loop-statement/__snapshots__/index.test.ts.snap
+++ b/e2e/cases/html/template-loop-statement/__snapshots__/index.test.ts.snap
@@ -1,0 +1,30 @@
+// Rstest Snapshot v1
+
+exports[`should render loop statements correctly 1`] = `
+"<body>
+<!-- for loop -->
+<div id="for">
+<ul>
+<li>for: Item 1</li>
+<li>for: Item 2</li>
+<li>for: Item 3</li>
+</ul>
+</div>
+<!-- forEach loop -->
+<div id="for-each">
+<ul>
+<li>for each: Item 1 0</li>
+<li>for each: Item 2 1</li>
+<li>for each: Item 3 2</li>
+</ul>
+</div>
+<!-- for...of loop -->
+<div id="for-of">
+<ul>
+<li>for of: Item 1</li>
+<li>for of: Item 2</li>
+<li>for of: Item 3</li>
+</ul>
+</div>
+</body>"
+`;

--- a/e2e/cases/html/template-loop-statement/index.test.ts
+++ b/e2e/cases/html/template-loop-statement/index.test.ts
@@ -6,8 +6,7 @@ test('should render loop statements correctly', async ({ build }) => {
   const files = rsbuild.getDistFiles();
 
   const indexHtml = getFileContent(files, 'index.html');
-  const body = normalizeEol(indexHtml)
-    .match(/<body>[\s\S]*<\/body>/)?.[0]
+  const body = (normalizeEol(indexHtml).match(/<body>[\s\S]*<\/body>/)?.[0] ?? '')
     .split('\n')
     .map((line) => line.trim())
     .filter(Boolean)

--- a/e2e/cases/html/template-loop-statement/index.test.ts
+++ b/e2e/cases/html/template-loop-statement/index.test.ts
@@ -1,27 +1,17 @@
 import { expect, test } from '@e2e/helper';
-import { getFileContent } from '@rstackjs/test-utils';
+import { getFileContent, normalizeEol } from '@rstackjs/test-utils';
 
 test('should render loop statements correctly', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
 
   const indexHtml = getFileContent(files, 'index.html');
+  const body = normalizeEol(indexHtml)
+    .match(/<body>[\s\S]*<\/body>/)?.[0]
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join('\n');
 
-  // Basic for loop
-  expect(indexHtml).toContain('<div id="for">');
-  expect(indexHtml).toContain('<li>for: Item 1</li>');
-  expect(indexHtml).toContain('<li>for: Item 2</li>');
-  expect(indexHtml).toContain('<li>for: Item 3</li>');
-
-  // forEach loop
-  expect(indexHtml).toContain('<div id="for-each">');
-  expect(indexHtml).toContain('<li>for each: Item 1 0</li>');
-  expect(indexHtml).toContain('<li>for each: Item 2 1</li>');
-  expect(indexHtml).toContain('<li>for each: Item 3 2</li>');
-
-  // for...of loop
-  expect(indexHtml).toContain('<div id="for-of">');
-  expect(indexHtml).toContain('<li>for of: Item 1</li>');
-  expect(indexHtml).toContain('<li>for of: Item 2</li>');
-  expect(indexHtml).toContain('<li>for of: Item 3</li>');
+  expect(body).toMatchSnapshot();
 });

--- a/e2e/cases/javascript-api/load-env/__snapshots__/index.test.ts.snap
+++ b/e2e/cases/javascript-api/load-env/__snapshots__/index.test.ts.snap
@@ -1,0 +1,5 @@
+// Rstest Snapshot v1
+
+exports[`should throw when prefixes contains empty string 1`] = `"[rsbuild:loadEnv] Invalid prefixes option: received "". An empty string matches every key in processEnv, so every environment variable would be treated as public and could be inlined into client-side code through process.env.* and import.meta.env.* replacements. Use a prefix with at least one non-whitespace character, such as "PUBLIC_"."`;
+
+exports[`should throw when prefixes contains whitespace-only string 1`] = `"[rsbuild:loadEnv] Invalid prefixes option: received "  ". A whitespace-only string is not a valid public environment variable prefix because it does not contain any non-whitespace characters. Use a prefix with at least one non-whitespace character, such as "PUBLIC_"."`;

--- a/e2e/cases/javascript-api/load-env/index.test.ts
+++ b/e2e/cases/javascript-api/load-env/index.test.ts
@@ -74,16 +74,11 @@ test('should not modify process.env if processEnv is provided', () => {
 test('should throw when prefixes contains empty string', () => {
   const message = stripAnsi(getLoadEnvError(['PUBLIC_', '']).message);
 
-  expect(message).toContain('Invalid prefixes option');
-  expect(message).toContain('received ""');
-  expect(message).toContain('An empty string matches every key in processEnv');
-  expect(message).toContain('process.env.* and import.meta.env.* replacements');
+  expect(message).toMatchSnapshot();
 });
 
 test('should throw when prefixes contains whitespace-only string', () => {
   const message = stripAnsi(getLoadEnvError(['PUBLIC_', '  ']).message);
 
-  expect(message).toContain('Invalid prefixes option');
-  expect(message).toContain('received "  "');
-  expect(message).toContain('A whitespace-only string is not a valid public');
+  expect(message).toMatchSnapshot();
 });

--- a/e2e/cases/print-file-size/basic/__snapshots__/index.test.ts.snap
+++ b/e2e/cases/print-file-size/basic/__snapshots__/index.test.ts.snap
@@ -1,0 +1,83 @@
+// Rstest Snapshot v1
+
+exports[`printFileSize.total: false should work 1`] = `
+"
+File (web)                             Size       Gzip
+dist/static/css/index.[[hash]].css     X.X kB    X.X kB
+dist/index.html                        X.X kB    X.X kB
+dist/static/js/index.[[hash]].js       X.X kB     X.X kB
+dist/static/image/icon.[[hash]].png    X.X kB
+dist/static/js/lib-react.[[hash]].js   X.X kB   X.X kB"
+`;
+
+exports[`should allow to custom exclude function 1`] = `
+"
+File (web)                             Size       Gzip
+dist/static/css/index.[[hash]].css     X.X kB    X.X kB
+dist/static/js/index.[[hash]].js       X.X kB     X.X kB
+dist/static/image/icon.[[hash]].png    X.X kB
+dist/static/js/lib-react.[[hash]].js   X.X kB   X.X kB
+                              Total:   X.X kB   X.X kB"
+`;
+
+exports[`should allow to disable gzip-compressed size 1`] = `
+"
+File (web)                             Size
+dist/static/css/index.[[hash]].css     X.X kB
+dist/index.html                        X.X kB
+dist/static/js/index.[[hash]].js       X.X kB
+dist/static/image/icon.[[hash]].png    X.X kB
+dist/static/js/lib-react.[[hash]].js   X.X kB
+                              Total:   X.X kB"
+`;
+
+exports[`should allow to filter assets by name 1`] = `
+"
+File (web)                             Size       Gzip
+dist/static/js/index.[[hash]].js       X.X kB     X.X kB
+dist/static/js/lib-react.[[hash]].js   X.X kB   X.X kB
+                              Total:   X.X kB   X.X kB"
+`;
+
+exports[`should allow to filter assets by size 1`] = `
+"
+File (web)                             Size       Gzip
+dist/static/js/lib-react.[[hash]].js   X.X kB   X.X kB"
+`;
+
+exports[`should print dist folder correctly if it is not a subdir of root 1`] = `
+"
+File (web)                                                 Size       Gzip
+../test-temp-folder/dist/static/css/index.[[hash]].css     X.X kB    X.X kB
+../test-temp-folder/dist/index.html                        X.X kB    X.X kB
+../test-temp-folder/dist/static/js/index.[[hash]].js       X.X kB     X.X kB
+../test-temp-folder/dist/static/image/icon.[[hash]].png    X.X kB
+../test-temp-folder/dist/static/js/lib-react.[[hash]].js   X.X kB   X.X kB
+                                                  Total:   X.X kB   X.X kB"
+`;
+
+exports[`should print file size after building by default 1`] = `
+"
+File (web)                             Size       Gzip
+dist/static/css/index.[[hash]].css     X.X kB    X.X kB
+dist/index.html                        X.X kB    X.X kB
+dist/static/js/index.[[hash]].js       X.X kB     X.X kB
+dist/static/image/icon.[[hash]].png    X.X kB
+dist/static/js/lib-react.[[hash]].js   X.X kB   X.X kB
+                              Total:   X.X kB   X.X kB"
+`;
+
+exports[`should print size of multiple environments correctly 1`] = `
+"
+File (web)                    Size       Gzip
+dist/static/css/index.css     X.X kB    X.X kB
+dist/index.html               X.X kB    X.X kB
+dist/static/js/index.js       X.X kB     X.X kB
+dist/static/image/icon.png    X.X kB
+dist/static/js/lib-react.js   X.X kB   X.X kB
+                     Total:   X.X kB   X.X kB
+File (node)                         Size
+dist/server/static/image/icon.png   X.X kB
+dist/server/index.js                X.X kB
+                           Total:   X.X kB"
+`;

--- a/e2e/cases/print-file-size/basic/index.test.ts
+++ b/e2e/cases/print-file-size/basic/index.test.ts
@@ -5,14 +5,7 @@ import { extractFileSizeLogs } from '../helper';
 test('should print file size after building by default', async ({ build }) => {
   const rsbuild = await build();
 
-  expect(extractFileSizeLogs(rsbuild.logs)).toEqual(`
-File (web)                             Size       Gzip
-dist/static/css/index.[[hash]].css     X.X kB    X.X kB
-dist/index.html                        X.X kB    X.X kB
-dist/static/js/index.[[hash]].js       X.X kB     X.X kB
-dist/static/image/icon.[[hash]].png    X.X kB
-dist/static/js/lib-react.[[hash]].js   X.X kB   X.X kB
-                              Total:   X.X kB   X.X kB`);
+  expect(extractFileSizeLogs(rsbuild.logs)).toMatchSnapshot();
 });
 
 test('should print size of multiple environments correctly', async ({ build }) => {
@@ -33,18 +26,7 @@ test('should print size of multiple environments correctly', async ({ build }) =
     },
   });
 
-  expect(extractFileSizeLogs(rsbuild.logs)).toEqual(`
-File (web)                    Size       Gzip
-dist/static/css/index.css     X.X kB    X.X kB
-dist/index.html               X.X kB    X.X kB
-dist/static/js/index.js       X.X kB     X.X kB
-dist/static/image/icon.png    X.X kB
-dist/static/js/lib-react.js   X.X kB   X.X kB
-                     Total:   X.X kB   X.X kB
-File (node)                         Size
-dist/server/static/image/icon.png   X.X kB
-dist/server/index.js                X.X kB
-                           Total:   X.X kB`);
+  expect(extractFileSizeLogs(rsbuild.logs)).toMatchSnapshot();
 });
 
 test('should not print logs when printFileSize is false', async ({ build }) => {
@@ -85,13 +67,7 @@ test('printFileSize.total: false should work', async ({ build }) => {
     },
   });
 
-  expect(extractFileSizeLogs(rsbuild.logs)).toEqual(`
-File (web)                             Size       Gzip
-dist/static/css/index.[[hash]].css     X.X kB    X.X kB
-dist/index.html                        X.X kB    X.X kB
-dist/static/js/index.[[hash]].js       X.X kB     X.X kB
-dist/static/image/icon.[[hash]].png    X.X kB
-dist/static/js/lib-react.[[hash]].js   X.X kB   X.X kB`);
+  expect(extractFileSizeLogs(rsbuild.logs)).toMatchSnapshot();
 });
 
 test('should print dist folder correctly if it is not a subdir of root', async ({ build }) => {
@@ -103,14 +79,7 @@ test('should print dist folder correctly if it is not a subdir of root', async (
     },
   });
 
-  expect(extractFileSizeLogs(rsbuild.logs)).toEqual(`
-File (web)                                                 Size       Gzip
-../test-temp-folder/dist/static/css/index.[[hash]].css     X.X kB    X.X kB
-../test-temp-folder/dist/index.html                        X.X kB    X.X kB
-../test-temp-folder/dist/static/js/index.[[hash]].js       X.X kB     X.X kB
-../test-temp-folder/dist/static/image/icon.[[hash]].png    X.X kB
-../test-temp-folder/dist/static/js/lib-react.[[hash]].js   X.X kB   X.X kB
-                                                  Total:   X.X kB   X.X kB`);
+  expect(extractFileSizeLogs(rsbuild.logs)).toMatchSnapshot();
 });
 
 test('should allow to disable gzip-compressed size', async ({ build }) => {
@@ -124,14 +93,7 @@ test('should allow to disable gzip-compressed size', async ({ build }) => {
     },
   });
 
-  expect(extractFileSizeLogs(rsbuild.logs)).toEqual(`
-File (web)                             Size
-dist/static/css/index.[[hash]].css     X.X kB
-dist/index.html                        X.X kB
-dist/static/js/index.[[hash]].js       X.X kB
-dist/static/image/icon.[[hash]].png    X.X kB
-dist/static/js/lib-react.[[hash]].js   X.X kB
-                              Total:   X.X kB`);
+  expect(extractFileSizeLogs(rsbuild.logs)).toMatchSnapshot();
 });
 
 test('should allow to filter assets by name', async ({ build }) => {
@@ -145,11 +107,7 @@ test('should allow to filter assets by name', async ({ build }) => {
     },
   });
 
-  expect(extractFileSizeLogs(rsbuild.logs)).toEqual(`
-File (web)                             Size       Gzip
-dist/static/js/index.[[hash]].js       X.X kB     X.X kB
-dist/static/js/lib-react.[[hash]].js   X.X kB   X.X kB
-                              Total:   X.X kB   X.X kB`);
+  expect(extractFileSizeLogs(rsbuild.logs)).toMatchSnapshot();
 });
 
 test('should allow to filter assets by size', async ({ build }) => {
@@ -163,9 +121,7 @@ test('should allow to filter assets by size', async ({ build }) => {
     },
   });
 
-  expect(extractFileSizeLogs(rsbuild.logs)).toEqual(`
-File (web)                             Size       Gzip
-dist/static/js/lib-react.[[hash]].js   X.X kB   X.X kB`);
+  expect(extractFileSizeLogs(rsbuild.logs)).toMatchSnapshot();
 });
 
 test('should allow to custom exclude function', async ({ build }) => {
@@ -180,26 +136,14 @@ test('should allow to custom exclude function', async ({ build }) => {
     },
   });
 
-  expect(extractFileSizeLogs(rsbuild.logs)).toEqual(`
-File (web)                             Size       Gzip
-dist/static/css/index.[[hash]].css     X.X kB    X.X kB
-dist/static/js/index.[[hash]].js       X.X kB     X.X kB
-dist/static/image/icon.[[hash]].png    X.X kB
-dist/static/js/lib-react.[[hash]].js   X.X kB   X.X kB
-                              Total:   X.X kB   X.X kB`);
+  expect(extractFileSizeLogs(rsbuild.logs)).toMatchSnapshot();
 });
 
 test('should not calculate gzip size if the asset is not compressible', async ({ build }) => {
   const rsbuild = await build();
+  const logs = extractFileSizeLogs(rsbuild.logs);
 
-  expect(extractFileSizeLogs(rsbuild.logs)).toEqual(`
-File (web)                             Size       Gzip
-dist/static/css/index.[[hash]].css     X.X kB    X.X kB
-dist/index.html                        X.X kB    X.X kB
-dist/static/js/index.[[hash]].js       X.X kB     X.X kB
-dist/static/image/icon.[[hash]].png    X.X kB
-dist/static/js/lib-react.[[hash]].js   X.X kB   X.X kB
-                              Total:   X.X kB   X.X kB`);
+  expect(logs).toMatch(/^dist\/static\/image\/icon\.\[\[hash\]\]\.png\s+X\.X kB$/m);
 });
 
 test('should calculate gzip size for script-like assets', async ({ build }) => {

--- a/e2e/cases/print-file-size/diff/__snapshots__/index.test.ts.snap
+++ b/e2e/cases/print-file-size/diff/__snapshots__/index.test.ts.snap
@@ -1,0 +1,36 @@
+// Rstest Snapshot v1
+
+exports[`should not print gzip total diff when change is below threshold 1`] = `
+"
+File (web)                         Size      Gzip
+dist/static/js/index.[[hash]].js   X.X kB   X.X kB
+dist/index.html                    X.X kB   X.X kB
+                          Total:   X.X kB   X.X kB"
+`;
+
+exports[`should print file size diff as expected 1`] = `
+"
+File (web)                         Size      Gzip
+dist/static/js/index.[[hash]].js   X.X kB   X.X kB
+dist/index.html                    X.X kB   X.X kB
+                          Total:   X.X kB   X.X kB"
+`;
+
+exports[`should print file size diff as expected 2`] = `
+"
+File (web)                           Size                 Gzip
+dist/static/css/index.[[hash]].css   X.X kB (+X.X kB)   X.X kB (+X.X kB)
+dist/index.html                      X.X kB (+X.X kB)   X.X kB (+X.X kB)
+dist/static/js/index.[[hash]].js     X.X kB (+X.X kB)   X.X kB (+X.X kB)
+dist/static/js/vendor.[[hash]].js    X.X kB (+X.X kB)   X.X kB (+X.X kB)
+                            Total:   X.X kB (+X.X kB)   X.X kB (+X.X kB)"
+`;
+
+exports[`should print file size diff as expected 3`] = `
+"
+File (web)                           Size                 Gzip
+dist/static/js/index.[[hash]].js     X.X kB (-X.X kB)   X.X kB (-X.X kB)
+dist/static/css/index.[[hash]].css   X.X kB              X.X kB
+dist/index.html                      X.X kB (-X.X kB)   X.X kB (-X.X kB)
+                            Total:   X.X kB (-X.X kB)   X.X kB (-X.X kB)"
+`;

--- a/e2e/cases/print-file-size/diff/index.test.ts
+++ b/e2e/cases/print-file-size/diff/index.test.ts
@@ -16,11 +16,7 @@ test('should print file size diff as expected', async ({ cwd, build, editFile, c
   };
 
   const rsbuild1 = await build({ config });
-  expect(extractFileSizeLogs(rsbuild1.logs)).toEqual(`
-File (web)                         Size      Gzip
-dist/static/js/index.[[hash]].js   X.X kB   X.X kB
-dist/index.html                    X.X kB   X.X kB
-                          Total:   X.X kB   X.X kB`);
+  expect(extractFileSizeLogs(rsbuild1.logs)).toMatchSnapshot();
   rsbuild1.clearLogs();
 
   editFile(
@@ -34,24 +30,13 @@ console.log(ReactDOM);
   );
 
   const rsbuild2 = await build({ config });
-  expect(extractFileSizeLogs(rsbuild2.logs)).toEqual(`
-File (web)                           Size                 Gzip
-dist/static/css/index.[[hash]].css   X.X kB (+X.X kB)   X.X kB (+X.X kB)
-dist/index.html                      X.X kB (+X.X kB)   X.X kB (+X.X kB)
-dist/static/js/index.[[hash]].js     X.X kB (+X.X kB)   X.X kB (+X.X kB)
-dist/static/js/vendor.[[hash]].js    X.X kB (+X.X kB)   X.X kB (+X.X kB)
-                            Total:   X.X kB (+X.X kB)   X.X kB (+X.X kB)`);
+  expect(extractFileSizeLogs(rsbuild2.logs)).toMatchSnapshot();
   rsbuild2.clearLogs();
 
   editFile(join(srcDir, 'index.js'), () => `import "./App.css";`);
 
   const rsbuild3 = await build({ config });
-  expect(extractFileSizeLogs(rsbuild3.logs)).toEqual(`
-File (web)                           Size                 Gzip
-dist/static/js/index.[[hash]].js     X.X kB (-X.X kB)   X.X kB (-X.X kB)
-dist/static/css/index.[[hash]].css   X.X kB              X.X kB
-dist/index.html                      X.X kB (-X.X kB)   X.X kB (-X.X kB)
-                            Total:   X.X kB (-X.X kB)   X.X kB (-X.X kB)`);
+  expect(extractFileSizeLogs(rsbuild3.logs)).toMatchSnapshot();
 });
 
 test('should not print gzip total diff when change is below threshold', async ({
@@ -90,9 +75,5 @@ test('should not print gzip total diff when change is below threshold', async ({
 
   const rsbuild2 = await build({ config });
 
-  expect(extractFileSizeLogs(rsbuild2.logs)).toEqual(`
-File (web)                         Size      Gzip
-dist/static/js/index.[[hash]].js   X.X kB   X.X kB
-dist/index.html                    X.X kB   X.X kB
-                          Total:   X.X kB   X.X kB`);
+  expect(extractFileSizeLogs(rsbuild2.logs)).toMatchSnapshot();
 });


### PR DESCRIPTION
## Summary

The Rstest migration makes external snapshots available for stable e2e output, avoiding repetitive substring assertions while keeping output changes reviewable.

This converts normalized file-size logs, CLI help, rendered templates, transformed CSS, and `loadEnv` errors to snapshots while retaining targeted assertions for dynamic bundles and runtime behavior.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/7776