### PR TITLE
docs: document onRestart trigger conditions

### DIFF
--- a/website/docs/en/config/dev/watch-files.mdx
+++ b/website/docs/en/config/dev/watch-files.mdx
@@ -114,6 +114,8 @@ export default {
 
 The `restart` functionality is provided by Rsbuild CLI. It is currently not supported by custom servers or frameworks that invoke Rsbuild through the JavaScript API.
 
+> Before the restart, Rsbuild calls the [onRestart hook](/plugins/dev/hooks#onrestart), which you can use to run custom logic before the dev server or watch build restarts.
+
 ### reload-server
 
 `reload-server` is a deprecated alias for `restart`. It remains supported for backward compatibility.

--- a/website/docs/en/shared/onRestart.mdx
+++ b/website/docs/en/shared/onRestart.mdx
@@ -1,5 +1,11 @@
 Called before Rsbuild CLI restarts the dev server or watch build.
 
+The hook is triggered in the following cases:
+
+- The contents of the Rsbuild config file or one of its dependencies change.
+- A file watched by [`dev.watchFiles`](/config/dev/watch-files) with `type: 'restart'` changes.
+- The dev server is manually restarted through a [CLI shortcut](/config/dev/cli-shortcuts).
+
 > This hook is not triggered for regular rebuilds.
 
 - **Type:**

--- a/website/docs/zh/config/dev/watch-files.mdx
+++ b/website/docs/zh/config/dev/watch-files.mdx
@@ -114,6 +114,8 @@ export default {
 
 `restart` 功能由 Rsbuild CLI 提供。如果你使用自定义 server，或者上层框架通过 JavaScript API 调用 Rsbuild，目前暂不支持此配置。
 
+> 重启前，Rsbuild 会调用 [onRestart hook](/plugins/dev/hooks#onrestart)，你可以通过该 hook 在 dev server 或监听构建重启前执行自定义逻辑。
+
 ### reload-server
 
 `reload-server` 是 `restart` 的废弃别名，为保证向后兼容，目前仍然支持。

--- a/website/docs/zh/shared/onRestart.mdx
+++ b/website/docs/zh/shared/onRestart.mdx
@@ -1,5 +1,11 @@
 在 Rsbuild CLI 重启 dev server 或监听构建前调用。
 
+该 hook 会在以下情况中触发：
+
+- Rsbuild 配置文件或其依赖的内容发生变化。
+- [`dev.watchFiles`](/config/dev/watch-files) 中 `type` 为 `'restart'` 的文件发生变化。
+- 通过 [CLI 快捷键](/config/dev/cli-shortcuts) 手动重启 dev server。
+
 > 普通的重新构建不会触发该 hook。
 
 - **类型：**


### PR DESCRIPTION
## Summary

This PR documents when the `onRestart` hook is triggered, including config changes, `dev.watchFiles` restarts, and manual CLI restarts. It also cross-links the hook and related restart configuration in both the English and Chinese docs.