### PR TITLE
fix(core): prevent duplicate restarts from stale watchers

### DIFF
--- a/e2e/cases/cli/watch-files-multiple-restart/index.test.ts
+++ b/e2e/cases/cli/watch-files-multiple-restart/index.test.ts
@@ -1,0 +1,28 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { expect, test } from '@e2e/helper';
+
+const defaultFile = path.join(import.meta.dirname, 'test-temp-default.txt');
+const customFile = path.join(import.meta.dirname, 'test-temp-custom.txt');
+const defaultRestartLog = 'restarting build as test-temp-default.txt changed';
+
+test('should restart once with multiple restart watchers', async ({ execCli, logHelper }) => {
+  fs.writeFileSync(defaultFile, '1');
+  fs.writeFileSync(customFile, '1');
+  execCli('build --watch');
+
+  const { clearLogs, expectBuildEnd, expectLog } = logHelper;
+  await expectBuildEnd();
+
+  clearLogs();
+  fs.writeFileSync(customFile, '2');
+  await expectLog('restarting build as test-temp-custom.txt changed');
+  await expectBuildEnd();
+
+  clearLogs();
+  fs.writeFileSync(defaultFile, '2');
+  await expectLog(defaultRestartLog);
+  await expectBuildEnd();
+
+  expect(logHelper.logs.filter((log) => log.includes(defaultRestartLog))).toHaveLength(1);
+});

--- a/e2e/cases/cli/watch-files-multiple-restart/rsbuild.config.ts
+++ b/e2e/cases/cli/watch-files-multiple-restart/rsbuild.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  dev: {
+    watchFiles: [
+      {
+        paths: './test-temp-default.txt',
+        type: 'restart',
+      },
+      {
+        paths: './test-temp-custom.txt',
+        type: 'restart',
+        options: {
+          cwd: '.',
+        },
+      },
+    ],
+  },
+});

--- a/e2e/cases/cli/watch-files-multiple-restart/src/index.js
+++ b/e2e/cases/cli/watch-files-multiple-restart/src/index.js
@@ -1,0 +1,1 @@
+console.log('Hello Rsbuild!');

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -163,31 +163,13 @@ export async function init({
         return;
       }
 
-      const files: string[] = [];
       const config = rsbuild.getNormalizedConfig();
-
-      if (config.dev.watchFiles) {
-        for (const watchConfig of config.dev.watchFiles) {
-          if (watchConfig.type !== 'restart' && watchConfig.type !== 'reload-server') {
-            continue;
-          }
-
-          const paths = castArray(watchConfig.paths);
-          if (watchConfig.options) {
-            watchFilesForRestart({
-              files: paths,
-              rsbuild,
-              isBuildWatch,
-              watchOptions: watchConfig.options,
-            });
-          } else {
-            files.push(...paths);
-          }
-        }
-      }
+      const watchFiles = config.dev.watchFiles.filter(
+        ({ type }) => type === 'restart' || type === 'reload-server',
+      );
 
       watchFilesForRestart({
-        files,
+        watchFiles,
         rsbuild,
         isBuildWatch,
       });

--- a/packages/core/src/restart.ts
+++ b/packages/core/src/restart.ts
@@ -1,11 +1,11 @@
 import path from 'node:path';
 import type { ChokidarOptions } from 'chokidar';
 import { init } from './cli/init';
-import { color, isTTY } from './helpers';
+import { castArray, color, isTTY } from './helpers';
 import { getRestartManager } from './helpers/restartManager';
 import type { Logger } from './logger';
 import { createChokidar } from './server/watchFiles';
-import type { RestartContext, RestartManager, RsbuildInstance } from './types';
+import type { RestartContext, RestartManager, RsbuildInstance, WatchFiles } from './types';
 
 const clearConsole = () => {
   if (isTTY() && !process.env.DEBUG) {
@@ -91,41 +91,63 @@ const restartBuild = async ({
 };
 
 export async function watchFilesForRestart({
-  files,
+  watchFiles,
   rsbuild,
   isBuildWatch,
-  watchOptions,
 }: {
-  files: string[];
+  watchFiles: WatchFiles[];
   rsbuild: RsbuildInstance;
   isBuildWatch: boolean;
-  watchOptions?: ChokidarOptions;
 }): Promise<void> {
-  if (!files.length) {
+  const watchGroups: { files: string[]; options?: ChokidarOptions }[] = [];
+  const defaultFiles: string[] = [];
+
+  for (const { paths, options } of watchFiles) {
+    const files = castArray(paths);
+    if (!files.length) {
+      continue;
+    }
+
+    if (options) {
+      watchGroups.push({ files, options });
+    } else {
+      defaultFiles.push(...files);
+    }
+  }
+
+  if (defaultFiles.length) {
+    watchGroups.push({ files: defaultFiles });
+  }
+
+  if (!watchGroups.length) {
     return;
   }
 
   const root = rsbuild.context.rootPath;
   const restartManager = getRestartManager(rsbuild);
-  // Chokidar reports event paths relative to `cwd` when it is configured.
-  const watchCwd = watchOptions?.cwd || root;
-  const watcher = await createChokidar(files, root, {
-    // do not trigger add for initial files
-    ignoreInitial: true,
-    // If watching fails due to read permissions, the errors will be suppressed silently.
-    ignorePermissionErrors: true,
-    ...watchOptions,
-  });
+  const watchers = await Promise.all(
+    watchGroups.map(async ({ files, options }) => ({
+      // Chokidar reports event paths relative to `cwd` when it is configured.
+      cwd: options?.cwd || root,
+      watcher: await createChokidar(files, root, {
+        // do not trigger add for initial files
+        ignoreInitial: true,
+        // If watching fails due to read permissions, the errors will be suppressed silently.
+        ignorePermissionErrors: true,
+        ...options,
+      }),
+    })),
+  );
 
   let restarting = false;
 
-  const onChange = async (filePath: string) => {
+  const onChange = async (filePath: string, cwd: string) => {
     if (restarting) {
       return;
     }
     restarting = true;
 
-    const absoluteFilePath = path.resolve(watchCwd, filePath);
+    const absoluteFilePath = path.resolve(cwd, filePath);
 
     const restarted = isBuildWatch
       ? await restartBuild({ filePath: absoluteFilePath, logger: rsbuild.logger, restartManager })
@@ -136,15 +158,18 @@ export async function watchFilesForRestart({
         });
 
     if (restarted) {
-      await watcher.close();
-    } else {
-      rsbuild.logger.error(isBuildWatch ? 'Restart build failed.' : 'Restart server failed.');
+      await Promise.all(watchers.map(({ watcher }) => watcher.close()));
+      return;
     }
 
+    rsbuild.logger.error(isBuildWatch ? 'Restart build failed.' : 'Restart server failed.');
     restarting = false;
   };
 
-  watcher.on('add', onChange);
-  watcher.on('change', onChange);
-  watcher.on('unlink', onChange);
+  for (const { cwd, watcher } of watchers) {
+    const handleChange = (filePath: string) => onChange(filePath, cwd);
+    watcher.on('add', handleChange);
+    watcher.on('change', handleChange);
+    watcher.on('unlink', handleChange);
+  }
 }


### PR DESCRIPTION
## Summary

This PR prevents stale restart watchers from triggering duplicate dev servers or watch builds after an Rsbuild restart. Restart watchers for one instance now share a restart state and are closed together after a successful restart, with a dedicated E2E test covering multiple watcher groups.

## Related Links

- Follow-up to https://github.com/web-infra-dev/rsbuild/pull/8129#discussion_r3607988393