### PR TITLE
refactor(core): decouple restart orchestration from CLI

### DIFF
--- a/e2e/cases/cli/shortcuts/dev.js
+++ b/e2e/cases/cli/shortcuts/dev.js
@@ -1,19 +1,6 @@
-import { createRsbuild } from '@rsbuild/core';
+import { runCLI } from '@rsbuild/core';
 
 process.stdin.isTTY = true;
 delete process.env.CI;
 
-async function main() {
-  const rsbuild = await createRsbuild({
-    cwd: import.meta.dirname,
-    config: {
-      dev: {
-        cliShortcuts: true,
-      },
-    },
-  });
-
-  await rsbuild.startDevServer();
-}
-
-await main();
+runCLI({ argv: ['node', 'rsbuild', 'dev'] });

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -1,11 +1,11 @@
 import path from 'node:path';
-import { createRsbuild } from '../createRsbuild';
+import { createRsbuildInternal } from '../createRsbuild';
 import { castArray } from '../helpers';
 import { ensureAbsolutePath } from '../helpers/path';
 import { loadConfig as baseLoadConfig } from '../loadConfig';
 import { defaultLogger } from '../logger';
 import { watchFilesForRestart } from '../restart';
-import type { RsbuildInstance } from '../types';
+import type { RestartContext, RsbuildInstance } from '../types';
 import type { CommonOptions } from './commands';
 
 export type CommandName = 'dev' | 'build' | 'preview' | 'inspect';
@@ -129,6 +129,26 @@ const loadConfig = async (root: string) => {
   return config;
 };
 
+const restart = async ({ action }: RestartContext): Promise<boolean> => {
+  const rsbuild = await init({
+    isRestart: true,
+    isBuildWatch: action === 'build',
+  });
+
+  // Skip restarting if the config cannot be loaded, for example while the
+  // config file contains incomplete edits.
+  if (!rsbuild) {
+    return false;
+  }
+
+  if (action === 'build') {
+    await rsbuild.build({ watch: true });
+  } else {
+    await rsbuild.startDevServer();
+  }
+  return true;
+};
+
 export async function init({
   isRestart,
   isBuildWatch = false,
@@ -143,18 +163,21 @@ export async function init({
     const cwd = process.cwd();
     const root = options.root ? ensureAbsolutePath(cwd, options.root) : cwd;
 
-    const rsbuild = await createRsbuild({
-      cwd: root,
-      config: () => loadConfig(root),
-      environment: options.environment,
-      loadEnv:
-        options.env === false
-          ? false
-          : {
-              cwd: getEnvDir(root, options.envDir),
-              mode: options.envMode,
-            },
-    });
+    const rsbuild = await createRsbuildInternal(
+      {
+        cwd: root,
+        config: () => loadConfig(root),
+        environment: options.environment,
+        loadEnv:
+          options.env === false
+            ? false
+            : {
+                cwd: getEnvDir(root, options.envDir),
+                mode: options.envMode,
+              },
+      },
+      { restart },
+    );
     logger = rsbuild.logger;
 
     rsbuild.onBeforeCreateCompiler(() => {

--- a/packages/core/src/createContext.ts
+++ b/packages/core/src/createContext.ts
@@ -4,7 +4,7 @@ import { DEFAULT_BROWSERSLIST, ROOT_DIST_DIR } from './constants';
 import { withDefaultConfig } from './defaultConfig';
 import { hash } from './helpers';
 import { ensureAbsolutePath, getCommonParentPath } from './helpers/path';
-import { createRestartManager } from './helpers/restartManager';
+import { createRestartManager, type RestartExecutor } from './helpers/restartManager';
 import { initHooks } from './hooks';
 import { getHTMLPathByEntry } from './initPlugins';
 import type { Logger } from './logger';
@@ -177,6 +177,7 @@ export async function createContext(
   options: ResolvedCreateRsbuildOptions,
   userConfig: RsbuildConfig,
   logger: Logger,
+  restart?: RestartExecutor,
 ): Promise<InternalContext> {
   const { cwd } = options;
   const rootPath = userConfig.root ? ensureAbsolutePath(cwd, userConfig.root) : cwd;
@@ -185,6 +186,7 @@ export async function createContext(
 
   const specifiedEnvironments =
     options.environment && options.environment.length > 0 ? options.environment : undefined;
+  const hooks = initHooks();
 
   return {
     version: RSBUILD_VERSION,
@@ -197,8 +199,11 @@ export async function createContext(
     environments: {},
     environmentList: [],
     publicPathnames: [],
-    hooks: initHooks(),
-    restartManager: createRestartManager(),
+    hooks,
+    restartManager: createRestartManager({
+      onRestart: hooks.onRestart.callBatch,
+      restart,
+    }),
     config: { ...rsbuildConfig },
     originalConfig: userConfig,
     specifiedEnvironments,

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -5,7 +5,7 @@ import { createCompiler as baseCreateCompiler } from './createCompiler';
 import { createContext } from './createContext';
 import { castArray, color, getNodeEnv, isFunction, pick, setNodeEnv } from './helpers';
 import { isEmptyDir } from './helpers/fs';
-import { setRestartManager } from './helpers/restartManager';
+import { setRestartManager, type RestartExecutor } from './helpers/restartManager';
 import { initConfigs as baseInitConfigs, initRsbuildConfig } from './initConfigs';
 import { initPluginAPI } from './initPlugins';
 import { inspectConfig as baseInspectConfig } from './inspectConfig';
@@ -148,7 +148,14 @@ function applyEnvsToConfig(config: RsbuildConfig, envs: LoadEnvResult | null) {
 /**
  * Create an Rsbuild instance.
  */
-export async function createRsbuild(options: CreateRsbuildOptions = {}): Promise<RsbuildInstance> {
+export function createRsbuild(options: CreateRsbuildOptions = {}): Promise<RsbuildInstance> {
+  return createRsbuildInternal(options);
+}
+
+export async function createRsbuildInternal(
+  options: CreateRsbuildOptions = {},
+  internalOptions?: { restart?: RestartExecutor },
+): Promise<RsbuildInstance> {
   const envs = options.loadEnv
     ? loadEnv({
         cwd: options.cwd,
@@ -185,7 +192,7 @@ export async function createRsbuild(options: CreateRsbuildOptions = {}): Promise
 
   const pluginManager = createPluginManager(logger);
 
-  const context = await createContext(resolvedOptions, config, logger);
+  const context = await createContext(resolvedOptions, config, logger, internalOptions?.restart);
 
   const getPluginAPI = initPluginAPI({ context, pluginManager });
   context.getPluginAPI = getPluginAPI;

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -265,7 +265,7 @@ export async function createRsbuildInternal(
     };
 
     if (options?.watch) {
-      unregisterRestart = context.restartManager.register(close);
+      unregisterRestart = context.restartManager.registerCleanup(close);
     }
 
     return {

--- a/packages/core/src/helpers/restartManager.ts
+++ b/packages/core/src/helpers/restartManager.ts
@@ -1,12 +1,27 @@
-import type { RestartManager } from '../types/context';
-import type { OnRestartFn } from '../types/hooks';
+import type { RestartContext } from '../types/hooks';
 import type { RsbuildInstance } from '../types/rsbuild';
+import type { MaybePromise } from '../types/utils';
 
-type Entry = { callback: OnRestartFn };
+type Entry = { callback: () => MaybePromise<void> };
+
+export type RestartExecutor = (context: RestartContext) => MaybePromise<boolean>;
+
+export type RestartManager = {
+  /** Register a cleanup callback and return a function that unregisters it. */
+  register(callback: () => MaybePromise<void>): () => void;
+  /** Handle a restart request and return whether the restart succeeded. */
+  request(context: RestartContext): Promise<boolean>;
+};
 
 const restartManagers = new WeakMap<RsbuildInstance, RestartManager>();
 
-export const createRestartManager = (): RestartManager => {
+export const createRestartManager = ({
+  onRestart,
+  restart,
+}: {
+  onRestart: (context: RestartContext) => MaybePromise<unknown>;
+  restart?: RestartExecutor;
+}): RestartManager => {
   let entries = new Set<Entry>();
 
   return {
@@ -18,16 +33,28 @@ export const createRestartManager = (): RestartManager => {
         entries.delete(entry);
       };
     },
-    async call(context) {
+    async request(context) {
+      if (!restart) {
+        await onRestart(context);
+        return false;
+      }
+
       const currentEntries = entries;
       entries = new Set();
 
       let hasError = false;
       let firstError: unknown;
 
+      try {
+        await onRestart(context);
+      } catch (error) {
+        hasError = true;
+        firstError = error;
+      }
+
       for (const entry of currentEntries) {
         try {
-          await entry.callback(context);
+          await entry.callback();
         } catch (error) {
           if (!hasError) {
             hasError = true;
@@ -39,6 +66,8 @@ export const createRestartManager = (): RestartManager => {
       if (hasError) {
         throw firstError;
       }
+
+      return restart(context);
     },
   };
 };

--- a/packages/core/src/helpers/restartManager.ts
+++ b/packages/core/src/helpers/restartManager.ts
@@ -2,15 +2,15 @@ import type { RestartContext } from '../types/hooks';
 import type { RsbuildInstance } from '../types/rsbuild';
 import type { MaybePromise } from '../types/utils';
 
-type Entry = { callback: () => MaybePromise<void> };
+type Cleanup = () => MaybePromise<void>;
 
 export type RestartExecutor = (context: RestartContext) => MaybePromise<boolean>;
 
 export type RestartManager = {
   /** Register a cleanup callback and return a function that unregisters it. */
-  register(callback: () => MaybePromise<void>): () => void;
+  registerCleanup(cleanup: Cleanup): () => void;
   /** Handle a restart request and return whether the restart succeeded. */
-  request(context: RestartContext): Promise<boolean>;
+  requestRestart(context: RestartContext): Promise<boolean>;
 };
 
 const restartManagers = new WeakMap<RsbuildInstance, RestartManager>();
@@ -22,25 +22,24 @@ export const createRestartManager = ({
   onRestart: (context: RestartContext) => MaybePromise<unknown>;
   restart?: RestartExecutor;
 }): RestartManager => {
-  let entries = new Set<Entry>();
+  let cleanups = new Set<Cleanup>();
 
   return {
-    register(callback) {
-      const entry = { callback };
-      entries.add(entry);
+    registerCleanup(cleanup) {
+      cleanups.add(cleanup);
 
       return () => {
-        entries.delete(entry);
+        cleanups.delete(cleanup);
       };
     },
-    async request(context) {
+    async requestRestart(context) {
       if (!restart) {
         await onRestart(context);
         return false;
       }
 
-      const currentEntries = entries;
-      entries = new Set();
+      const currentCleanups = cleanups;
+      cleanups = new Set();
 
       let hasError = false;
       let firstError: unknown;
@@ -52,9 +51,9 @@ export const createRestartManager = ({
         firstError = error;
       }
 
-      for (const entry of currentEntries) {
+      for (const cleanup of currentCleanups) {
         try {
-          await entry.callback();
+          await cleanup();
         } catch (error) {
           if (!hasError) {
             hasError = true;

--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -331,10 +331,6 @@ export function initPluginAPI({
     hooks.onExit.tap(cb);
   };
 
-  context.restartManager.register(async (restartContext) => {
-    await hooks.onRestart.callBatch(restartContext);
-  });
-
   // Each plugin returns different APIs depending on the registered environment info.
   return (environment?: string) => ({
     context: publicContext,

--- a/packages/core/src/restart.ts
+++ b/packages/core/src/restart.ts
@@ -36,7 +36,7 @@ export const requestRestart = ({
     logger.info(`restarting ${id}...\n`);
   }
 
-  return restartManager.request({ action, filePath });
+  return restartManager.requestRestart({ action, filePath });
 };
 
 export async function watchFilesForRestart({

--- a/packages/core/src/restart.ts
+++ b/packages/core/src/restart.ts
@@ -1,11 +1,10 @@
 import path from 'node:path';
 import type { ChokidarOptions } from 'chokidar';
-import { init } from './cli/init';
 import { castArray, color, isTTY } from './helpers';
-import { getRestartManager } from './helpers/restartManager';
+import { getRestartManager, type RestartManager } from './helpers/restartManager';
 import type { Logger } from './logger';
 import { createChokidar } from './server/watchFiles';
-import type { RestartContext, RestartManager, RsbuildInstance, WatchFiles } from './types';
+import type { RestartContext, RsbuildInstance, WatchFiles } from './types';
 
 const clearConsole = () => {
   if (isTTY() && !process.env.DEBUG) {
@@ -13,7 +12,7 @@ const clearConsole = () => {
   }
 };
 
-const beforeRestart = async ({
+export const requestRestart = ({
   filePath,
   clear = true,
   action,
@@ -23,7 +22,7 @@ const beforeRestart = async ({
   clear?: boolean;
   logger: Logger;
   restartManager: RestartManager;
-}): Promise<void> => {
+}): Promise<boolean> => {
   if (clear) {
     clearConsole();
   }
@@ -37,57 +36,7 @@ const beforeRestart = async ({
     logger.info(`restarting ${id}...\n`);
   }
 
-  await restartManager.call({ action, filePath });
-};
-
-export const restartDevServer = async ({
-  filePath,
-  clear = true,
-  logger,
-  restartManager,
-}: {
-  filePath?: string;
-  clear?: boolean;
-  logger: Logger;
-  restartManager: RestartManager;
-}): Promise<boolean> => {
-  await beforeRestart({ action: 'dev', filePath, clear, logger, restartManager });
-
-  const rsbuild = await init({ isRestart: true });
-
-  // Skip the following logic if restart failed,
-  // maybe user is editing config file and write some invalid config
-  if (!rsbuild) {
-    return false;
-  }
-
-  await rsbuild.startDevServer();
-  return true;
-};
-
-const restartBuild = async ({
-  filePath,
-  clear = true,
-  logger,
-  restartManager,
-}: {
-  filePath?: string;
-  clear?: boolean;
-  logger: Logger;
-  restartManager: RestartManager;
-}): Promise<boolean> => {
-  await beforeRestart({ action: 'build', filePath, clear, logger, restartManager });
-
-  const rsbuild = await init({ isRestart: true, isBuildWatch: true });
-
-  // Skip the following logic if restart failed,
-  // maybe user is editing config file and write some invalid config
-  if (!rsbuild) {
-    return false;
-  }
-
-  await rsbuild.build({ watch: true });
-  return true;
+  return restartManager.request({ action, filePath });
 };
 
 export async function watchFilesForRestart({
@@ -149,13 +98,12 @@ export async function watchFilesForRestart({
 
     const absoluteFilePath = path.resolve(cwd, filePath);
 
-    const restarted = isBuildWatch
-      ? await restartBuild({ filePath: absoluteFilePath, logger: rsbuild.logger, restartManager })
-      : await restartDevServer({
-          filePath: absoluteFilePath,
-          logger: rsbuild.logger,
-          restartManager,
-        });
+    const restarted = await requestRestart({
+      action: isBuildWatch ? 'build' : 'dev',
+      filePath: absoluteFilePath,
+      logger: rsbuild.logger,
+      restartManager,
+    });
 
     if (restarted) {
       await Promise.all(watchers.map(({ watcher }) => watcher.close()));

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -366,7 +366,7 @@ export async function createDevServer<
 
             await devServer.afterListen();
 
-            unregisterRestart = context.restartManager.register(closeServer);
+            unregisterRestart = context.restartManager.registerCleanup(closeServer);
 
             resolve({
               port,

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -2,7 +2,7 @@ import type { Server } from 'node:http';
 import type { Http2SecureServer } from 'node:http2';
 import { color } from '../helpers';
 import { getPublicPathFromCompiler, isMultiCompiler } from '../helpers/compiler';
-import { restartDevServer } from '../restart';
+import { requestRestart } from '../restart';
 import type {
   CreateCompiler,
   CreateDevServerOptions,
@@ -233,7 +233,12 @@ export async function createDevServer<
         closeServer,
         printUrls,
         restartServer: () =>
-          restartDevServer({ clear: false, logger, restartManager: context.restartManager }),
+          requestRestart({
+            action: 'dev',
+            clear: false,
+            logger,
+            restartManager: context.restartManager,
+          }),
         help: shortcutsOptions.help,
         customShortcuts: shortcutsOptions.custom,
         logger,

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -1,8 +1,9 @@
 import type { Hooks } from '../hooks';
+import type { RestartManager } from '../helpers/restartManager';
 import type { Logger } from '../logger';
 import type { SocketServer } from '../server/socketServer';
 import type { NormalizedConfig, RsbuildConfig } from './config';
-import type { EnvironmentContext, OnRestartFn, RestartContext } from './hooks';
+import type { EnvironmentContext } from './hooks';
 import type { RsbuildPluginAPI } from './plugin';
 import type { RsbuildStats } from './rsbuild';
 
@@ -82,13 +83,6 @@ export type BuildState = {
   hasErrors: boolean;
   /** The build time of each environment */
   time: Record<string, number>;
-};
-
-export type RestartManager = {
-  /** Register a restart callback and return a function that unregisters it. */
-  register(callback: OnRestartFn): () => void;
-  /** Invoke and clear all currently registered restart callbacks. */
-  call(context: RestartContext): Promise<void>;
 };
 
 /** The inner context. */

--- a/packages/core/tests/restartHook.test.ts
+++ b/packages/core/tests/restartHook.test.ts
@@ -5,7 +5,8 @@ describe('restartManager', () => {
   test('should execute all callbacks and clear the registry when one throws', async () => {
     const calls: string[] = [];
     const context = { action: 'build' } as const;
-    const manager = createRestartManager();
+    const restart = rstest.fn(() => true);
+    const manager = createRestartManager({ onRestart: () => {}, restart });
 
     manager.register(() => {
       calls.push('first');
@@ -16,21 +17,23 @@ describe('restartManager', () => {
     });
 
     // A thrown value should not prevent subsequent callbacks from running.
-    await expect(manager.call(context)).rejects.toBeNull();
+    await expect(manager.request(context)).rejects.toBeNull();
     expect(calls).toEqual(['first', 'second']);
+    expect(restart).not.toHaveBeenCalled();
 
     // The callback registry should be cleared after the first invocation.
-    await expect(manager.call(context)).resolves.toBeUndefined();
+    await expect(manager.request(context)).resolves.toBe(true);
     expect(calls).toEqual(['first', 'second']);
+    expect(restart).toHaveBeenCalledWith(context);
   });
 
   test('should unregister callbacks', async () => {
     const callback = rstest.fn();
-    const manager = createRestartManager();
+    const manager = createRestartManager({ onRestart: () => {}, restart: () => true });
     const unregister = manager.register(callback);
 
     unregister();
-    await manager.call({ action: 'dev' });
+    await manager.request({ action: 'dev' });
 
     expect(callback).not.toHaveBeenCalled();
   });
@@ -44,12 +47,12 @@ describe('restartManager', () => {
 
     first.onRestart(firstCallback);
     second.onRestart(secondCallback);
-    await getRestartManager(first).call(context);
+    await getRestartManager(first).request(context);
 
     expect(firstCallback).toHaveBeenCalledWith(context);
     expect(secondCallback).not.toHaveBeenCalled();
 
-    await getRestartManager(second).call(context);
+    await getRestartManager(second).request(context);
 
     expect(secondCallback).toHaveBeenCalledWith(context);
   });

--- a/packages/core/tests/restartHook.test.ts
+++ b/packages/core/tests/restartHook.test.ts
@@ -8,21 +8,21 @@ describe('restartManager', () => {
     const restart = rstest.fn(() => true);
     const manager = createRestartManager({ onRestart: () => {}, restart });
 
-    manager.register(() => {
+    manager.registerCleanup(() => {
       calls.push('first');
       throw null;
     });
-    manager.register(() => {
+    manager.registerCleanup(() => {
       calls.push('second');
     });
 
     // A thrown value should not prevent subsequent callbacks from running.
-    await expect(manager.request(context)).rejects.toBeNull();
+    await expect(manager.requestRestart(context)).rejects.toBeNull();
     expect(calls).toEqual(['first', 'second']);
     expect(restart).not.toHaveBeenCalled();
 
     // The callback registry should be cleared after the first invocation.
-    await expect(manager.request(context)).resolves.toBe(true);
+    await expect(manager.requestRestart(context)).resolves.toBe(true);
     expect(calls).toEqual(['first', 'second']);
     expect(restart).toHaveBeenCalledWith(context);
   });
@@ -30,10 +30,10 @@ describe('restartManager', () => {
   test('should unregister callbacks', async () => {
     const callback = rstest.fn();
     const manager = createRestartManager({ onRestart: () => {}, restart: () => true });
-    const unregister = manager.register(callback);
+    const unregister = manager.registerCleanup(callback);
 
     unregister();
-    await manager.request({ action: 'dev' });
+    await manager.requestRestart({ action: 'dev' });
 
     expect(callback).not.toHaveBeenCalled();
   });
@@ -47,12 +47,12 @@ describe('restartManager', () => {
 
     first.onRestart(firstCallback);
     second.onRestart(secondCallback);
-    await getRestartManager(first).request(context);
+    await getRestartManager(first).requestRestart(context);
 
     expect(firstCallback).toHaveBeenCalledWith(context);
     expect(secondCallback).not.toHaveBeenCalled();
 
-    await getRestartManager(second).request(context);
+    await getRestartManager(second).requestRestart(context);
 
     expect(secondCallback).toHaveBeenCalledWith(context);
   });


### PR DESCRIPTION
## Summary

This PR decouples restart orchestration from the CLI so restart requests can notify hooks and clean up the active task independently of the restart executor.

The CLI now injects its restart executor through an internal Rsbuild creation path, while JS API instances do not receive a default executor.

This removes core's reverse dependency on CLI initialization and prepares watch-file restart handling for a later core migration.