### PR TITLE
fix(core): hide unavailable restart shortcut

### DIFF
--- a/e2e/cases/cli/shortcuts/devJsApi.js
+++ b/e2e/cases/cli/shortcuts/devJsApi.js
@@ -1,0 +1,15 @@
+import { createRsbuild } from '@rsbuild/core';
+
+process.stdin.isTTY = true;
+delete process.env.CI;
+
+const rsbuild = await createRsbuild({
+  cwd: import.meta.dirname,
+  config: {
+    dev: {
+      cliShortcuts: true,
+    },
+  },
+});
+
+await rsbuild.startDevServer();

--- a/e2e/cases/cli/shortcuts/index.test.ts
+++ b/e2e/cases/cli/shortcuts/index.test.ts
@@ -21,6 +21,19 @@ test('should display shortcuts as expected in dev', async ({ exec, logHelper }) 
   await expectLog('➜  Local:    http://localhost:');
 });
 
+test('should not display restart shortcut without a restart executor', async ({
+  exec,
+  logHelper,
+}) => {
+  const { childProcess } = exec('node ./devJsApi.js');
+  const { expectLog, expectNoLog } = logHelper;
+
+  await expectLog('press h + enter to show shortcuts');
+  childProcess.stdin?.write('h\n');
+  await expectLog('u + enter  show urls');
+  expectNoLog('r + enter  restart server');
+});
+
 test('should display shortcuts as expected in preview', async ({ exec, logHelper }) => {
   const { childProcess } = exec('node ./preview.js');
   const { expectLog, clearLogs } = logHelper;

--- a/packages/core/src/helpers/restartManager.ts
+++ b/packages/core/src/helpers/restartManager.ts
@@ -7,6 +7,8 @@ type Cleanup = () => MaybePromise<void>;
 export type RestartExecutor = (context: RestartContext) => MaybePromise<boolean>;
 
 export type RestartManager = {
+  /** Whether a restart executor is available. */
+  readonly canRestart: boolean;
   /** Register a cleanup callback and return a function that unregisters it. */
   registerCleanup(cleanup: Cleanup): () => void;
   /** Handle a restart request and return whether the restart succeeded. */
@@ -25,6 +27,7 @@ export const createRestartManager = ({
   let cleanups = new Set<Cleanup>();
 
   return {
+    canRestart: Boolean(restart),
     registerCleanup(cleanup) {
       cleanups.add(cleanup);
 

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -232,13 +232,15 @@ export async function createDevServer<
         openPage,
         closeServer,
         printUrls,
-        restartServer: () =>
-          requestRestart({
-            action: 'dev',
-            clear: false,
-            logger,
-            restartManager: context.restartManager,
-          }),
+        restartServer: context.restartManager.canRestart
+          ? () =>
+              requestRestart({
+                action: 'dev',
+                clear: false,
+                logger,
+                restartManager: context.restartManager,
+              })
+          : undefined,
         help: shortcutsOptions.help,
         customShortcuts: shortcutsOptions.custom,
         logger,


### PR DESCRIPTION
## Summary

This PR prevents the `r` shortcut from being exposed when a JavaScript API instance has no restart executor.

`RestartManager.canRestart` now gates restart shortcut registration, while CLI instances keep restart support. A dedicated e2e case covers the JavaScript API behavior.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8133#discussion_r3609926068