### PR TITLE
feat(core): support restart watchers in JavaScript API

### DIFF
--- a/e2e/cases/javascript-api/restart-watch-files/index.test.ts
+++ b/e2e/cases/javascript-api/restart-watch-files/index.test.ts
@@ -20,16 +20,28 @@ const createConfig = (): RsbuildConfig => ({
   },
 });
 
-const expectRestart = (rsbuild: RsbuildInstance, action: RestartContext['action']) => {
-  const restart = new Promise<RestartContext>((resolve) => {
-    rsbuild.onRestart(resolve);
+const expectRestart = async (rsbuild: RsbuildInstance, action: RestartContext['action']) => {
+  let restartContext: RestartContext | undefined;
+  let version = 1;
+
+  rsbuild.onRestart((context) => {
+    restartContext = context;
   });
 
-  fs.writeFileSync(watchedFile, '2');
-  return expect(restart).resolves.toEqual({
-    action,
-    filePath: watchedFile,
-  });
+  await expect
+    .poll(
+      () => {
+        if (!restartContext) {
+          fs.writeFileSync(watchedFile, String(++version));
+        }
+        return restartContext;
+      },
+      { timeout: 5_000 },
+    )
+    .toEqual({
+      action,
+      filePath: watchedFile,
+    });
 };
 
 test.beforeEach(() => {

--- a/e2e/cases/javascript-api/restart-watch-files/index.test.ts
+++ b/e2e/cases/javascript-api/restart-watch-files/index.test.ts
@@ -1,0 +1,91 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { expect, test } from '@e2e/helper';
+import {
+  createRsbuild,
+  type RestartContext,
+  type RsbuildConfig,
+  type RsbuildInstance,
+} from '@rsbuild/core';
+import { getRandomPort } from '@rstackjs/test-utils';
+
+const watchedFile = path.join(import.meta.dirname, 'test-temp-watch.txt');
+
+const createConfig = (): RsbuildConfig => ({
+  dev: {
+    watchFiles: {
+      paths: watchedFile,
+      type: 'restart',
+    },
+  },
+});
+
+const expectRestart = (rsbuild: RsbuildInstance, action: RestartContext['action']) => {
+  const restart = new Promise<RestartContext>((resolve) => {
+    rsbuild.onRestart(resolve);
+  });
+
+  fs.writeFileSync(watchedFile, '2');
+  return expect(restart).resolves.toEqual({
+    action,
+    filePath: watchedFile,
+  });
+};
+
+test.beforeEach(() => {
+  fs.writeFileSync(watchedFile, '1');
+});
+
+test.afterAll(() => {
+  fs.rmSync(watchedFile, { force: true });
+});
+
+test('build({ watch: true }) should watch restart files', async ({ build, copySrcDir }) => {
+  const sourcePath = await copySrcDir();
+  const result = await build({
+    watch: true,
+    config: {
+      ...createConfig(),
+      source: {
+        entry: {
+          index: path.join(sourcePath, 'index.js'),
+        },
+      },
+    },
+  });
+  await result.expectBuildEnd();
+
+  await expectRestart(result.instance, 'build');
+
+  // Without a restart executor, the current watch build should remain active.
+  result.clearLogs();
+  fs.writeFileSync(path.join(sourcePath, 'index.js'), "console.log('updated');");
+  await result.expectBuildEnd();
+});
+
+test('startDevServer() should watch restart files', async ({ devOnly }) => {
+  const result = await devOnly({ config: createConfig() });
+
+  await expectRestart(result.instance, 'dev');
+
+  // Without a restart executor, the current server should remain available.
+  const response = await fetch(result.urls[0]);
+  expect(response.ok).toBeTruthy();
+});
+
+test('createDevServer() should watch restart files', async () => {
+  const rsbuild = await createRsbuild({
+    cwd: import.meta.dirname,
+    config: {
+      ...createConfig(),
+      server: {
+        port: await getRandomPort(),
+      },
+    },
+  });
+  const server = await rsbuild.createDevServer({ runCompile: false });
+
+  await expectRestart(rsbuild, 'dev');
+
+  await server.close();
+});

--- a/e2e/cases/javascript-api/restart-watch-files/src/index.js
+++ b/e2e/cases/javascript-api/restart-watch-files/src/index.js
@@ -1,0 +1,1 @@
+console.log('Hello Rsbuild!');

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -75,20 +75,15 @@ export const build = async (
     return closingPromise;
   };
 
-  let restartWatcher: Awaited<ReturnType<typeof watchFilesForRestart>>;
+  let restartWatcher: ReturnType<typeof watchFilesForRestart>;
   if (watch) {
     // Only close build resources before restart; keep the watcher alive for retries.
     unregisterRestart = context.restartManager.registerCleanup(closeBuild);
-    try {
-      restartWatcher = await watchFilesForRestart({
-        watchFiles: context.normalizedConfig!.dev.watchFiles,
-        context,
-        action: 'build',
-      });
-    } catch (error) {
-      await closeBuild();
-      throw error;
-    }
+    restartWatcher = watchFilesForRestart({
+      watchFiles: context.normalizedConfig!.dev.watchFiles,
+      context,
+      action: 'build',
+    });
   }
 
   const close = async () => {

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -2,6 +2,7 @@ import { rspack, type WatchOptions } from '@rspack/core';
 import { createCompiler } from './createCompiler';
 import { registerBuildHook } from './hooks';
 import type { InitConfigsOptions } from './initConfigs';
+import { watchFilesForRestart } from './restart';
 import type { Build, BuildOptions, Rspack } from './types';
 
 export const RSPACK_BUILD_ERROR = 'Rspack build failed.';
@@ -22,6 +23,9 @@ export const build = async (
     MultiStatsCtor: rspack.MultiStats,
   });
 
+  let stats: Rspack.Stats | Rspack.MultiStats | undefined;
+  let closeCompiler: (() => Promise<void>) | undefined;
+
   if (watch) {
     const watchOptions: WatchOptions[] = rspackConfigs.map((options) => options.watchOptions || {});
 
@@ -31,40 +35,69 @@ export const build = async (
       }
     });
 
-    return {
-      close: () =>
-        new Promise((resolve) => {
-          compiler.close(() => {
-            resolve();
-          });
-        }),
-    };
-  }
+    closeCompiler = () =>
+      new Promise((resolve) => {
+        compiler.close(() => {
+          resolve();
+        });
+      });
+  } else {
+    stats = await new Promise<Rspack.Stats | Rspack.MultiStats | undefined>((resolve, reject) => {
+      compiler.run((err, stats) => {
+        // When using run or watch, call close and wait for it to finish before calling run or watch again.
+        // Concurrent compilations will corrupt the output files.
+        compiler.close((closeErr) => {
+          if (closeErr) {
+            logger.error('Failed to close compiler: ', closeErr);
+          }
 
-  const { stats } = await new Promise<{
-    stats?: Rspack.Stats | Rspack.MultiStats;
-  }>((resolve, reject) => {
-    compiler.run((err, stats) => {
-      // When using run or watch, call close and wait for it to finish before calling run or watch again.
-      // Concurrent compilations will corrupt the output files.
-      compiler.close((closeErr) => {
-        if (closeErr) {
-          logger.error('Failed to close compiler: ', closeErr);
-        }
-
-        if (err) {
-          reject(err);
-        } else if (context.buildState.hasErrors) {
-          reject(new Error(RSPACK_BUILD_ERROR));
-        } else {
-          resolve({ stats });
-        }
+          if (err) {
+            reject(err);
+          } else if (context.buildState.hasErrors) {
+            reject(new Error(RSPACK_BUILD_ERROR));
+          } else {
+            resolve(stats);
+          }
+        });
       });
     });
-  });
+  }
+
+  let closingPromise: Promise<void> | undefined;
+  let unregisterRestart: (() => void) | undefined;
+  const closeBuild = () => {
+    closingPromise ||= (async () => {
+      unregisterRestart?.();
+      unregisterRestart = undefined;
+      await context.hooks.onCloseBuild.callBatch();
+      await closeCompiler?.();
+    })();
+    return closingPromise;
+  };
+
+  let restartWatcher: Awaited<ReturnType<typeof watchFilesForRestart>>;
+  if (watch) {
+    // Only close build resources before restart; keep the watcher alive for retries.
+    unregisterRestart = context.restartManager.registerCleanup(closeBuild);
+    try {
+      restartWatcher = await watchFilesForRestart({
+        watchFiles: context.normalizedConfig!.dev.watchFiles,
+        context,
+        action: 'build',
+      });
+    } catch (error) {
+      await closeBuild();
+      throw error;
+    }
+  }
+
+  const close = async () => {
+    await restartWatcher?.close();
+    await closeBuild();
+  };
 
   return {
     stats,
-    close: async () => {},
+    close,
   };
 };

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -116,9 +116,7 @@ export function setupCommands(argv: string[]): void {
           process.env.RSPACK_UNSAFE_FAST_DROP = 'true';
         }
 
-        const rsbuild = await init({
-          isBuildWatch: options.watch,
-        });
+        const rsbuild = await init();
         if (!rsbuild) {
           return;
         }

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -4,7 +4,6 @@ import { castArray } from '../helpers';
 import { ensureAbsolutePath } from '../helpers/path';
 import { loadConfig as baseLoadConfig } from '../loadConfig';
 import { defaultLogger } from '../logger';
-import { watchFilesForRestart } from '../restart';
 import type { RestartContext, RsbuildInstance } from '../types';
 import type { CommonOptions } from './commands';
 
@@ -130,10 +129,7 @@ const loadConfig = async (root: string) => {
 };
 
 const restart = async ({ action }: RestartContext): Promise<boolean> => {
-  const rsbuild = await init({
-    isRestart: true,
-    isBuildWatch: action === 'build',
-  });
+  const rsbuild = await init({ isRestart: true });
 
   // Skip restarting if the config cannot be loaded, for example while the
   // config file contains incomplete edits.
@@ -149,13 +145,9 @@ const restart = async ({ action }: RestartContext): Promise<boolean> => {
   return true;
 };
 
-export async function init({
-  isRestart,
-  isBuildWatch = false,
-}: {
-  isRestart?: boolean;
-  isBuildWatch?: boolean;
-} = {}): Promise<RsbuildInstance | undefined> {
+export async function init({ isRestart }: { isRestart?: boolean } = {}): Promise<
+  RsbuildInstance | undefined
+> {
   let logger = defaultLogger;
   const { options } = cliState;
 
@@ -179,24 +171,6 @@ export async function init({
       { restart },
     );
     logger = rsbuild.logger;
-
-    rsbuild.onBeforeCreateCompiler(() => {
-      // Skip watching files when not in dev mode or not in build watch mode
-      if (rsbuild.context.action !== 'dev' && !isBuildWatch) {
-        return;
-      }
-
-      const config = rsbuild.getNormalizedConfig();
-      const watchFiles = config.dev.watchFiles.filter(
-        ({ type }) => type === 'restart' || type === 'reload-server',
-      );
-
-      watchFilesForRestart({
-        watchFiles,
-        rsbuild,
-        isBuildWatch,
-      });
-    });
 
     return rsbuild;
   } catch (err) {

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -5,7 +5,7 @@ import { createCompiler as baseCreateCompiler } from './createCompiler';
 import { createContext } from './createContext';
 import { castArray, color, getNodeEnv, isFunction, pick, setNodeEnv } from './helpers';
 import { isEmptyDir } from './helpers/fs';
-import { setRestartManager, type RestartExecutor } from './helpers/restartManager';
+import type { RestartExecutor } from './helpers/restartManager';
 import { initConfigs as baseInitConfigs, initRsbuildConfig } from './initConfigs';
 import { initPluginAPI } from './initPlugins';
 import { inspectConfig as baseInspectConfig } from './inspectConfig';
@@ -251,27 +251,7 @@ export async function createRsbuildInternal(
       setNodeEnv('production');
     }
 
-    const buildInstance = await baseBuild(
-      { context, pluginManager, rsbuildOptions: resolvedOptions },
-      options,
-    );
-
-    let unregisterRestart: (() => void) | undefined;
-    const close = async () => {
-      unregisterRestart?.();
-      unregisterRestart = undefined;
-      await context.hooks.onCloseBuild.callBatch();
-      await buildInstance.close();
-    };
-
-    if (options?.watch) {
-      unregisterRestart = context.restartManager.registerCleanup(close);
-    }
-
-    return {
-      ...buildInstance,
-      close,
-    };
+    return baseBuild({ context, pluginManager, rsbuildOptions: resolvedOptions }, options);
   };
 
   const startDevServer: StartDevServer = async (options?: StartDevServerOptions) => {
@@ -391,8 +371,6 @@ export async function createRsbuildInternal(
       'onRestart',
     ]),
   };
-
-  setRestartManager(rsbuild, context.restartManager);
 
   if (envs) {
     rsbuild.onCloseBuild(envs.cleanup);

--- a/packages/core/src/helpers/restartManager.ts
+++ b/packages/core/src/helpers/restartManager.ts
@@ -1,5 +1,4 @@
 import type { RestartContext } from '../types/hooks';
-import type { RsbuildInstance } from '../types/rsbuild';
 import type { MaybePromise } from '../types/utils';
 
 type Cleanup = () => MaybePromise<void>;
@@ -14,8 +13,6 @@ export type RestartManager = {
   /** Handle a restart request and return whether the restart succeeded. */
   requestRestart(context: RestartContext): Promise<boolean>;
 };
-
-const restartManagers = new WeakMap<RsbuildInstance, RestartManager>();
 
 export const createRestartManager = ({
   onRestart,
@@ -72,16 +69,4 @@ export const createRestartManager = ({
       return restart(context);
     },
   };
-};
-
-export const setRestartManager = (instance: RsbuildInstance, manager: RestartManager): void => {
-  restartManagers.set(instance, manager);
-};
-
-export const getRestartManager = (instance: RsbuildInstance): RestartManager => {
-  const manager = restartManagers.get(instance);
-  if (!manager) {
-    throw new Error('Restart manager is not initialized.');
-  }
-  return manager;
 };

--- a/packages/core/src/restart.ts
+++ b/packages/core/src/restart.ts
@@ -1,10 +1,10 @@
 import path from 'node:path';
 import type { ChokidarOptions } from 'chokidar';
 import { castArray, color, isTTY } from './helpers';
-import { getRestartManager, type RestartManager } from './helpers/restartManager';
+import type { RestartManager } from './helpers/restartManager';
 import type { Logger } from './logger';
-import { createChokidar } from './server/watchFiles';
-import type { RestartContext, RsbuildInstance, WatchFiles } from './types';
+import { createChokidar, type WatchFilesResult } from './server/watchFiles';
+import type { InternalContext, RestartContext, WatchFiles } from './types';
 
 const clearConsole = () => {
   if (isTTY() && !process.env.DEBUG) {
@@ -23,17 +23,19 @@ export const requestRestart = ({
   logger: Logger;
   restartManager: RestartManager;
 }): Promise<boolean> => {
-  if (clear) {
-    clearConsole();
-  }
+  if (restartManager.canRestart) {
+    if (clear) {
+      clearConsole();
+    }
 
-  const id = action === 'dev' ? 'server' : 'build';
+    const id = action === 'dev' ? 'server' : 'build';
 
-  if (filePath) {
-    const filename = path.basename(filePath);
-    logger.info(`restarting ${id} as ${color.yellow(filename)} changed\n`);
-  } else {
-    logger.info(`restarting ${id}...\n`);
+    if (filePath) {
+      const filename = path.basename(filePath);
+      logger.info(`restarting ${id} as ${color.yellow(filename)} changed\n`);
+    } else {
+      logger.info(`restarting ${id}...\n`);
+    }
   }
 
   return restartManager.requestRestart({ action, filePath });
@@ -41,17 +43,25 @@ export const requestRestart = ({
 
 export async function watchFilesForRestart({
   watchFiles,
-  rsbuild,
-  isBuildWatch,
+  context,
+  action,
 }: {
   watchFiles: WatchFiles[];
-  rsbuild: RsbuildInstance;
-  isBuildWatch: boolean;
-}): Promise<void> {
+  context: InternalContext;
+  action: RestartContext['action'];
+}): Promise<WatchFilesResult | undefined> {
+  if (!watchFiles.length) {
+    return;
+  }
+
   const watchGroups: { files: string[]; options?: ChokidarOptions }[] = [];
   const defaultFiles: string[] = [];
 
-  for (const { paths, options } of watchFiles) {
+  for (const { paths, options, type } of watchFiles) {
+    if (type !== 'restart' && type !== 'reload-server') {
+      continue;
+    }
+
     const files = castArray(paths);
     if (!files.length) {
       continue;
@@ -72,16 +82,15 @@ export async function watchFilesForRestart({
     return;
   }
 
-  const root = rsbuild.context.rootPath;
-  const restartManager = getRestartManager(rsbuild);
+  const { logger, restartManager, rootPath: root } = context;
   const watchers = await Promise.all(
     watchGroups.map(async ({ files, options }) => ({
       // Chokidar reports event paths relative to `cwd` when it is configured.
       cwd: options?.cwd || root,
       watcher: await createChokidar(files, root, {
-        // do not trigger add for initial files
+        // Avoid initial add events.
         ignoreInitial: true,
-        // If watching fails due to read permissions, the errors will be suppressed silently.
+        // Ignore file permission errors.
         ignorePermissionErrors: true,
         ...options,
       }),
@@ -89,35 +98,50 @@ export async function watchFilesForRestart({
   );
 
   let restarting = false;
+  let closePromise: Promise<void> | undefined;
+
+  const close = () => {
+    if (!closePromise) {
+      closePromise = Promise.all(watchers.map(({ watcher }) => watcher.close())).then(() => {});
+    }
+    return closePromise;
+  };
 
   const onChange = async (filePath: string, cwd: string) => {
-    if (restarting) {
+    if (restarting || closePromise) {
       return;
     }
     restarting = true;
 
     const absoluteFilePath = path.resolve(cwd, filePath);
 
-    const restarted = await requestRestart({
-      action: isBuildWatch ? 'build' : 'dev',
-      filePath: absoluteFilePath,
-      logger: rsbuild.logger,
-      restartManager,
-    });
+    try {
+      const restarted = await requestRestart({
+        action,
+        filePath: absoluteFilePath,
+        logger,
+        restartManager,
+      });
 
-    if (restarted) {
-      await Promise.all(watchers.map(({ watcher }) => watcher.close()));
-      return;
+      // Close only after success; otherwise keep watching for a retry.
+      if (restarted) {
+        await close();
+      } else if (restartManager.canRestart) {
+        logger.error(action === 'build' ? 'Restart build failed.' : 'Restart server failed.');
+      }
+    } catch (error) {
+      logger.error(error);
+    } finally {
+      restarting = false;
     }
-
-    rsbuild.logger.error(isBuildWatch ? 'Restart build failed.' : 'Restart server failed.');
-    restarting = false;
   };
 
   for (const { cwd, watcher } of watchers) {
-    const handleChange = (filePath: string) => onChange(filePath, cwd);
+    const handleChange = (filePath: string) => void onChange(filePath, cwd);
     watcher.on('add', handleChange);
     watcher.on('change', handleChange);
     watcher.on('unlink', handleChange);
   }
+
+  return { close };
 }

--- a/packages/core/src/restart.ts
+++ b/packages/core/src/restart.ts
@@ -41,7 +41,7 @@ export const requestRestart = ({
   return restartManager.requestRestart({ action, filePath });
 };
 
-export async function watchFilesForRestart({
+export function watchFilesForRestart({
   watchFiles,
   context,
   action,
@@ -49,7 +49,7 @@ export async function watchFilesForRestart({
   watchFiles: WatchFiles[];
   context: InternalContext;
   action: RestartContext['action'];
-}): Promise<WatchFilesResult | undefined> {
+}): WatchFilesResult | undefined {
   if (!watchFiles.length) {
     return;
   }
@@ -83,29 +83,8 @@ export async function watchFilesForRestart({
   }
 
   const { logger, restartManager, rootPath: root } = context;
-  const watchers = await Promise.all(
-    watchGroups.map(async ({ files, options }) => ({
-      // Chokidar reports event paths relative to `cwd` when it is configured.
-      cwd: options?.cwd || root,
-      watcher: await createChokidar(files, root, {
-        // Avoid initial add events.
-        ignoreInitial: true,
-        // Ignore file permission errors.
-        ignorePermissionErrors: true,
-        ...options,
-      }),
-    })),
-  );
-
   let restarting = false;
   let closePromise: Promise<void> | undefined;
-
-  const close = () => {
-    if (!closePromise) {
-      closePromise = Promise.all(watchers.map(({ watcher }) => watcher.close())).then(() => {});
-    }
-    return closePromise;
-  };
 
   const onChange = async (filePath: string, cwd: string) => {
     if (restarting || closePromise) {
@@ -136,12 +115,38 @@ export async function watchFilesForRestart({
     }
   };
 
-  for (const { cwd, watcher } of watchers) {
-    const handleChange = (filePath: string) => void onChange(filePath, cwd);
-    watcher.on('add', handleChange);
-    watcher.on('change', handleChange);
-    watcher.on('unlink', handleChange);
-  }
+  // Initialize watchers in the background so task startup is not delayed.
+  const watchersPromise = Promise.all(
+    watchGroups.map(async ({ files, options }) => {
+      try {
+        const watcher = await createChokidar(files, root, {
+          // Avoid initial add events.
+          ignoreInitial: true,
+          // Ignore file permission errors.
+          ignorePermissionErrors: true,
+          ...options,
+        });
+        // Chokidar reports event paths relative to `cwd` when it is configured.
+        const cwd = options?.cwd || root;
+        const handleChange = (filePath: string) => void onChange(filePath, cwd);
+        watcher.on('add', handleChange);
+        watcher.on('change', handleChange);
+        watcher.on('unlink', handleChange);
+        return watcher;
+      } catch (error) {
+        logger.error(error);
+      }
+    }),
+  );
+
+  const close = () => {
+    if (!closePromise) {
+      closePromise = watchersPromise
+        .then((watchers) => Promise.all(watchers.map((watcher) => watcher?.close())))
+        .then(() => {});
+    }
+    return closePromise;
+  };
 
   return { close };
 }

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -442,16 +442,11 @@ export async function createDevServer<
 
   // Only close server resources before restart; keep the watcher alive for retries.
   unregisterRestart = context.restartManager.registerCleanup(closeServerResources);
-  try {
-    state.restartWatcher = await watchFilesForRestart({
-      watchFiles: config.dev.watchFiles,
-      context,
-      action: 'dev',
-    });
-  } catch (error) {
-    await closeServerResources();
-    throw error;
-  }
+  state.restartWatcher = watchFilesForRestart({
+    watchFiles: config.dev.watchFiles,
+    context,
+    action: 'dev',
+  });
 
   logger.debug('create dev server done');
 

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -2,7 +2,7 @@ import type { Server } from 'node:http';
 import type { Http2SecureServer } from 'node:http2';
 import { color } from '../helpers';
 import { getPublicPathFromCompiler, isMultiCompiler } from '../helpers/compiler';
-import { requestRestart } from '../restart';
+import { requestRestart, watchFilesForRestart } from '../restart';
 import type {
   CreateCompiler,
   CreateDevServerOptions,
@@ -193,21 +193,21 @@ export async function createDevServer<
 
   const state: {
     fileWatcher?: WatchFilesResult;
+    restartWatcher?: WatchFilesResult;
     devMiddlewares?: GetDevMiddlewaresResult;
     buildManager?: BuildManager;
   } = {};
 
   const cleanupGracefulShutdown = middlewareMode ? null : setupGracefulShutdown();
 
-  let closingPromise: Promise<void> | null = null;
+  let closingPromise: Promise<void> | undefined;
   let unregisterRestart: (() => void) | undefined;
 
-  const closeServer = async () => {
+  const closeServerResources = () => {
     if (!closingPromise) {
       unregisterRestart?.();
       unregisterRestart = undefined;
       closingPromise = (async () => {
-        // ensure closeServer is only called once
         removeCleanup(closeServer);
         cleanupGracefulShutdown?.();
         await context.hooks.onCloseDevServer.callBatch();
@@ -215,6 +215,11 @@ export async function createDevServer<
       })();
     }
     return closingPromise;
+  };
+
+  const closeServer = async () => {
+    await state.restartWatcher?.close();
+    await closeServerResources();
   };
 
   if (!middlewareMode) {
@@ -368,8 +373,6 @@ export async function createDevServer<
 
             await devServer.afterListen();
 
-            unregisterRestart = context.restartManager.registerCleanup(closeServer);
-
             resolve({
               port,
               urls: urls.map((item) => item.url),
@@ -436,6 +439,19 @@ export async function createDevServer<
 
   // start watching
   state.buildManager?.watch();
+
+  // Only close server resources before restart; keep the watcher alive for retries.
+  unregisterRestart = context.restartManager.registerCleanup(closeServerResources);
+  try {
+    state.restartWatcher = await watchFilesForRestart({
+      watchFiles: config.dev.watchFiles,
+      context,
+      action: 'dev',
+    });
+  } catch (error) {
+    await closeServerResources();
+    throw error;
+  }
 
   logger.debug('create dev server done');
 

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1957,7 +1957,7 @@ export type WatchFiles = {
   /**
    * Specifies the action to take when files change.
    * - `reload-page`: Reload the page.
-   * - `restart`: Restart the dev server or watch build.
+   * - `restart`: Trigger a restart request for the dev server or watch build.
    * - `reload-server`: Deprecated alias for `restart`.
    * @default 'reload-page'
    */
@@ -2075,7 +2075,7 @@ export interface DevConfig {
   writeToDisk?: WriteToDisk;
   /**
    * Watch specified files and directories for changes. When a file change is detected,
-   * it can trigger a page reload or restart the dev server or watch build.
+   * it can trigger a page reload or a restart request for the dev server or watch build.
    * @default undefined
    */
   watchFiles?: WatchFiles | WatchFiles[];

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -651,7 +651,7 @@ export type RsbuildPluginAPI = Readonly<{
    */
   onExit: PluginHook<OnExitFn>;
   /**
-   * Called before Rsbuild CLI restarts the dev server or watch build.
+   * Called when a restart is requested for the dev server or watch build.
    */
   onRestart: PluginHook<OnRestartFn>;
   /**

--- a/packages/core/tests/restartHook.test.ts
+++ b/packages/core/tests/restartHook.test.ts
@@ -1,5 +1,4 @@
-import { createRsbuild } from '../src';
-import { createRestartManager, getRestartManager } from '../src/helpers/restartManager';
+import { createRestartManager } from '../src/helpers/restartManager';
 
 describe('restartManager', () => {
   test('should execute all callbacks and clear the registry when one throws', async () => {
@@ -36,24 +35,5 @@ describe('restartManager', () => {
     await manager.requestRestart({ action: 'dev' });
 
     expect(callback).not.toHaveBeenCalled();
-  });
-
-  test('should isolate callbacks between Rsbuild instances', async () => {
-    const firstCallback = rstest.fn();
-    const secondCallback = rstest.fn();
-    const first = await createRsbuild();
-    const second = await createRsbuild();
-    const context = { action: 'dev' } as const;
-
-    first.onRestart(firstCallback);
-    second.onRestart(secondCallback);
-    await getRestartManager(first).requestRestart(context);
-
-    expect(firstCallback).toHaveBeenCalledWith(context);
-    expect(secondCallback).not.toHaveBeenCalled();
-
-    await getRestartManager(second).requestRestart(context);
-
-    expect(secondCallback).toHaveBeenCalledWith(context);
   });
 });

--- a/website/docs/en/config/dev/watch-files.mdx
+++ b/website/docs/en/config/dev/watch-files.mdx
@@ -92,7 +92,7 @@ export default {
 
 ### restart
 
-`restart` restarts the dev server when running `rsbuild dev`, or restarts the watch build when running `rsbuild build --watch`.
+`restart` requests a dev server restart when running `rsbuild dev`, or a watch build restart when running `rsbuild build --watch`.
 
 This can be used to watch configuration files whose changes require Rsbuild to be reinitialized.
 
@@ -112,9 +112,7 @@ export default {
 };
 ```
 
-The `restart` functionality is provided by Rsbuild CLI. It is currently not supported by custom servers or frameworks that invoke Rsbuild through the JavaScript API.
-
-> Before the restart, Rsbuild calls the [onRestart hook](/plugins/dev/hooks#onrestart), which you can use to run custom logic before the dev server or watch build restarts.
+When using the JavaScript API, `rsbuild.startDevServer()`, `rsbuild.createDevServer()`, and `rsbuild.build({ watch: true })` install restart watchers, while regular builds and preview servers do not. When a watched file changes, Rsbuild calls the [onRestart hook](/plugins/dev/hooks#onrestart) but does not automatically close or restart the active dev server or watch build. You can use this hook to run custom logic.
 
 ### reload-server
 

--- a/website/docs/en/plugins/dev/hooks.mdx
+++ b/website/docs/en/plugins/dev/hooks.mdx
@@ -20,7 +20,7 @@ This page outlines the plugin hooks available for Rsbuild plugins.
 - [onAfterCreateCompiler](#onaftercreatecompiler): Called after creating a compiler instance and before building.
 - [onBeforeEnvironmentCompile](#onbeforeenvironmentcompile): Called before the compilation of a single environment.
 - [onAfterEnvironmentCompile](#onafterenvironmentcompile): Called after the compilation of a single environment. You can get the build result information.
-- [onRestart](#onrestart): Called before Rsbuild CLI restarts the dev server or watch build.
+- [onRestart](#onrestart): Called when a restart is requested for the dev server or watch build.
 - [onExit](#onexit): Called when the process is about to exit.
 
 ### Dev hooks

--- a/website/docs/en/shared/onRestart.mdx
+++ b/website/docs/en/shared/onRestart.mdx
@@ -1,12 +1,14 @@
-Called before Rsbuild CLI restarts the dev server or watch build.
+Called when a restart is requested for the dev server or watch build.
 
 The hook is triggered in the following cases:
 
-- The contents of the Rsbuild config file or one of its dependencies change.
+- The Rsbuild CLI detects changes to the config file or one of its dependencies.
 - A file watched by [`dev.watchFiles`](/config/dev/watch-files) with `type: 'restart'` changes.
 - The dev server is manually restarted through a [CLI shortcut](/config/dev/cli-shortcuts).
 
 > This hook is not triggered for regular rebuilds.
+
+When using the JavaScript API, restart watchers are installed by `rsbuild.startDevServer()`, `rsbuild.createDevServer()`, and `rsbuild.build({ watch: true })`. The hook is called when a watched file changes, but Rsbuild does not automatically close or restart the active dev server or watch build.
 
 - **Type:**
 

--- a/website/docs/zh/config/dev/watch-files.mdx
+++ b/website/docs/zh/config/dev/watch-files.mdx
@@ -92,7 +92,7 @@ export default {
 
 ### restart
 
-`restart` 会在执行 `rsbuild dev` 时重启 dev server，在执行 `rsbuild build --watch` 时重启监听构建。
+`restart` 会在执行 `rsbuild dev` 时请求重启 dev server，在执行 `rsbuild build --watch` 时请求重启监听构建。
 
 这可以用于监听一些变更后需要重新初始化 Rsbuild 的配置文件。
 
@@ -112,9 +112,7 @@ export default {
 };
 ```
 
-`restart` 功能由 Rsbuild CLI 提供。如果你使用自定义 server，或者上层框架通过 JavaScript API 调用 Rsbuild，目前暂不支持此配置。
-
-> 重启前，Rsbuild 会调用 [onRestart hook](/plugins/dev/hooks#onrestart)，你可以通过该 hook 在 dev server 或监听构建重启前执行自定义逻辑。
+使用 JavaScript API 时，`rsbuild.startDevServer()`、`rsbuild.createDevServer()` 和 `rsbuild.build({ watch: true })` 会安装 restart watcher，普通构建和预览服务器则不会安装。被监听的文件发生变化时，Rsbuild 会调用 [onRestart hook](/plugins/dev/hooks#onrestart)，但不会自动关闭或重启当前 dev server 或监听构建。你可以通过该 hook 执行自定义逻辑。
 
 ### reload-server
 

--- a/website/docs/zh/plugins/dev/hooks.mdx
+++ b/website/docs/zh/plugins/dev/hooks.mdx
@@ -20,7 +20,7 @@ description: '本章节介绍 Rsbuild 插件可用的 hooks。'
 - [onAfterCreateCompiler](#onaftercreatecompiler)：在创建 compiler 实例后、执行构建前调用。
 - [onBeforeEnvironmentCompile](#onbeforeenvironmentcompile): 在每次执行单个 environment 的构建前调用。
 - [onAfterEnvironmentCompile](#onafterenvironmentcompile): 在每次单个 environment 的构建结束后调用。
-- [onRestart](#onrestart)：在 Rsbuild CLI 重启 dev server 或监听构建前调用。
+- [onRestart](#onrestart)：当 dev server 或监听构建被请求重启时调用。
 - [onExit](#onexit)：在进程即将退出时调用。
 
 ### Dev hooks

--- a/website/docs/zh/shared/onRestart.mdx
+++ b/website/docs/zh/shared/onRestart.mdx
@@ -1,12 +1,14 @@
-在 Rsbuild CLI 重启 dev server 或监听构建前调用。
+当 dev server 或监听构建被请求重启时调用。
 
 该 hook 会在以下情况中触发：
 
-- Rsbuild 配置文件或其依赖的内容发生变化。
+- Rsbuild CLI 检测到配置文件或其依赖发生变化。
 - [`dev.watchFiles`](/config/dev/watch-files) 中 `type` 为 `'restart'` 的文件发生变化。
 - 通过 [CLI 快捷键](/config/dev/cli-shortcuts) 手动重启 dev server。
 
 > 普通的重新构建不会触发该 hook。
+
+使用 JavaScript API 时，`rsbuild.startDevServer()`、`rsbuild.createDevServer()` 和 `rsbuild.build({ watch: true })` 会安装 restart watcher。被监听的文件发生变化时会调用该 hook，但 Rsbuild 不会自动关闭或重启当前 dev server 或监听构建。
 
 - **类型：**
 


### PR DESCRIPTION
## Summary

JavaScript API users currently need to set up their own file watchers to receive restart requests. This PR moves restart watcher lifecycle management into Core for `rsbuild.startDevServer()`, `rsbuild.createDevServer()`, and `rsbuild.build({ watch: true })`, while keeping the active task running when no restart executor is configured.

It removes the CLI-owned watcher setup, adds dedicated JavaScript API e2e coverage, and updates the English and Chinese documentation.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8133
- https://github.com/web-infra-dev/rsbuild/pull/8134