### PR TITLE
feat(core): add restart option to createRsbuild

### DIFF
--- a/e2e/cases/javascript-api/restart-option/index.test.ts
+++ b/e2e/cases/javascript-api/restart-option/index.test.ts
@@ -1,0 +1,76 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { expect, test } from '@e2e/helper';
+import { createRsbuild, type RestartContext, type RestartFn } from '@rsbuild/core';
+import { getRandomPort } from '@rstackjs/test-utils';
+
+const watchedFile = path.join(import.meta.dirname, 'test-temp-watch.txt');
+
+test.beforeAll(() => {
+  fs.writeFileSync(watchedFile, '1');
+});
+
+test.afterAll(() => {
+  fs.rmSync(watchedFile, { force: true });
+});
+
+test('createRsbuild should support a restart function', async () => {
+  const calls: string[] = [];
+  let restartResult:
+    | {
+        context: RestartContext;
+        calls: string[];
+      }
+    | undefined;
+
+  const restart: RestartFn = (context) => {
+    restartResult = { context, calls: [...calls] };
+    return true;
+  };
+
+  const rsbuild = await createRsbuild({
+    cwd: import.meta.dirname,
+    config: {
+      dev: {
+        watchFiles: {
+          paths: watchedFile,
+          type: 'restart',
+        },
+      },
+      server: {
+        port: await getRandomPort(),
+      },
+    },
+    restart,
+  });
+
+  rsbuild.onRestart(() => {
+    calls.push('onRestart');
+  });
+  rsbuild.onCloseDevServer(() => {
+    calls.push('onCloseDevServer');
+  });
+
+  const server = await rsbuild.createDevServer({ runCompile: false });
+  let version = 1;
+
+  await expect
+    .poll(
+      () => {
+        if (!restartResult) {
+          fs.writeFileSync(watchedFile, String(++version));
+        }
+        return restartResult;
+      },
+      { timeout: 5_000 },
+    )
+    .toEqual({
+      context: {
+        action: 'dev',
+        filePath: watchedFile,
+      },
+      calls: ['onRestart', 'onCloseDevServer'],
+    });
+
+  await server.close();
+});

--- a/e2e/cases/javascript-api/restart-option/src/index.js
+++ b/e2e/cases/javascript-api/restart-option/src/index.js
@@ -1,0 +1,1 @@
+console.log('restart option');

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { createRsbuildInternal } from '../createRsbuild';
+import { createRsbuild } from '../createRsbuild';
 import { castArray } from '../helpers';
 import { ensureAbsolutePath } from '../helpers/path';
 import { loadConfig as baseLoadConfig } from '../loadConfig';
@@ -155,21 +155,19 @@ export async function init({ isRestart }: { isRestart?: boolean } = {}): Promise
     const cwd = process.cwd();
     const root = options.root ? ensureAbsolutePath(cwd, options.root) : cwd;
 
-    const rsbuild = await createRsbuildInternal(
-      {
-        cwd: root,
-        config: () => loadConfig(root),
-        environment: options.environment,
-        loadEnv:
-          options.env === false
-            ? false
-            : {
-                cwd: getEnvDir(root, options.envDir),
-                mode: options.envMode,
-              },
-      },
-      { restart },
-    );
+    const rsbuild = await createRsbuild({
+      cwd: root,
+      config: () => loadConfig(root),
+      environment: options.environment,
+      loadEnv:
+        options.env === false
+          ? false
+          : {
+              cwd: getEnvDir(root, options.envDir),
+              mode: options.envMode,
+            },
+      restart,
+    });
     logger = rsbuild.logger;
 
     return rsbuild;

--- a/packages/core/src/createContext.ts
+++ b/packages/core/src/createContext.ts
@@ -4,7 +4,7 @@ import { DEFAULT_BROWSERSLIST, ROOT_DIST_DIR } from './constants';
 import { withDefaultConfig } from './defaultConfig';
 import { hash } from './helpers';
 import { ensureAbsolutePath, getCommonParentPath } from './helpers/path';
-import { createRestartManager, type RestartExecutor } from './helpers/restartManager';
+import { createRestartManager } from './helpers/restartManager';
 import { initHooks } from './hooks';
 import { getHTMLPathByEntry } from './initPlugins';
 import type { Logger } from './logger';
@@ -177,7 +177,6 @@ export async function createContext(
   options: ResolvedCreateRsbuildOptions,
   userConfig: RsbuildConfig,
   logger: Logger,
-  restart?: RestartExecutor,
 ): Promise<InternalContext> {
   const { cwd } = options;
   const rootPath = userConfig.root ? ensureAbsolutePath(cwd, userConfig.root) : cwd;
@@ -202,7 +201,7 @@ export async function createContext(
     hooks,
     restartManager: createRestartManager({
       onRestart: hooks.onRestart.callBatch,
-      restart,
+      restart: options.restart,
     }),
     config: { ...rsbuildConfig },
     originalConfig: userConfig,

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -5,7 +5,6 @@ import { createCompiler as baseCreateCompiler } from './createCompiler';
 import { createContext } from './createContext';
 import { castArray, color, getNodeEnv, isFunction, pick, setNodeEnv } from './helpers';
 import { isEmptyDir } from './helpers/fs';
-import type { RestartExecutor } from './helpers/restartManager';
 import { initConfigs as baseInitConfigs, initRsbuildConfig } from './initConfigs';
 import { initPluginAPI } from './initPlugins';
 import { inspectConfig as baseInspectConfig } from './inspectConfig';
@@ -148,14 +147,7 @@ function applyEnvsToConfig(config: RsbuildConfig, envs: LoadEnvResult | null) {
 /**
  * Create an Rsbuild instance.
  */
-export function createRsbuild(options: CreateRsbuildOptions = {}): Promise<RsbuildInstance> {
-  return createRsbuildInternal(options);
-}
-
-export async function createRsbuildInternal(
-  options: CreateRsbuildOptions = {},
-  internalOptions?: { restart?: RestartExecutor },
-): Promise<RsbuildInstance> {
+export async function createRsbuild(options: CreateRsbuildOptions = {}): Promise<RsbuildInstance> {
   const envs = options.loadEnv
     ? loadEnv({
         cwd: options.cwd,
@@ -192,7 +184,7 @@ export async function createRsbuildInternal(
 
   const pluginManager = createPluginManager(logger);
 
-  const context = await createContext(resolvedOptions, config, logger, internalOptions?.restart);
+  const context = await createContext(resolvedOptions, config, logger);
 
   const getPluginAPI = initPluginAPI({ context, pluginManager });
   context.getPluginAPI = getPluginAPI;

--- a/packages/core/src/helpers/restartManager.ts
+++ b/packages/core/src/helpers/restartManager.ts
@@ -1,9 +1,7 @@
-import type { RestartContext } from '../types/hooks';
+import type { RestartContext, RestartFn } from '../types/hooks';
 import type { MaybePromise } from '../types/utils';
 
 type Cleanup = () => MaybePromise<void>;
-
-export type RestartExecutor = (context: RestartContext) => MaybePromise<boolean>;
 
 export type RestartManager = {
   /** Whether a restart executor is available. */
@@ -19,7 +17,7 @@ export const createRestartManager = ({
   restart,
 }: {
   onRestart: (context: RestartContext) => MaybePromise<unknown>;
-  restart?: RestartExecutor;
+  restart?: RestartFn;
 }): RestartManager => {
   let cleanups = new Set<Cleanup>();
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -177,6 +177,7 @@ export type {
   ResolveHook,
   ResourceHintsIncludeType,
   RestartContext,
+  RestartFn,
   RsbuildConfig,
   RsbuildContext,
   RsbuildEntry,

--- a/packages/core/src/types/hooks.ts
+++ b/packages/core/src/types/hooks.ts
@@ -161,6 +161,9 @@ export type RestartContext = {
   filePath?: string;
 };
 
+/** Restart the current Rsbuild task and return whether the restart succeeded. */
+export type RestartFn = (context: RestartContext) => MaybePromise<boolean>;
+
 export type OnRestartFn = (context: RestartContext) => MaybePromise<void>;
 
 export type ModifyHTMLContext = {

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -5,6 +5,7 @@ import type { RsbuildDevServer } from '../server/devServer';
 import type { StartDevServerResult, StartPreviewServerResult } from '../server/helper';
 import type { NormalizedConfig, NormalizedEnvironmentConfig, RsbuildConfig } from './config';
 import type { RsbuildContext } from './context';
+import type { RestartFn } from './hooks';
 import type { RsbuildPlugin, RsbuildPluginAPI } from './plugin';
 import type { Rspack } from './rspack';
 import type { Falsy } from './utils';
@@ -148,12 +149,16 @@ export type CreateRsbuildOptions = {
    * @default false
    */
   loadEnv?: boolean | LoadEnvOptions;
+  /**
+   * Function used to restart the current dev server or watch build.
+   */
+  restart?: RestartFn;
 };
 
 export type ResolvedCreateRsbuildOptions = Required<
   Pick<CreateRsbuildOptions, 'cwd' | 'callerName'>
 > &
-  Pick<CreateRsbuildOptions, 'loadEnv' | 'environment'> & {
+  Pick<CreateRsbuildOptions, 'loadEnv' | 'environment' | 'restart'> & {
     rsbuildConfig: RsbuildConfig;
   };
 

--- a/website/docs/en/api/javascript-api/core.mdx
+++ b/website/docs/en/api/javascript-api/core.mdx
@@ -39,6 +39,7 @@ type CreateRsbuildOptions = {
   environment?: string[];
   loadEnv?: boolean | LoadEnvOptions;
   config?: RsbuildConfig | (() => Promise<RsbuildConfig>);
+  restart?: RestartFn;
 };
 ```
 
@@ -47,6 +48,7 @@ type CreateRsbuildOptions = {
 - `environment`: Build only specified [environments](/guide/advanced/environments). If not specified or an empty array is passed, all environments will be built.
 - `loadEnv`：Whether to call the [loadEnv](/api/javascript-api/core#loadenv) method to load environment variables and define them as global variables via [source.define](/config/source/define).
 - `config`: Rsbuild configuration object. Refer to [Configuration Overview](/config/) for all available configuration options.
+- `restart`: A function that handles restart requests for the current dev server or watch build. See [restart](#restart).
 
 :::tip
 `config` was introduced in Rsbuild 1.6. In earlier versions, use `rsbuildConfig` as an alternative.
@@ -94,6 +96,41 @@ const rsbuild = await createRsbuild({
   },
 });
 ```
+
+### restart
+
+The `restart` option allows the caller to control how Rsbuild restarts the current dev server or watch build. This is useful when the restart flow needs to be managed outside Rsbuild.
+
+When a restart is requested, Rsbuild calls the [onRestart hook](/plugins/dev/hooks#onrestart), closes the current task resources, and then calls `restart`.
+
+The function should return `true` when the replacement task starts successfully. If it returns `false` or throws an error, the restart watcher remains active so later file changes can retry the restart.
+
+```ts
+import { createRsbuild, type RestartFn } from '@rsbuild/core';
+
+async function createInstance() {
+  return createRsbuild({
+    restart,
+  });
+}
+
+const restart: RestartFn = async ({ action }) => {
+  const rsbuild = await createInstance();
+
+  if (action === 'build') {
+    await rsbuild.build({ watch: true });
+  } else {
+    await rsbuild.startDevServer();
+  }
+
+  return true;
+};
+
+const rsbuild = await createInstance();
+await rsbuild.startDevServer();
+```
+
+- **Version:** Added in v2.1.7
 
 ### Specify caller name
 

--- a/website/docs/en/api/javascript-api/core.mdx
+++ b/website/docs/en/api/javascript-api/core.mdx
@@ -99,6 +99,8 @@ const rsbuild = await createRsbuild({
 
 ### restart
 
+- **Version:** Added in v2.1.7
+
 The `restart` option allows the caller to control how Rsbuild restarts the current dev server or watch build. This is useful when the restart flow needs to be managed outside Rsbuild.
 
 When a restart is requested, Rsbuild calls the [onRestart hook](/plugins/dev/hooks#onrestart), closes the current task resources, and then calls `restart`.
@@ -129,8 +131,6 @@ const restart: RestartFn = async ({ action }) => {
 const rsbuild = await createInstance();
 await rsbuild.startDevServer();
 ```
-
-- **Version:** Added in v2.1.7
 
 ### Specify caller name
 

--- a/website/docs/en/config/dev/watch-files.mdx
+++ b/website/docs/en/config/dev/watch-files.mdx
@@ -112,7 +112,7 @@ export default {
 };
 ```
 
-When using the JavaScript API, `rsbuild.startDevServer()`, `rsbuild.createDevServer()`, and `rsbuild.build({ watch: true })` install restart watchers, while regular builds and preview servers do not. When a watched file changes, Rsbuild calls the [onRestart hook](/plugins/dev/hooks#onrestart) but does not automatically close or restart the active dev server or watch build. You can use this hook to run custom logic.
+When using the JavaScript API, `rsbuild.startDevServer()`, `rsbuild.createDevServer()`, and `rsbuild.build({ watch: true })` install restart watchers, while regular builds and preview servers do not. When a watched file changes, Rsbuild calls the [onRestart hook](/plugins/dev/hooks#onrestart). By default, Rsbuild does not close or restart the current task; you can pass the [`restart` option](/api/javascript-api/core#restart) to handle restart requests.
 
 ### reload-server
 

--- a/website/docs/en/shared/onRestart.mdx
+++ b/website/docs/en/shared/onRestart.mdx
@@ -8,7 +8,7 @@ The hook is triggered in the following cases:
 
 > This hook is not triggered for regular rebuilds.
 
-When using the JavaScript API, restart watchers are installed by `rsbuild.startDevServer()`, `rsbuild.createDevServer()`, and `rsbuild.build({ watch: true })`. The hook is called when a watched file changes, but Rsbuild does not automatically close or restart the active dev server or watch build.
+When using the JavaScript API, restart watchers are installed by `rsbuild.startDevServer()`, `rsbuild.createDevServer()`, and `rsbuild.build({ watch: true })`. The hook is called when a watched file changes. By default, Rsbuild does not close or restart the current task; you can pass the [`restart` option](/api/javascript-api/core#restart) to handle restart requests.
 
 - **Type:**
 

--- a/website/docs/zh/api/javascript-api/core.mdx
+++ b/website/docs/zh/api/javascript-api/core.mdx
@@ -99,6 +99,8 @@ const rsbuild = await createRsbuild({
 
 ### restart
 
+- **版本：** v2.1.7 新增
+
 `restart` 选项允许调用方控制 Rsbuild 如何重启当前 dev server 或监听构建，适用于需要在 Rsbuild 外部管理重启流程的场景。
 
 当请求重启时，Rsbuild 会调用 [onRestart hook](/plugins/dev/hooks#onrestart)，关闭当前任务的资源，然后调用 `restart`。
@@ -129,8 +131,6 @@ const restart: RestartFn = async ({ action }) => {
 const rsbuild = await createInstance();
 await rsbuild.startDevServer();
 ```
-
-- **版本：** v2.1.7 新增
 
 ### 指定调用者名称 \{#specify-caller-name}
 

--- a/website/docs/zh/api/javascript-api/core.mdx
+++ b/website/docs/zh/api/javascript-api/core.mdx
@@ -39,6 +39,7 @@ type CreateRsbuildOptions = {
   environment?: string[];
   loadEnv?: boolean | LoadEnvOptions;
   config?: RsbuildConfig | (() => Promise<RsbuildConfig>);
+  restart?: RestartFn;
 };
 ```
 
@@ -47,6 +48,7 @@ type CreateRsbuildOptions = {
 - `environment`：只构建指定的 [environments](/guide/advanced/environments)，如果未指定或传入空数组，则构建所有环境。
 - `loadEnv`：是否调用 [loadEnv](/api/javascript-api/core#loadenv) 方法来加载环境变量，并通过 [source.define](/config/source/define) 定义为全局变量。
 - `config`：Rsbuild 配置对象。参考 [配置总览](/config/) 查看所有可用的配置项。
+- `restart`：处理当前 dev server 或监听构建重启请求的函数，详见 [restart](#restart)。
 
 :::tip
 `config` 是 Rsbuild 1.6 新增的选项。在旧版本中，可使用 `rsbuildConfig` 作为替代。
@@ -94,6 +96,41 @@ const rsbuild = await createRsbuild({
   },
 });
 ```
+
+### restart
+
+`restart` 选项允许调用方控制 Rsbuild 如何重启当前 dev server 或监听构建，适用于需要在 Rsbuild 外部管理重启流程的场景。
+
+当请求重启时，Rsbuild 会调用 [onRestart hook](/plugins/dev/hooks#onrestart)，关闭当前任务的资源，然后调用 `restart`。
+
+新任务成功启动时，该函数应返回 `true`。如果返回 `false` 或抛出错误，restart watcher 会保持运行，以便后续文件变化时再次尝试重启。
+
+```ts
+import { createRsbuild, type RestartFn } from '@rsbuild/core';
+
+async function createInstance() {
+  return createRsbuild({
+    restart,
+  });
+}
+
+const restart: RestartFn = async ({ action }) => {
+  const rsbuild = await createInstance();
+
+  if (action === 'build') {
+    await rsbuild.build({ watch: true });
+  } else {
+    await rsbuild.startDevServer();
+  }
+
+  return true;
+};
+
+const rsbuild = await createInstance();
+await rsbuild.startDevServer();
+```
+
+- **版本：** v2.1.7 新增
 
 ### 指定调用者名称 \{#specify-caller-name}
 

--- a/website/docs/zh/config/dev/watch-files.mdx
+++ b/website/docs/zh/config/dev/watch-files.mdx
@@ -112,7 +112,7 @@ export default {
 };
 ```
 
-使用 JavaScript API 时，`rsbuild.startDevServer()`、`rsbuild.createDevServer()` 和 `rsbuild.build({ watch: true })` 会安装 restart watcher，普通构建和预览服务器则不会安装。被监听的文件发生变化时，Rsbuild 会调用 [onRestart hook](/plugins/dev/hooks#onrestart)，但不会自动关闭或重启当前 dev server 或监听构建。你可以通过该 hook 执行自定义逻辑。
+使用 JavaScript API 时，`rsbuild.startDevServer()`、`rsbuild.createDevServer()` 和 `rsbuild.build({ watch: true })` 会安装 restart watcher，普通构建和预览服务器则不会安装。被监听的文件发生变化时，Rsbuild 会调用 [onRestart hook](/plugins/dev/hooks#onrestart)。默认情况下，Rsbuild 不会关闭或重启当前任务；你可以传入 [`restart` 选项](/api/javascript-api/core#restart) 来处理重启请求。
 
 ### reload-server
 

--- a/website/docs/zh/shared/onRestart.mdx
+++ b/website/docs/zh/shared/onRestart.mdx
@@ -8,7 +8,7 @@
 
 > 普通的重新构建不会触发该 hook。
 
-使用 JavaScript API 时，`rsbuild.startDevServer()`、`rsbuild.createDevServer()` 和 `rsbuild.build({ watch: true })` 会安装 restart watcher。被监听的文件发生变化时会调用该 hook，但 Rsbuild 不会自动关闭或重启当前 dev server 或监听构建。
+使用 JavaScript API 时，`rsbuild.startDevServer()`、`rsbuild.createDevServer()` 和 `rsbuild.build({ watch: true })` 会安装 restart watcher。被监听的文件发生变化时会调用该 hook。默认情况下，Rsbuild 不会关闭或重启当前任务；你可以传入 [`restart` 选项](/api/javascript-api/core#restart) 来处理重启请求。
 
 - **类型：**
 


### PR DESCRIPTION
## Summary

This PR exposes a `restart` option in `createRsbuild` so JavaScript API callers can control how dev servers and watch builds restart.

The callback receives the restart context and reports whether the replacement task started successfully, while the default behavior remains unchanged when no callback is provided.
