### PR TITLE
feat(core): expose config files in context

### DIFF
--- a/e2e/cases/javascript-api/context-config-files/index.test.ts
+++ b/e2e/cases/javascript-api/context-config-files/index.test.ts
@@ -1,0 +1,17 @@
+import { realpath } from 'node:fs/promises';
+import { join } from 'node:path';
+import { expect, test } from '@e2e/helper';
+import { createRsbuild, loadConfig } from '@rsbuild/core';
+
+test('should expose config files through context', async () => {
+  const { content } = await loadConfig({ cwd: import.meta.dirname });
+  const rsbuild = await createRsbuild({
+    cwd: import.meta.dirname,
+    config: content,
+  });
+
+  expect(rsbuild.context.configFile).toBe(join(import.meta.dirname, 'rsbuild.config.mjs'));
+  expect(rsbuild.context.configFileDependencies).toEqual([
+    await realpath(join(import.meta.dirname, 'shared.config.mjs')),
+  ]);
+});

--- a/e2e/cases/javascript-api/context-config-files/rsbuild.config.mjs
+++ b/e2e/cases/javascript-api/context-config-files/rsbuild.config.mjs
@@ -1,0 +1,3 @@
+import { sharedConfig } from './shared.config.mjs';
+
+export default sharedConfig;

--- a/e2e/cases/javascript-api/context-config-files/shared.config.mjs
+++ b/e2e/cases/javascript-api/context-config-files/shared.config.mjs
@@ -1,0 +1,1 @@
+export const sharedConfig = {};

--- a/e2e/cases/javascript-api/context-config-files/src/index.js
+++ b/e2e/cases/javascript-api/context-config-files/src/index.js
@@ -1,0 +1,1 @@
+console.log('hello');

--- a/packages/core/src/createContext.ts
+++ b/packages/core/src/createContext.ts
@@ -147,6 +147,8 @@ export function createPublicContext(context: InternalContext): Readonly<RsbuildC
     'action',
     'version',
     'rootPath',
+    'configFile',
+    'configFileDependencies',
     'distPath',
     'devServer',
     'cachePath',
@@ -186,10 +188,13 @@ export async function createContext(
   const specifiedEnvironments =
     options.environment && options.environment.length > 0 ? options.environment : undefined;
   const hooks = initHooks();
+  const configMeta = userConfig._privateMeta;
 
   return {
     version: RSBUILD_VERSION,
     rootPath,
+    configFile: configMeta?.configFilePath,
+    configFileDependencies: configMeta?.configFileDependencies ?? [],
     distPath: '',
     cachePath,
     logger,

--- a/packages/core/src/loadConfig.ts
+++ b/packages/core/src/loadConfig.ts
@@ -112,6 +112,7 @@ export async function loadConfig<Config = RsbuildConfig>({
 
   (result.content as RsbuildConfig)._privateMeta = {
     configFilePath: result.filePath,
+    configFileDependencies: result.dependencies,
   };
 
   defaultLogger.debug('configuration loaded from:', result.filePath);

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -2157,6 +2157,10 @@ export type RsbuildConfigMeta = {
    * Path to the rsbuild config file.
    */
   configFilePath: string;
+  /**
+   * Paths to files imported by the rsbuild config file.
+   */
+  configFileDependencies?: string[];
 };
 
 /**

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -17,6 +17,10 @@ export type RsbuildContext = {
   version: string;
   /** The root path of current project. */
   rootPath: string;
+  /** Absolute path to the loaded configuration file. */
+  configFile?: string;
+  /** Absolute paths of files imported by the configuration file. */
+  configFileDependencies: readonly string[];
   /** Absolute path of output files. */
   distPath: string;
   /** Absolute path of cache files. */

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -53,6 +53,19 @@ The root path of the current build, corresponding to the `cwd` option of the [cr
 type RootPath = string;
 ```
 
+### context.configFile
+
+The absolute path to the configuration file loaded by [loadConfig](/api/javascript-api/core#loadconfig). It is `undefined` when no configuration file is loaded.
+
+- **Type:** `string | undefined`
+
+### context.configFileDependencies
+
+The absolute paths of files imported by the configuration file. The dependencies are collected by [loadConfig](/api/javascript-api/core#loadconfig).
+
+- **Type:** `readonly string[]`
+- **Default:** `[]`
+
 ### context.distPath
 
 The absolute path of the output directory, corresponding to the [output.distPath.root](/config/output/dist-path) config in `RsbuildConfig`.

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -53,6 +53,19 @@ type Version = string;
 type RootPath = string;
 ```
 
+### context.configFile
+
+通过 [loadConfig](/api/javascript-api/core#loadconfig) 加载的配置文件绝对路径。未加载配置文件时为 `undefined`。
+
+- **类型：** `string | undefined`
+
+### context.configFileDependencies
+
+配置文件所导入文件的绝对路径，由 [loadConfig](/api/javascript-api/core#loadconfig) 收集。
+
+- **类型：** `readonly string[]`
+- **默认值：** `[]`
+
 ### context.distPath
 
 构建产物输出目录的绝对路径，对应 `RsbuildConfig` 中的 [output.distPath.root](/config/output/dist-path) 配置项。


### PR DESCRIPTION
## Summary

Integrations currently need private config metadata to discover the loaded config file and its imports. This PR exposes `context.configFile` and `context.configFileDependencies`, while keeping `_privateMeta` as the temporary internal transport. It adds JavaScript API e2e coverage and documents both fields in English and Chinese.