### PR TITLE
refactor(core): use context config files

### DIFF
--- a/packages/core/src/plugins/cache.ts
+++ b/packages/core/src/plugins/cache.ts
@@ -4,7 +4,6 @@ import { findExists, isFileExists } from '../helpers/fs';
 import type {
   BuildCacheOptions,
   EnvironmentContext,
-  NormalizedEnvironmentConfig,
   RsbuildContext,
   RsbuildPlugin,
 } from '../types';
@@ -22,7 +21,6 @@ function getCacheDirectory({ cacheDirectory }: BuildCacheOptions, context: Rsbui
  */
 async function getBuildDependencies(
   context: Readonly<RsbuildContext>,
-  config: NormalizedEnvironmentConfig,
   environmentContext: EnvironmentContext,
   additionalDependencies?: string[],
 ) {
@@ -40,8 +38,8 @@ async function getBuildDependencies(
     buildDependencies.tsconfig = [tsconfigPath];
   }
 
-  if (config._privateMeta?.configFilePath) {
-    buildDependencies.rsbuildConfig = [config._privateMeta.configFilePath];
+  if (context.configFile) {
+    buildDependencies.rsbuildConfig = [context.configFile, ...context.configFileDependencies];
   }
 
   if (await isFileExists(browserslistConfig)) {
@@ -84,7 +82,6 @@ export const pluginCache = (): RsbuildPlugin => ({
       const cacheDirectory = getCacheDirectory(cacheConfig, context);
       const buildDependencies = await getBuildDependencies(
         context,
-        config,
         environment,
         cacheConfig.buildDependencies,
       );

--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -540,10 +540,10 @@ export const pluginFileSize = (context: InternalContext): RsbuildPlugin => ({
         return typeof printFileSize === 'object' && Boolean(printFileSize.diff);
       });
 
-      // If `configFilePath` is provided, use it to generate a unique snapshot path
+      // If `configFile` is provided, use it to generate a unique snapshot path
       // to avoid collision when using multiple Rsbuild config files
-      const { configFilePath } = api.getNormalizedConfig()._privateMeta || {};
-      const snapshotHash = showDiff && configFilePath ? await hash(configFilePath) : '';
+      const { configFile } = api.context;
+      const snapshotHash = showDiff && configFile ? await hash(configFile) : '';
       const snapshotPath = showDiff ? getSnapshotPath(api.context.cachePath, snapshotHash) : '';
 
       // Load previous build sizes for comparison (only if diff is enabled)


### PR DESCRIPTION
## Summary

Core plugins still read configuration source metadata from `_privateMeta` after it has been exposed through `RsbuildContext`. This PR updates build cache dependencies and file-size snapshot keys to use the context fields, and includes files imported by the configuration in Rspack build dependencies.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8144