### PR TITLE
test(e2e): cover config file build dependencies

### DIFF
--- a/e2e/cases/cache/config-file-dependencies/index.test.ts
+++ b/e2e/cases/cache/config-file-dependencies/index.test.ts
@@ -1,0 +1,20 @@
+import { realpath } from 'node:fs/promises';
+import { join } from 'node:path';
+import { expect, test } from '@e2e/helper';
+import { createRsbuild, loadConfig } from '@rsbuild/core';
+
+test('should add config files to build dependencies', async () => {
+  const { content } = await loadConfig({ cwd: import.meta.dirname });
+  const rsbuild = await createRsbuild({
+    cwd: import.meta.dirname,
+    config: content,
+  });
+  const [config] = await rsbuild.initConfigs();
+
+  expect(config.cache).toMatchObject({
+    buildDependencies: expect.arrayContaining([
+      join(import.meta.dirname, 'rsbuild.config.mts'),
+      await realpath(join(import.meta.dirname, 'shared.config.mts')),
+    ]),
+  });
+});

--- a/e2e/cases/cache/config-file-dependencies/index.test.ts
+++ b/e2e/cases/cache/config-file-dependencies/index.test.ts
@@ -3,6 +3,8 @@ import { join } from 'node:path';
 import { expect, test } from '@e2e/helper';
 import { createRsbuild, loadConfig } from '@rsbuild/core';
 
+// `.mts` is intentional because Rspack cannot recursively detect its imports
+// as build dependencies, so Rsbuild must add them explicitly.
 test('should add config files to build dependencies', async () => {
   const { content } = await loadConfig({ cwd: import.meta.dirname });
   const rsbuild = await createRsbuild({

--- a/e2e/cases/cache/config-file-dependencies/rsbuild.config.mts
+++ b/e2e/cases/cache/config-file-dependencies/rsbuild.config.mts
@@ -1,0 +1,3 @@
+import { sharedConfig } from './shared.config.mts';
+
+export default sharedConfig;

--- a/e2e/cases/cache/config-file-dependencies/shared.config.mts
+++ b/e2e/cases/cache/config-file-dependencies/shared.config.mts
@@ -1,0 +1,5 @@
+export const sharedConfig = {
+  performance: {
+    buildCache: true,
+  },
+};

--- a/e2e/cases/cache/config-file-dependencies/src/index.js
+++ b/e2e/cases/cache/config-file-dependencies/src/index.js
@@ -1,0 +1,1 @@
+console.log('hello');


### PR DESCRIPTION
## Summary

This PR adds a focused e2e case to ensure the loaded Rsbuild config file and its imported dependencies are forwarded to Rspack build dependencies.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8145