### PR TITLE
feat(core): accept loadConfig result as config input

### DIFF
--- a/e2e/cases/javascript-api/create-rsbuild-config/index.test.ts
+++ b/e2e/cases/javascript-api/create-rsbuild-config/index.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from '@e2e/helper';
+import { createRsbuild, loadConfig } from '@rsbuild/core';
+
+test('should accept loadConfig result as config input', async () => {
+  const result = await loadConfig({ cwd: import.meta.dirname });
+  const rsbuild = await createRsbuild({
+    cwd: import.meta.dirname,
+    config: result,
+  });
+
+  expect(rsbuild.context.configFile).toBe(result.filePath);
+  expect(rsbuild.context.configFileDependencies).toEqual(result.dependencies);
+});

--- a/e2e/cases/javascript-api/create-rsbuild-config/rsbuild.config.mjs
+++ b/e2e/cases/javascript-api/create-rsbuild-config/rsbuild.config.mjs
@@ -1,0 +1,3 @@
+import { sharedConfig } from './shared.config.mjs';
+
+export default sharedConfig;

--- a/e2e/cases/javascript-api/create-rsbuild-config/shared.config.mjs
+++ b/e2e/cases/javascript-api/create-rsbuild-config/shared.config.mjs
@@ -1,0 +1,1 @@
+export const sharedConfig = {};

--- a/e2e/cases/javascript-api/create-rsbuild-config/src/index.js
+++ b/e2e/cases/javascript-api/create-rsbuild-config/src/index.js
@@ -1,0 +1,1 @@
+console.log('hello');

--- a/packages/core/src/createContext.ts
+++ b/packages/core/src/createContext.ts
@@ -7,6 +7,7 @@ import { ensureAbsolutePath, getCommonParentPath } from './helpers/path';
 import { createRestartManager } from './helpers/restartManager';
 import { initHooks } from './hooks';
 import { getHTMLPathByEntry } from './initPlugins';
+import type { LoadConfigResult } from './loadConfig';
 import type { Logger } from './logger';
 import type {
   EnvironmentContext,
@@ -179,6 +180,7 @@ export async function createContext(
   options: ResolvedCreateRsbuildOptions,
   userConfig: RsbuildConfig,
   logger: Logger,
+  loadConfigResult?: LoadConfigResult,
 ): Promise<InternalContext> {
   const { cwd } = options;
   const rootPath = userConfig.root ? ensureAbsolutePath(cwd, userConfig.root) : cwd;
@@ -188,13 +190,15 @@ export async function createContext(
   const specifiedEnvironments =
     options.environment && options.environment.length > 0 ? options.environment : undefined;
   const hooks = initHooks();
-  const configMeta = userConfig._privateMeta;
+  const configFile = loadConfigResult?.filePath ?? userConfig._privateMeta?.configFilePath;
+  const configFileDependencies =
+    loadConfigResult?.dependencies ?? userConfig._privateMeta?.configFileDependencies ?? [];
 
   return {
     version: RSBUILD_VERSION,
     rootPath,
-    configFile: configMeta?.configFilePath,
-    configFileDependencies: configMeta?.configFileDependencies ?? [],
+    configFile,
+    configFileDependencies,
     distPath: '',
     cachePath,
     logger,

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -8,6 +8,7 @@ import { isEmptyDir } from './helpers/fs';
 import { initConfigs as baseInitConfigs, initRsbuildConfig } from './initConfigs';
 import { initPluginAPI } from './initPlugins';
 import { inspectConfig as baseInspectConfig } from './inspectConfig';
+import type { LoadConfigResult } from './loadConfig';
 import { type LoadEnvResult, loadEnv } from './loadEnv';
 import { createLogger, defaultLogger, isDebug } from './logger';
 import { createPluginManager } from './pluginManager';
@@ -144,6 +145,10 @@ function applyEnvsToConfig(config: RsbuildConfig, envs: LoadEnvResult | null) {
   }
 }
 
+function isLoadConfigResult(result: unknown): result is LoadConfigResult {
+  return typeof result === 'object' && result !== null && 'content' in result;
+}
+
 /**
  * Create an Rsbuild instance.
  */
@@ -156,7 +161,13 @@ export async function createRsbuild(options: CreateRsbuildOptions = {}): Promise
     : null;
 
   const configOrFactory = options.config ?? options.rsbuildConfig;
-  const config = isFunction(configOrFactory) ? await configOrFactory() : configOrFactory || {};
+  let config = isFunction(configOrFactory) ? await configOrFactory() : configOrFactory;
+  let loadConfigResult: LoadConfigResult | undefined;
+  if (isLoadConfigResult(config)) {
+    loadConfigResult = config;
+    config = config.content;
+  }
+  config ||= {};
 
   const logger =
     config.customLogger ??
@@ -184,7 +195,7 @@ export async function createRsbuild(options: CreateRsbuildOptions = {}): Promise
 
   const pluginManager = createPluginManager(logger);
 
-  const context = await createContext(resolvedOptions, config, logger);
+  const context = await createContext(resolvedOptions, config, logger, loadConfigResult);
 
   const getPluginAPI = initPluginAPI({ context, pluginManager });
   context.getPluginAPI = getPluginAPI;

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -146,7 +146,13 @@ function applyEnvsToConfig(config: RsbuildConfig, envs: LoadEnvResult | null) {
 }
 
 function isLoadConfigResult(result: unknown): result is LoadConfigResult {
-  return typeof result === 'object' && result !== null && 'content' in result;
+  return (
+    typeof result === 'object' &&
+    result !== null &&
+    'content' in result &&
+    'filePath' in result &&
+    'dependencies' in result
+  );
 }
 
 /**

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -1,4 +1,5 @@
 import type { Compiler, MultiCompiler } from '@rspack/core';
+import type { LoadConfigResult } from '../loadConfig';
 import type { LoadEnvOptions } from '../loadEnv';
 import type { Logger } from '../logger';
 import type { RsbuildDevServer } from '../server/devServer';
@@ -114,6 +115,8 @@ export type InspectConfigResult = {
 
 export type CreateCompiler = () => Promise<Compiler | MultiCompiler>;
 
+type RsbuildConfigInput = RsbuildConfig | LoadConfigResult;
+
 export type CreateRsbuildOptions = {
   /**
    * The root path of current project.
@@ -137,12 +140,12 @@ export type CreateRsbuildOptions = {
    * Alias for `config`.
    * This option will be deprecated in the future.
    */
-  rsbuildConfig?: RsbuildConfig | (() => Promise<RsbuildConfig>);
+  rsbuildConfig?: RsbuildConfigInput | (() => Promise<RsbuildConfigInput>);
   /**
-   * Rsbuild configurations.
+   * Rsbuild configuration or the result returned by `loadConfig`.
    * Passing a function to load the config asynchronously with custom logic.
    */
-  config?: RsbuildConfig | (() => Promise<RsbuildConfig>);
+  config?: RsbuildConfigInput | (() => Promise<RsbuildConfigInput>);
   /**
    * Whether to call `loadEnv` to load environment variables and define them
    * as global variables via `source.define`.

--- a/website/docs/en/api/javascript-api/core.mdx
+++ b/website/docs/en/api/javascript-api/core.mdx
@@ -38,7 +38,7 @@ type CreateRsbuildOptions = {
   callerName?: string;
   environment?: string[];
   loadEnv?: boolean | LoadEnvOptions;
-  config?: RsbuildConfig | (() => Promise<RsbuildConfig>);
+  config?: RsbuildConfig | LoadConfigResult | (() => Promise<RsbuildConfig | LoadConfigResult>);
   restart?: RestartFn;
 };
 ```
@@ -47,7 +47,7 @@ type CreateRsbuildOptions = {
 - `callerName`: The name of the framework or tool currently invoking Rsbuild, defaults to `'rsbuild'`, see [Specify caller name](#specify-caller-name).
 - `environment`: Build only specified [environments](/guide/advanced/environments). If not specified or an empty array is passed, all environments will be built.
 - `loadEnv`：Whether to call the [loadEnv](/api/javascript-api/core#loadenv) method to load environment variables and define them as global variables via [source.define](/config/source/define).
-- `config`: Rsbuild configuration object. Refer to [Configuration Overview](/config/) for all available configuration options.
+- `config`: Rsbuild configuration object or the result returned by [`loadConfig`](#loadconfig). Refer to [Configuration Overview](/config/) for all available configuration options.
 - `restart`: A function that handles restart requests for the current dev server or watch build. See [restart](#restart).
 
 :::tip
@@ -63,12 +63,14 @@ import { createRsbuild, loadConfig } from '@rsbuild/core';
 
 const rsbuild = await createRsbuild({
   config: async () => {
-    const { content } = await loadConfig();
-    someFunctionToUpdateConfig(content);
-    return content;
+    const result = await loadConfig();
+    someFunctionToUpdateConfig(result.content);
+    return result;
   },
 });
 ```
+
+When the complete `loadConfig` result is passed, the absolute paths of the config file and its imported dependencies are stored in [`rsbuild.context.configFile`](/api/javascript-api/instance#contextconfigfile) and [`rsbuild.context.configFileDependencies`](/api/javascript-api/instance#contextconfigfiledependencies), respectively, and used as build dependencies when persistent build cache is enabled.
 
 ### Load environment variables
 
@@ -211,12 +213,12 @@ function loadConfig<Config = RsbuildConfig>(params?: {
 import { loadConfig } from '@rsbuild/core';
 
 // Load `rsbuild.config.*` from cwd using the default lookup order
-const { content } = await loadConfig();
+const result = await loadConfig();
 
-console.log(content); // -> Rsbuild config object
+console.log(result.content); // -> Rsbuild config object
 
 const rsbuild = await createRsbuild({
-  config: content,
+  config: result,
 });
 ```
 

--- a/website/docs/zh/api/javascript-api/core.mdx
+++ b/website/docs/zh/api/javascript-api/core.mdx
@@ -38,7 +38,7 @@ type CreateRsbuildOptions = {
   callerName?: string;
   environment?: string[];
   loadEnv?: boolean | LoadEnvOptions;
-  config?: RsbuildConfig | (() => Promise<RsbuildConfig>);
+  config?: RsbuildConfig | LoadConfigResult | (() => Promise<RsbuildConfig | LoadConfigResult>);
   restart?: RestartFn;
 };
 ```
@@ -47,7 +47,7 @@ type CreateRsbuildOptions = {
 - `callerName`：当前调用者的名称，默认值为 `'rsbuild'`，详见 [指定调用者名称](#specify-caller-name)。
 - `environment`：只构建指定的 [environments](/guide/advanced/environments)，如果未指定或传入空数组，则构建所有环境。
 - `loadEnv`：是否调用 [loadEnv](/api/javascript-api/core#loadenv) 方法来加载环境变量，并通过 [source.define](/config/source/define) 定义为全局变量。
-- `config`：Rsbuild 配置对象。参考 [配置总览](/config/) 查看所有可用的配置项。
+- `config`：Rsbuild 配置对象或 [`loadConfig`](#loadconfig) 返回的结果。参考 [配置总览](/config/) 查看所有可用的配置项。
 - `restart`：处理当前 dev server 或监听构建重启请求的函数，详见 [restart](#restart)。
 
 :::tip
@@ -63,12 +63,14 @@ import { createRsbuild, loadConfig } from '@rsbuild/core';
 
 const rsbuild = await createRsbuild({
   config: async () => {
-    const { content } = await loadConfig();
-    someFunctionToUpdateConfig(content);
-    return content;
+    const result = await loadConfig();
+    someFunctionToUpdateConfig(result.content);
+    return result;
   },
 });
 ```
+
+传入完整的 `loadConfig` 返回结果后，配置文件及其导入依赖的绝对路径会分别记录在 [`rsbuild.context.configFile`](/api/javascript-api/instance#contextconfigfile) 和 [`rsbuild.context.configFileDependencies`](/api/javascript-api/instance#contextconfigfiledependencies) 中，并在启用持久化构建缓存时作为构建依赖。
 
 ### 加载环境变量
 
@@ -211,12 +213,12 @@ function loadConfig<Config = RsbuildConfig>(params?: {
 import { loadConfig } from '@rsbuild/core';
 
 // 按默认查找顺序从 cwd 加载 `rsbuild.config.*` 配置文件
-const { content } = await loadConfig();
+const result = await loadConfig();
 
-console.log(content); // -> Rsbuild config object
+console.log(result.content); // -> Rsbuild config object
 
 const rsbuild = await createRsbuild({
-  config: content,
+  config: result,
 });
 ```
 


### PR DESCRIPTION
## Summary

This PR allows `createRsbuild` to accept the complete result returned by `loadConfig` as config input, including from async config factories. This preserves the loaded config file and dependency metadata for public context and persistent build cache without requiring callers to access private metadata.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8144
- https://github.com/web-infra-dev/rsbuild/pull/8145