### PR TITLE
refactor(cli): pass loadConfig result to createRsbuild

### DIFF
--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -40,17 +40,14 @@ const getEnvDir = (cwd: string, envDir?: string) => {
 
 const loadConfig = async (root: string) => {
   const { options, command } = cliState;
-  const {
-    content: config,
-    filePath,
-    dependencies,
-  } = await baseLoadConfig({
+  const result = await baseLoadConfig({
     cwd: root,
     path: options.config,
     envMode: options.envMode,
     loader: options.configLoader,
     command,
   });
+  const { content: config, filePath, dependencies } = result;
 
   config.dev ||= {};
   config.source ||= {};
@@ -125,7 +122,7 @@ const loadConfig = async (root: string) => {
     ];
   }
 
-  return config;
+  return result;
 };
 
 const restart = async ({ action }: RestartContext): Promise<boolean> => {


### PR DESCRIPTION
## Summary

The CLI currently unwraps `loadConfig` before calling `createRsbuild`, so configuration file metadata still reaches Core through private config metadata. This PR keeps applying CLI options to the loaded content while passing the complete result to `createRsbuild`, without changing restart behavior.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8147