### PR TITLE
docs: clarify configuration file watching

### DIFF
--- a/website/docs/en/guide/configuration/rsbuild.mdx
+++ b/website/docs/en/guide/configuration/rsbuild.mdx
@@ -164,14 +164,6 @@ When using Node.js's native loader, note the following limitations:
 
 > See [Node.js - Running TypeScript Natively](https://nodejs.org/en/learn/typescript/run-natively#running-typescript-natively) for more details.
 
-## Configuration file watching
-
-When using the Rsbuild CLI, `rsbuild dev` and `rsbuild build --watch` automatically watch the loaded configuration file and its imported dependencies. When one of these files changes, Rsbuild reloads the configuration and restarts the current dev server or watch build.
-
-When using the JavaScript API, pass the complete [`loadConfig`](/api/javascript-api/core#loadconfig) result to `createRsbuild` so Rsbuild can track and automatically watch these files.
-
-`rsbuild.startDevServer()`, `rsbuild.createDevServer()`, and `rsbuild.build({ watch: true })` install restart watchers, while regular builds and preview servers do not. When a watched file changes, Rsbuild calls the [onRestart hook](/plugins/dev/hooks#onrestart). By default, Rsbuild does not close or restart the current task; you can pass the [`restart` option](/api/javascript-api/core#restart) to handle restart requests.
-
 ## Using environment variables
 
 In the configuration file, you can use Node.js environment variables such as `process.env.NODE_ENV` to dynamically set different configurations:
@@ -271,6 +263,22 @@ const config2 = defineConfig({
 // { dev: { port: '3001' }
 export default mergeRsbuildConfig(config1, config2);
 ```
+
+## Configuration file watching
+
+### Rsbuild CLI
+
+When using the Rsbuild CLI, `rsbuild dev` and `rsbuild build --watch` automatically watch the loaded configuration file and its imported dependencies.
+
+When one of these files changes, Rsbuild reloads the configuration and restarts the current dev server or watch build.
+
+### JavaScript API
+
+When using the JavaScript API, pass the complete result returned by [`loadConfig`](/api/javascript-api/core#loadconfig) to `createRsbuild`. This allows Rsbuild to track the configuration file and its imported dependencies.
+
+When calling `rsbuild.startDevServer()`, `rsbuild.createDevServer()`, or `rsbuild.build({ watch: true })`, Rsbuild installs a restart watcher and automatically watches these files. Regular builds and preview servers do not install a watcher. When a watched file changes, Rsbuild calls the [onRestart hook](/plugins/dev/hooks#onrestart).
+
+By default, Rsbuild only calls this hook and does not automatically restart the current task. To run the restart process, pass the [`restart` option](/api/javascript-api/core#restart).
 
 ## Debug the config
 

--- a/website/docs/zh/guide/configuration/rsbuild.mdx
+++ b/website/docs/zh/guide/configuration/rsbuild.mdx
@@ -164,14 +164,6 @@ Rsbuild 提供了三种配置文件加载方式：
 
 > 详见 [Node.js - Running TypeScript Natively](https://nodejs.org/en/learn/typescript/run-natively#running-typescript-natively)。
 
-## 配置文件监听 \{#configuration-file-watching}
-
-使用 Rsbuild CLI 时，`rsbuild dev` 和 `rsbuild build --watch` 会自动监听已加载的配置文件及其导入依赖。当其中任一文件发生变化时，Rsbuild 会重新加载配置，并重启当前 dev server 或监听构建。
-
-使用 JavaScript API 时，请将完整的 [`loadConfig`](/api/javascript-api/core#loadconfig) 返回结果传入 `createRsbuild`，使 Rsbuild 可以追踪并自动监听这些文件。
-
-`rsbuild.startDevServer()`、`rsbuild.createDevServer()` 和 `rsbuild.build({ watch: true })` 会安装 restart watcher，普通构建和预览服务器则不会安装。被监听的文件发生变化时，Rsbuild 会调用 [onRestart hook](/plugins/dev/hooks#onrestart)。默认情况下，Rsbuild 不会关闭或重启当前任务；你可以传入 [`restart` 选项](/api/javascript-api/core#restart) 来处理重启请求。
-
 ## 使用环境变量
 
 在配置文件中，你可以使用 `process.env.NODE_ENV` 等 Node.js 环境变量，来动态写入不同的配置：
@@ -271,6 +263,22 @@ const config2 = defineConfig({
 // { dev: { port: '3001' }
 export default mergeRsbuildConfig(config1, config2);
 ```
+
+## 配置文件监听 \{#configuration-file-watching}
+
+### Rsbuild CLI
+
+使用 Rsbuild CLI 时，`rsbuild dev` 和 `rsbuild build --watch` 会自动监听已加载的配置文件及其导入依赖。
+
+当其中任一文件发生变化时，Rsbuild 会重新加载配置，并重启当前 dev server 或监听构建。
+
+### JavaScript API
+
+使用 JavaScript API 时，请将 [`loadConfig`](/api/javascript-api/core#loadconfig) 的完整返回结果传入 `createRsbuild`。Rsbuild 会据此追踪配置文件及其导入依赖。
+
+调用 `rsbuild.startDevServer()`、`rsbuild.createDevServer()` 或 `rsbuild.build({ watch: true })` 时，Rsbuild 会安装 restart 监听器，并自动监听上述文件；普通构建和预览服务器不会安装监听器。被监听的文件发生变化时，Rsbuild 会调用 [onRestart hook](/plugins/dev/hooks#onrestart)。
+
+默认情况下，Rsbuild 仅调用该 hook，不会自动重启当前任务。如需执行重启流程，可以传入 [`restart` 选项](/api/javascript-api/core#restart)。
 
 ## 调试配置
 


### PR DESCRIPTION
## Summary

This PR clarifies how the Rsbuild CLI and JavaScript API watch loaded configuration files and their imported dependencies.
It also documents when restart watchers are installed and how to opt into restart handling in both English and Chinese.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8149