### PR TITLE
feat(core): support multiple JS minimizer options

### DIFF
--- a/packages/core/src/plugins/minimize.ts
+++ b/packages/core/src/plugins/minimize.ts
@@ -121,10 +121,10 @@ export const pluginMinimize = (): RsbuildPlugin => ({
       chain.optimization.minimize(minifyJs || minifyCss);
 
       if (minifyJs) {
-        const configuredOptions = castArray<SwcJsMinimizerRspackPluginOptions>(jsOptions);
-        const jsOptionsList = configuredOptions.length > 0 ? configuredOptions : [undefined];
-
-        jsOptionsList.forEach((jsOptionsItem, index) => {
+        const registerJsMinimizer = (
+          jsOptionsItem?: SwcJsMinimizerRspackPluginOptions,
+          index = 0,
+        ) => {
           const minimizerId =
             index === 0 ? CHAIN_ID.MINIMIZER.JS : `${CHAIN_ID.MINIMIZER.JS}-${index}`;
 
@@ -132,7 +132,15 @@ export const pluginMinimize = (): RsbuildPlugin => ({
             .minimizer(minimizerId)
             .use(rspack.SwcJsMinimizerRspackPlugin, [getSwcMinimizerOptions(config, jsOptionsItem)])
             .end();
-        });
+        };
+
+        const jsOptionsList = castArray<SwcJsMinimizerRspackPluginOptions>(jsOptions);
+
+        if (jsOptionsList.length > 0) {
+          jsOptionsList.forEach(registerJsMinimizer);
+        } else {
+          registerJsMinimizer();
+        }
       }
 
       if (minifyCss) {

--- a/packages/core/src/plugins/minimize.ts
+++ b/packages/core/src/plugins/minimize.ts
@@ -3,8 +3,8 @@ import type {
   SwcJsMinimizerRspackPluginOptions,
 } from '@rspack/core';
 import deepmerge from 'deepmerge';
-import { isPlainObject, pick } from '../helpers';
-import type { NormalizedEnvironmentConfig, RsbuildPlugin } from '../types';
+import { castArray, isPlainObject, pick } from '../helpers';
+import type { NormalizedEnvironmentConfig, OneOrMany, RsbuildPlugin } from '../types';
 import { getLightningCSSLoaderOptions } from './css';
 
 const CONSOLE_METHODS = [
@@ -88,7 +88,7 @@ export function getSwcMinimizerOptions(
 export function parseMinifyOptions(config: NormalizedEnvironmentConfig): {
   minifyJs: boolean;
   minifyCss: boolean;
-  jsOptions?: SwcJsMinimizerRspackPluginOptions;
+  jsOptions?: OneOrMany<SwcJsMinimizerRspackPluginOptions>;
   cssOptions?: LightningCssMinimizerRspackPluginOptions;
 } {
   const isProd = config.mode === 'production';
@@ -121,10 +121,18 @@ export const pluginMinimize = (): RsbuildPlugin => ({
       chain.optimization.minimize(minifyJs || minifyCss);
 
       if (minifyJs) {
-        chain.optimization
-          .minimizer(CHAIN_ID.MINIMIZER.JS)
-          .use(rspack.SwcJsMinimizerRspackPlugin, [getSwcMinimizerOptions(config, jsOptions)])
-          .end();
+        const configuredOptions = castArray<SwcJsMinimizerRspackPluginOptions>(jsOptions);
+        const jsOptionsList = configuredOptions.length > 0 ? configuredOptions : [undefined];
+
+        jsOptionsList.forEach((jsOptionsItem, index) => {
+          const minimizerId =
+            index === 0 ? CHAIN_ID.MINIMIZER.JS : `${CHAIN_ID.MINIMIZER.JS}-${index}`;
+
+          chain.optimization
+            .minimizer(minimizerId)
+            .use(rspack.SwcJsMinimizerRspackPlugin, [getSwcMinimizerOptions(config, jsOptionsItem)])
+            .end();
+        });
       }
 
       if (minifyCss) {

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1176,9 +1176,11 @@ export type Minify =
       js?: boolean | 'always';
       /**
        * Minimizer options of JavaScript, which will be passed to SWC.
+       * When using an array, each item registers a separate minimizer and the first matching item
+       * applies to each JavaScript asset.
        * @default {}
        */
-      jsOptions?: SwcJsMinimizerRspackPluginOptions;
+      jsOptions?: OneOrMany<SwcJsMinimizerRspackPluginOptions>;
       /**
        * Whether to enable minification for CSS bundles.
        * - `true`: Enabled in production mode.

--- a/packages/core/tests/minimize.test.ts
+++ b/packages/core/tests/minimize.test.ts
@@ -110,6 +110,58 @@ describe('plugin-minimize', () => {
     });
   });
 
+  it('should accept an array of options for JS minimizers', async () => {
+    rs.stubEnv('NODE_ENV', 'production');
+
+    const rsbuild = await createRsbuild({
+      config: {
+        output: {
+          minify: {
+            css: false,
+            jsOptions: [
+              {
+                include: 'vendor.js',
+                minimizerOptions: {
+                  mangle: true,
+                },
+              },
+              {
+                exclude: 'vendor.js',
+                minimizerOptions: {
+                  mangle: false,
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const rspackConfigs = await rsbuild.initConfigs();
+
+    expect(rspackConfigs[0].optimization?.minimizer).toHaveLength(2);
+    expect(rspackConfigs[0].optimization?.minimizer?.[0]).toMatchObject({
+      _args: [
+        {
+          include: 'vendor.js',
+          minimizerOptions: {
+            mangle: true,
+          },
+        },
+      ],
+    });
+    expect(rspackConfigs[0].optimization?.minimizer?.[1]).toMatchObject({
+      _args: [
+        {
+          exclude: 'vendor.js',
+          minimizerOptions: {
+            mangle: false,
+          },
+        },
+      ],
+    });
+  });
+
   it('should dropConsole when performance.removeConsole is true', async () => {
     rs.stubEnv('NODE_ENV', 'production');
 

--- a/website/docs/en/config/output/minify.mdx
+++ b/website/docs/en/config/output/minify.mdx
@@ -11,7 +11,8 @@ type Minify =
   | boolean
   | {
       js?: boolean | 'always';
-      jsOptions?: Rspack.SwcJsMinimizerRspackPluginOptions;
+      jsOptions?:
+        Rspack.SwcJsMinimizerRspackPluginOptions | Rspack.SwcJsMinimizerRspackPluginOptions[];
       css?: boolean | 'always';
       cssOptions?: Rspack.LightningcssMinimizerRspackPluginOptions;
     };
@@ -101,7 +102,7 @@ export default {
 
 ### minify.jsOptions
 
-- **Type:** `Rspack.SwcJsMinimizerRspackPluginOptions`
+- **Type:** `Rspack.SwcJsMinimizerRspackPluginOptions | Rspack.SwcJsMinimizerRspackPluginOptions[]`
 - **Default:** `{}`
 
 `output.minify.jsOptions` configures SWC's minification options. See [SwcJsMinimizerRspackPlugin](https://rspack.rs/plugins/rspack/swc-js-minimizer-rspack-plugin) for detailed configuration options.
@@ -123,6 +124,33 @@ export default {
 ```
 
 > Refer to [Configure SWC](/guide/configuration/swc) for more details.
+
+You can pass an array of options to apply different minification settings to different files. Each item registers a separate `SwcJsMinimizerRspackPlugin` instance:
+
+```ts title="rsbuild.config.ts"
+export default {
+  output: {
+    minify: {
+      jsOptions: [
+        {
+          include: /vendor\.js$/,
+          minimizerOptions: {
+            mangle: true,
+          },
+        },
+        {
+          exclude: /vendor\.js$/,
+          minimizerOptions: {
+            mangle: false,
+          },
+        },
+      ],
+    },
+  },
+};
+```
+
+Each JavaScript asset is minimized only once. If an asset matches multiple items, the first matching item takes effect, so we recommend using mutually exclusive `test`, `include`, or `exclude` conditions.
 
 ### minify.css
 

--- a/website/docs/zh/config/output/minify.mdx
+++ b/website/docs/zh/config/output/minify.mdx
@@ -11,7 +11,8 @@ type Minify =
   | boolean
   | {
       js?: boolean | 'always';
-      jsOptions?: Rspack.SwcJsMinimizerRspackPluginOptions;
+      jsOptions?:
+        Rspack.SwcJsMinimizerRspackPluginOptions | Rspack.SwcJsMinimizerRspackPluginOptions[];
       css?: boolean | 'always';
       cssOptions?: Rspack.LightningcssMinimizerRspackPluginOptions;
     };
@@ -101,7 +102,7 @@ export default {
 
 ### minify.jsOptions
 
-- **类型：** `Rspack.SwcJsMinimizerRspackPluginOptions`
+- **类型：** `Rspack.SwcJsMinimizerRspackPluginOptions | Rspack.SwcJsMinimizerRspackPluginOptions[]`
 - **默认值：** `{}`
 
 `output.minify.jsOptions` 用于配置 SWC 的压缩选项，具体配置项请参考 [SwcJsMinimizerRspackPlugin 文档](https://rspack.rs/zh/plugins/rspack/swc-js-minimizer-rspack-plugin)。
@@ -123,6 +124,33 @@ export default {
 ```
 
 > 参考 [配置 SWC](/guide/configuration/swc) 了解更多。
+
+你可以传入一个选项数组，为不同文件设置不同的压缩配置。每一项都会注册一个独立的 `SwcJsMinimizerRspackPlugin` 实例：
+
+```ts title="rsbuild.config.ts"
+export default {
+  output: {
+    minify: {
+      jsOptions: [
+        {
+          include: /vendor\.js$/,
+          minimizerOptions: {
+            mangle: true,
+          },
+        },
+        {
+          exclude: /vendor\.js$/,
+          minimizerOptions: {
+            mangle: false,
+          },
+        },
+      ],
+    },
+  },
+};
+```
+
+每个 JavaScript 产物只会被压缩一次。如果一个产物匹配了多个配置项，则第一个匹配项生效，因此建议使用互斥的 `test`、`include` 或 `exclude` 条件。
 
 ### minify.css
 


### PR DESCRIPTION
## Summary

`output.minify.jsOptions` currently accepts only one SWC minimizer configuration, which prevents applying different minification policies to different output files. This PR adds array support while preserving the existing object form, registers one minimizer per item in order, and documents that the first matching rule applies to each asset.