### PR TITLE
feat(core): support multiple CSS minimizer options

### DIFF
--- a/e2e/cases/optimization/css-minify-options-array/index.test.ts
+++ b/e2e/cases/optimization/css-minify-options-array/index.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
+
+test('should apply different CSS minify options to different assets', async ({ build }) => {
+  const rsbuild = await build();
+  const files = rsbuild.getDistFiles();
+  const foo = getFileContent(files, 'static/css/foo.css');
+  const bar = getFileContent(files, 'static/css/bar.css');
+
+  expect(foo).not.toContain('.foo-unused');
+  expect(foo).toContain('.foo-keep');
+  expect(bar).not.toContain('.bar-unused');
+  expect(bar).toContain('.bar-keep');
+});

--- a/e2e/cases/optimization/css-minify-options-array/rsbuild.config.ts
+++ b/e2e/cases/optimization/css-minify-options-array/rsbuild.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  source: {
+    entry: {
+      foo: './src/foo.js',
+      bar: './src/bar.js',
+    },
+  },
+  output: {
+    filenameHash: false,
+    minify: {
+      js: false,
+      cssOptions: [
+        {
+          include: /foo\.css$/,
+          minimizerOptions: {
+            unusedSymbols: ['foo-unused'],
+          },
+        },
+        {
+          include: /bar\.css$/,
+          minimizerOptions: {
+            unusedSymbols: ['bar-unused'],
+          },
+        },
+      ],
+    },
+  },
+});

--- a/e2e/cases/optimization/css-minify-options-array/src/bar.css
+++ b/e2e/cases/optimization/css-minify-options-array/src/bar.css
@@ -1,0 +1,7 @@
+.bar-unused {
+  color: blue;
+}
+
+.bar-keep {
+  color: purple;
+}

--- a/e2e/cases/optimization/css-minify-options-array/src/bar.js
+++ b/e2e/cases/optimization/css-minify-options-array/src/bar.js
@@ -1,0 +1,1 @@
+import './bar.css';

--- a/e2e/cases/optimization/css-minify-options-array/src/foo.css
+++ b/e2e/cases/optimization/css-minify-options-array/src/foo.css
@@ -1,0 +1,7 @@
+.foo-unused {
+  color: red;
+}
+
+.foo-keep {
+  color: green;
+}

--- a/e2e/cases/optimization/css-minify-options-array/src/foo.js
+++ b/e2e/cases/optimization/css-minify-options-array/src/foo.js
@@ -1,0 +1,1 @@
+import './foo.css';

--- a/packages/core/src/plugins/minimize.ts
+++ b/packages/core/src/plugins/minimize.ts
@@ -89,7 +89,7 @@ export function parseMinifyOptions(config: NormalizedEnvironmentConfig): {
   minifyJs: boolean;
   minifyCss: boolean;
   jsOptions?: OneOrMany<SwcJsMinimizerRspackPluginOptions>;
-  cssOptions?: LightningCssMinimizerRspackPluginOptions;
+  cssOptions?: OneOrMany<LightningCssMinimizerRspackPluginOptions>;
 } {
   const isProd = config.mode === 'production';
   const { minify = true } = config.output;
@@ -170,14 +170,29 @@ export const pluginMinimize = (): RsbuildPlugin => ({
           },
         };
 
-        const mergedOptions = cssOptions
-          ? deepmerge<LightningCssMinimizerRspackPluginOptions>(defaultOptions, cssOptions)
-          : defaultOptions;
+        const registerCssMinimizer = (
+          cssOptionsItem?: LightningCssMinimizerRspackPluginOptions,
+          index = 0,
+        ) => {
+          const options = cssOptionsItem
+            ? deepmerge<LightningCssMinimizerRspackPluginOptions>(defaultOptions, cssOptionsItem)
+            : defaultOptions;
+          const minimizerId =
+            index === 0 ? CHAIN_ID.MINIMIZER.CSS : `${CHAIN_ID.MINIMIZER.CSS}-${index}`;
 
-        chain.optimization
-          .minimizer(CHAIN_ID.MINIMIZER.CSS)
-          .use(rspack.LightningCssMinimizerRspackPlugin, [mergedOptions])
-          .end();
+          chain.optimization
+            .minimizer(minimizerId)
+            .use(rspack.LightningCssMinimizerRspackPlugin, [options])
+            .end();
+        };
+
+        const cssOptionsList = castArray<LightningCssMinimizerRspackPluginOptions>(cssOptions);
+
+        if (cssOptionsList.length > 0) {
+          cssOptionsList.forEach(registerCssMinimizer);
+        } else {
+          registerCssMinimizer();
+        }
       }
     });
   },

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1191,9 +1191,11 @@ export type Minify =
       css?: boolean | 'always';
       /**
        * Minimizer options of CSS, which will be passed to LightningCSS.
+       * When using an array, each item registers a separate minimizer and the first matching item
+       * applies to each CSS asset.
        * @default inherit from `tools.lightningcssLoader` config
        */
-      cssOptions?: LightningCssMinimizerRspackPluginOptions;
+      cssOptions?: OneOrMany<LightningCssMinimizerRspackPluginOptions>;
     };
 
 export type InlineChunkTestFunction = (params: { size: number; name: string }) => boolean;

--- a/packages/core/tests/minimize.test.ts
+++ b/packages/core/tests/minimize.test.ts
@@ -162,6 +162,58 @@ describe('plugin-minimize', () => {
     });
   });
 
+  it('should accept an array of options for CSS minimizers', async () => {
+    rs.stubEnv('NODE_ENV', 'production');
+
+    const rsbuild = await createRsbuild({
+      config: {
+        output: {
+          minify: {
+            js: false,
+            cssOptions: [
+              {
+                include: 'foo.css',
+                minimizerOptions: {
+                  unusedSymbols: ['foo-unused'],
+                },
+              },
+              {
+                include: 'bar.css',
+                minimizerOptions: {
+                  unusedSymbols: ['bar-unused'],
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const rspackConfigs = await rsbuild.initConfigs();
+
+    expect(rspackConfigs[0].optimization?.minimizer).toHaveLength(2);
+    expect(rspackConfigs[0].optimization?.minimizer?.[0]).toMatchObject({
+      _args: [
+        {
+          include: 'foo.css',
+          minimizerOptions: {
+            unusedSymbols: ['foo-unused'],
+          },
+        },
+      ],
+    });
+    expect(rspackConfigs[0].optimization?.minimizer?.[1]).toMatchObject({
+      _args: [
+        {
+          include: 'bar.css',
+          minimizerOptions: {
+            unusedSymbols: ['bar-unused'],
+          },
+        },
+      ],
+    });
+  });
+
   it('should dropConsole when performance.removeConsole is true', async () => {
     rs.stubEnv('NODE_ENV', 'production');
 

--- a/website/docs/en/config/output/minify.mdx
+++ b/website/docs/en/config/output/minify.mdx
@@ -14,7 +14,7 @@ type Minify =
       jsOptions?: SwcJsMinimizerRspackPluginOptions | SwcJsMinimizerRspackPluginOptions[];
       css?: boolean | 'always';
       cssOptions?:
-        LightningcssMinimizerRspackPluginOptions | LightningcssMinimizerRspackPluginOptions[];
+        LightningCssMinimizerRspackPluginOptions | LightningCssMinimizerRspackPluginOptions[];
     };
 ```
 
@@ -189,7 +189,7 @@ export default {
 
 ### minify.cssOptions
 
-- **Type:** `LightningcssMinimizerRspackPluginOptions | LightningcssMinimizerRspackPluginOptions[]`
+- **Type:** `LightningCssMinimizerRspackPluginOptions | LightningCssMinimizerRspackPluginOptions[]`
 - **Default:** inherit from [tools.lightningcssLoader](/config/tools/lightningcss-loader)
 
 `output.minify.cssOptions` configures Lightning CSS's minification options. See [LightningCssMinimizerRspackPlugin Documentation](https://rspack.rs/plugins/rspack/lightning-css-minimizer-rspack-plugin) for detailed configuration options.

--- a/website/docs/en/config/output/minify.mdx
+++ b/website/docs/en/config/output/minify.mdx
@@ -11,10 +11,10 @@ type Minify =
   | boolean
   | {
       js?: boolean | 'always';
-      jsOptions?:
-        Rspack.SwcJsMinimizerRspackPluginOptions | Rspack.SwcJsMinimizerRspackPluginOptions[];
+      jsOptions?: SwcJsMinimizerRspackPluginOptions | SwcJsMinimizerRspackPluginOptions[];
       css?: boolean | 'always';
-      cssOptions?: Rspack.LightningcssMinimizerRspackPluginOptions;
+      cssOptions?:
+        LightningcssMinimizerRspackPluginOptions | LightningcssMinimizerRspackPluginOptions[];
     };
 ```
 
@@ -102,7 +102,7 @@ export default {
 
 ### minify.jsOptions
 
-- **Type:** `Rspack.SwcJsMinimizerRspackPluginOptions | Rspack.SwcJsMinimizerRspackPluginOptions[]`
+- **Type:** `SwcJsMinimizerRspackPluginOptions | SwcJsMinimizerRspackPluginOptions[]`
 - **Default:** `{}`
 
 `output.minify.jsOptions` configures SWC's minification options. See [SwcJsMinimizerRspackPlugin](https://rspack.rs/plugins/rspack/swc-js-minimizer-rspack-plugin) for detailed configuration options.
@@ -189,7 +189,7 @@ export default {
 
 ### minify.cssOptions
 
-- **Type:** `Rspack.LightningcssMinimizerRspackPluginOptions`
+- **Type:** `LightningcssMinimizerRspackPluginOptions | LightningcssMinimizerRspackPluginOptions[]`
 - **Default:** inherit from [tools.lightningcssLoader](/config/tools/lightningcss-loader)
 
 `output.minify.cssOptions` configures Lightning CSS's minification options. See [LightningCssMinimizerRspackPlugin Documentation](https://rspack.rs/plugins/rspack/lightning-css-minimizer-rspack-plugin) for detailed configuration options.
@@ -213,6 +213,33 @@ export default {
 :::tip
 When you configure options in [tools.lightningcssLoader](/config/tools/lightningcss-loader), `output.minify.cssOptions` will automatically inherit these options, ensuring that CSS code transformation behavior in the development build is consistent with the production build.
 :::
+
+You can pass an array of options to apply different minification settings to different files. Each item registers a separate `LightningCssMinimizerRspackPlugin` instance:
+
+```ts title="rsbuild.config.ts"
+export default {
+  output: {
+    minify: {
+      cssOptions: [
+        {
+          include: /foo\.css$/,
+          minimizerOptions: {
+            unusedSymbols: ['foo-unused'],
+          },
+        },
+        {
+          include: /bar\.css$/,
+          minimizerOptions: {
+            unusedSymbols: ['bar-unused'],
+          },
+        },
+      ],
+    },
+  },
+};
+```
+
+Each CSS asset is minimized only once. If an asset matches multiple items, the first matching item takes effect, so we recommend using mutually exclusive `test`, `include`, or `exclude` conditions.
 
 ## Switching minifier
 
@@ -264,7 +291,8 @@ When using a custom JS minifier, the `minify.jsOptions` option will no longer ta
 
 ## Version history
 
-| Version | Changes                                                  |
-| ------- | -------------------------------------------------------- |
-| v2.1.7  | Added support for setting `minify.jsOptions` to an array |
-| v2.0.0  | Defaults to `false` for `node` target                    |
+| Version | Changes                                                   |
+| ------- | --------------------------------------------------------- |
+| v2.1.8  | Added support for setting `minify.cssOptions` to an array |
+| v2.1.7  | Added support for setting `minify.jsOptions` to an array  |
+| v2.0.0  | Defaults to `false` for `node` target                     |

--- a/website/docs/zh/config/output/minify.mdx
+++ b/website/docs/zh/config/output/minify.mdx
@@ -11,10 +11,10 @@ type Minify =
   | boolean
   | {
       js?: boolean | 'always';
-      jsOptions?:
-        Rspack.SwcJsMinimizerRspackPluginOptions | Rspack.SwcJsMinimizerRspackPluginOptions[];
+      jsOptions?: SwcJsMinimizerRspackPluginOptions | SwcJsMinimizerRspackPluginOptions[];
       css?: boolean | 'always';
-      cssOptions?: Rspack.LightningcssMinimizerRspackPluginOptions;
+      cssOptions?:
+        LightningcssMinimizerRspackPluginOptions | LightningcssMinimizerRspackPluginOptions[];
     };
 ```
 
@@ -102,7 +102,7 @@ export default {
 
 ### minify.jsOptions
 
-- **类型：** `Rspack.SwcJsMinimizerRspackPluginOptions | Rspack.SwcJsMinimizerRspackPluginOptions[]`
+- **类型：** `SwcJsMinimizerRspackPluginOptions | SwcJsMinimizerRspackPluginOptions[]`
 - **默认值：** `{}`
 
 `output.minify.jsOptions` 用于配置 SWC 的压缩选项，具体配置项请参考 [SwcJsMinimizerRspackPlugin 文档](https://rspack.rs/zh/plugins/rspack/swc-js-minimizer-rspack-plugin)。
@@ -189,7 +189,7 @@ export default {
 
 ### minify.cssOptions
 
-- **类型：** `Rspack.LightningcssMinimizerRspackPluginOptions`
+- **类型：** `LightningcssMinimizerRspackPluginOptions | LightningcssMinimizerRspackPluginOptions[]`
 - **默认值：** 继承 [tools.lightningcssLoader](/config/tools/lightningcss-loader) 的值
 
 `output.minify.cssOptions` 用于配置 Lightning CSS 的压缩选项，具体配置项请参考 [LightningCssMinimizerRspackPlugin 文档](https://rspack.rs/zh/plugins/rspack/lightning-css-minimizer-rspack-plugin)。
@@ -213,6 +213,33 @@ export default {
 :::tip
 当你在 [tools.lightningcssLoader](/config/tools/lightningcss-loader) 中配置了一些选项时，`output.minify.cssOptions` 会自动继承这些选项，这样可以确保开发环境和生产环境的 CSS 代码转换行为保持一致。
 :::
+
+你可以传入一个选项数组，为不同文件设置不同的压缩配置。每一项都会注册一个独立的 `LightningCssMinimizerRspackPlugin` 实例：
+
+```ts title="rsbuild.config.ts"
+export default {
+  output: {
+    minify: {
+      cssOptions: [
+        {
+          include: /foo\.css$/,
+          minimizerOptions: {
+            unusedSymbols: ['foo-unused'],
+          },
+        },
+        {
+          include: /bar\.css$/,
+          minimizerOptions: {
+            unusedSymbols: ['bar-unused'],
+          },
+        },
+      ],
+    },
+  },
+};
+```
+
+每个 CSS 产物只会被压缩一次。如果一个产物匹配了多个配置项，则第一个匹配项生效，因此建议使用互斥的 `test`、`include` 或 `exclude` 条件。
 
 ## 切换压缩器 \{#switching-minifier}
 
@@ -264,7 +291,8 @@ export default {
 
 ## 版本历史
 
-| 版本   | 变更内容                             |
-| ------ | ------------------------------------ |
-| v2.1.7 | 支持将 `minify.jsOptions` 设置为数组 |
-| v2.0.0 | `node` 产物的默认值改为 `false`      |
+| 版本   | 变更内容                              |
+| ------ | ------------------------------------- |
+| v2.1.8 | 支持将 `minify.cssOptions` 设置为数组 |
+| v2.1.7 | 支持将 `minify.jsOptions` 设置为数组  |
+| v2.0.0 | `node` 产物的默认值改为 `false`       |

--- a/website/docs/zh/config/output/minify.mdx
+++ b/website/docs/zh/config/output/minify.mdx
@@ -14,7 +14,7 @@ type Minify =
       jsOptions?: SwcJsMinimizerRspackPluginOptions | SwcJsMinimizerRspackPluginOptions[];
       css?: boolean | 'always';
       cssOptions?:
-        LightningcssMinimizerRspackPluginOptions | LightningcssMinimizerRspackPluginOptions[];
+        LightningCssMinimizerRspackPluginOptions | LightningCssMinimizerRspackPluginOptions[];
     };
 ```
 
@@ -189,7 +189,7 @@ export default {
 
 ### minify.cssOptions
 
-- **类型：** `LightningcssMinimizerRspackPluginOptions | LightningcssMinimizerRspackPluginOptions[]`
+- **类型：** `LightningCssMinimizerRspackPluginOptions | LightningCssMinimizerRspackPluginOptions[]`
 - **默认值：** 继承 [tools.lightningcssLoader](/config/tools/lightningcss-loader) 的值
 
 `output.minify.cssOptions` 用于配置 Lightning CSS 的压缩选项，具体配置项请参考 [LightningCssMinimizerRspackPlugin 文档](https://rspack.rs/zh/plugins/rspack/lightning-css-minimizer-rspack-plugin)。


### PR DESCRIPTION
## Summary

This PR adds array support for `output.minify.cssOptions`, allowing file-specific Lightning CSS minification settings. Each array item registers a separate minimizer, and the first matching item handles each CSS asset. It also adds unit and E2E coverage and updates the English and Chinese docs for v2.1.8.