### PR TITLE
perf(core): minify large third-party chunks

### DIFF
--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -12,6 +12,9 @@ export const define = {
   'process.env.WS_NO_UTF_8_VALIDATE': true,
 };
 
+const fullyMinifiedChunks =
+  /^(?:chokidar|connect-next|http-proxy-middleware|launch-editor-middleware|manifest-plugin|memfs|open|tinyglobby|ws)\.js$/;
+
 const regexpMap: Record<string, RegExp> = {};
 
 for (const item of prebundleConfig.dependencies) {
@@ -204,7 +207,18 @@ export default defineConfig({
         },
       },
       output: {
-        minify: nodeMinifyConfig,
+        minify: {
+          jsOptions: [
+            {
+              // Fully minify large chunks composed primarily of third-party code.
+              include: fullyMinifiedChunks,
+            },
+            {
+              ...nodeMinifyConfig.jsOptions,
+              exclude: fullyMinifiedChunks,
+            },
+          ],
+        },
         filename: {
           js: ({ chunk }) => {
             // Use `.mjs` for Rspack loaders

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1411,7 +1411,7 @@ importers:
         version: 24.13.3
       rsbuild-plugin-arethetypeswrong:
         specifier: 'catalog:'
-        version: 0.3.1(@rsbuild/core@2.1.6)(typescript@6.0.3)
+        version: 0.3.1(@rsbuild/core@2.1.7)(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -2479,6 +2479,16 @@ packages:
 
   '@rsbuild/core@2.1.6':
     resolution: {integrity: sha512-w2WxblstOgHnDElkqJZVO/jM/EqPaEhg7zqQhON3Xu3Mj9FlVOJx+SgimOtghFzxLt8x7atX4oMUtMTNSZGf0Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      core-js: '>= 3.0.0'
+    peerDependenciesMeta:
+      core-js:
+        optional: true
+
+  '@rsbuild/core@2.1.7':
+    resolution: {integrity: sha512-Xhs8DkLw2Vk5ydwjNG3GMJe1h03lqlCO4dV9EOG9HSR6vDfh07K48aq3KJ8/ncEL/YuFBaCIJrVc7rMFoR1y7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -6484,6 +6494,15 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
+  '@rsbuild/core@2.1.7(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)':
+    dependencies:
+      '@rspack/core': 2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23)
+      '@swc/helpers': 0.5.23
+    optionalDependencies:
+      core-js: 3.49.0
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+
   '@rsbuild/plugin-check-syntax@2.0.0(@rsbuild/core@packages+core)':
     dependencies:
       acorn: 8.17.0
@@ -6524,8 +6543,8 @@ snapshots:
 
   '@rslib/core@1.0.0-beta.0(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)
-      rsbuild-plugin-dts: 1.0.0-beta.0(@rsbuild/core@2.1.6)(typescript@6.0.3)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)
+      rsbuild-plugin-dts: 1.0.0-beta.0(@rsbuild/core@2.1.7)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -6780,7 +6799,7 @@ snapshots:
 
   '@rspress/shared@2.0.18(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)':
     dependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)
       '@shikijs/rehype': 4.3.0
       unified: 11.0.5
     transitivePeerDependencies:
@@ -9224,16 +9243,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.4
       fsevents: 2.3.3
 
-  rsbuild-plugin-arethetypeswrong@0.3.1(@rsbuild/core@2.1.6)(typescript@6.0.3):
+  rsbuild-plugin-arethetypeswrong@0.3.1(@rsbuild/core@2.1.7)(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)
 
-  rsbuild-plugin-dts@1.0.0-beta.0(@rsbuild/core@2.1.6)(typescript@6.0.3):
+  rsbuild-plugin-dts@1.0.0-beta.0(@rsbuild/core@2.1.7)(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)
     optionalDependencies:
       typescript: 6.0.3
 

--- a/scripts/config/rslib.config.ts
+++ b/scripts/config/rslib.config.ts
@@ -3,7 +3,7 @@ import { pluginAreTheTypesWrong } from 'rsbuild-plugin-arethetypeswrong';
 
 export const commonExternals: Array<string | RegExp> = ['webpack', /[\\/]compiled[\\/]/];
 
-export const nodeMinifyConfig: Rsbuild.Minify = {
+export const nodeMinifyConfig = {
   js: true,
   css: false,
   jsOptions: {
@@ -16,7 +16,7 @@ export const nodeMinifyConfig: Rsbuild.Minify = {
       },
     },
   },
-};
+} satisfies Rsbuild.Minify;
 
 export const esmConfig: LibConfig = {
   syntax: 'es2023',


### PR DESCRIPTION
## Summary

This PR fully minifies nine large `@rsbuild/core` chunks composed primarily of third-party code while preserving readable output for the remaining chunks. It also updates Rslib's indirect `@rsbuild/core` resolution from 2.1.6 to 2.1.7 to enable multiple JS minimizer options.

| Chunk | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| `open.js` | 19.0 kB | 9.7 kB | 48.9% |
| `launch-editor-middleware.js` | 30.2 kB | 15.4 kB | 48.9% |
| `manifest-plugin.js` | 37.6 kB | 16.9 kB | 55.1% |
| `chokidar.js` | 43.7 kB | 21.3 kB | 51.3% |
| `connect-next.js` | 46.5 kB | 22.2 kB | 52.1% |
| `tinyglobby.js` | 86.9 kB | 37.1 kB | 57.3% |
| `ws.js` | 97.0 kB | 49.4 kB | 49.1% |
| `http-proxy-middleware.js` | 163.0 kB | 72.8 kB | 55.3% |
| `memfs.js` | 326.3 kB | 160.4 kB | 50.9% |
| **Total** | **850.1 kB** | **405.2 kB** | **52.3%** |

The selected chunks' gzip size decreases from 157.2 kB to 117.1 kB (-25.5%). The complete Node output decreases from 1408.0 kB to 963.0 kB (-31.6%), with gzip decreasing from 291.6 kB to 251.5 kB (-13.8%). Measurements were collected from `packages/core/dist` after `pnpm --filter @rsbuild/core run build`, using gzip level 9.

## Related Links

- https://github.com/web-infra-dev/rsbuild/releases/tag/v2.1.7