### PR TITLE
docs: improve restart option heading

### DIFF
--- a/website/docs/en/api/javascript-api/core.mdx
+++ b/website/docs/en/api/javascript-api/core.mdx
@@ -48,7 +48,7 @@ type CreateRsbuildOptions = {
 - `environment`: Build only specified [environments](/guide/advanced/environments). If not specified or an empty array is passed, all environments will be built.
 - `loadEnv`：Whether to call the [loadEnv](/api/javascript-api/core#loadenv) method to load environment variables and define them as global variables via [source.define](/config/source/define).
 - `config`: Rsbuild configuration object or the result returned by [`loadConfig`](#loadconfig). Refer to [Configuration Overview](/config/) for all available configuration options.
-- `restart`: A function that handles restart requests for the current dev server or watch build. See [restart](#restart).
+- `restart`: A function that handles restart requests for the current dev server or watch build. See [restart](#restart-handling).
 
 :::tip
 `config` was introduced in Rsbuild 1.6. In earlier versions, use `rsbuildConfig` as an alternative.
@@ -99,7 +99,7 @@ const rsbuild = await createRsbuild({
 });
 ```
 
-### restart
+### Restart handling
 
 - **Version:** Added in v2.1.7
 

--- a/website/docs/en/guide/configuration/rsbuild.mdx
+++ b/website/docs/en/guide/configuration/rsbuild.mdx
@@ -278,7 +278,7 @@ When using the JavaScript API, pass the complete result returned by [`loadConfig
 
 When calling `rsbuild.startDevServer()`, `rsbuild.createDevServer()`, or `rsbuild.build({ watch: true })`, Rsbuild installs a restart watcher and automatically watches these files. Regular builds and preview servers do not install a watcher. When a watched file changes, Rsbuild calls the [onRestart hook](/plugins/dev/hooks#onrestart).
 
-By default, Rsbuild only calls this hook and does not automatically restart the current task. To run the restart process, pass the [`restart` option](/api/javascript-api/core#restart).
+By default, Rsbuild only calls this hook and does not automatically restart the current task. To run the restart process, pass the [`restart` option](/api/javascript-api/core#restart-handling).
 
 ## Debug the config
 

--- a/website/docs/en/shared/onRestart.mdx
+++ b/website/docs/en/shared/onRestart.mdx
@@ -8,7 +8,7 @@ The hook is triggered in the following cases:
 
 > This hook is not triggered for regular rebuilds.
 
-When using the JavaScript API, restart watchers are installed by `rsbuild.startDevServer()`, `rsbuild.createDevServer()`, and `rsbuild.build({ watch: true })`. The hook is called when a watched file changes. By default, Rsbuild does not close or restart the current task; you can pass the [`restart` option](/api/javascript-api/core#restart) to handle restart requests.
+When using the JavaScript API, restart watchers are installed by `rsbuild.startDevServer()`, `rsbuild.createDevServer()`, and `rsbuild.build({ watch: true })`. The hook is called when a watched file changes. By default, Rsbuild does not close or restart the current task; you can pass the [`restart` option](/api/javascript-api/core#restart-handling) to handle restart requests.
 
 - **Type:**
 

--- a/website/docs/zh/api/javascript-api/core.mdx
+++ b/website/docs/zh/api/javascript-api/core.mdx
@@ -48,7 +48,7 @@ type CreateRsbuildOptions = {
 - `environment`：只构建指定的 [environments](/guide/advanced/environments)，如果未指定或传入空数组，则构建所有环境。
 - `loadEnv`：是否调用 [loadEnv](/api/javascript-api/core#loadenv) 方法来加载环境变量，并通过 [source.define](/config/source/define) 定义为全局变量。
 - `config`：Rsbuild 配置对象或 [`loadConfig`](#loadconfig) 返回的结果。参考 [配置总览](/config/) 查看所有可用的配置项。
-- `restart`：处理当前 dev server 或监听构建重启请求的函数，详见 [restart](#restart)。
+- `restart`：处理当前 dev server 或监听构建重启请求的函数，详见 [restart](#restart-handling)。
 
 :::tip
 `config` 是 Rsbuild 1.6 新增的选项。在旧版本中，可使用 `rsbuildConfig` 作为替代。
@@ -99,7 +99,7 @@ const rsbuild = await createRsbuild({
 });
 ```
 
-### restart
+### 重启处理 \{#restart-handling}
 
 - **版本：** v2.1.7 新增
 

--- a/website/docs/zh/guide/configuration/rsbuild.mdx
+++ b/website/docs/zh/guide/configuration/rsbuild.mdx
@@ -278,7 +278,7 @@ export default mergeRsbuildConfig(config1, config2);
 
 调用 `rsbuild.startDevServer()`、`rsbuild.createDevServer()` 或 `rsbuild.build({ watch: true })` 时，Rsbuild 会安装 restart 监听器，并自动监听上述文件；普通构建和预览服务器不会安装监听器。被监听的文件发生变化时，Rsbuild 会调用 [onRestart hook](/plugins/dev/hooks#onrestart)。
 
-默认情况下，Rsbuild 仅调用该 hook，不会自动重启当前任务。如需执行重启流程，可以传入 [`restart` 选项](/api/javascript-api/core#restart)。
+默认情况下，Rsbuild 仅调用该 hook，不会自动重启当前任务。如需执行重启流程，可以传入 [`restart` 选项](/api/javascript-api/core#restart-handling)。
 
 ## 调试配置
 

--- a/website/docs/zh/shared/onRestart.mdx
+++ b/website/docs/zh/shared/onRestart.mdx
@@ -8,7 +8,7 @@
 
 > 普通的重新构建不会触发该 hook。
 
-使用 JavaScript API 时，`rsbuild.startDevServer()`、`rsbuild.createDevServer()` 和 `rsbuild.build({ watch: true })` 会安装 restart watcher。被监听的文件发生变化时会调用该 hook。默认情况下，Rsbuild 不会关闭或重启当前任务；你可以传入 [`restart` 选项](/api/javascript-api/core#restart) 来处理重启请求。
+使用 JavaScript API 时，`rsbuild.startDevServer()`、`rsbuild.createDevServer()` 和 `rsbuild.build({ watch: true })` 会安装 restart watcher。被监听的文件发生变化时会调用该 hook。默认情况下，Rsbuild 不会关闭或重启当前任务；你可以传入 [`restart` 选项](/api/javascript-api/core#restart-handling) 来处理重启请求。
 
 - **类型：**
 


### PR DESCRIPTION
## Summary

This PR updates the `restart` option headings in the English and Chinese JavaScript API docs to use clearer descriptive wording. It also aligns the localized anchor IDs and updates all affected internal links.