### PR TITLE
chore: migrate Rspress to Rstack CLI

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1424,9 +1424,6 @@ importers:
 
   website:
     devDependencies:
-      '@rsbuild/core':
-        specifier: workspace:*
-        version: link:../packages/core
       '@rsbuild/plugin-sass':
         specifier: workspace:*
         version: link:../packages/plugin-sass
@@ -1471,13 +1468,16 @@ importers:
         version: 19.2.7(react@19.2.7)
       rsbuild-plugin-google-analytics:
         specifier: 'catalog:'
-        version: 1.0.6(@rsbuild/core@packages+core)
+        version: 1.0.6(@rsbuild/core@2.1.7)
       rsbuild-plugin-open-graph:
         specifier: 'catalog:'
-        version: 1.1.3(@rsbuild/core@packages+core)
+        version: 1.1.3(@rsbuild/core@2.1.7)
       rspress-plugin-font-open-sans:
         specifier: 'catalog:'
         version: 1.0.4(@rspress/core@2.0.18)
+      rstack:
+        specifier: 'catalog:'
+        version: 0.1.0(@module-federation/runtime-tools@2.8.0)(@rspress/core@2.0.18)(core-js@3.49.0)(jiti@2.7.0)(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -9238,13 +9238,13 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@packages+core):
+  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.1.7):
     optionalDependencies:
-      '@rsbuild/core': link:packages/core
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)
 
-  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@packages+core):
+  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.1.7):
     optionalDependencies:
-      '@rsbuild/core': link:packages/core
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)
 
   rslog@2.3.0: {}
 

--- a/website/package.json
+++ b/website/package.json
@@ -4,12 +4,11 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "build": "rspress build",
-    "dev": "rspress dev",
-    "preview": "rspress preview"
+    "build": "rs doc build",
+    "dev": "rs doc",
+    "preview": "rs doc preview"
   },
   "devDependencies": {
-    "@rsbuild/core": "workspace:*",
     "@rsbuild/plugin-sass": "workspace:*",
     "@rspress/core": "catalog:",
     "@rspress/plugin-algolia": "catalog:",
@@ -27,6 +26,7 @@
     "rsbuild-plugin-google-analytics": "catalog:",
     "rsbuild-plugin-open-graph": "catalog:",
     "rspress-plugin-font-open-sans": "catalog:",
+    "rstack": "catalog:",
     "typescript": "catalog:"
   }
 }

--- a/website/rstack.config.ts
+++ b/website/rstack.config.ts
@@ -1,5 +1,4 @@
 import { pluginSass } from '@rsbuild/plugin-sass';
-import { defineConfig } from '@rspress/core';
 import { pluginAlgolia } from '@rspress/plugin-algolia';
 import { pluginClientRedirects } from '@rspress/plugin-client-redirects';
 import { pluginRss } from '@rspress/plugin-rss';
@@ -12,12 +11,13 @@ import {
 import { pluginGoogleAnalytics } from 'rsbuild-plugin-google-analytics';
 import { pluginOpenGraph } from 'rsbuild-plugin-open-graph';
 import { pluginFontOpenSans } from 'rspress-plugin-font-open-sans';
-import { rsbuildPluginOverview } from './theme/rsbuildPluginOverview';
+import { define } from 'rstack';
+import { rsbuildPluginOverview } from './theme/rsbuildPluginOverview.ts';
 
 const siteUrl = 'https://rsbuild.rs';
 const description = 'The Rspack-based build tool';
 
-export default defineConfig({
+define.doc({
   plugins: [
     pluginAlgolia(),
     pluginSitemap({

--- a/website/theme/env.d.ts
+++ b/website/theme/env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="@rsbuild/core/types" />
+/// <reference types="rstack/types" />

--- a/website/theme/rsbuildPluginOverview.ts
+++ b/website/theme/rsbuildPluginOverview.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
-import type { RsbuildPlugin } from '@rsbuild/core';
 import glob from 'fast-glob';
+import type { RsbuildPlugin } from 'rstack/app';
 import type { Group } from './components/Overview';
 
 const camelCase = (input: string): string => input.replace(/[-_](\w)/g, (_, c) => c.toUpperCase());

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "extends": "@scripts/config/tsconfig",
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "jsx": "react-jsx",
-    "outDir": "dist",
+    "noEmit": true,
     "paths": {
       "@theme": ["./theme"],
       "@components/*": ["./theme/components/*"],
@@ -14,5 +15,5 @@
   "mdx": {
     "checkMdx": true
   },
-  "include": ["docs", "rspress.config.ts", "theme", "env.d.ts"]
+  "include": ["docs", "rstack.config.ts", "theme", "env.d.ts"]
 }


### PR DESCRIPTION
## Summary

This PR migrates the Rsbuild website from standalone Rspress commands and configuration to Rstack CLI, keeping the existing documentation behavior while using the unified `rs doc` workflow. It also routes website Rsbuild types through Rstack and removes the direct `@rsbuild/core` dependency.