### PR TITLE
chore(build): simplify Rslib configs

### DIFF
--- a/packages/plugin-less/rslib.config.ts
+++ b/packages/plugin-less/rslib.config.ts
@@ -1,3 +1,9 @@
 import { pureEsmPackage } from '@scripts/config/rslib.config.ts';
+import { defineConfig } from '@rslib/core';
 
-export default pureEsmPackage;
+export default defineConfig({
+  ...pureEsmPackage,
+  output: {
+    externals: /[\\/]compiled[\\/]/,
+  },
+});

--- a/packages/plugin-sass/rslib.config.ts
+++ b/packages/plugin-sass/rslib.config.ts
@@ -1,3 +1,9 @@
 import { pureEsmPackage } from '@scripts/config/rslib.config.ts';
+import { defineConfig } from '@rslib/core';
 
-export default pureEsmPackage;
+export default defineConfig({
+  ...pureEsmPackage,
+  output: {
+    externals: /[\\/]compiled[\\/]/,
+  },
+});

--- a/packages/plugin-solid/rslib.config.ts
+++ b/packages/plugin-solid/rslib.config.ts
@@ -1,3 +1,15 @@
-import { dualPackage } from '@scripts/config/rslib.config.ts';
+import { esmConfig, nodeMinifyConfig } from '@scripts/config/rslib.config.ts';
+import { defineConfig } from '@rslib/core';
 
-export default dualPackage;
+export default defineConfig({
+  lib: [
+    esmConfig,
+    {
+      format: 'cjs',
+      syntax: 'es2023',
+      output: {
+        minify: nodeMinifyConfig,
+      },
+    },
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,9 +298,6 @@ catalogs:
     resolve-url-loader:
       specifier: ^5.0.0
       version: 5.0.0
-    rsbuild-plugin-arethetypeswrong:
-      specifier: 0.3.1
-      version: 0.3.1
     rsbuild-plugin-google-analytics:
       specifier: ^1.0.6
       version: 1.0.6
@@ -1400,9 +1397,6 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
-      rsbuild-plugin-arethetypeswrong:
-        specifier: 'catalog:'
-        version: 0.3.1(@rsbuild/core@2.1.7)(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -4846,16 +4840,6 @@ packages:
     resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
-
-  rsbuild-plugin-arethetypeswrong@0.3.1:
-    resolution: {integrity: sha512-083Kpz7qFWOPUrwnfAw7414VTSJnch+BKmrR/eu90IJOTe6c8lCW8be7BzI6Fs9synDWdvwLbTvxMHmR4nFVZw==}
-    engines: {node: '>=20.12.0'}
-    peerDependencies:
-      '@rsbuild/core': ^1.0.0 || ^2.0.0-0
-      typescript: '*'
-    peerDependenciesMeta:
-      '@rsbuild/core':
-        optional: true
 
   rsbuild-plugin-dts@1.0.0-beta.0:
     resolution: {integrity: sha512-+WOBPjcADvQPdjQuIiNI6LLQgDFnwSDo7tl1Yn/sXmUH8YISp5PveSEU08B7ABPeiTgBUdevUnVrb8f/deYaxw==}
@@ -9224,12 +9208,6 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.60.4
       '@rollup/rollup-win32-x64-msvc': 4.60.4
       fsevents: 2.3.3
-
-  rsbuild-plugin-arethetypeswrong@0.3.1(@rsbuild/core@2.1.7)(typescript@6.0.3):
-    dependencies:
-      typescript: 6.0.3
-    optionalDependencies:
-      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)
 
   rsbuild-plugin-dts@1.0.0-beta.0(@rsbuild/core@2.1.7)(typescript@6.0.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -113,7 +113,6 @@ catalog:
   'react-refresh': '^0.18.0'
   'reduce-configs': '^2.0.1'
   'resolve-url-loader': '^5.0.0'
-  'rsbuild-plugin-arethetypeswrong': '0.3.1'
   'rsbuild-plugin-google-analytics': '^1.0.6'
   'rsbuild-plugin-open-graph': '^1.1.3'
   'rslog': '^2.3.0'

--- a/scripts/config/package.json
+++ b/scripts/config/package.json
@@ -6,7 +6,6 @@
   "devDependencies": {
     "@rslib/core": "catalog:",
     "@types/node": "catalog:",
-    "rsbuild-plugin-arethetypeswrong": "catalog:",
     "typescript": "catalog:"
   }
 }

--- a/scripts/config/rslib.config.ts
+++ b/scripts/config/rslib.config.ts
@@ -1,11 +1,6 @@
 import { defineConfig, type LibConfig, type Rsbuild } from '@rslib/core';
-import { pluginAreTheTypesWrong } from 'rsbuild-plugin-arethetypeswrong';
-
-export const commonExternals: Array<string | RegExp> = ['webpack', /[\\/]compiled[\\/]/];
 
 export const nodeMinifyConfig = {
-  js: true,
-  css: false,
   jsOptions: {
     minimizerOptions: {
       // preserve variable name and disable minify for easier debugging
@@ -28,54 +23,6 @@ export const esmConfig: LibConfig = {
   },
 };
 
-export const cjsConfig: LibConfig = {
-  format: 'cjs',
-  syntax: 'es2023',
-  output: {
-    minify: nodeMinifyConfig,
-  },
-};
-
 export const pureEsmPackage = defineConfig({
   lib: [esmConfig],
-  tools: {
-    rspack: {
-      experiments: {
-        nativeWatcher: true,
-      },
-      externals: commonExternals,
-    },
-  },
-  plugins: [
-    pluginAreTheTypesWrong({
-      enable: Boolean(process.env.CI),
-      areTheTypesWrongOptions: {
-        // Pure ESM packages are expected to be import-only in Node.
-        ignoreRules: ['cjs-resolves-to-esm'],
-      },
-    }),
-  ],
-});
-
-export const dualPackage = defineConfig({
-  lib: [esmConfig, cjsConfig],
-  tools: {
-    rspack: {
-      experiments: {
-        nativeWatcher: true,
-      },
-      externals: commonExternals,
-    },
-  },
-  plugins: [
-    pluginAreTheTypesWrong({
-      enable: Boolean(process.env.CI),
-      areTheTypesWrongOptions: {
-        ignoreRules: [
-          // The dual package always provide the ESM types.
-          'false-esm',
-        ],
-      },
-    }),
-  ],
 });


### PR DESCRIPTION
## Summary

The shared Rslib configuration currently carries options used by only a subset of packages. This PR moves the Solid dual-package setup and compiled externals into package-local configs, removes the unused `rsbuild-plugin-arethetypeswrong` integration, and relies on existing minification defaults. Generated package artifacts remain unchanged.