### PR TITLE
fix(core): preserve async config inference

### DIFF
--- a/e2e/type-tests/resolution-bundler/defineConfig.ts
+++ b/e2e/type-tests/resolution-bundler/defineConfig.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from '@rsbuild/core';
+
+defineConfig({
+  mode: 'production',
+});
+
+defineConfig(() => ({
+  mode: 'production',
+}));
+
+defineConfig(async () => ({
+  mode: 'production',
+}));
+
+// @ts-expect-error invalid mode
+defineConfig(async () => ({
+  mode: 'invalid',
+}));

--- a/e2e/type-tests/resolution-bundler/rsbuild.config.ts
+++ b/e2e/type-tests/resolution-bundler/rsbuild.config.ts
@@ -1,5 +1,0 @@
-import { defineConfig } from '@rsbuild/core';
-
-export default defineConfig(async () => ({
-  mode: 'production',
-}));

--- a/e2e/type-tests/resolution-bundler/rsbuild.config.ts
+++ b/e2e/type-tests/resolution-bundler/rsbuild.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig(async () => ({
+  mode: 'production',
+}));

--- a/e2e/type-tests/resolution-bundler/tsconfig.json
+++ b/e2e/type-tests/resolution-bundler/tsconfig.json
@@ -5,5 +5,5 @@
     "moduleResolution": "bundler",
     "skipLibCheck": false
   },
-  "include": ["index.ts", "rsbuild.config.ts"]
+  "include": ["defineConfig.ts", "index.ts"]
 }

--- a/e2e/type-tests/resolution-bundler/tsconfig.json
+++ b/e2e/type-tests/resolution-bundler/tsconfig.json
@@ -5,5 +5,5 @@
     "moduleResolution": "bundler",
     "skipLibCheck": false
   },
-  "include": ["index.ts"]
+  "include": ["index.ts", "rsbuild.config.ts"]
 }

--- a/e2e/type-tests/resolution-nodenext/defineConfig.ts
+++ b/e2e/type-tests/resolution-nodenext/defineConfig.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from '@rsbuild/core';
+
+defineConfig({
+  mode: 'production',
+});
+
+defineConfig(() => ({
+  mode: 'production',
+}));
+
+defineConfig(async () => ({
+  mode: 'production',
+}));
+
+// @ts-expect-error invalid mode
+defineConfig(async () => ({
+  mode: 'invalid',
+}));

--- a/e2e/type-tests/resolution-nodenext/tsconfig.json
+++ b/e2e/type-tests/resolution-nodenext/tsconfig.json
@@ -5,5 +5,5 @@
     "moduleResolution": "NodeNext",
     "skipLibCheck": false
   },
-  "include": ["index.ts"]
+  "include": ["defineConfig.ts", "index.ts"]
 }

--- a/packages/core/src/loadConfig.ts
+++ b/packages/core/src/loadConfig.ts
@@ -51,9 +51,13 @@ export type LoadConfigResult<Config = RsbuildConfig> = Pick<
  * This function helps you to autocomplete configuration types.
  * It accepts a Rsbuild config object, or a function that returns a config.
  */
+export function defineConfig<const Config extends RsbuildConfig>(
+  config: (env: ConfigParams) => Config,
+): RsbuildConfigSyncFn;
+export function defineConfig<const Config extends RsbuildConfig>(
+  config: (env: ConfigParams) => Promise<Config>,
+): RsbuildConfigAsyncFn;
 export function defineConfig(config: RsbuildConfig): RsbuildConfig;
-export function defineConfig(config: RsbuildConfigSyncFn): RsbuildConfigSyncFn;
-export function defineConfig(config: RsbuildConfigAsyncFn): RsbuildConfigAsyncFn;
 export function defineConfig(config: RsbuildConfigDefinition): RsbuildConfigDefinition;
 export function defineConfig(config: RsbuildConfigDefinition) {
   return config;


### PR DESCRIPTION
## Summary

Async `defineConfig` callbacks can widen literal config values, causing valid configurations such as `{ mode: 'production' }` to fail overload resolution. This PR adds const-generic sync and async overloads while preserving the existing callback return types, and covers the regression with a public type test.

## Related Links

- https://github.com/web-infra-dev/rslib/pull/1787