### PR TITLE
chore(deps): upgrade Rslib to 1.0.0-beta.1

### DIFF
--- a/e2e/type-tests/resolution-bundler/thirdParty.ts
+++ b/e2e/type-tests/resolution-bundler/thirdParty.ts
@@ -1,0 +1,23 @@
+import type { HtmlRspackPlugin, PostCSSOptions, PostCSSPlugin, ServerConfig } from '@rsbuild/core';
+
+type CorsOptions = Exclude<ServerConfig['cors'], boolean | undefined>;
+
+export const corsOptions = {
+  origin: 'https://example.com',
+  methods: ['GET', 'POST'],
+} satisfies CorsOptions;
+
+export const htmlPluginOptions = {
+  filename: 'index.html',
+  inject: 'body',
+} satisfies HtmlRspackPlugin.Options;
+
+export const postcssPlugin = {
+  postcssPlugin: 'type-test',
+} satisfies PostCSSPlugin;
+
+export const postcssOptions = {
+  from: 'input.css',
+  to: 'output.css',
+  plugins: [postcssPlugin],
+} satisfies PostCSSOptions;

--- a/e2e/type-tests/resolution-bundler/tsconfig.json
+++ b/e2e/type-tests/resolution-bundler/tsconfig.json
@@ -5,5 +5,5 @@
     "moduleResolution": "bundler",
     "skipLibCheck": false
   },
-  "include": ["defineConfig.ts", "index.ts"]
+  "include": ["defineConfig.ts", "index.ts", "thirdParty.ts"]
 }

--- a/e2e/type-tests/resolution-nodenext/thirdParty.ts
+++ b/e2e/type-tests/resolution-nodenext/thirdParty.ts
@@ -1,0 +1,23 @@
+import type { HtmlRspackPlugin, PostCSSOptions, PostCSSPlugin, ServerConfig } from '@rsbuild/core';
+
+type CorsOptions = Exclude<ServerConfig['cors'], boolean | undefined>;
+
+export const corsOptions = {
+  origin: 'https://example.com',
+  methods: ['GET', 'POST'],
+} satisfies CorsOptions;
+
+export const htmlPluginOptions = {
+  filename: 'index.html',
+  inject: 'body',
+} satisfies HtmlRspackPlugin.Options;
+
+export const postcssPlugin = {
+  postcssPlugin: 'type-test',
+} satisfies PostCSSPlugin;
+
+export const postcssOptions = {
+  from: 'input.css',
+  to: 'output.css',
+  plugins: [postcssPlugin],
+} satisfies PostCSSOptions;

--- a/e2e/type-tests/resolution-nodenext/tsconfig.json
+++ b/e2e/type-tests/resolution-nodenext/tsconfig.json
@@ -5,5 +5,5 @@
     "moduleResolution": "NodeNext",
     "skipLibCheck": false
   },
-  "include": ["defineConfig.ts", "index.ts"]
+  "include": ["defineConfig.ts", "index.ts", "thirdParty.ts"]
 }

--- a/packages/core/prebundle.config.ts
+++ b/packages/core/prebundle.config.ts
@@ -17,7 +17,14 @@ export default {
     typescript: 'typescript',
   },
   dependencies: [
-    'html-rspack-plugin',
+    {
+      name: 'html-rspack-plugin',
+      afterBundle(task) {
+        replaceFileContent(join(task.distPath, 'index.d.ts'), (content) =>
+          content.replace('export { HtmlRspackPlugin as default };', 'export = HtmlRspackPlugin;'),
+        );
+      },
+    },
     {
       name: '@rstackjs/load-config',
       dtsOnly: true,
@@ -29,6 +36,11 @@ export default {
     {
       name: 'cors',
       dtsOnly: true,
+      afterBundle(task) {
+        replaceFileContent(join(task.distPath, 'index.d.ts'), (content) =>
+          content.replace('export { e as default };', 'export = e;'),
+        );
+      },
     },
     {
       name: 'connect-next',

--- a/packages/core/rstack.config.ts
+++ b/packages/core/rstack.config.ts
@@ -1,4 +1,3 @@
-import fs from 'node:fs';
 import path from 'node:path';
 import { define as rstack } from 'rstack';
 import type { Rsbuild, Rspack } from 'rstack/lib';
@@ -61,27 +60,6 @@ const externals: Rspack.Configuration['externals'] = [
     callback();
   },
 ];
-
-const pluginFixDtsTypes: Rsbuild.RsbuildPlugin = {
-  name: 'fix-dts-types',
-  setup(api) {
-    api.onAfterBuild(() => {
-      const typesDir = path.join(process.cwd(), 'dist-types');
-      const pkgPath = path.join(typesDir, 'package.json');
-      if (!fs.existsSync(typesDir)) {
-        fs.mkdirSync(typesDir);
-      }
-      fs.writeFileSync(
-        pkgPath,
-        JSON.stringify({
-          '//': 'This file is for making TypeScript work with moduleResolution nodenext.',
-          version: '1.0.0',
-        }),
-        'utf8',
-      );
-    });
-  },
-};
 
 // Rslib currently doesn't provide a way to preserve `__webpack_require__.*`
 // references in the emitted bundle.
@@ -182,7 +160,6 @@ rstack.lib(async () => {
       {
         id: 'node',
         syntax: 'es2023',
-        plugins: [pluginFixDtsTypes],
         source: {
           entry: {
             index: './src/index.ts',
@@ -199,7 +176,7 @@ rstack.lib(async () => {
             // alias to pre-bundled types as they are public API
             cors: './compiled/cors',
             rslog: './compiled/rslog',
-            postcss: './compiled/postcss',
+            postcss: './compiled/postcss/lib/postcss',
             chokidar: './compiled/chokidar',
             'connect-next': './compiled/connect-next',
             '@rstackjs/load-config': './compiled/@rstackjs/load-config',

--- a/packages/core/src/helpers/vendors.ts
+++ b/packages/core/src/helpers/vendors.ts
@@ -2,7 +2,7 @@ import { createRequire } from 'node:module';
 import { COMPILED_PATH } from '../constants';
 
 type CompiledPackages = {
-  'html-rspack-plugin': typeof import('../../compiled/html-rspack-plugin').default;
+  'html-rspack-plugin': typeof import('../../compiled/html-rspack-plugin');
 };
 
 export const require: NodeJS.Require = createRequire(import.meta.url);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2462,8 +2462,8 @@ packages:
       '@typescript/native-preview':
         optional: true
 
-  '@rslib/core@1.0.0-beta.0':
-    resolution: {integrity: sha512-l+NKLyVBnNPZ2WQoyVM8KoKhi4/mwo96A2fYqcPBXWg0nBJUdaIyJ5sJKAMxa39LR2a15ItShDHKYrQ48aUTbw==}
+  '@rslib/core@1.0.0-beta.1':
+    resolution: {integrity: sha512-HHPZ+wTUKT/3bEhw2y0JB0O62wMuljkSHVZelLbSGhBflCaUt+D3LohBcIxYW6bhzPbUp4gkJXo1pdTpxiuNLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -4786,8 +4786,8 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  rsbuild-plugin-dts@1.0.0-beta.0:
-    resolution: {integrity: sha512-+WOBPjcADvQPdjQuIiNI6LLQgDFnwSDo7tl1Yn/sXmUH8YISp5PveSEU08B7ABPeiTgBUdevUnVrb8f/deYaxw==}
+  rsbuild-plugin-dts@1.0.0-beta.1:
+    resolution: {integrity: sha512-hAEjOXhfIHR4erqjsqjRvA9Yqzc6Thry06tHheXDJUVwmR3VbN8BSMDC8kBZzyKdypDF0IJ98FmLQRiC194sMA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@microsoft/api-extractor': ^7
@@ -6452,10 +6452,10 @@ snapshots:
       - '@rspack/core'
       - typescript
 
-  '@rslib/core@1.0.0-beta.0(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)(typescript@6.0.3)':
+  '@rslib/core@1.0.0-beta.1(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)(typescript@6.0.3)':
     dependencies:
       '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)
-      rsbuild-plugin-dts: 1.0.0-beta.0(@rsbuild/core@2.1.7)(typescript@6.0.3)
+      rsbuild-plugin-dts: 1.0.0-beta.1(@rsbuild/core@2.1.7)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -9147,7 +9147,7 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.4
       fsevents: 2.3.3
 
-  rsbuild-plugin-dts@1.0.0-beta.0(@rsbuild/core@2.1.7)(typescript@6.0.3):
+  rsbuild-plugin-dts@1.0.0-beta.1(@rsbuild/core@2.1.7)(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)
@@ -9192,7 +9192,7 @@ snapshots:
   rstack@0.1.0(@module-federation/runtime-tools@2.8.0)(@rspress/core@2.0.18)(core-js@3.49.0)(jiti@2.7.0)(typescript@6.0.3):
     dependencies:
       '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)
-      '@rslib/core': 1.0.0-beta.0(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)(typescript@6.0.3)
+      '@rslib/core': 1.0.0-beta.1(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)(typescript@6.0.3)
       '@rslint/core': 0.7.0(jiti@2.7.0)
       '@rstest/core': 0.11.3(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)
     optionalDependencies:


### PR DESCRIPTION
## Summary

This PR upgrades Rslib to v1.0.0-beta.1, which enables declaration extension redirects by default.
It removes the obsolete CommonJS marker for core declarations, resolves PostCSS through its concrete type entry, and preserves CommonJS exports for the pre-bundled CORS and HtmlRspackPlugin declarations.
Bundler and NodeNext type tests now cover the affected public third-party types.

## Related Links

- https://github.com/web-infra-dev/rslib/releases/tag/v1.0.0-beta.1
- https://github.com/web-infra-dev/rslib/pull/1784