### PR TITLE
chore: add Rstack CLI best practices skill

### DIFF
--- a/.agents/skills/pr-creator/SKILL.md
+++ b/.agents/skills/pr-creator/SKILL.md
@@ -33,6 +33,7 @@ metadata:
    - Prioritize high-signal information: public API changes, behavior changes, breaking changes, migration notes, and important compatibility implications.
    - Then describe the main implementation change only as much as needed to understand the review.
    - Keep the PR body concise and review-oriented: use 1-4 short standalone sentences for typical changes, covering why it matters, what changed, and any reviewer-important impact.
+   - Omit incidental updates to tests, documentation, and supporting artifacts from the PR description; mention them only when they are the PR's primary purpose or carry reviewer-relevant risk.
    - Avoid low-signal sections such as `Test plan` or `Validation`, routine verification commands, generated file lists, or obvious implementation details unless the repository template explicitly requires them or the change has unusual validation risk.
    - Good background examples:
      - `This PR adds support for custom logger injection so CLI output can be isolated per instance.`

--- a/.agents/skills/rstack-cli-best-practices/SKILL.md
+++ b/.agents/skills/rstack-cli-best-practices/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: rstack-cli-best-practices
+description: Guidance on using Rstack CLI, including `rs` commands, the `rstack.config.ts` file, and import paths from the `rstack` package. Use for Rstack CLI-related tasks.
+---
+
+# Rstack CLI Best Practices
+
+Rstack CLI is the `rstack` package, exposed through the `rs` binaries. It provides one CLI, one config file, and a consistent workflow for the Rstack JavaScript toolchain.
+
+It covers web app, library, docs, test, lint, and staged-file workflows.
+
+## Commands
+
+Use `rs -h` for top-level help, and `rs <command> -h` for command help where supported.
+
+| Command      | Purpose                          | Underlying tool | Config          |
+| ------------ | -------------------------------- | --------------- | --------------- |
+| `rs dev`     | Run the app dev server           | Rsbuild         | `define.app`    |
+| `rs build`   | Build the app for production     | Rsbuild         | `define.app`    |
+| `rs preview` | Preview the app production build | Rsbuild         | `define.app`    |
+| `rs lib`     | Build a library                  | Rslib           | `define.lib`    |
+| `rs doc`     | Serve or build docs              | Rspress         | `define.doc`    |
+| `rs test`    | Run tests                        | Rstest          | `define.test`   |
+| `rs lint`    | Lint code                        | Rslint          | `define.lint`   |
+| `rs staged`  | Run tasks on staged Git files    | lint-staged     | `define.staged` |
+
+Key behavior:
+
+- Unless `define.test` already sets `extends`, `rs test` extends `define.app` through `@rstest/adapter-rsbuild` or falls back to `define.lib` through `@rstest/adapter-rslib`. The app config takes precedence when both are defined.
+- `rs doc` requires the optional `@rspress/core` dependency.
+
+## rstack.config.ts
+
+Rstack CLI loads `rstack.config.{ts,js,mts,mjs}` by default.
+
+Register config with `define.*`:
+
+```ts
+import { define } from 'rstack';
+
+define.app({
+  // Rsbuild config for `rs dev`, `rs build`, and `rs preview`
+});
+
+define.test({
+  // Rstest config for `rs test`
+});
+```
+
+- `define.app(config)`: Rsbuild config for `rs dev`, `rs build`, and `rs preview`. Docs: https://rsbuild.rs/config/
+- `define.lib(config)`: Rslib config for `rs lib`; Docs: https://rslib.rs/config/
+- `define.doc(config)`: Rspress config for `rs doc`; Docs: https://rspress.rs/api/config/config-basic
+- `define.test(config)`: Rstest config for `rs test`; Docs: https://rstest.rs/config/
+- `define.lint(config)`: Rslint config for `rs lint`; Docs: https://rslint.rs/config/
+- `define.staged(config)`: lint-staged config for `rs staged`; accepts `Record<string, string | string[]>`.
+
+### Lazy Configuration
+
+Prefer async functions with dynamic imports for dependencies. Avoid top-level sync imports of heavy dependencies in `rstack.config.ts`.
+
+```ts
+import { define } from 'rstack';
+
+define.app(async () => {
+  const { pluginReact } = await import('@rsbuild/plugin-react');
+  return {
+    plugins: [pluginReact()],
+  };
+});
+```
+
+## Import Paths
+
+Prefer Rstack-exported paths:
+
+| Instead of                | Prefer                   |
+| ------------------------- | ------------------------ |
+| `@rsbuild/core`           | `rstack/app`             |
+| `@rslib/core`             | `rstack/lib`             |
+| `@rstest/core`            | `rstack/test`            |
+| `@rslint/core`            | `rstack/lint`            |
+| `@rsbuild/core/types`     | `rstack/types`           |
+| `@rslib/core/types`       | `rstack/types`           |
+| `@rstest/core/globals`    | `rstack/test/globals`    |
+| `@rstest/core/importMeta` | `rstack/test/importMeta` |

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -11,7 +11,7 @@
       "source": "rstackjs/agent-skills",
       "sourceType": "github",
       "skillPath": ".agents/skills/pr-creator/SKILL.md",
-      "computedHash": "c49fcbba72894d08a34d054a00720610d19a2e87e25942aee05da09e87b268df"
+      "computedHash": "c115b708a4c627af4b6dbaca0cfa0ae0fb0153f122bd2229f7803c803fa97c67"
     },
     "release-blog-writer": {
       "source": "rstackjs/agent-skills",
@@ -24,6 +24,12 @@
       "sourceType": "github",
       "skillPath": "skills/rspress-description-generator/SKILL.md",
       "computedHash": "ca2693ca055d1b4e5903bdfacab522f46ca0e13cbc5db59e6c9589fdc8efc6ad"
+    },
+    "rstack-cli-best-practices": {
+      "source": "rstackjs/rstack-cli",
+      "sourceType": "github",
+      "skillPath": ".agents/skills/rstack-cli-best-practices/SKILL.md",
+      "computedHash": "428df66995c4ff446d2ab04f58654a31b4dee440590e1929fc7d4a7ea8e53fa0"
     }
   }
 }


### PR DESCRIPTION
## Summary

Add repository-level Rstack CLI best practices so agents consistently use the unified `rs` commands, `rstack.config.ts`, and `rstack` import paths. Refresh the tracked skills metadata to record the new skill and latest `pr-creator` guidance.