### PR TITLE
refactor(core): output declaration files to dist

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,16 +18,15 @@
   "files": [
     "bin",
     "dist",
-    "dist-types",
     "static",
     "compiled",
     "types.d.ts"
   ],
   "type": "module",
-  "types": "./dist-types/index.d.ts",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist-types/index.d.ts",
+      "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
     "./types": {

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
-    "declarationDir": "dist-types",
     "composite": true,
     "isolatedDeclarations": true,
     "types": ["@rspack/core/module"]


### PR DESCRIPTION
## Summary

This PR emits `@rsbuild/core` declaration files into `dist` now that Rslib redirects declaration imports to explicit JavaScript extensions by default. It removes the separate `dist-types` publish entry and points the package type metadata to `dist/index.d.ts`, without changing the public API.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8173
- https://github.com/web-infra-dev/rslib/pull/1784