### PR TITLE
feat(core): reload page for added and removed watched files

### DIFF
--- a/e2e/cases/server/watch-files/index.test.ts
+++ b/e2e/cases/server/watch-files/index.test.ts
@@ -6,12 +6,14 @@ const watchedDir1 = path.join(import.meta.dirname, 'test-temp-1');
 const watchedDir2 = path.join(import.meta.dirname, 'test-temp-2');
 const watchedFile1 = path.join(watchedDir1, 'test.txt');
 const watchedFile2 = path.join(watchedDir2, 'test.txt');
+const addedFile = path.join(watchedDir1, 'added.txt');
 
 test.beforeEach(() => {
   fs.mkdirSync(watchedDir1, { recursive: true });
   fs.mkdirSync(watchedDir2, { recursive: true });
   fs.writeFileSync(watchedFile1, '');
   fs.writeFileSync(watchedFile2, '');
+  fs.rmSync(addedFile, { force: true });
 });
 
 test.afterAll(() => {
@@ -33,7 +35,7 @@ test('should work with string and path to file', async ({ dev, page }) => {
   await Promise.all([page.waitForEvent('load'), fs.promises.writeFile(watchedFile1, 'test')]);
 });
 
-test('should work with string and path to directory', async ({ dev, page }) => {
+test('should reload when a watched file is added, changed, or removed', async ({ dev, page }) => {
   await dev({
     config: {
       dev: {
@@ -44,7 +46,9 @@ test('should work with string and path to directory', async ({ dev, page }) => {
     },
   });
 
+  await Promise.all([page.waitForEvent('load'), fs.promises.writeFile(addedFile, 'test')]);
   await Promise.all([page.waitForEvent('load'), fs.promises.writeFile(watchedFile1, 'test')]);
+  await Promise.all([page.waitForEvent('load'), fs.promises.rm(addedFile)]);
 });
 
 test('should work with string array directory', async ({ dev, page }) => {

--- a/packages/core/src/server/watchFiles.ts
+++ b/packages/core/src/server/watchFiles.ts
@@ -141,13 +141,21 @@ async function startWatchFiles(
     return;
   }
 
-  const watcher = await createChokidar(paths, root, options);
+  const watcher = await createChokidar(paths, root, {
+    // Avoid triggering page reloads for files that already exist.
+    ignoreInitial: true,
+    ...options,
+  });
 
-  watcher.on('change', () => {
+  const reloadPage = () => {
     buildManager.socketServer.sendMessage({
       type: 'full-reload',
     });
-  });
+  };
+
+  watcher.on('add', reloadPage);
+  watcher.on('change', reloadPage);
+  watcher.on('unlink', reloadPage);
 
   return watcher;
 }

--- a/website/docs/en/config/dev/watch-files.mdx
+++ b/website/docs/en/config/dev/watch-files.mdx
@@ -79,7 +79,7 @@ Specifies whether to trigger a page reload or restart the dev server or watch bu
 
 ### reload-page
 
-`reload-page` means that when a file changes, the page in the browser will automatically reload. If the type is not explicitly specified, Rsbuild defaults to the `reload-page` behavior.
+`reload-page` means that when a watched file is added, changed, or removed, the page in the browser will automatically reload. If the type is not explicitly specified, Rsbuild defaults to the `reload-page` behavior.
 
 This can be used to watch changes to static assets, such as files in the [public directory](/config/server/public-dir).
 
@@ -154,6 +154,7 @@ If you want to prevent some files from triggering a rebuild when they change, yo
 
 ## Version history
 
-| Version | Changes                                              |
-| ------- | ---------------------------------------------------- |
-| v2.1.7  | Added the `restart` type; deprecated `reload-server` |
+| Version | Changes                                               |
+| ------- | ----------------------------------------------------- |
+| v2.1.8  | `reload-page` now responds to added and removed files |
+| v2.1.7  | Added the `restart` type; deprecated `reload-server`  |

--- a/website/docs/en/config/dev/watch-files.mdx
+++ b/website/docs/en/config/dev/watch-files.mdx
@@ -65,6 +65,8 @@ export default {
 ```
 
 :::tip
+Glob patterns are expanded when the watcher starts and do not include new matching paths created later. To observe files that may be added after startup, watch their parent directory instead.
+
 Glob patterns should use forward slashes (`/`) as path separators on all platforms. Avoid using `path.join()` to construct glob patterns because it produces backslashes on Windows, where backslashes are interpreted as escape characters in glob syntax.
 
 Use a string literal or `path.posix.join()` to construct relative glob patterns.
@@ -88,7 +90,7 @@ export default {
   dev: {
     watchFiles: {
       type: 'reload-page',
-      paths: 'public/**/*',
+      paths: 'public',
     },
   },
 };

--- a/website/docs/zh/config/dev/watch-files.mdx
+++ b/website/docs/zh/config/dev/watch-files.mdx
@@ -65,6 +65,8 @@ export default {
 ```
 
 :::tip
+Glob 模式会在 watcher 启动时展开，因此不会包含之后新建的匹配路径。如需监听启动后可能新增的文件，请改为监听其父目录。
+
 在所有平台上，glob 模式都应使用正斜杠（`/`）作为路径分隔符。请勿使用 `path.join()` 构造 glob 模式，因为它在 Windows 上会生成反斜杠，而反斜杠在 glob 语法中会被解释为转义符。
 
 请使用字符串字面量或 `path.posix.join()` 构造相对 glob 模式。
@@ -88,7 +90,7 @@ export default {
   dev: {
     watchFiles: {
       type: 'reload-page',
-      paths: 'public/**/*',
+      paths: 'public',
     },
   },
 };

--- a/website/docs/zh/config/dev/watch-files.mdx
+++ b/website/docs/zh/config/dev/watch-files.mdx
@@ -79,7 +79,7 @@ export default {
 
 ### reload-page
 
-reload-page 表示当文件发生变化时，浏览器打开的页面会自动重新加载。如果未明确指定 type，Rsbuild 会默认采用 reload-page 行为。
+reload-page 表示当被监听的文件新增、修改或删除时，浏览器打开的页面会自动重新加载。如果未明确指定 type，Rsbuild 会默认采用 reload-page 行为。
 
 这可以用于监听一些静态资源文件的变化，例如 [public 目录](/config/server/public-dir) 下的文件。
 
@@ -177,4 +177,5 @@ export default {
 
 | 版本   | 变更内容                                  |
 | ------ | ----------------------------------------- |
+| v2.1.8 | `reload-page` 现在会响应文件新增和删除    |
 | v2.1.7 | 新增 `restart` 类型，废弃 `reload-server` |


### PR DESCRIPTION
## Summary

`dev.watchFiles` with `reload-page` only reloaded the browser when existing files changed, so adding or removing files in watched directories was ignored.

This PR listens to `add`, `change`, and `unlink` while ignoring initial add events, and documents the behavior for v2.1.8.