### PR TITLE
feat(core): support filtering watch file events

### DIFF
--- a/e2e/cases/javascript-api/dev-server-restart/index.test.ts
+++ b/e2e/cases/javascript-api/dev-server-restart/index.test.ts
@@ -46,6 +46,7 @@ test('should watch loaded config dependencies for restart', async () => {
       })
       .toEqual({
         action: 'dev',
+        event: 'change',
         filePath: configDep,
         options: {},
       });

--- a/e2e/cases/javascript-api/restart-option/index.test.ts
+++ b/e2e/cases/javascript-api/restart-option/index.test.ts
@@ -67,6 +67,7 @@ test('createRsbuild should support a restart function', async () => {
     .toEqual({
       context: {
         action: 'dev',
+        event: 'change',
         filePath: watchedFile,
         options: {},
       },

--- a/e2e/cases/javascript-api/restart-preserve-options/index.test.ts
+++ b/e2e/cases/javascript-api/restart-preserve-options/index.test.ts
@@ -51,6 +51,7 @@ test('should preserve startDevServer options after restart', async () => {
       )
       .toEqual({
         action: 'dev',
+        event: 'change',
         filePath: watchedFile,
         options: {
           getPortSilently: true,
@@ -99,6 +100,7 @@ test('should preserve build options after restart', async () => {
       )
       .toEqual({
         action: 'build',
+        event: 'change',
         filePath: watchedFile,
         options: {
           watch: true,

--- a/e2e/cases/javascript-api/restart-watch-files/index.test.ts
+++ b/e2e/cases/javascript-api/restart-watch-files/index.test.ts
@@ -10,6 +10,7 @@ import {
 import { getRandomPort } from '@rstackjs/test-utils';
 
 const watchedFile = path.join(import.meta.dirname, 'test-temp-watch.txt');
+const watchedDir = path.join(import.meta.dirname, 'test-temp-watch-dir');
 
 const createConfig = (): RsbuildConfig => ({
   dev: {
@@ -40,6 +41,7 @@ const expectRestart = async (rsbuild: RsbuildInstance, action: RestartContext['a
     )
     .toEqual({
       action,
+      event: 'change',
       filePath: watchedFile,
       options: action === 'build' ? { watch: true } : {},
     });
@@ -47,10 +49,12 @@ const expectRestart = async (rsbuild: RsbuildInstance, action: RestartContext['a
 
 test.beforeEach(() => {
   fs.writeFileSync(watchedFile, '1');
+  fs.mkdirSync(watchedDir, { recursive: true });
 });
 
 test.afterAll(() => {
   fs.rmSync(watchedFile, { force: true });
+  fs.rmSync(watchedDir, { force: true, recursive: true });
 });
 
 test('build({ watch: true }) should watch restart files', async ({ build, copySrcDir }) => {
@@ -101,4 +105,40 @@ test('createDevServer() should watch restart files', async () => {
   await expectRestart(rsbuild, 'dev');
 
   await server.close();
+});
+
+test('should include a selected restart event in context', async ({ devOnly }) => {
+  const result = await devOnly({
+    config: {
+      dev: {
+        watchFiles: {
+          paths: watchedDir,
+          type: 'restart',
+          events: ['add'],
+        },
+      },
+    },
+  });
+
+  let restartContext: RestartContext | undefined;
+  result.instance.onRestart((context) => {
+    restartContext = context;
+  });
+
+  let fileIndex = 0;
+  await expect
+    .poll(
+      () => {
+        if (!restartContext) {
+          fs.writeFileSync(path.join(watchedDir, `added-${++fileIndex}.mdx`), 'added');
+        }
+        return restartContext;
+      },
+      { timeout: 5_000 },
+    )
+    .toMatchObject({
+      action: 'dev',
+      event: 'add',
+      options: {},
+    });
 });

--- a/e2e/cases/server/watch-files/index.test.ts
+++ b/e2e/cases/server/watch-files/index.test.ts
@@ -97,3 +97,19 @@ test('should work with options', async ({ dev, page }) => {
 
   await Promise.all([page.waitForEvent('load'), fs.promises.writeFile(watchedFile1, 'test')]);
 });
+
+test('should reload the page for selected events', async ({ dev, page }) => {
+  await dev({
+    config: {
+      dev: {
+        watchFiles: {
+          paths: watchedDir1,
+          events: ['add', 'unlink'],
+        },
+      },
+    },
+  });
+
+  await Promise.all([page.waitForEvent('load'), fs.promises.writeFile(addedFile, 'test')]);
+  await Promise.all([page.waitForEvent('load'), fs.promises.rm(addedFile)]);
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -214,6 +214,7 @@ export type {
   TransformHandler,
   TransformHook,
   TransformImport,
+  WatchFileEvent,
   WatchFiles,
   WebSocketUrlResolver,
 } from './types';

--- a/packages/core/src/restart.ts
+++ b/packages/core/src/restart.ts
@@ -3,8 +3,12 @@ import type { ChokidarOptions } from 'chokidar';
 import { castArray, color, isTTY } from './helpers';
 import type { RestartManager } from './helpers/restartManager';
 import type { Logger } from './logger';
-import { createChokidar, type WatchFilesResult } from './server/watchFiles';
-import type { InternalContext, RestartContext, WatchFiles } from './types';
+import {
+  createChokidar,
+  DEFAULT_WATCH_FILE_EVENTS,
+  type WatchFilesResult,
+} from './server/watchFiles';
+import type { InternalContext, RestartContext, WatchFileEvent, WatchFiles } from './types';
 
 const clearConsole = () => {
   if (isTTY() && !process.env.DEBUG) {
@@ -60,10 +64,18 @@ export function watchFilesForRestart({
     return;
   }
 
-  const watchGroups: { files: string[]; options?: ChokidarOptions }[] = [];
+  const watchGroups: {
+    files: string[];
+    events?: WatchFileEvent[];
+    options?: ChokidarOptions;
+  }[] = [];
 
-  for (const { paths, options, type } of watchFiles) {
+  for (const { paths, events, options, type } of watchFiles) {
     if (type !== 'restart' && type !== 'reload-server') {
+      continue;
+    }
+
+    if (events?.length === 0) {
       continue;
     }
 
@@ -72,8 +84,8 @@ export function watchFilesForRestart({
       continue;
     }
 
-    if (options) {
-      watchGroups.push({ files, options });
+    if (options || events) {
+      watchGroups.push({ files, events, options });
     } else {
       defaultFiles.push(...files);
     }
@@ -91,7 +103,7 @@ export function watchFilesForRestart({
   let restarting = false;
   let closePromise: Promise<void> | undefined;
 
-  const onChange = async (filePath: string, cwd: string) => {
+  const onWatchEvent = async (event: WatchFileEvent, filePath: string, cwd: string) => {
     if (restarting || closePromise) {
       return;
     }
@@ -103,6 +115,7 @@ export function watchFilesForRestart({
       const restarted = await requestRestart({
         restartContext: {
           ...restartContext,
+          event,
           filePath: absoluteFilePath,
         },
         logger,
@@ -126,7 +139,7 @@ export function watchFilesForRestart({
 
   // Initialize watchers in the background so task startup is not delayed.
   const watchersPromise = Promise.all(
-    watchGroups.map(async ({ files, options }) => {
+    watchGroups.map(async ({ files, events, options }) => {
       try {
         const watcher = await createChokidar(files, root, {
           // Avoid initial add events.
@@ -136,11 +149,11 @@ export function watchFilesForRestart({
           ...options,
         });
         // Chokidar reports event paths relative to `cwd` when it is configured.
-        const cwd = options?.cwd || root;
-        const handleChange = (filePath: string) => void onChange(filePath, cwd);
-        watcher.on('add', handleChange);
-        watcher.on('change', handleChange);
-        watcher.on('unlink', handleChange);
+        const cwd = options?.cwd ?? root;
+        const watchEvents = events ? new Set(events) : DEFAULT_WATCH_FILE_EVENTS;
+        for (const event of watchEvents) {
+          watcher.on(event, (filePath) => onWatchEvent(event, filePath, cwd));
+        }
         return watcher;
       } catch (error) {
         logger.error(error);

--- a/packages/core/src/server/watchFiles.ts
+++ b/packages/core/src/server/watchFiles.ts
@@ -5,9 +5,12 @@ import type {
   DevConfig,
   NormalizedConfig,
   NormalizedServerConfig,
+  WatchFileEvent,
   WatchFiles,
 } from '../types';
 import type { BuildManager } from './buildManager';
+
+export const DEFAULT_WATCH_FILE_EVENTS: readonly WatchFileEvent[] = ['add', 'change', 'unlink'];
 
 type WatchFilesOptions = {
   root: string;
@@ -47,8 +50,8 @@ async function watchDevFiles(devConfig: DevConfig, buildManager: BuildManager, r
 
   const watchers: FSWatcher[] = [];
 
-  for (const { paths, options, type } of castArray(watchFiles)) {
-    const watchOptions = prepareWatchOptions(paths, options, type);
+  for (const { paths, events, options, type } of castArray(watchFiles)) {
+    const watchOptions = prepareWatchOptions(paths, options, type, events);
     const watcher = await startWatchFiles(watchOptions, buildManager, root);
     if (watcher) {
       watchers.push(watcher);
@@ -85,9 +88,11 @@ function prepareWatchOptions(
   paths: string | string[],
   options: ChokidarOptions = {},
   type?: WatchFiles['type'],
+  events?: WatchFileEvent[],
 ) {
   return {
     paths: typeof paths === 'string' ? [paths] : paths,
+    events,
     options,
     type,
   };
@@ -133,11 +138,15 @@ export async function createChokidar(
 }
 
 async function startWatchFiles(
-  { paths, options, type = 'reload-page' }: ReturnType<typeof prepareWatchOptions>,
+  { paths, events, options, type = 'reload-page' }: ReturnType<typeof prepareWatchOptions>,
   buildManager: BuildManager,
   root: string,
 ) {
   if (type !== 'reload-page') {
+    return;
+  }
+
+  if (events?.length === 0) {
     return;
   }
 
@@ -153,9 +162,10 @@ async function startWatchFiles(
     });
   };
 
-  watcher.on('add', reloadPage);
-  watcher.on('change', reloadPage);
-  watcher.on('unlink', reloadPage);
+  const watchEvents = events ? new Set(events) : DEFAULT_WATCH_FILE_EVENTS;
+  for (const event of watchEvents) {
+    watcher.on(event, reloadPage);
+  }
 
   return watcher;
 }

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -25,6 +25,7 @@ import type {
   ModifyBundlerChainUtils,
   ModifyChainUtils,
   Routes,
+  WatchFileEvent,
 } from './hooks';
 import type { RsbuildPlugins } from './plugin';
 import type { RsbuildEntry, RsbuildMode, RsbuildTarget } from './rsbuild';
@@ -1954,6 +1955,14 @@ export type WatchFiles = {
    * Paths of the files or directories to watch, supports glob syntax.
    */
   paths: string | string[];
+  /**
+   * File events that trigger the configured action.
+   * - `add`: A file is created.
+   * - `change`: A file is modified.
+   * - `unlink`: A file is deleted.
+   * @default ['add', 'change', 'unlink']
+   */
+  events?: WatchFileEvent[];
   /**
    * Watch options passed to [chokidar](https://github.com/paulmillr/chokidar).
    */

--- a/packages/core/src/types/hooks.ts
+++ b/packages/core/src/types/hooks.ts
@@ -149,12 +149,19 @@ export type OnAfterCreateCompilerFn<Compiler = Rspack.Compiler | Rspack.MultiCom
 
 export type OnExitFn = (context: { exitCode: number }) => void;
 
+export type WatchFileEvent = 'add' | 'change' | 'unlink';
+
 export type RestartContext = {
   /**
    * The absolute path of the file that triggered the restart.
    * It is undefined when the restart is manually triggered.
    */
   filePath?: string;
+  /**
+   * The file event that triggered the restart.
+   * It is undefined when the restart is manually triggered.
+   */
+  event?: WatchFileEvent;
 } & (
   | {
       /**

--- a/website/docs/en/plugins/dev/hooks.mdx
+++ b/website/docs/en/plugins/dev/hooks.mdx
@@ -975,8 +975,8 @@ import OnRestart from '@en/shared/onRestart.mdx';
 ```ts
 const myPlugin = () => ({
   setup(api) {
-    api.onRestart(async ({ action, filePath }) => {
-      console.log('restart!', action, filePath);
+    api.onRestart(async ({ action, event, filePath }) => {
+      console.log('restart!', action, event, filePath);
     });
   },
 });

--- a/website/docs/zh/plugins/dev/hooks.mdx
+++ b/website/docs/zh/plugins/dev/hooks.mdx
@@ -971,8 +971,8 @@ import OnRestart from '@zh/shared/onRestart.mdx';
 ```ts
 const myPlugin = () => ({
   setup(api) {
-    api.onRestart(async ({ action, filePath }) => {
-      console.log('restart!', action, filePath);
+    api.onRestart(async ({ action, event, filePath }) => {
+      console.log('restart!', action, event, filePath);
     });
   },
 });


### PR DESCRIPTION
## Summary

This PR allows `dev.watchFiles` to select which `add`, `change`, and `unlink` events trigger the configured action. Restart requests now expose the triggering file event through `RestartContext.event`.