### PR TITLE
docs: document watchFiles events

### DIFF
--- a/website/docs/en/config/dev/watch-files.mdx
+++ b/website/docs/en/config/dev/watch-files.mdx
@@ -7,8 +7,11 @@ description: 'Watch specified files and directories for changes. When a change i
 - **Type:**
 
 ```ts
+type WatchFileEvent = 'add' | 'change' | 'unlink';
+
 type WatchFiles = {
   paths: string | string[];
+  events?: WatchFileEvent[];
   type?: 'reload-page' | 'restart' | 'reload-server';
   // watch options for chokidar
   options?: ChokidarOptions;
@@ -71,6 +74,33 @@ Glob patterns should use forward slashes (`/`) as path separators on all platfor
 
 Use a string literal or `path.posix.join()` to construct relative glob patterns.
 :::
+
+## events
+
+- **Type:** `('add' | 'change' | 'unlink')[]`
+- **Default:** `['add', 'change', 'unlink']`
+
+Specifies the file events that trigger the configured action:
+
+- `add`: A watched file appears after the watcher starts.
+- `change`: A watched file changes.
+- `unlink`: A watched file disappears.
+
+These events describe what the watcher observes. For example, renaming a file may produce `unlink` for the old path and `add` for the new path, while an atomic write may be reported as `change`.
+
+For example, to restart only when files are added to or removed from a directory:
+
+```ts title="rsbuild.config.ts"
+export default {
+  dev: {
+    watchFiles: {
+      paths: './config',
+      type: 'restart',
+      events: ['add', 'unlink'],
+    },
+  },
+};
+```
 
 ## type
 
@@ -156,7 +186,7 @@ If you want to prevent some files from triggering a rebuild when they change, yo
 
 ## Version history
 
-| Version | Changes                                               |
-| ------- | ----------------------------------------------------- |
-| v2.1.8  | `reload-page` now responds to added and removed files |
-| v2.1.7  | Added the `restart` type; deprecated `reload-server`  |
+| Version | Changes                                                                          |
+| ------- | -------------------------------------------------------------------------------- |
+| v2.1.8  | Added the `events` option; `reload-page` now responds to added and removed files |
+| v2.1.7  | Added the `restart` type; deprecated `reload-server`                             |

--- a/website/docs/en/config/dev/watch-files.mdx
+++ b/website/docs/en/config/dev/watch-files.mdx
@@ -86,8 +86,6 @@ Specifies the file events that trigger the configured action:
 - `change`: A watched file changes.
 - `unlink`: A watched file disappears.
 
-These events describe what the watcher observes. For example, renaming a file may produce `unlink` for the old path and `add` for the new path, while an atomic write may be reported as `change`.
-
 For example, to restart only when files are added to or removed from a directory:
 
 ```ts title="rsbuild.config.ts"
@@ -111,7 +109,7 @@ Specifies whether to trigger a page reload or restart the dev server or watch bu
 
 ### reload-page
 
-`reload-page` means that when a watched file is added, changed, or removed, the page in the browser will automatically reload. If the type is not explicitly specified, Rsbuild defaults to the `reload-page` behavior.
+`reload-page` means that when a watched file event specified by [`events`](#events) occurs, the page in the browser automatically reloads. By default, additions, changes, and removals all trigger a reload. If `type` is not explicitly specified, Rsbuild uses `reload-page`.
 
 This can be used to watch changes to static assets, such as files in the [public directory](/config/server/public-dir).
 

--- a/website/docs/en/config/dev/watch-files.mdx
+++ b/website/docs/en/config/dev/watch-files.mdx
@@ -82,7 +82,7 @@ Use a string literal or `path.posix.join()` to construct relative glob patterns.
 
 Specifies the file events that trigger the configured action:
 
-- `add`: A watched file appears after the watcher starts.
+- `add`: A watched file is detected. By default, only files that appear after the watcher starts trigger this event. If [`options.ignoreInitial`](#options) is `false`, existing files also trigger it during startup.
 - `change`: A watched file changes.
 - `unlink`: A watched file disappears.
 

--- a/website/docs/en/shared/onRestart.mdx
+++ b/website/docs/en/shared/onRestart.mdx
@@ -3,18 +3,21 @@ Called when a restart is requested for the dev server or watch build.
 The hook is triggered in the following cases:
 
 - The Rsbuild CLI detects changes to the config file or one of its dependencies.
-- A file watched by [`dev.watchFiles`](/config/dev/watch-files) with `type: 'restart'` changes.
+- A configured file event occurs for a file watched by [`dev.watchFiles`](/config/dev/watch-files) with `type: 'restart'`.
 - The dev server is manually restarted through a [CLI shortcut](/config/dev/cli-shortcuts).
 
 > This hook is not triggered for regular rebuilds.
 
-When using the JavaScript API, restart watchers are installed by `rsbuild.startDevServer()`, `rsbuild.createDevServer()`, and `rsbuild.build({ watch: true })`. The hook is called when a watched file changes. By default, Rsbuild does not close or restart the current task; you can pass the [`restart` option](/api/javascript-api/core#restart-handling) to handle restart requests.
+When using the JavaScript API, restart watchers are installed by `rsbuild.startDevServer()`, `rsbuild.createDevServer()`, and `rsbuild.build({ watch: true })`. The hook is called when a configured file event occurs. By default, Rsbuild does not close or restart the current task; you can pass the [`restart` option](/api/javascript-api/core#restart-handling) to handle restart requests.
 
 - **Type:**
 
 ```ts
+type WatchFileEvent = 'add' | 'change' | 'unlink';
+
 type RestartContext = {
   filePath?: string;
+  event?: WatchFileEvent;
 } & (
   | {
       action: 'build';
@@ -31,6 +34,7 @@ function OnRestart(callback: (context: RestartContext) => Promise<void> | void):
 
 - `action`: The current Rsbuild action being restarted.
 - `filePath`: The absolute path of the file that triggered the restart. It is `undefined` when the restart is manually triggered.
+- `event`: The file event that triggered the restart. It is `undefined` when the restart is manually triggered.
 - `options`: The options passed to the current `rsbuild.build()` or `rsbuild.startDevServer()` call.
 
-- **Version:** Added in v2.1.7
+- **Version:** Added in v2.1.7.

--- a/website/docs/en/shared/onRestart.mdx
+++ b/website/docs/en/shared/onRestart.mdx
@@ -34,7 +34,7 @@ function OnRestart(callback: (context: RestartContext) => Promise<void> | void):
 
 - `action`: The current Rsbuild action being restarted.
 - `filePath`: The absolute path of the file that triggered the restart. It is `undefined` when the restart is manually triggered.
-- `event`: The file event that triggered the restart. It is `undefined` when the restart is manually triggered.
+- `event`: The file event that triggered the restart. It is `undefined` when the restart is manually triggered. Available in v2.1.8 or later.
 - `options`: The options passed to the current `rsbuild.build()` or `rsbuild.startDevServer()` call.
 
-- **Version:** Added in v2.1.7.
+- **Version:** Added in v2.1.7

--- a/website/docs/zh/config/dev/watch-files.mdx
+++ b/website/docs/zh/config/dev/watch-files.mdx
@@ -7,8 +7,11 @@ description: '监听指定文件和目录的变化。当文件发生变化时，
 - **类型：**
 
 ```ts
-type WatchFilesOptions = {
+type WatchFileEvent = 'add' | 'change' | 'unlink';
+
+type WatchFiles = {
   paths: string | string[];
+  events?: WatchFileEvent[];
   type?: 'reload-page' | 'restart' | 'reload-server';
   //  chokidar 选项
   options?: ChokidarOptions;
@@ -71,6 +74,33 @@ Glob 模式会在 watcher 启动时展开，因此不会包含之后新建的匹
 
 请使用字符串字面量或 `path.posix.join()` 构造相对 glob 模式。
 :::
+
+## events
+
+- **类型：** `('add' | 'change' | 'unlink')[]`
+- **默认值：** `['add', 'change', 'unlink']`
+
+指定触发对应操作的文件事件：
+
+- `add`：watcher 启动后，监听范围内新增文件。
+- `change`：监听范围内的文件发生变更。
+- `unlink`：监听范围内的文件被删除。
+
+这些事件描述的是 watcher 观察到的结果。例如，重命名文件可能会对旧路径产生 `unlink`，对新路径产生 `add`；原子写入则可能被报告为 `change`。
+
+例如，只在目录中新增或移除文件时触发重启：
+
+```ts title="rsbuild.config.ts"
+export default {
+  dev: {
+    watchFiles: {
+      paths: './config',
+      type: 'restart',
+      events: ['add', 'unlink'],
+    },
+  },
+};
+```
 
 ## type
 
@@ -156,7 +186,7 @@ export default {
     watchFiles: [
       {
         type: 'reload-page',
-        paths: 'public/**/*',
+        paths: 'public',
       },
       {
         type: 'restart',
@@ -177,7 +207,7 @@ export default {
 
 ## 版本历史
 
-| 版本   | 变更内容                                  |
-| ------ | ----------------------------------------- |
-| v2.1.8 | `reload-page` 现在会响应文件新增和删除    |
-| v2.1.7 | 新增 `restart` 类型，废弃 `reload-server` |
+| 版本   | 变更内容                                                   |
+| ------ | ---------------------------------------------------------- |
+| v2.1.8 | 新增 `events` 选项；`reload-page` 现在会响应文件新增和删除 |
+| v2.1.7 | 新增 `restart` 类型，废弃 `reload-server`                  |

--- a/website/docs/zh/config/dev/watch-files.mdx
+++ b/website/docs/zh/config/dev/watch-files.mdx
@@ -82,7 +82,7 @@ Glob 模式会在 watcher 启动时展开，因此不会包含之后新建的匹
 
 指定触发对应操作的文件事件：
 
-- `add`：watcher 启动后，监听范围内新增文件。
+- `add`：监听范围内检测到文件。默认仅对 watcher 启动后新增的文件触发；将 [`options.ignoreInitial`](#options) 设为 `false` 时，启动时已存在的文件也会触发该事件。
 - `change`：监听范围内的文件发生变更。
 - `unlink`：监听范围内的文件被删除。
 

--- a/website/docs/zh/config/dev/watch-files.mdx
+++ b/website/docs/zh/config/dev/watch-files.mdx
@@ -86,8 +86,6 @@ Glob 模式会在 watcher 启动时展开，因此不会包含之后新建的匹
 - `change`：监听范围内的文件发生变更。
 - `unlink`：监听范围内的文件被删除。
 
-这些事件描述的是 watcher 观察到的结果。例如，重命名文件可能会对旧路径产生 `unlink`，对新路径产生 `add`；原子写入则可能被报告为 `change`。
-
 例如，只在目录中新增或移除文件时触发重启：
 
 ```ts title="rsbuild.config.ts"
@@ -111,7 +109,7 @@ export default {
 
 ### reload-page
 
-reload-page 表示当被监听的文件新增、修改或删除时，浏览器打开的页面会自动重新加载。如果未明确指定 type，Rsbuild 会默认采用 reload-page 行为。
+`reload-page` 表示当监听文件发生 [`events`](#events) 指定的事件时，浏览器中的页面会自动重新加载。默认情况下，新增、修改和删除都会触发重新加载。如果未明确指定 `type`，Rsbuild 默认采用 `reload-page`。
 
 这可以用于监听一些静态资源文件的变化，例如 [public 目录](/config/server/public-dir) 下的文件。
 

--- a/website/docs/zh/shared/onRestart.mdx
+++ b/website/docs/zh/shared/onRestart.mdx
@@ -3,12 +3,12 @@
 该 hook 会在以下情况中触发：
 
 - Rsbuild CLI 检测到配置文件或其依赖发生变化。
-- [`dev.watchFiles`](/config/dev/watch-files) 中 `type` 为 `'restart'` 的监听项检测到文件变动。
+- [`dev.watchFiles`](/config/dev/watch-files) 中 `type` 为 `'restart'` 的监听项检测到 `events` 中指定的文件事件。
 - 通过 [CLI 快捷键](/config/dev/cli-shortcuts) 手动重启 dev server。
 
 > 普通的重新构建不会触发该 hook。
 
-使用 JavaScript API 时，`rsbuild.startDevServer()`、`rsbuild.createDevServer()` 和 `rsbuild.build({ watch: true })` 会安装 restart watcher。检测到文件变动时会调用该 hook。默认情况下，Rsbuild 不会关闭或重启当前任务；你可以传入 [`restart` 选项](/api/javascript-api/core#restart-handling) 来处理重启请求。
+使用 JavaScript API 时，`rsbuild.startDevServer()`、`rsbuild.createDevServer()` 和 `rsbuild.build({ watch: true })` 会安装 restart watcher。只有检测到 `events` 中指定的文件事件时才会调用该 hook。默认情况下，Rsbuild 不会关闭或重启当前任务；你可以传入 [`restart` 选项](/api/javascript-api/core#restart-handling) 来处理重启请求。
 
 - **类型：**
 
@@ -34,7 +34,7 @@ function OnRestart(callback: (context: RestartContext) => Promise<void> | void):
 
 - `action`：当前正在重启的 Rsbuild 操作类型。
 - `filePath`：触发重启的文件绝对路径，手动触发重启时为 `undefined`。
-- `event`：触发重启的文件事件，手动触发重启时为 `undefined`。
+- `event`：触发重启的文件事件，手动触发重启时为 `undefined`。该属性自 v2.1.8 起可用。
 - `options`：当前调用 `rsbuild.build()` 或 `rsbuild.startDevServer()` 时传入的选项。
 
-- **版本：** 新增于 v2.1.7。
+- **版本：** 新增于 v2.1.7

--- a/website/docs/zh/shared/onRestart.mdx
+++ b/website/docs/zh/shared/onRestart.mdx
@@ -3,18 +3,21 @@
 该 hook 会在以下情况中触发：
 
 - Rsbuild CLI 检测到配置文件或其依赖发生变化。
-- [`dev.watchFiles`](/config/dev/watch-files) 中 `type` 为 `'restart'` 的文件发生变化。
+- [`dev.watchFiles`](/config/dev/watch-files) 中 `type` 为 `'restart'` 的监听项检测到文件变动。
 - 通过 [CLI 快捷键](/config/dev/cli-shortcuts) 手动重启 dev server。
 
 > 普通的重新构建不会触发该 hook。
 
-使用 JavaScript API 时，`rsbuild.startDevServer()`、`rsbuild.createDevServer()` 和 `rsbuild.build({ watch: true })` 会安装 restart watcher。被监听的文件发生变化时会调用该 hook。默认情况下，Rsbuild 不会关闭或重启当前任务；你可以传入 [`restart` 选项](/api/javascript-api/core#restart-handling) 来处理重启请求。
+使用 JavaScript API 时，`rsbuild.startDevServer()`、`rsbuild.createDevServer()` 和 `rsbuild.build({ watch: true })` 会安装 restart watcher。检测到文件变动时会调用该 hook。默认情况下，Rsbuild 不会关闭或重启当前任务；你可以传入 [`restart` 选项](/api/javascript-api/core#restart-handling) 来处理重启请求。
 
 - **类型：**
 
 ```ts
+type WatchFileEvent = 'add' | 'change' | 'unlink';
+
 type RestartContext = {
   filePath?: string;
+  event?: WatchFileEvent;
 } & (
   | {
       action: 'build';
@@ -31,6 +34,7 @@ function OnRestart(callback: (context: RestartContext) => Promise<void> | void):
 
 - `action`：当前正在重启的 Rsbuild 操作类型。
 - `filePath`：触发重启的文件绝对路径，手动触发重启时为 `undefined`。
+- `event`：触发重启的文件事件，手动触发重启时为 `undefined`。
 - `options`：当前调用 `rsbuild.build()` 或 `rsbuild.startDevServer()` 时传入的选项。
 
-- **版本：** 新增于 v2.1.7
+- **版本：** 新增于 v2.1.7。


### PR DESCRIPTION
## Summary

This PR documents the `dev.watchFiles.events` option introduced in #8178, including the supported events, default behavior, and watcher semantics in English and Chinese. It also documents `RestartContext.event` for `onRestart` and updates the directory-watching example to avoid relying on a glob for newly added files.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8178