### PR TITLE
docs: mention Vue DevTools integration

### DIFF
--- a/website/docs/en/guide/framework/vue.mdx
+++ b/website/docs/en/guide/framework/vue.mdx
@@ -95,3 +95,9 @@ declare module '*.vue' {
   export default Vue;
 }
 ```
+
+## Vue DevTools
+
+Vue DevTools is designed to enhance the Vue developer experience; it can significantly improve your productivity and debugging capabilities when working with Vue applications.
+
+For Vue applications built with Rsbuild, use [vue-devtools-rstack](https://github.com/OskarLebuda/vue-devtools-rstack) to integrate Vue DevTools.

--- a/website/docs/zh/guide/framework/vue.mdx
+++ b/website/docs/zh/guide/framework/vue.mdx
@@ -95,3 +95,9 @@ declare module '*.vue' {
   export default Vue;
 }
 ```
+
+## Vue DevTools
+
+Vue DevTools 旨在提升 Vue 开发体验，可以显著提高开发和调试 Vue 应用的效率。
+
+对于使用 Rsbuild 构建的 Vue 应用，可以通过 [vue-devtools-rstack](https://github.com/OskarLebuda/vue-devtools-rstack) 集成 Vue DevTools。


### PR DESCRIPTION
## Summary

This PR adds a brief Vue DevTools section to the Vue guides. It explains the developer experience benefits and points Rsbuild users to `vue-devtools-rstack` for integration.

## Related Links

- https://github.com/OskarLebuda/vue-devtools-rstack