### PR TITLE
chore(deps): update Rstest to 0.11.4

### DIFF
--- a/e2e/helper/fixture.ts
+++ b/e2e/helper/fixture.ts
@@ -8,7 +8,7 @@ import {
 import { constants as fsConstants, promises } from 'node:fs';
 import path from 'node:path';
 import { expect, test as base } from '@rstest/playwright';
-import type { PlaywrightFixture, PlaywrightOptions } from '@rstest/playwright';
+import type { PlaywrightOptions } from '@rstest/playwright';
 import {
   copyNodeModules as baseCopyNodeModules,
   editFile as baseEditFile,
@@ -16,7 +16,6 @@ import {
   prepareDist as basePrepareDist,
 } from '@rstackjs/test-utils';
 import fse from 'fs-extra';
-import type { TestContext, TestOptions } from 'rstack/test';
 import { RSBUILD_BIN_PATH } from './constants.ts';
 import {
   type Build,
@@ -400,19 +399,6 @@ const rsbuildTest = rsbuildBase.extend<RsbuildFixture>({
   },
 });
 
-// TODO: Remove these hook type overrides after https://github.com/web-infra-dev/rstest/pull/1604 is released.
-type MaybePromise<T> = T | Promise<T>;
-type RsbuildTestContext = TestContext & PlaywrightFixture & RsbuildFixture;
-type TestCallback = (context: RsbuildTestContext) => MaybePromise<void>;
-type AfterEachCallback = (context: RsbuildTestContext) => MaybePromise<void>;
-type BeforeEachCallback = (context: RsbuildTestContext) => MaybePromise<void | AfterEachCallback>;
-type RsbuildTest = Omit<typeof rsbuildTest, 'afterEach' | 'beforeEach'> & {
-  (description: string, callback?: TestCallback, timeout?: number): void;
-  (description: string, options: TestOptions, callback?: TestCallback): void;
-  afterEach: (callback: AfterEachCallback, timeout?: number) => void;
-  beforeEach: (callback: BeforeEachCallback, timeout?: number) => void;
-};
-
-export const test = rsbuildTest as unknown as RsbuildTest;
+export const test = rsbuildTest;
 
 export { expect };

--- a/packages/create-rsbuild/template-rstest/react-js/package.json
+++ b/packages/create-rsbuild/template-rstest/react-js/package.json
@@ -4,8 +4,8 @@
     "test:watch": "rstest --watch"
   },
   "devDependencies": {
-    "@rstest/adapter-rsbuild": "^0.11.2",
-    "@rstest/core": "^0.11.2",
+    "@rstest/adapter-rsbuild": "^0.11.4",
+    "@rstest/core": "^0.11.4",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/packages/create-rsbuild/template-rstest/react-ts/package.json
+++ b/packages/create-rsbuild/template-rstest/react-ts/package.json
@@ -4,8 +4,8 @@
     "test:watch": "rstest --watch"
   },
   "devDependencies": {
-    "@rstest/adapter-rsbuild": "^0.11.2",
-    "@rstest/core": "^0.11.2",
+    "@rstest/adapter-rsbuild": "^0.11.4",
+    "@rstest/core": "^0.11.4",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/packages/create-rsbuild/template-rstest/vanilla-js/package.json
+++ b/packages/create-rsbuild/template-rstest/vanilla-js/package.json
@@ -4,8 +4,8 @@
     "test:watch": "rstest --watch"
   },
   "devDependencies": {
-    "@rstest/adapter-rsbuild": "^0.11.2",
-    "@rstest/core": "^0.11.2",
+    "@rstest/adapter-rsbuild": "^0.11.4",
+    "@rstest/core": "^0.11.4",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "happy-dom": "^20.11.0"

--- a/packages/create-rsbuild/template-rstest/vanilla-ts/package.json
+++ b/packages/create-rsbuild/template-rstest/vanilla-ts/package.json
@@ -4,8 +4,8 @@
     "test:watch": "rstest --watch"
   },
   "devDependencies": {
-    "@rstest/adapter-rsbuild": "^0.11.2",
-    "@rstest/core": "^0.11.2",
+    "@rstest/adapter-rsbuild": "^0.11.4",
+    "@rstest/core": "^0.11.4",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "happy-dom": "^20.11.0"

--- a/packages/create-rsbuild/template-rstest/vue-js/package.json
+++ b/packages/create-rsbuild/template-rstest/vue-js/package.json
@@ -4,8 +4,8 @@
     "test:watch": "rstest --watch"
   },
   "devDependencies": {
-    "@rstest/adapter-rsbuild": "^0.11.2",
-    "@rstest/core": "^0.11.2",
+    "@rstest/adapter-rsbuild": "^0.11.4",
+    "@rstest/core": "^0.11.4",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/vue": "^8.1.0",

--- a/packages/create-rsbuild/template-rstest/vue-ts/package.json
+++ b/packages/create-rsbuild/template-rstest/vue-ts/package.json
@@ -4,8 +4,8 @@
     "test:watch": "rstest --watch"
   },
   "devDependencies": {
-    "@rstest/adapter-rsbuild": "^0.11.2",
-    "@rstest/core": "^0.11.2",
+    "@rstest/adapter-rsbuild": "^0.11.4",
+    "@rstest/core": "^0.11.4",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/vue": "^8.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,8 +89,8 @@ catalogs:
       specifier: ^0.2.0
       version: 0.2.0
     '@rstest/playwright':
-      specifier: ^0.11.2
-      version: 0.11.2
+      specifier: ^0.11.4
+      version: 0.11.4
     '@shikijs/transformers':
       specifier: ^4.3.1
       version: 4.3.1
@@ -510,7 +510,7 @@ importers:
         version: 0.2.0
       '@rstest/playwright':
         specifier: 'catalog:'
-        version: 0.11.2(@rstest/core@0.11.3)(playwright@1.61.1)
+        version: 0.11.4(@rstest/core@0.11.4)(playwright@1.61.1)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../scripts/test-helper
@@ -2751,8 +2751,8 @@ packages:
   '@rstackjs/test-utils@0.2.0':
     resolution: {integrity: sha512-P+LOo1WE3xYeGkHmEthyq2cIpN69k4LhiB/4UBSceD+nW9hDlhWv8MC0LTLWokZXccWl4ntcfOBjQFllkcBlPA==}
 
-  '@rstest/core@0.11.3':
-    resolution: {integrity: sha512-TXBvW8snHQntxRRYX71a3vTkhQ9SVvbG1PlqmiyxkSwcVxBXdwghJCpYEHu75L6Ay61eQtsc0R8MIq+Qd3aicA==}
+  '@rstest/core@0.11.4':
+    resolution: {integrity: sha512-HfBP4mmvLVq2vpyRvHHaeu1+K2e9XSjDCHbj15s+NExnniS2b+y/ABXyjJldpRSoiirKnfIqY7BVGOaO+G+W0w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -2764,11 +2764,11 @@ packages:
       jsdom:
         optional: true
 
-  '@rstest/playwright@0.11.2':
-    resolution: {integrity: sha512-Jm464bw45XIgXbkURjJCldvj91IZKfGRgALEbwMtaWJW62N/+5AJgn00pW7h1l7dX+qxmGVb/rr4+XMVb3auDA==}
+  '@rstest/playwright@0.11.4':
+    resolution: {integrity: sha512-N7xG7yzJb4d7iNjQOrNMDesvcN3nVAf7vgn17pBRIMce83QCkZIyNS+Dfit0XNAOPp3zJiGsVkby3MorPg5DJg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      '@rstest/core': ^0.11.2
+      '@rstest/core': ^0.11.4
       playwright: ^1.49.1
 
   '@shikijs/core@4.3.0':
@@ -6727,7 +6727,7 @@ snapshots:
 
   '@rstackjs/test-utils@0.2.0': {}
 
-  '@rstest/core@0.11.3(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)':
+  '@rstest/core@0.11.4(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)':
     dependencies:
       '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)
       '@types/chai': 5.2.3
@@ -6735,9 +6735,9 @@ snapshots:
       - '@module-federation/runtime-tools'
       - core-js
 
-  '@rstest/playwright@0.11.2(@rstest/core@0.11.3)(playwright@1.61.1)':
+  '@rstest/playwright@0.11.4(@rstest/core@0.11.4)(playwright@1.61.1)':
     dependencies:
-      '@rstest/core': 0.11.3(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)
+      '@rstest/core': 0.11.4(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)
       playwright: 1.61.1
 
   '@shikijs/core@4.3.0':
@@ -9194,7 +9194,7 @@ snapshots:
       '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)
       '@rslib/core': 1.0.0-beta.1(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)(typescript@6.0.3)
       '@rslint/core': 0.7.0(jiti@2.7.0)
-      '@rstest/core': 0.11.3(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)
+      '@rstest/core': 0.11.4(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)
     optionalDependencies:
       '@rspress/core': 2.0.18(@module-federation/runtime-tools@2.8.0)(@rspack/core@2.1.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(core-js@3.49.0)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@8.1.1)
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,7 +43,7 @@ catalog:
   '@rstack-dev/doc-ui': '1.14.7'
   '@rstackjs/load-config': '^0.1.2'
   '@rstackjs/test-utils': '^0.2.0'
-  '@rstest/playwright': '^0.11.2'
+  '@rstest/playwright': '^0.11.4'
   '@shikijs/transformers': '^4.3.1'
   '@svgr/core': '8.1.0'
   '@svgr/plugin-jsx': '8.1.0'


### PR DESCRIPTION
## Summary

This PR updates Rstest to 0.11.4 so e2e hooks can infer extended Playwright fixture types without local overrides. It also aligns the create-rsbuild Rstest templates with the same release.

## Related Links

- https://github.com/web-infra-dev/rstest/pull/1620