### PR TITLE
test(e2e): make prepareDist fixture lazy

### DIFF
--- a/e2e/helper/fixture.ts
+++ b/e2e/helper/fixture.ts
@@ -263,15 +263,11 @@ const rsbuildTest = rsbuildBase.extend<RsbuildFixture>({
     }
   },
 
-  prepareDist: [
-    async ({ cwd }, use) => {
-      const prepareDist: PrepareDist = (distFolderName = 'dist') =>
-        basePrepareDist(path.join(cwd, distFolderName));
-      await use(prepareDist);
-    },
-    // Keep prepareDist available in beforeEach and afterEach hooks.
-    { auto: true },
-  ],
+  prepareDist: async ({ cwd }, use) => {
+    const prepareDist: PrepareDist = (distFolderName = 'dist') =>
+      basePrepareDist(path.join(cwd, distFolderName));
+    await use(prepareDist);
+  },
 
   dev: async ({ cwd, page, logHelper }, use) => {
     const closes: Close[] = [];


### PR DESCRIPTION
## Summary

Rstest 0.11.4 resolves fixtures requested by per-test hooks, so `prepareDist` no longer needs to run automatically for every e2e test. This PR removes the `auto: true` workaround and keeps the fixture lazy until a test or hook requests it.

## Related Links

- https://github.com/web-infra-dev/rstest/pull/1606