### PR TITLE
fix(core): apply inspect mode before config generation

### DIFF
--- a/e2e/cases/config/inspect-config/index.test.ts
+++ b/e2e/cases/config/inspect-config/index.test.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { expect, test } from '@e2e/helper';
 import type { RsbuildPlugin } from '@rsbuild/core';
 import { createRsbuild } from '@rsbuild/core';
+import { rs } from 'rstack/test';
 
 test.afterEach(async ({ prepareDist }) => {
   await prepareDist();
@@ -97,55 +98,45 @@ test('should not generate config files when writeToDisk is false', async () => {
 });
 
 test('should apply mode before generating configs', async () => {
-  const originalNodeEnv = process.env.NODE_ENV;
+  using env = rs.stubEnv('NODE_ENV', undefined);
 
-  try {
-    delete process.env.NODE_ENV;
+  const developmentRsbuild = await createRsbuild({
+    cwd: import.meta.dirname,
+  });
+  const developmentResult = await developmentRsbuild.inspectConfig();
 
-    const developmentRsbuild = await createRsbuild({
-      cwd: import.meta.dirname,
-    });
-    const developmentResult = await developmentRsbuild.inspectConfig();
+  expect(developmentResult.origin.rsbuildConfig.mode).toBe('development');
+  expect(developmentResult.origin.bundlerConfigs[0].mode).toBe('development');
 
-    expect(developmentResult.origin.rsbuildConfig.mode).toBe('development');
-    expect(developmentResult.origin.bundlerConfigs[0].mode).toBe('development');
+  env.stubEnv('NODE_ENV', 'staging');
 
-    process.env.NODE_ENV = 'staging';
+  const unknownEnvRsbuild = await createRsbuild({
+    cwd: import.meta.dirname,
+  });
+  const unknownEnvResult = await unknownEnvRsbuild.inspectConfig();
 
-    const unknownEnvRsbuild = await createRsbuild({
-      cwd: import.meta.dirname,
-    });
-    const unknownEnvResult = await unknownEnvRsbuild.inspectConfig();
+  expect(unknownEnvResult.origin.rsbuildConfig.mode).toBe('none');
+  expect(unknownEnvResult.origin.bundlerConfigs[0].mode).toBe('none');
 
-    expect(unknownEnvResult.origin.rsbuildConfig.mode).toBe('none');
-    expect(unknownEnvResult.origin.bundlerConfigs[0].mode).toBe('none');
+  const noneRsbuild = await createRsbuild({
+    cwd: import.meta.dirname,
+  });
+  const noneResult = await noneRsbuild.inspectConfig({
+    mode: 'none',
+  });
 
-    const noneRsbuild = await createRsbuild({
-      cwd: import.meta.dirname,
-    });
-    const noneResult = await noneRsbuild.inspectConfig({
-      mode: 'none',
-    });
+  expect(noneResult.origin.rsbuildConfig.mode).toBe('none');
+  expect(noneResult.origin.bundlerConfigs[0].mode).toBe('none');
 
-    expect(noneResult.origin.rsbuildConfig.mode).toBe('none');
-    expect(noneResult.origin.bundlerConfigs[0].mode).toBe('none');
+  const productionRsbuild = await createRsbuild({
+    cwd: import.meta.dirname,
+  });
+  const productionResult = await productionRsbuild.inspectConfig({
+    mode: 'production',
+  });
 
-    const productionRsbuild = await createRsbuild({
-      cwd: import.meta.dirname,
-    });
-    const productionResult = await productionRsbuild.inspectConfig({
-      mode: 'production',
-    });
-
-    expect(productionResult.origin.rsbuildConfig.mode).toBe('production');
-    expect(productionResult.origin.bundlerConfigs[0].mode).toBe('production');
-  } finally {
-    if (originalNodeEnv === undefined) {
-      delete process.env.NODE_ENV;
-    } else {
-      process.env.NODE_ENV = originalNodeEnv;
-    }
-  }
+  expect(productionResult.origin.rsbuildConfig.mode).toBe('production');
+  expect(productionResult.origin.bundlerConfigs[0].mode).toBe('production');
 });
 
 test('should allow to specify absolute output path', async ({ logHelper }) => {
@@ -188,7 +179,7 @@ test('should generate extra config files', async ({ logHelper }) => {
 });
 
 test('should apply plugin correctly', async () => {
-  const originalNodeEnv = process.env.NODE_ENV;
+  using env = rs.stubEnv('NODE_ENV', undefined);
   let servePluginApplied = false;
   let buildPluginApplied = false;
 
@@ -208,38 +199,29 @@ test('should apply plugin correctly', async () => {
     },
   };
 
-  try {
-    delete process.env.NODE_ENV;
+  const rsbuild1 = await createRsbuild({
+    cwd: import.meta.dirname,
+    config: {
+      plugins: [servePlugin, buildPlugin],
+    },
+  });
+  await rsbuild1.inspectConfig();
 
-    const rsbuild1 = await createRsbuild({
-      cwd: import.meta.dirname,
-      config: {
-        plugins: [servePlugin, buildPlugin],
-      },
-    });
-    await rsbuild1.inspectConfig();
+  expect(servePluginApplied).toBe(true);
+  expect(buildPluginApplied).toBe(false);
 
-    expect(servePluginApplied).toBe(true);
-    expect(buildPluginApplied).toBe(false);
+  servePluginApplied = false;
+  env.stubEnv('NODE_ENV', 'development');
 
-    servePluginApplied = false;
+  const rsbuild2 = await createRsbuild({
+    cwd: import.meta.dirname,
+    config: {
+      mode: 'production',
+      plugins: [servePlugin, buildPlugin],
+    },
+  });
+  await rsbuild2.inspectConfig();
 
-    const rsbuild2 = await createRsbuild({
-      cwd: import.meta.dirname,
-      config: {
-        mode: 'production',
-        plugins: [servePlugin, buildPlugin],
-      },
-    });
-    await rsbuild2.inspectConfig();
-
-    expect(servePluginApplied).toBe(false);
-    expect(buildPluginApplied).toBe(true);
-  } finally {
-    if (originalNodeEnv === undefined) {
-      delete process.env.NODE_ENV;
-    } else {
-      process.env.NODE_ENV = originalNodeEnv;
-    }
-  }
+  expect(servePluginApplied).toBe(false);
+  expect(buildPluginApplied).toBe(true);
 });

--- a/e2e/cases/config/inspect-config/index.test.ts
+++ b/e2e/cases/config/inspect-config/index.test.ts
@@ -112,6 +112,24 @@ test('should apply mode before generating configs', async () => {
 
     process.env.NODE_ENV = 'staging';
 
+    const unknownEnvRsbuild = await createRsbuild({
+      cwd: import.meta.dirname,
+    });
+    const unknownEnvResult = await unknownEnvRsbuild.inspectConfig();
+
+    expect(unknownEnvResult.origin.rsbuildConfig.mode).toBe('none');
+    expect(unknownEnvResult.origin.bundlerConfigs[0].mode).toBe('none');
+
+    const noneRsbuild = await createRsbuild({
+      cwd: import.meta.dirname,
+    });
+    const noneResult = await noneRsbuild.inspectConfig({
+      mode: 'none',
+    });
+
+    expect(noneResult.origin.rsbuildConfig.mode).toBe('none');
+    expect(noneResult.origin.bundlerConfigs[0].mode).toBe('none');
+
     const productionRsbuild = await createRsbuild({
       cwd: import.meta.dirname,
     });
@@ -170,6 +188,7 @@ test('should generate extra config files', async ({ logHelper }) => {
 });
 
 test('should apply plugin correctly', async () => {
+  const originalNodeEnv = process.env.NODE_ENV;
   let servePluginApplied = false;
   let buildPluginApplied = false;
 
@@ -189,29 +208,38 @@ test('should apply plugin correctly', async () => {
     },
   };
 
-  const rsbuild1 = await createRsbuild({
-    cwd: import.meta.dirname,
-    config: {
-      mode: 'development',
-      plugins: [servePlugin, buildPlugin],
-    },
-  });
-  await rsbuild1.inspectConfig();
+  try {
+    delete process.env.NODE_ENV;
 
-  expect(servePluginApplied).toBe(true);
-  expect(buildPluginApplied).toBe(false);
+    const rsbuild1 = await createRsbuild({
+      cwd: import.meta.dirname,
+      config: {
+        plugins: [servePlugin, buildPlugin],
+      },
+    });
+    await rsbuild1.inspectConfig();
 
-  servePluginApplied = false;
+    expect(servePluginApplied).toBe(true);
+    expect(buildPluginApplied).toBe(false);
 
-  const rsbuild2 = await createRsbuild({
-    cwd: import.meta.dirname,
-    config: {
-      mode: 'production',
-      plugins: [servePlugin, buildPlugin],
-    },
-  });
-  await rsbuild2.inspectConfig();
+    servePluginApplied = false;
 
-  expect(servePluginApplied).toBe(false);
-  expect(buildPluginApplied).toBe(true);
+    const rsbuild2 = await createRsbuild({
+      cwd: import.meta.dirname,
+      config: {
+        mode: 'production',
+        plugins: [servePlugin, buildPlugin],
+      },
+    });
+    await rsbuild2.inspectConfig();
+
+    expect(servePluginApplied).toBe(false);
+    expect(buildPluginApplied).toBe(true);
+  } finally {
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+  }
 });

--- a/e2e/cases/config/inspect-config/index.test.ts
+++ b/e2e/cases/config/inspect-config/index.test.ts
@@ -96,6 +96,40 @@ test('should not generate config files when writeToDisk is false', async () => {
   expect(fs.existsSync(rspackConfig)).toBeFalsy();
 });
 
+test('should apply mode before generating configs', async () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  try {
+    delete process.env.NODE_ENV;
+
+    const developmentRsbuild = await createRsbuild({
+      cwd: import.meta.dirname,
+    });
+    const developmentResult = await developmentRsbuild.inspectConfig();
+
+    expect(developmentResult.origin.rsbuildConfig.mode).toBe('development');
+    expect(developmentResult.origin.bundlerConfigs[0].mode).toBe('development');
+
+    process.env.NODE_ENV = 'staging';
+
+    const productionRsbuild = await createRsbuild({
+      cwd: import.meta.dirname,
+    });
+    const productionResult = await productionRsbuild.inspectConfig({
+      mode: 'production',
+    });
+
+    expect(productionResult.origin.rsbuildConfig.mode).toBe('production');
+    expect(productionResult.origin.bundlerConfigs[0].mode).toBe('production');
+  } finally {
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+  }
+});
+
 test('should allow to specify absolute output path', async ({ logHelper }) => {
   const { expectLog } = logHelper;
 

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -307,9 +307,9 @@ export async function createRsbuild(options: CreateRsbuildOptions = {}): Promise
     );
   };
 
-  const initAction = () => {
+  const initAction = (mode: string | undefined = config.mode) => {
     if (!context.action) {
-      context.action = config.mode === 'development' ? 'dev' : 'build';
+      context.action = mode === 'development' ? 'dev' : 'build';
     }
   };
 
@@ -320,7 +320,7 @@ export async function createRsbuild(options: CreateRsbuildOptions = {}): Promise
       setNodeEnv('development');
     }
 
-    initAction();
+    initAction(config.mode ?? getNodeEnv());
 
     const { rspackConfigs } = await baseInitConfigs({
       context,

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -313,7 +313,13 @@ export async function createRsbuild(options: CreateRsbuildOptions = {}): Promise
     }
   };
 
-  const inspectConfig: InspectConfig = async (inspectOptions) => {
+  const inspectConfig: InspectConfig = async (inspectOptions = {}) => {
+    if (inspectOptions.mode) {
+      setNodeEnv(inspectOptions.mode);
+    } else if (!getNodeEnv()) {
+      setNodeEnv('development');
+    }
+
     initAction();
 
     const { rspackConfigs } = await baseInitConfigs({

--- a/packages/core/src/inspectConfig.ts
+++ b/packages/core/src/inspectConfig.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import { isAbsolute, join } from 'node:path';
 import { RSBUILD_OUTPUTS_PATH } from './constants';
-import { color, getNodeEnv, RspackChain, setNodeEnv, upperFirst } from './helpers';
+import { color, RspackChain, upperFirst } from './helpers';
 import type { InitConfigsOptions } from './initConfigs';
 import type { Logger } from './logger';
 import type {
@@ -121,12 +121,6 @@ export async function inspectConfig({
   inspectOptions?: InspectConfigOptions;
   bundlerConfigs: Rspack.Configuration[];
 }): Promise<InspectConfigResult> {
-  if (inspectOptions.mode) {
-    setNodeEnv(inspectOptions.mode);
-  } else if (!getNodeEnv()) {
-    setNodeEnv('development');
-  }
-
   const stringifiedBundlerConfigs = bundlerConfigs.map((config, index) => ({
     name: config.name || String(index),
     content: stringifyConfig(config, inspectOptions.verbose),

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -67,8 +67,9 @@ export type InitConfigsOptions = Pick<RsbuildContext, 'action'>;
 export type InspectConfigOptions = {
   /**
    * Inspect the config in the specified mode.
-   * Available options: 'development' or 'production'.
-   * @default 'development'
+   * Available options: 'development', 'production', or 'none'.
+   * @default Inferred from `process.env.NODE_ENV`: 'development' when unset,
+   * 'development' or 'production' when matching, otherwise 'none'.
    */
   mode?: RsbuildMode;
   /**

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -698,8 +698,9 @@ The method serializes these configurations to strings and optionally writes them
 type InspectConfigOptions = {
   /**
    * Inspect the config in the specified mode.
-   * Available options: 'development' or 'production'.
-   * @default 'development'
+   * Available options: 'development', 'production', or 'none'.
+   * @default Inferred from `process.env.NODE_ENV`: 'development' when unset,
+   * 'development' or 'production' when matching, otherwise 'none'.
    */
   mode?: RsbuildMode;
   /**

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -699,8 +699,9 @@ console.log(buildConfigs);
 type InspectConfigOptions = {
   /**
    * 检查指定 mode 下的配置
-   * 可选值：'development' 或 'production'
-   * @default 'development'
+   * 可选值：'development'、'production' 或 'none'
+   * @default 根据 `process.env.NODE_ENV` 推断：未设置时为 'development'，
+   * 匹配 'development' 或 'production' 时使用对应值，否则为 'none'
    */
   mode?: RsbuildMode;
   /**


### PR DESCRIPTION
## Summary

`rsbuild.inspectConfig()` currently applies its mode after Rsbuild and Rspack configurations have already been generated, so the requested mode may not affect the inspection result.

This PR applies the inspection mode before configuration initialization and adds regression coverage for the default and explicit mode paths.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/8187