### PR TITLE
docs: update stale plugin references

### DIFF
--- a/website/docs/en/plugins/dev/core.mdx
+++ b/website/docs/en/plugins/dev/core.mdx
@@ -342,6 +342,8 @@ type TransformDescriptor = {
   issuerLayer?: string;
   with?: Record<string, RuleSetCondition>;
   mimetype?: RuleSetCondition;
+  /** @deprecated Use `order` instead. */
+  enforce?: 'pre' | 'post';
   order?: 'pre' | 'post' | 'default';
 };
 ```
@@ -429,15 +431,18 @@ api.transform({ mimetype: 'text/javascript' }, ({ code }) => {
 });
 ```
 
-- `enforce`: Specifies the execution order of the transform function, the same as Rspack's [rules[].enforce](https://rspack.rs/config/module-rules#rulesenforce).
-  - When `enforce` is `pre`, the transform function will be executed before other transform functions (or Rspack loaders).
-  - When `enforce` is `post`, the transform function will be executed after other transform functions (or Rspack loaders).
+- `order`: Specifies the execution order of the transform function, corresponding to Rspack's [rules[].enforce](https://rspack.rs/config/module-rules#rulesenforce).
+  - When `order` is `pre`, the transform function will be executed before other transform functions (or Rspack loaders).
+  - When `order` is `post`, the transform function will be executed after other transform functions (or Rspack loaders).
+  - When `order` is `default`, the transform function will use the default loader order.
 
 ```js
-api.transform({ test: /\.md$/, enforce: 'pre' }, ({ code }) => {
+api.transform({ test: /\.md$/, order: 'pre' }, ({ code }) => {
   // ...
 });
 ```
+
+- `enforce`: Deprecated. Use `order` instead.
 
 ### Handler param
 
@@ -692,6 +697,7 @@ Here's the list of supported stages. Rspack will execute these stages sequential
 - `pre-process` — basic preprocessing of the assets.
 - `derived` — derive new assets from the existing assets.
 - `additions` — add additional sections to the existing assets, e.g., banner or initialization code.
+- `none` — run at `PROCESS_ASSETS_STAGE_NONE`, without selecting a specialized processing stage.
 - `optimize` — optimize existing assets in a general way.
 - `optimize-count` — optimize the count of existing assets, e.g., by merging them.
 - `optimize-compatibility` — optimize the compatibility of existing assets, e.g., add polyfills or vendor prefixes.

--- a/website/docs/en/plugins/dev/hooks.mdx
+++ b/website/docs/en/plugins/dev/hooks.mdx
@@ -297,14 +297,14 @@ type ModifyEnvironmentConfigUtils = {
   name: string;
   mergeEnvironmentConfig: (
     ...configs: ArrayAtLeastOne<MergedEnvironmentConfig, EnvironmentConfig>
-  ) => EnvironmentConfig;
+  ) => MergedEnvironmentConfig;
 };
 
 function ModifyEnvironmentConfig(
   callback: (
-    config: EnvironmentConfig,
+    config: MergedEnvironmentConfig,
     utils: ModifyEnvironmentConfigUtils,
-  ) => MaybePromise<EnvironmentConfig | void>,
+  ) => MaybePromise<MergedEnvironmentConfig | void>,
 ): void;
 ```
 
@@ -362,13 +362,15 @@ To modify the Rspack config, you can directly modify the config object, or retur
 ```ts
 type ModifyRspackConfigUtils = {
   environment: EnvironmentContext;
+  environments: Record<string, EnvironmentContext>;
   env: string;
   isDev: boolean;
   isProd: boolean;
   target: RsbuildTarget;
   isServer: boolean;
   isWebWorker: boolean;
-  rspack: Rspack;
+  CHAIN_ID: ChainIdentifier;
+  rspack: typeof import('@rspack/core').rspack;
   HtmlPlugin: typeof import('html-rspack-plugin');
   // more...
 };
@@ -377,7 +379,7 @@ function ModifyRspackConfig(
   callback: (
     config: Rspack.Configuration,
     utils: ModifyRspackConfigUtils,
-  ) => Promise<RspackConfig | void> | Rspack.Configuration | void,
+  ) => MaybePromise<Rspack.Configuration | void>,
 ): void;
 ```
 
@@ -410,6 +412,7 @@ import RspackChain from '@en/shared/rspackChain.mdx';
 ```ts
 type ModifyBundlerChainUtils = {
   environment: EnvironmentContext;
+  environments: Record<string, EnvironmentContext>;
   env: string;
   isDev: boolean;
   isProd: boolean;
@@ -417,10 +420,10 @@ type ModifyBundlerChainUtils = {
   isServer: boolean;
   isWebWorker: boolean;
   CHAIN_ID: ChainIdentifier;
+  rspack: typeof import('@rspack/core').rspack;
   HtmlPlugin: typeof import('html-rspack-plugin');
-  bundler: {
-    // some Rspack built-in plugins
-  };
+  /** @deprecated Use `rspack` instead. */
+  bundler: typeof import('@rspack/core').rspack;
 };
 
 function ModifyBundlerChain(
@@ -623,9 +626,9 @@ See [html.tags](/config/html/tags) for more details on how to define tags.
 
 When using `modifyHTML`, `modifyHTMLTags`, and `html.tags` options together, the execution order is as follows:
 
-1. [modifyHTML](#modifyhtml)
-2. [modifyHTMLTags](#modifyhtmltags)
-3. [html.tags](/config/html/tags)
+1. [modifyHTMLTags](#modifyhtmltags)
+2. [html.tags](/config/html/tags)
+3. [modifyHTML](#modifyhtml)
 
 :::
 

--- a/website/docs/en/plugins/list/plugin-less.mdx
+++ b/website/docs/en/plugins/list/plugin-less.mdx
@@ -43,17 +43,7 @@ To customize the compilation behavior of Less, use the following options.
 You can modify the config of [less-loader](https://github.com/webpack/less-loader) via `lessLoaderOptions`.
 
 - **Type:** `Object | Function`
-- **Default:**
-
-```js
-const defaultOptions = {
-  lessOptions: {
-    javascriptEnabled: true,
-    paths: [path.join(rootPath, 'node_modules')],
-  },
-  sourceMap: rsbuildConfig.output.sourceMap.css,
-};
-```
+- **Default:** Enables Less JavaScript, resolves imports from `node_modules`, and follows [output.sourceMap](/config/output/source-map) for source maps.
 
 - **Example:**
 

--- a/website/docs/en/plugins/list/plugin-less.mdx
+++ b/website/docs/en/plugins/list/plugin-less.mdx
@@ -43,7 +43,17 @@ To customize the compilation behavior of Less, use the following options.
 You can modify the config of [less-loader](https://github.com/webpack/less-loader) via `lessLoaderOptions`.
 
 - **Type:** `Object | Function`
-- **Default:** Enables Less JavaScript, resolves imports from `node_modules`, and follows [output.sourceMap](/config/output/source-map) for source maps.
+- **Default:**
+
+```js
+const defaultOptions = {
+  lessOptions: {
+    javascriptEnabled: true,
+    paths: [path.join(rootPath, 'node_modules')],
+  },
+  sourceMap: '<follows output.sourceMap>',
+};
+```
 
 - **Example:**
 

--- a/website/docs/en/plugins/list/plugin-less.mdx
+++ b/website/docs/en/plugins/list/plugin-less.mdx
@@ -51,7 +51,7 @@ const defaultOptions = {
     javascriptEnabled: true,
     paths: [path.join(rootPath, 'node_modules')],
   },
-  sourceMap: '<follows output.sourceMap>',
+  sourceMap: false, // Controlled by output.sourceMap
 };
 ```
 

--- a/website/docs/en/plugins/list/plugin-preact.mdx
+++ b/website/docs/en/plugins/list/plugin-preact.mdx
@@ -94,7 +94,7 @@ The default value is the same as `@rspack/plugin-preact-refresh`:
 ```js
 const defaultOptions = {
   test: /\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/,
-  exclude: /node_modules/,
+  exclude: /[\\/]node_modules[\\/]/,
 };
 ```
 

--- a/website/docs/en/plugins/list/plugin-react.mdx
+++ b/website/docs/en/plugins/list/plugin-react.mdx
@@ -294,7 +294,19 @@ As Windows does not support the above usage, you can also use [cross-env](https:
 - **Type:**
 
 ```ts
-type ReactRefreshOptions = import('@rspack/plugin-react-refresh').PluginOptions;
+type ReactRefreshOptions = {
+  // @link https://rspack.rs/config/module-rules#condition
+  test?: Rspack.RuleSetCondition;
+  include?: Rspack.RuleSetCondition | null;
+  exclude?: Rspack.RuleSetCondition | null;
+  resourceQuery?: Rspack.RuleSetCondition;
+  library?: string;
+  forceEnable?: boolean;
+  injectLoader?: boolean;
+  injectEntry?: boolean;
+  reloadOnRuntimeErrors?: boolean;
+  reactRefreshLoader?: string;
+};
 ```
 
 - **Default:** Matches the built-in JavaScript rule and excludes `?raw` requests.

--- a/website/docs/en/plugins/list/plugin-react.mdx
+++ b/website/docs/en/plugins/list/plugin-react.mdx
@@ -309,7 +309,7 @@ type ReactRefreshOptions = {
 };
 ```
 
-- **Default:** Matches the built-in JavaScript rule and excludes `?raw` requests.
+- **Default:** React Fast Refresh applies to files handled by Rsbuild's built-in JavaScript rule, except files imported with `?raw`.
 
 Set the options for [@rspack/plugin-react-refresh](https://github.com/rstackjs/rspack-plugin-react-refresh). The passed value will be shallowly merged with the default value.
 

--- a/website/docs/en/plugins/list/plugin-react.mdx
+++ b/website/docs/en/plugins/list/plugin-react.mdx
@@ -62,14 +62,7 @@ interface ReactConfig {
 
 - **Default:**
 
-```ts
-const isDev = process.env.NODE_ENV === 'development';
-const defaultOptions = {
-  development: isDev,
-  refresh: isDev,
-  runtime: 'automatic',
-};
-```
+Uses the automatic JSX runtime. Development transforms and Fast Refresh are enabled when applicable.
 
 ### swcReactOptions.runtime
 
@@ -144,7 +137,7 @@ pluginReact({
 ### swcReactOptions.refresh
 
 - **Type:** `boolean`
-- **Default:** based on [fastRefresh](#fastrefresh) and [dev.hmr](/config/dev/hmr)
+- **Default:** enabled for development web builds when [fastRefresh](#fastrefresh) and [dev.hmr](/config/dev/hmr) are enabled
 
 Whether to enable [React Fast Refresh](https://npmjs.com/package/react-refresh).
 
@@ -301,30 +294,10 @@ As Windows does not support the above usage, you can also use [cross-env](https:
 - **Type:**
 
 ```ts
-type ReactRefreshOptions = {
-  // @link https://rspack.rs/config/module-rules#condition
-  test?: Rspack.RuleSetCondition;
-  include?: Rspack.RuleSetCondition;
-  exclude?: Rspack.RuleSetCondition;
-  library?: string;
-  forceEnable?: boolean;
-};
+type ReactRefreshOptions = import('@rspack/plugin-react-refresh').PluginOptions;
 ```
 
-- **Default:**
-
-```js
-const defaultOptions = {
-  test: [/\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/],
-  include: [
-    // Same as Rsbuild's `source.include` configuration
-  ],
-  exclude: [
-    // Same as Rsbuild's `source.exclude` configuration
-  ],
-  resourceQuery: { not: /^\?raw$/ },
-};
-```
+- **Default:** Matches the built-in JavaScript rule and excludes `?raw` requests.
 
 Set the options for [@rspack/plugin-react-refresh](https://github.com/rstackjs/rspack-plugin-react-refresh). The passed value will be shallowly merged with the default value.
 
@@ -345,7 +318,7 @@ pluginReact({
 
 Whether to enable [React Fast Refresh](https://npmjs.com/package/react-refresh) in development mode.
 
-If `fastRefresh` is set to `true`, `@rsbuild/plugin-react` will automatically register the [@rspack/plugin-react-refresh](https://github.com/rstackjs/rspack-plugin-react-refresh) plugin.
+If `fastRefresh` is set to `true`, `@rsbuild/plugin-react` will automatically register the [@rspack/plugin-react-refresh](https://github.com/rstackjs/rspack-plugin-react-refresh) plugin for development web builds with HMR enabled.
 
 To disable Fast Refresh, set it to `false`:
 

--- a/website/docs/en/plugins/list/plugin-sass.mdx
+++ b/website/docs/en/plugins/list/plugin-sass.mdx
@@ -52,8 +52,6 @@ Modify the config of [sass-loader](https://github.com/webpack/sass-loader).
 - **Type:** `Object | Function`
 - **Default:** Uses `sass-embedded` with the modern compiler API, enables URL rewriting, and suppresses dependency and import deprecation warnings.
 
-When `api` is set to `'legacy'` and `silenceDeprecations` is not customized, the plugin also adds `'legacy-js-api'` to `silenceDeprecations`.
-
 - **Example:**
 
 If `sassLoaderOptions` is an object, it is merged with the default config through `Object.assign`. It should be noted that `sassOptions` is merged through deepMerge in a deep way.

--- a/website/docs/en/plugins/list/plugin-sass.mdx
+++ b/website/docs/en/plugins/list/plugin-sass.mdx
@@ -50,7 +50,7 @@ To customize the compilation behavior of Sass, use the following options.
 Modify the config of [sass-loader](https://github.com/webpack/sass-loader).
 
 - **Type:** `Object | Function`
-- **Default:** Uses `sass-embedded` with the modern compiler API, enables URL rewriting, and suppresses dependency and import deprecation warnings.
+- **Default:** Uses `sass-embedded` with the modern compiler API and suppresses dependency and import deprecation warnings.
 
 - **Example:**
 

--- a/website/docs/en/plugins/list/plugin-sass.mdx
+++ b/website/docs/en/plugins/list/plugin-sass.mdx
@@ -50,19 +50,9 @@ To customize the compilation behavior of Sass, use the following options.
 Modify the config of [sass-loader](https://github.com/webpack/sass-loader).
 
 - **Type:** `Object | Function`
-- **Default:**
+- **Default:** Uses `sass-embedded` with the modern compiler API, enables URL rewriting, and suppresses dependency and import deprecation warnings.
 
-```js
-const defaultOptions = {
-  api: 'modern-compiler',
-  implementation: require.resolve('sass-embedded'),
-  sourceMap: rsbuildConfig.output.sourceMap.css,
-  sassOptions: {
-    quietDeps: true,
-    silenceDeprecations: ['legacy-js-api', 'import'],
-  },
-};
-```
+When `api` is set to `'legacy'` and `silenceDeprecations` is not customized, the plugin also adds `'legacy-js-api'` to `silenceDeprecations`.
 
 - **Example:**
 

--- a/website/docs/en/shared/onAfterCreateCompiler.mdx
+++ b/website/docs/en/shared/onAfterCreateCompiler.mdx
@@ -5,8 +5,10 @@ You can access the [Compiler instance](https://rspack.rs/api/javascript-api/comp
 - **Type:**
 
 ```ts
-function OnAfterCreateCompiler(callback: (params: {
-  compiler: Compiler | MultiCompiler;
-  environments: Record<string, EnvironmentContext>;
-}) => Promise<void> | void;): void;
+function OnAfterCreateCompiler(
+  callback: (params: {
+    compiler: Compiler | MultiCompiler;
+    environments: Record<string, EnvironmentContext>;
+  }) => Promise<void> | void,
+): void;
 ```

--- a/website/docs/zh/plugins/dev/core.mdx
+++ b/website/docs/zh/plugins/dev/core.mdx
@@ -342,6 +342,8 @@ type TransformDescriptor = {
   issuerLayer?: string;
   with?: Record<string, RuleSetCondition>;
   mimetype?: RuleSetCondition;
+  /** @deprecated 请使用 `order` */
+  enforce?: 'pre' | 'post';
   order?: 'pre' | 'post' | 'default';
 };
 ```
@@ -429,15 +431,18 @@ api.transform({ mimetype: 'text/javascript' }, ({ code }) => {
 });
 ```
 
-- `enforce`：指定 transform 函数的执行顺序，等同于 Rspack 的 [rules[].enforce](https://rspack.rs/zh/config/module-rules#rulesenforce)。
-  - 当 `enforce` 为 `pre` 时，transform 函数会在其他 transform 函数（或 Rspack loader）之前执行。
-  - 当 `enforce` 为 `post` 时，transform 函数会在其他 transform 函数（或 Rspack loader）之后执行。
+- `order`：指定 transform 函数的执行顺序，对应 Rspack 的 [rules[].enforce](https://rspack.rs/zh/config/module-rules#rulesenforce)。
+  - 当 `order` 为 `pre` 时，transform 函数会在其他 transform 函数（或 Rspack loader）之前执行。
+  - 当 `order` 为 `post` 时，transform 函数会在其他 transform 函数（或 Rspack loader）之后执行。
+  - 当 `order` 为 `default` 时，transform 函数会使用默认的 loader 顺序。
 
 ```js
-api.transform({ test: /\.md$/, enforce: 'pre' }, ({ code }) => {
+api.transform({ test: /\.md$/, order: 'pre' }, ({ code }) => {
   // ...
 });
 ```
+
+- `enforce`：已废弃，请使用 `order` 代替。
 
 ### handler 参数
 
@@ -692,6 +697,7 @@ handler 函数提供以下参数：
 - `pre-process` — asset 进行了基础的预处理。
 - `derived` — 从现有 asset 中派生新的 asset。
 - `additions` — 为现有的 asset 添加额外的内容，例如 banner 或初始代码。
+- `none` — 在 `PROCESS_ASSETS_STAGE_NONE` 阶段运行，不指定专门的处理阶段。
 - `optimize` — 以通用的方式优化现有 asset。
 - `optimize-count` — 优化现有 asset 的数量，例如，进行合并操作。
 - `optimize-compatibility` — 优化现有 asset 的兼容性，例如添加 polyfills 或者 vendor prefixes。

--- a/website/docs/zh/plugins/dev/hooks.mdx
+++ b/website/docs/zh/plugins/dev/hooks.mdx
@@ -294,14 +294,14 @@ type ModifyEnvironmentConfigUtils = {
   name: string;
   mergeEnvironmentConfig: (
     ...configs: ArrayAtLeastOne<MergedEnvironmentConfig, EnvironmentConfig>
-  ) => EnvironmentConfig;
+  ) => MergedEnvironmentConfig;
 };
 
 function ModifyEnvironmentConfig(
   callback: (
-    config: EnvironmentConfig,
+    config: MergedEnvironmentConfig,
     utils: ModifyEnvironmentConfigUtils,
-  ) => MaybePromise<EnvironmentConfig | void>,
+  ) => MaybePromise<MergedEnvironmentConfig | void>,
 ): void;
 ```
 
@@ -358,13 +358,15 @@ const myPlugin = () => ({
 ```ts
 type ModifyRspackConfigUtils = {
   environment: EnvironmentContext;
+  environments: Record<string, EnvironmentContext>;
   env: string;
   isDev: boolean;
   isProd: boolean;
   target: RsbuildTarget;
   isServer: boolean;
   isWebWorker: boolean;
-  rspack: Rspack;
+  CHAIN_ID: ChainIdentifier;
+  rspack: typeof import('@rspack/core').rspack;
   HtmlPlugin: typeof import('html-rspack-plugin');
   // more...
 };
@@ -373,7 +375,7 @@ function ModifyRspackConfig(
   callback: (
     config: Rspack.Configuration,
     utils: ModifyRspackConfigUtils,
-  ) => Promise<RspackConfig | void> | Rspack.Configuration | void,
+  ) => MaybePromise<Rspack.Configuration | void>,
 ): void;
 ```
 
@@ -406,6 +408,7 @@ import RspackChain from '@zh/shared/rspackChain.mdx';
 ```ts
 type ModifyBundlerChainUtils = {
   environment: EnvironmentContext;
+  environments: Record<string, EnvironmentContext>;
   env: string;
   isDev: boolean;
   isProd: boolean;
@@ -413,10 +416,10 @@ type ModifyBundlerChainUtils = {
   isServer: boolean;
   isWebWorker: boolean;
   CHAIN_ID: ChainIdentifier;
+  rspack: typeof import('@rspack/core').rspack;
   HtmlPlugin: typeof import('html-rspack-plugin');
-  bundler: {
-    // some Rspack built-in plugins
-  };
+  /** @deprecated 请使用 `rspack` */
+  bundler: typeof import('@rspack/core').rspack;
 };
 
 function ModifyBundlerChain(
@@ -619,9 +622,9 @@ const tagsPlugin = () => ({
 
 当同时使用 `modifyHTML`，`modifyHTMLTags` 和 `html.tags` 选项时，执行顺序如下：
 
-1. [modifyHTML](#modifyhtml)
-2. [modifyHTMLTags](#modifyhtmltags)
-3. [html.tags](/config/html/tags)
+1. [modifyHTMLTags](#modifyhtmltags)
+2. [html.tags](/config/html/tags)
+3. [modifyHTML](#modifyhtml)
 
 :::
 

--- a/website/docs/zh/plugins/list/plugin-less.mdx
+++ b/website/docs/zh/plugins/list/plugin-less.mdx
@@ -43,17 +43,7 @@ export default {
 修改 [less-loader](https://github.com/webpack/less-loader) 的配置。
 
 - **类型：** `Object | Function`
-- **默认值：**
-
-```js
-const defaultOptions = {
-  lessOptions: {
-    javascriptEnabled: true,
-    paths: [path.join(rootPath, 'node_modules')],
-  },
-  sourceMap: rsbuildConfig.output.sourceMap.css,
-};
-```
+- **默认值：** 启用 Less JavaScript，支持从 `node_modules` 解析导入，source map 设置跟随 [output.sourceMap](/config/output/source-map)。
 
 - **示例：**
 

--- a/website/docs/zh/plugins/list/plugin-less.mdx
+++ b/website/docs/zh/plugins/list/plugin-less.mdx
@@ -51,7 +51,7 @@ const defaultOptions = {
     javascriptEnabled: true,
     paths: [path.join(rootPath, 'node_modules')],
   },
-  sourceMap: '<follows output.sourceMap>',
+  sourceMap: false, // Controlled by output.sourceMap
 };
 ```
 

--- a/website/docs/zh/plugins/list/plugin-less.mdx
+++ b/website/docs/zh/plugins/list/plugin-less.mdx
@@ -43,7 +43,17 @@ export default {
 修改 [less-loader](https://github.com/webpack/less-loader) 的配置。
 
 - **类型：** `Object | Function`
-- **默认值：** 启用 Less JavaScript，支持从 `node_modules` 解析导入，source map 设置跟随 [output.sourceMap](/config/output/source-map)。
+- **默认值：**
+
+```js
+const defaultOptions = {
+  lessOptions: {
+    javascriptEnabled: true,
+    paths: [path.join(rootPath, 'node_modules')],
+  },
+  sourceMap: '<follows output.sourceMap>',
+};
+```
 
 - **示例：**
 

--- a/website/docs/zh/plugins/list/plugin-preact.mdx
+++ b/website/docs/zh/plugins/list/plugin-preact.mdx
@@ -94,7 +94,7 @@ type PreactRefreshOptions = {
 ```js
 const defaultOptions = {
   test: /\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/,
-  exclude: /node_modules/,
+  exclude: /[\\/]node_modules[\\/]/,
 };
 ```
 

--- a/website/docs/zh/plugins/list/plugin-react.mdx
+++ b/website/docs/zh/plugins/list/plugin-react.mdx
@@ -309,7 +309,7 @@ type ReactRefreshOptions = {
 };
 ```
 
-- **默认值：** 匹配内置 JavaScript rule，并排除 `?raw` 请求。
+- **默认值：** Rsbuild 会对内置 JavaScript 规则处理的文件应用 React Fast Refresh，但通过 `?raw` 导入的文件除外。
 
 设置 [@rspack/plugin-react-refresh](https://github.com/rstackjs/rspack-plugin-react-refresh) 的选项，传入的值会与默认值进行浅合并。
 

--- a/website/docs/zh/plugins/list/plugin-react.mdx
+++ b/website/docs/zh/plugins/list/plugin-react.mdx
@@ -62,14 +62,7 @@ interface ReactConfig {
 
 - **默认值：**
 
-```ts
-const isDev = process.env.NODE_ENV === 'development';
-const defaultOptions = {
-  development: isDev,
-  refresh: isDev,
-  runtime: 'automatic',
-};
-```
+使用 automatic JSX runtime，并在适用时启用开发模式转换和 Fast Refresh。
 
 ### swcReactOptions.runtime
 
@@ -144,7 +137,7 @@ pluginReact({
 ### swcReactOptions.refresh
 
 - **类型：** `boolean`
-- **默认值：** 基于 [fastRefresh](#fastrefresh) 和 [dev.hmr](/config/dev/hmr)
+- **默认值：** 当 [fastRefresh](#fastrefresh) 和 [dev.hmr](/config/dev/hmr) 启用时，在开发模式的 web 构建中启用
 
 是否启用 [React Fast Refresh](https://npmjs.com/package/react-refresh)。
 
@@ -301,30 +294,10 @@ pluginReact({
 - **类型：**
 
 ```ts
-type ReactRefreshOptions = {
-  // @link https://rspack.rs/zh/config/module-rules#condition
-  test?: Rspack.RuleSetCondition;
-  include?: Rspack.RuleSetCondition;
-  exclude?: Rspack.RuleSetCondition;
-  library?: string;
-  forceEnable?: boolean;
-};
+type ReactRefreshOptions = import('@rspack/plugin-react-refresh').PluginOptions;
 ```
 
-- **默认值：**
-
-```js
-const defaultOptions = {
-  test: [/\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/],
-  include: [
-    // Same as Rsbuild's `source.include` configuration
-  ],
-  exclude: [
-    // Same as Rsbuild's `source.exclude` configuration
-  ],
-  resourceQuery: { not: /^\?raw$/ },
-};
-```
+- **默认值：** 匹配内置 JavaScript rule，并排除 `?raw` 请求。
 
 设置 [@rspack/plugin-react-refresh](https://github.com/rstackjs/rspack-plugin-react-refresh) 的选项，传入的值会与默认值进行浅合并。
 
@@ -345,7 +318,7 @@ pluginReact({
 
 是否在开发模式下启用 [React Fast Refresh](https://npmjs.com/package/react-refresh)。
 
-当 `fastRefresh` 设置为 `true` 时，`@rsbuild/plugin-react` 会自动注册 [@rspack/plugin-react-refresh](https://github.com/rstackjs/rspack-plugin-react-refresh) 插件。
+当 `fastRefresh` 设置为 `true` 时，`@rsbuild/plugin-react` 会在启用 HMR 的开发模式 web 构建中自动注册 [@rspack/plugin-react-refresh](https://github.com/rstackjs/rspack-plugin-react-refresh) 插件。
 
 如果你需要禁用 Fast Refresh，可以将其设置为 `false`：
 

--- a/website/docs/zh/plugins/list/plugin-react.mdx
+++ b/website/docs/zh/plugins/list/plugin-react.mdx
@@ -294,7 +294,19 @@ pluginReact({
 - **类型：**
 
 ```ts
-type ReactRefreshOptions = import('@rspack/plugin-react-refresh').PluginOptions;
+type ReactRefreshOptions = {
+  // @link https://rspack.rs/zh/config/module-rules#condition
+  test?: Rspack.RuleSetCondition;
+  include?: Rspack.RuleSetCondition | null;
+  exclude?: Rspack.RuleSetCondition | null;
+  resourceQuery?: Rspack.RuleSetCondition;
+  library?: string;
+  forceEnable?: boolean;
+  injectLoader?: boolean;
+  injectEntry?: boolean;
+  reloadOnRuntimeErrors?: boolean;
+  reactRefreshLoader?: string;
+};
 ```
 
 - **默认值：** 匹配内置 JavaScript rule，并排除 `?raw` 请求。

--- a/website/docs/zh/plugins/list/plugin-sass.mdx
+++ b/website/docs/zh/plugins/list/plugin-sass.mdx
@@ -50,19 +50,9 @@ export default {
 修改 [sass-loader](https://github.com/webpack/sass-loader) 的配置。
 
 - **类型：** `Object | Function`
-- **默认值：**
+- **默认值：** 使用 `sass-embedded` 的 modern compiler API，启用 URL 重写，并抑制依赖项警告和 import 弃用警告。
 
-```js
-const defaultOptions = {
-  api: 'modern-compiler',
-  implementation: require.resolve('sass-embedded'),
-  sourceMap: rsbuildConfig.output.sourceMap.css,
-  sassOptions: {
-    quietDeps: true,
-    silenceDeprecations: ['legacy-js-api', 'import'],
-  },
-};
-```
+当 `api` 设置为 `'legacy'` 且未自定义 `silenceDeprecations` 时，插件还会将 `'legacy-js-api'` 添加到 `silenceDeprecations`。
 
 - **示例：**
 

--- a/website/docs/zh/plugins/list/plugin-sass.mdx
+++ b/website/docs/zh/plugins/list/plugin-sass.mdx
@@ -50,7 +50,7 @@ export default {
 修改 [sass-loader](https://github.com/webpack/sass-loader) 的配置。
 
 - **类型：** `Object | Function`
-- **默认值：** 使用 `sass-embedded` 的 modern compiler API，启用 URL 重写，并抑制依赖项警告和 import 弃用警告。
+- **默认值：** 使用 `sass-embedded` 的 modern compiler API，并抑制依赖项警告和 import 弃用警告。
 
 - **示例：**
 

--- a/website/docs/zh/plugins/list/plugin-sass.mdx
+++ b/website/docs/zh/plugins/list/plugin-sass.mdx
@@ -52,8 +52,6 @@ export default {
 - **类型：** `Object | Function`
 - **默认值：** 使用 `sass-embedded` 的 modern compiler API，启用 URL 重写，并抑制依赖项警告和 import 弃用警告。
 
-当 `api` 设置为 `'legacy'` 且未自定义 `silenceDeprecations` 时，插件还会将 `'legacy-js-api'` 添加到 `silenceDeprecations`。
-
 - **示例：**
 
 当 `sassLoaderOptions` 的值是一个对象时，它会与默认配置通过 `Object.assign` 进行浅层合并，值得注意的是，`sassOptions` 会通过 deepMerge 进行深层合并。

--- a/website/docs/zh/shared/onAfterCreateCompiler.mdx
+++ b/website/docs/zh/shared/onAfterCreateCompiler.mdx
@@ -5,8 +5,10 @@
 - **类型：**
 
 ```ts
-function OnAfterCreateCompiler(callback: (params: {
-  compiler: Compiler | MultiCompiler;
-  environments: Record<string, EnvironmentContext>;
-}) => Promise<void> | void;): void;
+function OnAfterCreateCompiler(
+  callback: (params: {
+    compiler: Compiler | MultiCompiler;
+    environments: Record<string, EnvironmentContext>;
+  }) => Promise<void> | void,
+): void;
 ```


### PR DESCRIPTION
## Summary

This PR updates stale English and Chinese plugin API references to match the current implementations. Lengthy internal default-option logic is replaced with concise conceptual descriptions.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8188