### PR TITLE
chore: migrate nano-staged to Rstack CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,21 +26,13 @@
     "cross-env": "catalog:",
     "cspell-ban-words": "catalog:",
     "heading-case": "catalog:",
-    "nano-staged": "catalog:",
     "oxfmt": "catalog:",
     "rstack": "catalog:",
     "simple-git-hooks": "catalog:",
     "typescript": "catalog:"
   },
   "simple-git-hooks": {
-    "pre-commit": "pnpm exec nano-staged"
-  },
-  "nano-staged": {
-    "*.{md,mdx,json,css,less,scss}": "oxfmt --no-error-on-unmatched-pattern",
-    "*.{js,jsx,ts,tsx,mjs,cjs}": [
-      "rs lint --type-check",
-      "oxfmt --no-error-on-unmatched-pattern"
-    ]
+    "pre-commit": "pnpm exec rs staged"
   },
   "engines": {
     "node": ">=22.18.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,9 +241,6 @@ catalogs:
     mrmime:
       specifier: ^2.0.1
       version: 2.0.1
-    nano-staged:
-      specifier: ^1.0.2
-      version: 1.0.2
     on-finished:
       specifier: 2.4.1
       version: 2.4.1
@@ -405,9 +402,6 @@ importers:
       heading-case:
         specifier: 'catalog:'
         version: 1.1.3
-      nano-staged:
-        specifier: 'catalog:'
-        version: 1.0.2
       oxfmt:
         specifier: 'catalog:'
         version: 0.60.0(svelte@5.56.8)
@@ -4378,11 +4372,6 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-
-  nano-staged@1.0.2:
-    resolution: {integrity: sha512-Fytar3zHLY99nlMfqPPbraxZodqQAHPpdPRyYaplL+lB9DCR6pUrafxbG+Btz4+7fO5Rm/+DO4ZeDO/nLSUMhw==}
-    engines: {node: ^22 || >= 24}
-    hasBin: true
 
   nanoid@3.3.16:
     resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
@@ -8681,8 +8670,6 @@ snapshots:
     optional: true
 
   ms@2.1.3: {}
-
-  nano-staged@1.0.2: {}
 
   nanoid@3.3.16: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -94,7 +94,6 @@ catalog:
   'loader-utils': '^3.3.1'
   'memfs': '^4.64.0'
   'mrmime': '^2.0.1'
-  'nano-staged': '^1.0.2'
   'on-finished': '2.4.1'
   'open': '^11.0.0'
   'oxfmt': '^0.60.0'

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -1,5 +1,10 @@
 import { define } from 'rstack';
 
+define.staged({
+  '*.{md,mdx,json,css,less,scss}': 'oxfmt --no-error-on-unmatched-pattern',
+  '*.{js,jsx,ts,tsx,mjs,cjs}': ['rs lint --type-check', 'oxfmt --no-error-on-unmatched-pattern'],
+});
+
 define.lint(async () => {
   const { globalIgnores, js, ts } = await import('rstack/lint');
 


### PR DESCRIPTION
## Summary

This PR migrates pre-commit staged-file checks from `nano-staged` to Rstack CLI so they use the repository's unified toolchain. It moves the existing file patterns and commands to `define.staged`, updates the Git hook to run `rs staged`, and removes the obsolete `nano-staged` dependency while preserving the existing checks.

## Related Links

- https://rstack.rs/guide/cli/staged