### PR TITLE
fix(plugin-preact): use environment HMR config

### DIFF
--- a/packages/plugin-preact/src/index.ts
+++ b/packages/plugin-preact/src/index.ts
@@ -91,8 +91,8 @@ export const pluginPreact = (userOptions: PluginPreactOptions = {}): RsbuildPlug
       return mergeEnvironmentConfig(extraConfig, config);
     });
 
-    api.modifyBundlerChain(async (chain, { isDev, target }) => {
-      const config = api.getNormalizedConfig();
+    api.modifyBundlerChain(async (chain, { environment, isDev, target }) => {
+      const { config } = environment;
       const usePrefresh = isDev && options.prefreshEnabled && config.dev.hmr && target === 'web';
 
       if (!usePrefresh) {

--- a/packages/plugin-preact/tests/index.test.ts
+++ b/packages/plugin-preact/tests/index.test.ts
@@ -1,4 +1,5 @@
 import { createRsbuild } from '@rsbuild/core';
+import { matchPlugin } from '@scripts/test-helper';
 import { pluginPreact } from '../src';
 
 describe('plugins/preact', () => {
@@ -35,5 +36,36 @@ describe('plugins/preact', () => {
 
     const configs = await rsbuild.initConfigs();
     expect(configs[0].resolve?.alias).not.toMatchObject(preactAlias);
+  });
+
+  it('should respect the HMR config of each environment', async () => {
+    for (const hmr of [true, false]) {
+      const rsbuild = await createRsbuild({
+        cwd: __dirname,
+        config: {
+          mode: 'development',
+          dev: {
+            hmr,
+          },
+          environments: {
+            hmrEnabled: {
+              dev: {
+                hmr: true,
+              },
+            },
+            hmrDisabled: {
+              dev: {
+                hmr: false,
+              },
+            },
+          },
+          plugins: [pluginPreact()],
+        },
+      });
+
+      const configs = await rsbuild.initConfigs();
+      expect(matchPlugin(configs[0], 'PreactRefreshRspackPlugin')).toBeTruthy();
+      expect(matchPlugin(configs[1], 'PreactRefreshRspackPlugin')).toBeFalsy();
+    }
   });
 });


### PR DESCRIPTION
## Summary

Fix Preact Refresh setup in multi-environment builds so each environment uses its own `dev.hmr` setting instead of the top-level normalized config.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/8203