### PR TITLE
docs: clarify getNormalizedConfig usage

### DIFF
--- a/website/docs/en/plugins/dev/core.mdx
+++ b/website/docs/en/plugins/dev/core.mdx
@@ -244,6 +244,19 @@ const pluginFoo = () => ({
 });
 ```
 
+When a plugin hook provides [`environment`](/api/javascript-api/environment-api#environment-context) in its callback arguments, we recommend using `environment.config` to access the normalized config for the current environment. This config is created by merging the base config with the [config for the current environment](/guide/advanced/environments) and then normalizing the result.
+
+```ts
+const pluginFoo = () => ({
+  setup(api) {
+    api.onBeforeEnvironmentCompile(({ environment }) => {
+      const { config } = environment;
+      console.log(config.output.target);
+    });
+  },
+});
+```
+
 ## api.logger
 
 A logger instance that can be used to output logs in a format consistent with Rsbuild.

--- a/website/docs/en/shared/getNormalizedConfig.mdx
+++ b/website/docs/en/shared/getNormalizedConfig.mdx
@@ -1,16 +1,16 @@
-Get the normalized Rsbuild config for all environments or a specific one. Call this method only after the [modifyRsbuildConfig](/plugins/dev/hooks#modifyrsbuildconfig) hook has executed.
+Returns either the complete normalized Rsbuild config, including all environments, or the normalized config for a specific environment. You can call this method only after the [modifyRsbuildConfig](/plugins/dev/hooks#modifyrsbuildconfig) hook has completed.
 
-Compared with the `api.getRsbuildConfig` method, the config returned by this method has been normalized, and the type definition of the config will be narrowed. For example, the `undefined` type of `config.html` will be removed.
+Unlike [`getRsbuildConfig`](/plugins/dev/core#apigetrsbuildconfig), this method returns a normalized config with narrower types. For example, the type of `config.html` no longer includes `undefined`.
 
-We recommend using this method to get the Rsbuild config.
+Use `getNormalizedConfig()` to get the complete config, including all environments. To get the config for a specific environment, use `getNormalizedConfig({ environment: name })`.
 
 - **Type:**
 
 ```ts
 type GetNormalizedConfig = {
-  /** Get all normalized Rsbuild configurations */
+  /** Get the complete normalized config, including all environments */
   (): NormalizedConfig;
-  /** Get the normalized Rsbuild configuration of the specified environment */
+  /** Get the normalized config for a specific environment */
   (options: { environment: string }): NormalizedEnvironmentConfig;
 };
 ```

--- a/website/docs/zh/plugins/dev/core.mdx
+++ b/website/docs/zh/plugins/dev/core.mdx
@@ -244,6 +244,19 @@ const pluginFoo = () => ({
 });
 ```
 
+当插件钩子的回调参数中包含 [`environment`](/api/javascript-api/environment-api#environment-context) 时，建议通过 `environment.config` 获取当前环境的归一化配置。该配置由基础配置与[当前环境的配置](/guide/advanced/environments)合并后归一化得到。
+
+```ts
+const pluginFoo = () => ({
+  setup(api) {
+    api.onBeforeEnvironmentCompile(({ environment }) => {
+      const { config } = environment;
+      console.log(config.output.target);
+    });
+  },
+});
+```
+
 ## api.logger
 
 提供统一日志输出格式的实例，可以用于输出与 Rsbuild 一致的日志格式。

--- a/website/docs/zh/shared/getNormalizedConfig.mdx
+++ b/website/docs/zh/shared/getNormalizedConfig.mdx
@@ -1,14 +1,14 @@
-获取归一化后的全部 Rsbuild 配置，或指定环境的 Rsbuild 配置。该方法必须在 [modifyRsbuildConfig](/plugins/dev/hooks#modifyrsbuildconfig) 钩子执行完成后才能被调用。
+获取归一化后的完整 Rsbuild 配置（包含所有环境），或指定环境的归一化配置。该方法只能在 [modifyRsbuildConfig](/plugins/dev/hooks#modifyrsbuildconfig) 钩子执行完毕后调用。
 
-相较于 `getRsbuildConfig` 方法，该方法返回的配置经过了归一化处理，配置的类型定义会得到收敛，比如 `config.html` 的 `undefined` 类型将被移除。
+与 [`getRsbuildConfig`](/plugins/dev/core#apigetrsbuildconfig) 相比，该方法返回经过归一化处理、类型更明确的配置。例如，`config.html` 的类型不再包含 `undefined`。
 
-推荐优先使用该方法获取配置。
+使用 `getNormalizedConfig()` 获取包含所有环境的完整配置。如需获取指定环境的配置，则使用 `getNormalizedConfig({ environment: name })`。
 
 - **类型：**
 
 ```ts
 type GetNormalizedConfig = {
-  /** 获取归一化后的全部 Rsbuild 配置 */
+  /** 获取包含所有环境的完整归一化配置 */
   (): NormalizedConfig;
   /** 获取指定环境的归一化 Rsbuild 配置 */
   (options: { environment: string }): NormalizedEnvironmentConfig;


### PR DESCRIPTION
## Summary

Plugins can accidentally read the top-level normalized config when a hook is handling a specific environment. This PR clarifies the `getNormalizedConfig` overloads and adds an environment-scoped example that recommends using `environment.config`.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/8204