### PR TITLE
docs: improve plugin config guidance

### DIFF
--- a/website/docs/en/guide/migration/vite-plugin.mdx
+++ b/website/docs/en/guide/migration/vite-plugin.mdx
@@ -19,13 +19,17 @@ Rsbuild plugin is defined in a way similar to Vite, usually a function that acce
 
 The main difference is that Vite's hooks are defined directly on the plugin description object, while Rsbuild's hooks are accessed and called through the [api object](/plugins/dev/core). This allows you to control the timing of plugin API calls more flexibly.
 
+The following example transforms `.foo` files into JavaScript modules:
+
 - Vite plugin:
 
 ```ts title="vitePlugin.ts"
-const vitePlugin = (options) => ({
+const vitePlugin = () => ({
   name: 'vite-plugin',
-  transform() {
-    // ...
+  transform(code, id) {
+    if (id.endsWith('.foo')) {
+      return `export default ${JSON.stringify(code)};`;
+    }
   },
 });
 ```
@@ -33,11 +37,11 @@ const vitePlugin = (options) => ({
 - Rsbuild plugin:
 
 ```ts title="rsbuildPlugin.ts"
-const rsbuildPlugin = (options) => ({
+const rsbuildPlugin = () => ({
   name: 'rsbuild-plugin',
   setup(api) {
-    api.transform(() => {
-      // ...
+    api.transform({ test: /\.foo$/ }, ({ code }) => {
+      return `export default ${JSON.stringify(code)};`;
     });
   },
 });
@@ -143,6 +147,10 @@ const rsbuildPlugin = {
 
 Rsbuild provides the [api.getNormalizedConfig](/plugins/dev/core#apigetnormalizedconfig) method to get the resolved configuration. This method serves a similar purpose to Vite's `configResolved` hook.
 
+When a plugin hook provides an [environment context](/api/javascript-api/environment-api#environment-context), we recommend using `environment.config` to get the normalized config for the current environment.
+
+The following example reads the resolved config while transforming `.foo` files:
+
 - Vite plugin:
 
 ```ts title="vitePlugin.ts"
@@ -153,9 +161,12 @@ const vitePlugin = () => {
     configResolved(resolvedConfig) {
       config = resolvedConfig;
     },
-    transform() {
+    transform(code, id) {
+      if (!id.endsWith('.foo')) {
+        return;
+      }
       console.log(config);
-      // ...
+      return `export default ${JSON.stringify(code)};`;
     },
   };
 };
@@ -167,10 +178,10 @@ const vitePlugin = () => {
 const rsbuildPlugin = () => ({
   name: 'read-config',
   setup(api) {
-    api.transform(() => {
-      const config = api.getNormalizedConfig();
+    api.transform({ test: /\.foo$/ }, ({ code, environment }) => {
+      const { config } = environment;
       console.log(config);
-      // ...
+      return `export default ${JSON.stringify(code)};`;
     });
   },
 });

--- a/website/docs/en/plugins/dev/index.mdx
+++ b/website/docs/en/plugins/dev/index.mdx
@@ -194,7 +194,7 @@ Rsbuild does not take over the hooks of the underlying Rspack, whose documents c
 
 See [Migrate Vite plugin](/guide/migration/vite-plugin) to learn how to migrate a Vite plugin to Rsbuild plugin.
 
-## Read and modify Rsbuild config \{#use-rsbuild-config}
+## Read and modify Rsbuild config \{#read-and-modify-rsbuild-config}
 
 When a plugin needs to read or modify the project's Rsbuild config, use Rsbuild's config APIs.
 

--- a/website/docs/en/plugins/dev/index.mdx
+++ b/website/docs/en/plugins/dev/index.mdx
@@ -194,78 +194,68 @@ Rsbuild does not take over the hooks of the underlying Rspack, whose documents c
 
 See [Migrate Vite plugin](/guide/migration/vite-plugin) to learn how to migrate a Vite plugin to Rsbuild plugin.
 
-## Use Rsbuild config
+## Read and modify Rsbuild config \{#use-rsbuild-config}
 
-Custom plugins usually receive their options from the parameters passed to the initialization function, so you can define and use those arguments however you like.
+When a plugin needs to read or modify the project's Rsbuild config, use Rsbuild's config APIs.
 
-Sometimes a plugin needs to read or modify Rsbuild's configuration. To do that effectively, it's helpful to understand how Rsbuild generates and consumes its config:
+### Modify the base config
 
-- Read, parse config and merge with default values.
-- Plugins modify the config by `api.modifyRsbuildConfig(...)`.
-- Normalize the config and provide it to consume, then the config can no longer be modified.
-
-Refer to this tiny example:
+Register [api.modifyRsbuildConfig](/plugins/dev/hooks#modifyrsbuildconfig) during `setup` to modify the base config before it is merged with each environment's config:
 
 ```ts
-export const pluginUploadDist = (): RsbuildPlugin => ({
-  name: 'plugin-upload-dist',
-  setup(api) {
-    api.modifyRsbuildConfig((config) => {
-      // Try to disable minification.
-      config.output.minify = false;
-      // Other plugins might re-enable it...
-    });
-    api.onBeforeBuild(() => {
-      // use the normalized config.
-      const config = api.getNormalizedConfig();
-      if (config.output.minify !== false) {
-        // let it crash when enable minimize.
-        throw new Error('You must disable minimize to upload readable dist files.');
-      }
-    });
-    api.onAfterBuild(() => {
-      const config = api.getNormalizedConfig();
-      const distRoot = config.output.distPath.root;
-
-      // upload all files in `distRoot`...
-    });
-  },
+api.modifyRsbuildConfig((config) => {
+  config.output.minify = false;
 });
 ```
 
-There are 3 ways to use Rsbuild config:
+`modifyRsbuildConfig` is a global hook. If a change applies only to certain environments or depends on the current environment, use [api.modifyEnvironmentConfig](/plugins/dev/hooks#modifyenvironmentconfig) instead. See [Global hooks vs environment hooks](/plugins/dev/hooks#global-hooks-vs-environment-hooks) for details.
 
-- register callback with `api.modifyRsbuildConfig(config => {})` to modify config.
-- use `api.getRsbuildConfig()` to get Rsbuild config.
-- use `api.getNormalizedConfig()` to get finally normalized config.
+### Read the normalized config
 
-When normalized, the config object is merged with the default values again and most optional properties are removed, ensuring those fields are always available. For `pluginUploadDist`, part of its type looks like:
+After the config modification hooks have run, call [api.getNormalizedConfig](/plugins/dev/core#apigetnormalizedconfig) without arguments to get the complete normalized config for all environments. It includes default values, so its type is narrower than the value returned by [api.getRsbuildConfig](/plugins/dev/core#apigetrsbuildconfig).
 
 ```ts
-api.modifyRsbuildConfig((config: RsbuildConfig) => {});
-api.getRsbuildConfig() as RsbuildConfig;
-type RsbuildConfig = {
-  output?: {
-    minify?: boolean;
-    distPath?: { root?: string };
-  };
-};
-
-api.getNormalizedConfig() as NormalizedConfig;
-type NormalizedConfig = {
-  output: {
-    minify: boolean;
-    distPath: { root: string };
-  };
-};
+api.onBeforeBuild(() => {
+  const config = api.getNormalizedConfig();
+  console.log(Object.keys(config.environments));
+});
 ```
 
-The return type of `getNormalizedConfig()` differs slightly from `RsbuildConfig`; it's narrower because defaults have already been applied. You don't need to provide default values when you use it.
+If no environment context is available but you need the config for one environment, pass its name to `getNormalizedConfig`:
 
-Therefore, the best way to use configuration options is to:
+```ts
+api.onBeforeBuild(() => {
+  const config = api.getNormalizedConfig({ environment: 'web' });
+  console.log(config.output.target);
+});
+```
 
-- **Modify the config** with `api.modifyRsbuildConfig(config => {})`.
-- Read `api.getNormalizedConfig()` as the **actual config used by the plugin** later in its lifecycle.
+See [NormalizedConfig](/api/javascript-api/types#normalizedconfig) and [NormalizedEnvironmentConfig](/api/javascript-api/types#normalizedenvironmentconfig) for their return types.
+
+### Read the current environment config \{#current-environment-config}
+
+When a hook callback includes an [environment context](/api/javascript-api/environment-api#environment-context), prefer `environment.config`. It is the normalized result of merging the base config with the [current environment's config](/guide/advanced/environments).
+
+```ts
+api.onBeforeEnvironmentCompile(({ environment }) => {
+  const { name, config } = environment;
+  console.log(`${name}: ${config.output.target}`);
+});
+```
+
+### Read all environment configs
+
+Global hooks such as [onBeforeBuild](/plugins/dev/hooks#onbeforebuild) and [onAfterBuild](/plugins/dev/hooks#onafterbuild) receive `environments`, which contains the context for every environment. Iterate over it when a plugin needs to read each environment's config:
+
+```ts
+api.onBeforeBuild(({ environments }) => {
+  for (const { name, config } of Object.values(environments)) {
+    console.log(`${name}: ${config.output.distPath.root}`);
+  }
+});
+```
+
+See [Multi-environment builds](/guide/advanced/environments) for more details about environment configs.
 
 ## Modify Rspack configuration
 

--- a/website/docs/zh/guide/migration/vite-plugin.mdx
+++ b/website/docs/zh/guide/migration/vite-plugin.mdx
@@ -19,13 +19,17 @@ Rsbuild 插件的定义方式与 Vite 相似，通常都是一个接收插件选
 
 两者的主要区别在于：Vite 的 hooks 直接定义在插件描述对象上，而 Rsbuild 的 hooks 是通过 [api 对象](/plugins/dev/core) 来访问和调用，这允许你更灵活地控制插件 API 的调用时机。
 
+以下示例将 `.foo` 文件转换为 JavaScript 模块：
+
 - Vite 插件：
 
 ```ts title="vitePlugin.ts"
-const vitePlugin = (options) => ({
+const vitePlugin = () => ({
   name: 'vite-plugin',
-  transform() {
-    // ...
+  transform(code, id) {
+    if (id.endsWith('.foo')) {
+      return `export default ${JSON.stringify(code)};`;
+    }
   },
 });
 ```
@@ -33,11 +37,11 @@ const vitePlugin = (options) => ({
 - Rsbuild 插件：
 
 ```ts title="rsbuildPlugin.ts"
-const rsbuildPlugin = (options) => ({
+const rsbuildPlugin = () => ({
   name: 'rsbuild-plugin',
   setup(api) {
-    api.transform(() => {
-      // ...
+    api.transform({ test: /\.foo$/ }, ({ code }) => {
+      return `export default ${JSON.stringify(code)};`;
     });
   },
 });
@@ -143,6 +147,10 @@ const rsbuildPlugin = {
 
 Rsbuild 提供了 [api.getNormalizedConfig](/plugins/dev/core#apigetnormalizedconfig) 方法来获取已解析的配置。这个方法与 Vite 的 `configResolved` 钩子的使用场景类似。
 
+当插件钩子提供 [environment context](/api/javascript-api/environment-api#environment-context) 时，建议通过 `environment.config` 获取当前环境的归一化配置。
+
+以下示例在转换 `.foo` 文件时读取归一化配置：
+
 - Vite 插件：
 
 ```ts title="vitePlugin.ts"
@@ -153,9 +161,12 @@ const vitePlugin = () => {
     configResolved(resolvedConfig) {
       config = resolvedConfig;
     },
-    transform() {
+    transform(code, id) {
+      if (!id.endsWith('.foo')) {
+        return;
+      }
       console.log(config);
-      // ...
+      return `export default ${JSON.stringify(code)};`;
     },
   };
 };
@@ -167,10 +178,10 @@ const vitePlugin = () => {
 const rsbuildPlugin = () => ({
   name: 'read-config',
   setup(api) {
-    api.transform(() => {
-      const config = api.getNormalizedConfig();
+    api.transform({ test: /\.foo$/ }, ({ code, environment }) => {
+      const { config } = environment;
       console.log(config);
-      // ...
+      return `export default ${JSON.stringify(code)};`;
     });
   },
 });

--- a/website/docs/zh/plugins/dev/index.mdx
+++ b/website/docs/zh/plugins/dev/index.mdx
@@ -194,81 +194,68 @@ Rsbuild 不会接管底层 Rspack 的生命周期，相关生命周期钩子的�
 
 参考 [迁移 Vite 插件](/guide/migration/vite-plugin) 了解如何迁移一个 Vite 插件到 Rsbuild 插件。
 
-## 使用配置项
+## 读写 Rsbuild 配置 \{#use-rsbuild-config}
 
-自行编写的插件通常使用初始化时传入函数的参数作为配置项即可，开发者可以随意定义和使用函数的入参。
+当插件需要读取或修改项目的 Rsbuild 配置时，可以使用 Rsbuild 提供的配置 API。
 
-但某些情况下插件可能需要读取 / 修改 Rsbuild 公用的配置项，这时就需要了解 Rsbuild 内部对配置项的生产和消费流程：
+### 修改基础配置 \{#modify-the-base-config}
 
-- 读取、解析配置并合并默认值
-- 插件通过 `api.modifyRsbuildConfig(...)` 回调修改配置项
-- 归一化配置项并提供给插件后续消费，此后无法再修改配置项
-
-整套流程可以通过这个简单的插件体现：
+在 `setup` 中注册 [api.modifyRsbuildConfig](/plugins/dev/hooks#modifyrsbuildconfig)，可以在基础配置与各个 environment 的配置合并前对其进行修改：
 
 ```ts
-export const pluginUploadDist = (): RsbuildPlugin => ({
-  name: 'plugin-upload-dist',
-  setup(api) {
-    api.modifyRsbuildConfig((config) => {
-      // 关闭代码压缩
-      config.output.minify = false;
-      // 轮到其它插件修改配置...
-    });
-
-    api.onBeforeBuild(() => {
-      // 读取最终的配置
-      const config = api.getNormalizedConfig();
-      if (config.output.minify !== false) {
-        // 其它插件又启用了压缩则报错
-        throw new Error('You must disable minimize to upload readable dist files.');
-      }
-    });
-
-    api.onAfterBuild(() => {
-      const config = api.getNormalizedConfig();
-      const distRoot = config.output.distPath.root;
-
-      // 上传 `distRoot` 目录下所有产物文件...
-    });
-  },
+api.modifyRsbuildConfig((config) => {
+  config.output.minify = false;
 });
 ```
 
-插件中有三种方式使用配置项对象：
+`modifyRsbuildConfig` 是全局 hook。如果修改仅针对部分 environment，或需要根据当前 environment 调整配置，建议改用 [api.modifyEnvironmentConfig](/plugins/dev/hooks#modifyenvironmentconfig)。详细说明请参考[全局 hooks 与 environment hooks](/plugins/dev/hooks#global-hooks-vs-environment-hooks)。
 
-- `api.modifyRsbuildConfig(config => {})` 在回调中修改配置
-- `api.getRsbuildConfig()` 获取配置项
-- `api.getNormalizedConfig()` 获取归一化后的配置项
+### 读取归一化配置 \{#read-the-normalized-config}
 
-归一化的配置项会再次合并默认值，并移除大部分可选类型，对于 `PluginUploadDist` 的例子，其部分类型定义为：
+配置修改 hooks 执行完毕后，可以无参数调用 [api.getNormalizedConfig](/plugins/dev/core#apigetnormalizedconfig)，获取包含所有 environment 的完整归一化配置。该配置包含默认值，类型也比 [api.getRsbuildConfig](/plugins/dev/core#apigetrsbuildconfig) 的返回值更明确。
 
 ```ts
-api.modifyRsbuildConfig((config: RsbuildConfig) => {});
-api.getRsbuildConfig() as RsbuildConfig;
-type RsbuildConfig = {
-  output?: {
-    minify?: boolean;
-    distPath?: { root?: string };
-  };
-};
-
-api.getNormalizedConfig() as NormalizedConfig;
-type NormalizedConfig = {
-  output: {
-    minify: boolean;
-    distPath: { root: string };
-  };
-};
+api.onBeforeBuild(() => {
+  const config = api.getNormalizedConfig();
+  console.log(Object.keys(config.environments));
+});
 ```
 
-`getNormalizedConfig()` 的返回值类型与 `RsbuildConfig` 的略有不同、相比文档其它地方描述的类型进行了收窄，
-在使用时无需自行判空、填充默认值。
+如果当前没有 environment context，但需要读取某个 environment 的配置，可以将其名称传给 `getNormalizedConfig`：
 
-因此使用配置项的最佳方式应该是：
+```ts
+api.onBeforeBuild(() => {
+  const config = api.getNormalizedConfig({ environment: 'web' });
+  console.log(config.output.target);
+});
+```
 
-- 通过 `api.modifyRsbuildConfig(config => {})` 来**修改配置**
-- 在其后的生命周期中读取 `api.getNormalizedConfig()` 作为插件**实际使用的配置**
+返回值类型请参考 [NormalizedConfig](/api/javascript-api/types#normalizedconfig) 和 [NormalizedEnvironmentConfig](/api/javascript-api/types#normalizedenvironmentconfig)。
+
+### 读取当前环境的配置 \{#current-environment-config}
+
+当 hook 的回调参数中包含 [environment context](/api/javascript-api/environment-api#environment-context) 时，建议通过 `environment.config` 获取配置。该配置由基础配置与[当前 environment 的配置](/guide/advanced/environments)合并后归一化得到。
+
+```ts
+api.onBeforeEnvironmentCompile(({ environment }) => {
+  const { name, config } = environment;
+  console.log(`${name}: ${config.output.target}`);
+});
+```
+
+### 读取所有环境的配置 \{#read-all-environment-configs}
+
+[onBeforeBuild](/plugins/dev/hooks#onbeforebuild) 和 [onAfterBuild](/plugins/dev/hooks#onafterbuild) 等全局 hooks 会提供 `environments`，其中包含所有 environment 的上下文。当插件需要读取每个 environment 的配置时，可以遍历该对象：
+
+```ts
+api.onBeforeBuild(({ environments }) => {
+  for (const { name, config } of Object.values(environments)) {
+    console.log(`${name}: ${config.output.distPath.root}`);
+  }
+});
+```
+
+多环境配置的详细说明请参考[多环境构建](/guide/advanced/environments)。
 
 ## 修改 Rspack 配置
 

--- a/website/docs/zh/plugins/dev/index.mdx
+++ b/website/docs/zh/plugins/dev/index.mdx
@@ -194,7 +194,7 @@ Rsbuild 不会接管底层 Rspack 的生命周期，相关生命周期钩子的�
 
 参考 [迁移 Vite 插件](/guide/migration/vite-plugin) 了解如何迁移一个 Vite 插件到 Rsbuild 插件。
 
-## 读写 Rsbuild 配置 \{#use-rsbuild-config}
+## 读写 Rsbuild 配置 \{#read-and-modify-rsbuild-config}
 
 当插件需要读取或修改项目的 Rsbuild 配置时，可以使用 Rsbuild 提供的配置 API。
 


### PR DESCRIPTION
## Summary

Plugin developers need clearer guidance on choosing between global and environment-scoped Rsbuild configs. This PR rewrites the plugin configuration section into practical guides for modifying the base config, reading normalized config, and handling one or all environments. It also replaces abstract Vite migration snippets with minimal `.foo` transform examples that demonstrate `environment.config`.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/8208