### PR TITLE
docs: refine normalized config terminology

### DIFF
--- a/website/docs/zh/api/javascript-api/environment-api.mdx
+++ b/website/docs/zh/api/javascript-api/environment-api.mdx
@@ -72,7 +72,7 @@ api.modifyRspackConfig((config, { environment }) => {
 
 ### config
 
-当前环境使用的 Rsbuild 配置（经过归一化处理）。
+当前环境使用的 Rsbuild 配置（已经过规范化处理）。
 
 - **类型：**
 

--- a/website/docs/zh/api/javascript-api/types.mdx
+++ b/website/docs/zh/api/javascript-api/types.mdx
@@ -46,7 +46,7 @@ import type {
 
 ## NormalizedConfig
 
-Rsbuild 配置归一化后的类型，对应 [getNormalizedConfig](/plugins/dev/core#apigetnormalizedconfig) 方法的返回值。
+Rsbuild 配置经过规范化后的类型，对应 [getNormalizedConfig](/plugins/dev/core#apigetnormalizedconfig) 方法的返回值。
 
 ```ts
 import type { NormalizedConfig } from '@rsbuild/core';
@@ -54,7 +54,7 @@ import type { NormalizedConfig } from '@rsbuild/core';
 const config: NormalizedConfig = api.getNormalizedConfig();
 ```
 
-你也可以引用归一化后的 Rsbuild 配置中各个字段的类型定义：
+你也可以引用规范化后的 Rsbuild 配置中各个字段的类型定义：
 
 ```ts
 import type {
@@ -72,7 +72,7 @@ import type {
 
 ## NormalizedEnvironmentConfig
 
-指定环境下的 Rsbuild 归一化配置类型，对应 [`getNormalizedConfig({ environment })`](/plugins/dev/core#apigetnormalizedconfig) 方法的返回值。
+指定环境下经过规范化的 Rsbuild 配置类型，对应 [`getNormalizedConfig({ environment })`](/plugins/dev/core#apigetnormalizedconfig) 方法的返回值。
 
 ```ts
 import type { NormalizedEnvironmentConfig } from '@rsbuild/core';

--- a/website/docs/zh/guide/migration/vite-plugin.mdx
+++ b/website/docs/zh/guide/migration/vite-plugin.mdx
@@ -147,9 +147,9 @@ const rsbuildPlugin = {
 
 Rsbuild 提供了 [api.getNormalizedConfig](/plugins/dev/core#apigetnormalizedconfig) 方法来获取已解析的配置。这个方法与 Vite 的 `configResolved` 钩子的使用场景类似。
 
-当插件钩子提供 [environment context](/api/javascript-api/environment-api#environment-context) 时，建议通过 `environment.config` 获取当前环境的归一化配置。
+当插件钩子提供 [environment context](/api/javascript-api/environment-api#environment-context) 时，建议通过 `environment.config` 获取当前环境的规范化配置。
 
-以下示例在转换 `.foo` 文件时读取归一化配置：
+以下示例在转换 `.foo` 文件时读取规范化后的配置：
 
 - Vite 插件：
 

--- a/website/docs/zh/plugins/dev/core.mdx
+++ b/website/docs/zh/plugins/dev/core.mdx
@@ -244,7 +244,7 @@ const pluginFoo = () => ({
 });
 ```
 
-当插件钩子的回调参数中包含 [`environment`](/api/javascript-api/environment-api#environment-context) 时，建议通过 `environment.config` 获取当前环境的归一化配置。该配置由基础配置与[当前环境的配置](/guide/advanced/environments)合并后归一化得到。
+当插件钩子的回调参数中包含 [`environment`](/api/javascript-api/environment-api#environment-context) 时，建议通过 `environment.config` 获取当前环境的规范化配置。该配置由基础配置与[当前环境的配置](/guide/advanced/environments)合并并经过规范化处理后得到。
 
 ```ts
 const pluginFoo = () => ({

--- a/website/docs/zh/plugins/dev/index.mdx
+++ b/website/docs/zh/plugins/dev/index.mdx
@@ -210,9 +210,9 @@ api.modifyRsbuildConfig((config) => {
 
 `modifyRsbuildConfig` 是全局 hook。如果修改仅针对部分 environment，或需要根据当前 environment 调整配置，建议改用 [api.modifyEnvironmentConfig](/plugins/dev/hooks#modifyenvironmentconfig)。详细说明请参考[全局 hooks 与 environment hooks](/plugins/dev/hooks#global-hooks-vs-environment-hooks)。
 
-### 读取归一化配置 \{#read-the-normalized-config}
+### 读取规范化后的配置 \{#read-the-normalized-config}
 
-配置修改 hooks 执行完毕后，可以无参数调用 [api.getNormalizedConfig](/plugins/dev/core#apigetnormalizedconfig)，获取包含所有 environment 的完整归一化配置。该配置包含默认值，类型也比 [api.getRsbuildConfig](/plugins/dev/core#apigetrsbuildconfig) 的返回值更明确。
+配置修改 hooks 执行完毕后，可以无参数调用 [api.getNormalizedConfig](/plugins/dev/core#apigetnormalizedconfig)，获取包含所有 environment 的完整配置。该配置已经过规范化处理并包含默认值，类型也比 [api.getRsbuildConfig](/plugins/dev/core#apigetrsbuildconfig) 的返回值更明确。
 
 ```ts
 api.onBeforeBuild(() => {
@@ -234,7 +234,7 @@ api.onBeforeBuild(() => {
 
 ### 读取当前环境的配置 \{#current-environment-config}
 
-当 hook 的回调参数中包含 [environment context](/api/javascript-api/environment-api#environment-context) 时，建议通过 `environment.config` 获取配置。该配置由基础配置与[当前 environment 的配置](/guide/advanced/environments)合并后归一化得到。
+当 hook 的回调参数中包含 [environment context](/api/javascript-api/environment-api#environment-context) 时，建议通过 `environment.config` 获取配置。该配置由基础配置与[当前 environment 的配置](/guide/advanced/environments)合并并经过规范化处理后得到。
 
 ```ts
 api.onBeforeEnvironmentCompile(({ environment }) => {

--- a/website/docs/zh/shared/getNormalizedConfig.mdx
+++ b/website/docs/zh/shared/getNormalizedConfig.mdx
@@ -1,6 +1,6 @@
-获取归一化后的完整 Rsbuild 配置（包含所有环境），或指定环境的归一化配置。该方法只能在 [modifyRsbuildConfig](/plugins/dev/hooks#modifyrsbuildconfig) 钩子执行完毕后调用。
+获取规范化后的完整 Rsbuild 配置（包含所有环境），或指定环境的规范化配置。该方法只能在 [modifyRsbuildConfig](/plugins/dev/hooks#modifyrsbuildconfig) 钩子执行完毕后调用。
 
-与 [`getRsbuildConfig`](/plugins/dev/core#apigetrsbuildconfig) 相比，该方法返回经过归一化处理、类型更明确的配置。例如，`config.html` 的类型不再包含 `undefined`。
+与 [`getRsbuildConfig`](/plugins/dev/core#apigetrsbuildconfig) 相比，该方法返回经过规范化处理、类型更明确的配置。例如，`config.html` 的类型不再包含 `undefined`。
 
 使用 `getNormalizedConfig()` 获取包含所有环境的完整配置。如需获取指定环境的配置，则使用 `getNormalizedConfig({ environment: name })`。
 
@@ -8,9 +8,9 @@
 
 ```ts
 type GetNormalizedConfig = {
-  /** 获取包含所有环境的完整归一化配置 */
+  /** 获取包含所有环境的完整规范化配置 */
   (): NormalizedConfig;
-  /** 获取指定环境的归一化 Rsbuild 配置 */
+  /** 获取指定环境的规范化 Rsbuild 配置 */
   (options: { environment: string }): NormalizedEnvironmentConfig;
 };
 ```

--- a/website/docs/zh/shared/getRsbuildConfig.mdx
+++ b/website/docs/zh/shared/getRsbuildConfig.mdx
@@ -23,7 +23,7 @@ getRsbuildConfig('original');
 // 比如 `modifyRsbuildConfig` 钩子执行后会修改当前 Rsbuild 配置的内容。
 getRsbuildConfig('current');
 
-// 获取归一化后的 Rsbuild 配置。
+// 获取规范化后的 Rsbuild 配置。
 // 该方法必须在 `modifyRsbuildConfig` 钩子执行完成后才能被调用。
 // 等价于 `getNormalizedConfig` 方法。
 getRsbuildConfig('normalized');


### PR DESCRIPTION
## Summary

The Chinese docs currently translate `normalized config` as “归一化配置,” which can sound mathematical and is uncommon in frontend documentation. This PR consistently uses “规范化配置” across the Chinese API and plugin docs while keeping the English terminology and anchor IDs unchanged.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/8209