### PR TITLE
perf(core): avoid eager asset source reads

### DIFF
--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -297,13 +297,15 @@ async function printFileSizes(
     const compilationAssets = stats.compilation.assets;
 
     for (const assetName of Object.keys(compilationAssets)) {
-      const value = compilationAssets[assetName];
       const filePath = getFilePath(assetName);
 
       if (!exclude && EXCLUDE_ASSET_REGEX.test(filePath)) {
         continue;
       }
 
+      // Accessing an asset retrieves its Source through the Rust-JS bridge,
+      // so filter by filename before reading it.
+      const value = compilationAssets[assetName];
       const content = options.compressed && isCompressible(filePath) ? value.source() : undefined;
       const size = content === undefined ? value.size() : Buffer.byteLength(content);
 


### PR DESCRIPTION
## Summary

File size reporting currently reads every Rspack asset Source before applying the default filename exclusions, adding unnecessary Rust–JS bridge and memory overhead for source maps and other excluded assets.

This PR applies filename-based exclusions before retrieving the Source, without changing report behavior. In a synthetic benchmark with 1,200 assets and 40 retained, Source reads dropped from 1,200 to 40.

## Related Links

https://github.com/web-infra-dev/rspress/pull/3459