### PR TITLE
perf(core): avoid reading inlined asset sources

### DIFF
--- a/packages/core/src/plugins/inlineChunk.ts
+++ b/packages/core/src/plugins/inlineChunk.ts
@@ -255,16 +255,21 @@ export const pluginInlineChunk = (): RsbuildPlugin => ({
 
         const hasSourceMap = devtool !== 'hidden-source-map' && devtool !== false;
         for (const name of inlinedAssets) {
-          const asset = compilation.assets[name];
-          if (!asset) {
-            continue;
-          }
-          // Preserve source maps of inlined assets. Setting `related.sourceMap` to `null` prevents
-          // `deleteAsset` from removing the source map file.
           if (hasSourceMap) {
+            const asset = compilation.assets[name];
+            if (!asset) {
+              continue;
+            }
+            // Preserve source maps of inlined assets. Setting `related.sourceMap` to `null` prevents
+            // `deleteAsset` from removing the source map file.
             compilation.updateAsset(name, asset, {
               related: { sourceMap: null },
             });
+          } else {
+            // Check existence without retrieving the Source through the Rust-JS bridge.
+            if (!(name in compilation.assets)) {
+              continue;
+            }
           }
           compilation.deleteAsset(name);
         }


### PR DESCRIPTION
## Summary

This PR avoids retrieving inlined asset sources when source maps are disabled, eliminating unnecessary Rust–JavaScript bridge work during asset cleanup. It uses the assets proxy's existence check before deletion while preserving the existing source-map handling path.

## Related Links

https://github.com/web-infra-dev/rspress/pull/3459