### PR TITLE
fix(core): check favicon asset by output path

### DIFF
--- a/e2e/cases/html/favicon/index.test.ts
+++ b/e2e/cases/html/favicon/index.test.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import { expect, test } from '@e2e/helper';
 import { findFile, getFileContent } from '@rstackjs/test-utils';
+import type { Rspack } from '@rsbuild/core';
 import fse from 'fs-extra';
 
 test('should emit local favicon to dist path', async ({ build }) => {
@@ -125,6 +126,41 @@ test('should allow to custom favicon dist path with a relative path', async ({ b
       output: {
         distPath: {
           favicon: 'static/favicon',
+        },
+      },
+    },
+  });
+
+  const files = rsbuild.getDistFiles();
+  const faviconFile = findFile(files, 'static/favicon/icon.png');
+  expect(faviconFile.endsWith('/static/favicon/icon.png')).toBeTruthy();
+
+  const html = getFileContent(files, 'index.html');
+  expect(html).toContain('<link rel="icon" href="/static/favicon/icon.png">');
+});
+
+test('should distinguish favicon output path from assets with the same basename', async ({
+  build,
+}) => {
+  const rsbuild = await build({
+    config: {
+      html: {
+        favicon: '../../../assets/icon.png',
+      },
+      output: {
+        distPath: {
+          favicon: 'static/favicon',
+        },
+      },
+      tools: {
+        rspack(_config, { appendPlugins, rspack }) {
+          appendPlugins({
+            apply(compiler: Rspack.Compiler) {
+              compiler.hooks.thisCompilation.tap('test-favicon-output-path', (compilation) => {
+                compilation.emitAsset('icon.png', new rspack.sources.RawSource('root icon'));
+              });
+            },
+          });
         },
       },
     },

--- a/packages/core/src/rspack-plugins/RsbuildHtmlPlugin.ts
+++ b/packages/core/src/rspack-plugins/RsbuildHtmlPlugin.ts
@@ -251,9 +251,11 @@ export class RsbuildHtmlPlugin {
       logger: Logger;
     }) => {
       const name = path.basename(favicon);
+      const outputFilename = path.posix.join(faviconDistPath, name);
 
-      if (compilation.assets[name]) {
-        return name;
+      // Check existence without retrieving the Source through the Rust-JS bridge.
+      if (outputFilename in compilation.assets) {
+        return outputFilename;
       }
 
       const inputFs = compilation.inputFileSystem;
@@ -288,7 +290,6 @@ export class RsbuildHtmlPlugin {
       }
 
       const source = new rspack.sources.RawSource(fileContent, false);
-      const outputFilename = path.posix.join(faviconDistPath, name);
       compilation.emitAsset(outputFilename, source);
 
       return outputFilename;


### PR DESCRIPTION
## Summary

Favicon emission checks the asset basename even though the asset is emitted under its configured output path. This can miss an existing favicon in multi-page builds with a custom favicon directory, causing repeated file reads and emissions, or incorrectly match a root asset with the same basename. This PR checks the full output filename through the assets proxy without retrieving its Source.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/8222
https://github.com/web-infra-dev/rspress/pull/3459