### PR TITLE
perf(core): defer inline asset source reads

### DIFF
--- a/packages/core/src/plugins/inlineChunk.ts
+++ b/packages/core/src/plugins/inlineChunk.ts
@@ -45,14 +45,31 @@ function updateSourceMappingURL({
   return source;
 }
 
-function matchTests(name: string, asset: Rspack.sources.Source, tests: InlineChunkTest[]) {
-  return tests.some((test) => {
+function getMatchedAsset(
+  name: string,
+  assets: Rspack.Compilation['assets'],
+  tests: InlineChunkTest[],
+) {
+  let asset: Rspack.sources.Source | undefined;
+  const matched = tests.some((test) => {
     if (isFunction(test)) {
+      asset ??= assets[name];
+      if (!asset) {
+        return false;
+      }
       const size = asset.size();
       return test({ name, size });
     }
     return test.exec(name);
   });
+
+  if (!matched) {
+    return;
+  }
+
+  // Accessing an asset retrieves its Source through the Rust-JS bridge,
+  // so defer the lookup until the filename matches.
+  return asset ?? assets[name];
 }
 
 export function getInlineTests(config: NormalizedEnvironmentConfig): {
@@ -134,14 +151,8 @@ export const pluginInlineChunk = (): RsbuildPlugin => ({
       const { src, ...otherAttrs } = tag.attrs;
       const scriptName = publicPath ? src.replace(publicPath, '') : src;
 
-      // If asset is not found, skip it
-      const asset = assets[scriptName];
-      if (asset == null) {
-        return tag;
-      }
-
-      const shouldInline = matchTests(scriptName, asset, scriptTests);
-      if (!shouldInline) {
+      const asset = getMatchedAsset(scriptName, assets, scriptTests);
+      if (!asset) {
         return tag;
       }
 
@@ -183,14 +194,8 @@ export const pluginInlineChunk = (): RsbuildPlugin => ({
 
       const linkName = publicPath ? tag.attrs.href.replace(publicPath, '') : tag.attrs.href;
 
-      // If asset is not found, skip it
-      const asset = assets[linkName];
-      if (asset == null) {
-        return tag;
-      }
-
-      const shouldInline = matchTests(linkName, asset, styleTests);
-      if (!shouldInline) {
+      const asset = getMatchedAsset(linkName, assets, styleTests);
+      if (!asset) {
         return tag;
       }
 


### PR DESCRIPTION
## Summary

Inline chunk filtering currently retrieves each script and style asset source before checking filename-based tests, which adds unnecessary Rust–JS bridge work for non-matching files.

This PR matches RegExp tests before reading the asset and reuses the retrieved source when function tests need its size.

## Related Links

- https://github.com/web-infra-dev/rspress/pull/3459
- https://github.com/web-infra-dev/rsbuild/pull/8222