### PR TITLE
chore: switch VS Code formatter to Prettier

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,7 @@
   "mdx.validate.validateFileLinks": "ignore",
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   // Temporary workaround until we switch to the Rstack VS Code extension.
+  "prettier.printWidth": 100,
   "prettier.singleQuote": true,
   "js/ts.tsdk.path": "node_modules/typescript/lib",
   "json.schemas": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,9 @@
     "**/.DS_Store": true
   },
   "mdx.validate.validateFileLinks": "ignore",
-  "editor.defaultFormatter": "oxc.oxc-vscode",
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  // Temporary workaround until we switch to the Rstack VS Code extension.
+  "prettier.singleQuote": true,
   "js/ts.tsdk.path": "node_modules/typescript/lib",
   "json.schemas": [
     {
@@ -27,12 +29,12 @@
     }
   ],
   "[typescript]": {
-    "editor.defaultFormatter": "oxc.oxc-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[javascript]": {
-    "editor.defaultFormatter": "oxc.oxc-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[mdx]": {
-    "editor.defaultFormatter": "oxc.oxc-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   }
 }


### PR DESCRIPTION
## Summary

This PR aligns the VS Code workspace formatting setup with Rspack by temporarily using Prettier until the Rstack VS Code extension is adopted. It also enables single-quote formatting to preserve the repository style.