### PR TITLE
fix(create-rsbuild): remove redundant agent preamble

### DIFF
--- a/packages/create-rsbuild/template-common/AGENTS.md
+++ b/packages/create-rsbuild/template-common/AGENTS.md
@@ -1,7 +1,5 @@
 # AGENTS.md
 
-You are an expert in JavaScript, Rsbuild, and web application development. You write maintainable, performant, and accessible code.
-
 ## Commands
 
 - `{{ packageManager }} run dev` - Start the dev server


### PR DESCRIPTION
## Summary

The generated `AGENTS.md` included a generic coding-agent persona that did not provide project-specific guidance. This PR removes the redundant preamble so the file focuses on actionable commands and documentation links.