### PR TITLE
chore(deps): upgrade rstack to v0.4.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,8 +314,8 @@ catalogs:
       specifier: ^1.0.4
       version: 1.0.4
     rstack:
-      specifier: ^0.3.4
-      version: 0.3.4
+      specifier: ^0.4.0
+      version: 0.4.0
     sass:
       specifier: ^1.102.0
       version: 1.102.0
@@ -401,7 +401,7 @@ importers:
         version: 1.1.4
       rstack:
         specifier: 'catalog:'
-        version: 0.3.4(@module-federation/runtime-tools@2.8.1)(@rspress/core@2.0.19)(core-js@3.49.0)(jiti@2.7.0)(typescript@6.0.3)
+        version: 0.4.0(@module-federation/runtime-tools@2.8.1)(@rspress/core@2.0.19)(core-js@3.49.0)(jiti@2.7.0)(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1342,7 +1342,7 @@ importers:
         version: 0.6.0
       rstack:
         specifier: 'catalog:'
-        version: 0.3.4(@module-federation/runtime-tools@2.8.1)(@rspress/core@2.0.19)(core-js@3.49.0)(jiti@2.7.0)(typescript@6.0.3)
+        version: 0.4.0(@module-federation/runtime-tools@2.8.1)(@rspress/core@2.0.19)(core-js@3.49.0)(jiti@2.7.0)(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1414,7 +1414,7 @@ importers:
         version: 1.0.4(@rspress/core@2.0.19)
       rstack:
         specifier: 'catalog:'
-        version: 0.3.4(@module-federation/runtime-tools@2.8.1)(@rspress/core@2.0.19)(core-js@3.49.0)(jiti@2.7.0)(typescript@6.0.3)
+        version: 0.4.0(@module-federation/runtime-tools@2.8.1)(@rspress/core@2.0.19)(core-js@3.49.0)(jiti@2.7.0)(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -4756,8 +4756,8 @@ packages:
     peerDependencies:
       '@rspress/core': ^2.0.0
 
-  rstack@0.3.4:
-    resolution: {integrity: sha512-1rdpf/uEb7+VrvlSr6TlvcVP4BmNb4OC+fqwhf+h2ti84eyTXg3loFds57d5MZmiPZ0zXuBMpQ/PlH9z/xiYLw==}
+  rstack@0.4.0:
+    resolution: {integrity: sha512-D+UoBYDhmoWbvCMCfVEFQOe+wdrPPAZXYCUppDVy/KRGC8UOKruyjlTzh3IA9zCzGT7gVDziIQXBuhULmJJpgA==}
     engines: {node: '>=22.12.0'}
     hasBin: true
     peerDependencies:
@@ -8994,7 +8994,7 @@ snapshots:
     dependencies:
       '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.8)(core-js@3.49.0)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@8.1.1)
 
-  rstack@0.3.4(@module-federation/runtime-tools@2.8.1)(@rspress/core@2.0.19)(core-js@3.49.0)(jiti@2.7.0)(typescript@6.0.3):
+  rstack@0.4.0(@module-federation/runtime-tools@2.8.1)(@rspress/core@2.0.19)(core-js@3.49.0)(jiti@2.7.0)(typescript@6.0.3):
     dependencies:
       '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)(core-js@3.49.0)
       '@rslib/core': 1.0.0-beta.2(@module-federation/runtime-tools@2.8.1)(core-js@3.49.0)(typescript@6.0.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -118,7 +118,7 @@ catalog:
   'rspack-merge': '1.0.1'
   'rspack-vue-loader': '^17.6.1'
   'rspress-plugin-font-open-sans': '^1.0.4'
-  'rstack': '^0.3.4'
+  'rstack': '^0.4.0'
   'sass': '^1.102.0'
   'sass-embedded': '^1.100.0'
   'sass-loader': '^16.0.8'


### PR DESCRIPTION
## Summary

This PR upgrades `rstack` from v0.3.4 to v0.4.0, enabling the new persistent `rs fmt` cache and upstream formatter optimizations.

Benchmark: Node.js v24.12.0 on macOS, `./node_modules/.bin/rs fmt --check` over 3,213 files, with seven measured wall-time runs per scenario.

| Scenario | Median | Range | vs. v0.3.4 |
| --- | ---: | ---: | ---: |
| v0.3.4 baseline | 1,512.9 ms | 1,432.9–1,553.6 ms | — |
| v0.4.0 without cache | 1,396.5 ms | 1,316.6–1,536.6 ms | -7.69% |
| v0.4.0 cold cache | 1,420.2 ms | 1,360.8–1,467.8 ms | -6.13% |
| v0.4.0 warm cache | 222.0 ms | 217.9–227.5 ms | **-85.33% (6.82× faster)** |

Validated with `pnpm build`, `pnpm lint`, `pnpm format:check`, and `pnpm test` (385 tests passed).

## Related Links

- https://github.com/rstackjs/rstack-cli/releases/tag/v0.4.0