### PR TITLE
chore(create-rsbuild): remove redundant DOM testing dependency

### DIFF
--- a/packages/create-rsbuild/template-rstest/vue-js/package.json
+++ b/packages/create-rsbuild/template-rstest/vue-js/package.json
@@ -6,7 +6,6 @@
   "devDependencies": {
     "@rstest/adapter-rsbuild": "^0.11.5",
     "@rstest/core": "^0.11.5",
-    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/vue": "^8.1.0",
     "happy-dom": "^20.11.1"

--- a/packages/create-rsbuild/template-rstest/vue-ts/package.json
+++ b/packages/create-rsbuild/template-rstest/vue-ts/package.json
@@ -6,7 +6,6 @@
   "devDependencies": {
     "@rstest/adapter-rsbuild": "^0.11.5",
     "@rstest/core": "^0.11.5",
-    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/vue": "^8.1.0",
     "happy-dom": "^20.11.1"


### PR DESCRIPTION
## Summary

`@testing-library/vue` already provides `@testing-library/dom`, so the Vue Rstest templates do not need to declare it directly. This removes the redundant dependency from both the JavaScript and TypeScript templates.