### PR TITLE
refactor(create-rsbuild): use Vue Test Utils in templates

### DIFF
--- a/packages/create-rsbuild/template-rstest/vue-js/package.json
+++ b/packages/create-rsbuild/template-rstest/vue-js/package.json
@@ -7,7 +7,7 @@
     "@rstest/adapter-rsbuild": "^0.11.5",
     "@rstest/core": "^0.11.5",
     "@testing-library/jest-dom": "^7.0.0",
-    "@testing-library/vue": "^8.1.0",
+    "@vue/test-utils": "^2.4.11",
     "happy-dom": "^20.11.1"
   }
 }

--- a/packages/create-rsbuild/template-rstest/vue-js/tests/index.test.js
+++ b/packages/create-rsbuild/template-rstest/vue-js/tests/index.test.js
@@ -1,9 +1,9 @@
 import { expect, test } from '@rstest/core';
-import { render, screen } from '@testing-library/vue';
+import { mount } from '@vue/test-utils';
 import App from '../src/App.vue';
 
 test('renders the main page', () => {
   const testMessage = 'Rsbuild with Vue';
-  render(App);
-  expect(screen.getByText(testMessage)).toBeInTheDocument();
+  const wrapper = mount(App);
+  expect(wrapper.element).toHaveTextContent(testMessage);
 });

--- a/packages/create-rsbuild/template-rstest/vue-js/tests/rstest.setup.js
+++ b/packages/create-rsbuild/template-rstest/vue-js/tests/rstest.setup.js
@@ -1,4 +1,6 @@
-import { expect } from '@rstest/core';
+import { afterEach, expect } from '@rstest/core';
 import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
+import { enableAutoUnmount } from '@vue/test-utils';
 
 expect.extend(jestDomMatchers);
+enableAutoUnmount(afterEach);

--- a/packages/create-rsbuild/template-rstest/vue-ts/package.json
+++ b/packages/create-rsbuild/template-rstest/vue-ts/package.json
@@ -7,7 +7,7 @@
     "@rstest/adapter-rsbuild": "^0.11.5",
     "@rstest/core": "^0.11.5",
     "@testing-library/jest-dom": "^7.0.0",
-    "@testing-library/vue": "^8.1.0",
+    "@vue/test-utils": "^2.4.11",
     "happy-dom": "^20.11.1"
   }
 }

--- a/packages/create-rsbuild/template-rstest/vue-ts/tests/index.test.ts
+++ b/packages/create-rsbuild/template-rstest/vue-ts/tests/index.test.ts
@@ -1,9 +1,9 @@
 import { expect, test } from '@rstest/core';
-import { render, screen } from '@testing-library/vue';
+import { mount } from '@vue/test-utils';
 import App from '../src/App.vue';
 
 test('renders the main page', () => {
   const testMessage = 'Rsbuild with Vue';
-  render(App);
-  expect(screen.getByText(testMessage)).toBeInTheDocument();
+  const wrapper = mount(App);
+  expect(wrapper.element).toHaveTextContent(testMessage);
 });

--- a/packages/create-rsbuild/template-rstest/vue-ts/tests/rstest.setup.ts
+++ b/packages/create-rsbuild/template-rstest/vue-ts/tests/rstest.setup.ts
@@ -1,4 +1,6 @@
-import { expect } from '@rstest/core';
+import { afterEach, expect } from '@rstest/core';
 import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
+import { enableAutoUnmount } from '@vue/test-utils';
 
 expect.extend(jestDomMatchers);
+enableAutoUnmount(afterEach);


### PR DESCRIPTION
## Summary

`@testing-library/vue` has seen limited maintenance, while Vue Test Utils is the official Vue component testing utility.

This PR replaces `@testing-library/vue` with `@vue/test-utils` in the Vue JavaScript and TypeScript Rstest templates.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/269