### PR TITLE
docs: document create-rsbuild --no-git option

### DIFF
--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -46,9 +46,10 @@ import { PackageManagerTabs } from '@theme';
 
 Follow the prompts to choose options, such as whether to add optional tools like TypeScript and ESLint.
 
+By default, the scaffold initializes a Git repository in the generated project. Pass `--no-git` to skip Git initialization.
+
 After creating the application, do the following:
 
-- Run `git init` to initialize a Git repository.
 - Run `npm install` (or your package manager's install command) to install dependencies.
 - Run `npm run dev` to start the dev server, which runs on `http://localhost:3000` by default.
 
@@ -126,6 +127,7 @@ Options:
   -h, --help            display help for command
   -d, --dir <dir>       create project in specified directory
   -t, --template <tpl>  specify the template to use
+  --no-git              skip Git repository initialization
   --tools <tool>        add additional tools, comma separated
   --skill <skill>       add optional skills, comma separated
   --override            override files in target directory

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -46,9 +46,10 @@ import { PackageManagerTabs } from '@theme';
 
 按照提示操作，并按需选择 TypeScript、ESLint 等额外工具。
 
+脚手架默认会在生成的项目中初始化 Git 仓库。如需跳过 Git 初始化，请在创建命令中添加 `--no-git`。
+
 创建完成后，执行以下步骤：
 
-- 执行 `git init` 来初始化 Git 仓库。
 - 执行 `npm install`（或其他包管理器的 install 命令）安装 npm 依赖。
 - 执行 `npm run dev` 启动开发服务器，服务器默认运行在 `localhost:3000`。
 
@@ -126,6 +127,7 @@ Options:
   -h, --help            display help for command
   -d, --dir <dir>       create project in specified directory
   -t, --template <tpl>  specify the template to use
+  --no-git              skip Git repository initialization
   --tools <tool>        add additional tools, comma separated
   --skill <skill>       add optional skills, comma separated
   --override            override files in target directory


### PR DESCRIPTION
## Summary

`create-rsbuild` now initializes a Git repository by default, but the quick-start guide still asks users to run `git init` and omits the `--no-git` opt-out from its CLI reference. This PR updates the English and Chinese guides to describe the default behavior, remove the stale manual step, and document `--no-git`.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8237
- https://github.com/web-infra-dev/rspress/pull/3594