### PR TITLE
chore(deps): upgrade create-toolkit to v2.2.1

### DIFF
--- a/packages/create-rsbuild/src/index.ts
+++ b/packages/create-rsbuild/src/index.ts
@@ -123,7 +123,6 @@ create({
     'solid-js',
     'solid-ts',
   ],
-  git: !process.argv.includes('--no-git'),
   getTemplateName,
   mapESLintTemplate,
   mapRslintTemplate,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,8 +83,8 @@ catalogs:
       specifier: 1.14.7
       version: 1.14.7
     '@rstackjs/create-toolkit':
-      specifier: 2.2.0
-      version: 2.2.0
+      specifier: 2.2.1
+      version: 2.2.1
     '@rstackjs/load-config':
       specifier: ^0.1.2
       version: 0.1.2
@@ -1007,7 +1007,7 @@ importers:
     dependencies:
       '@rstackjs/create-toolkit':
         specifier: 'catalog:'
-        version: 2.2.0
+        version: 2.2.1
     devDependencies:
       '@rsbuild/core':
         specifier: workspace:*
@@ -2569,8 +2569,8 @@ packages:
       '@rspress/core':
         optional: true
 
-  '@rstackjs/create-toolkit@2.2.0':
-    resolution: {integrity: sha512-FYoJSxELw7E2qsq88GnkOSugG00KwczMVAtzG5qawwYIYdGgHa2ljW1Omm3xHbVfPshGzZJIKlfjcxlTxUVwMw==}
+  '@rstackjs/create-toolkit@2.2.1':
+    resolution: {integrity: sha512-zH0wfbjU8caMuCNn9PWp49u4Y6XuB40RBkuwM8Vo40XGeqWs8RkP527ojmDIPqm4dL3ojRksHYsKy1ROGSXBoA==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   '@rstackjs/load-config@0.1.2':
@@ -6520,7 +6520,7 @@ snapshots:
     optionalDependencies:
       '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.8)(core-js@3.49.0)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@8.1.1)
 
-  '@rstackjs/create-toolkit@2.2.0': {}
+  '@rstackjs/create-toolkit@2.2.1': {}
 
   '@rstackjs/load-config@0.1.2(jiti@2.7.0)':
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,7 +41,7 @@ catalog:
   '@rspress/plugin-rss': '^2.0.19'
   '@rspress/plugin-sitemap': '^2.0.19'
   '@rstack-dev/doc-ui': '1.14.7'
-  '@rstackjs/create-toolkit': '2.2.0'
+  '@rstackjs/create-toolkit': '2.2.1'
   '@rstackjs/load-config': '^0.1.2'
   '@rstackjs/test-utils': '^0.2.0'
   '@rstest/core': '^0.11.5'


### PR DESCRIPTION
## Summary

This PR upgrades `@rstackjs/create-toolkit` to v2.2.1 so create-rsbuild can rely on the toolkit's built-in `--no-git` handling. It removes the redundant `process.argv` check while preserving the documented CLI behavior.

## Related Links

- https://github.com/rstackjs/create-toolkit/releases/tag/v2.2.1