### PR TITLE
docs: recommend pnpm in quick start

### DIFF
--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -30,28 +30,26 @@ Use one of the following installation guides to set up a runtime:
 
 ## Create an Rsbuild application
 
-Create a new Rsbuild application with [create-rsbuild](https://www.npmjs.com/package/create-rsbuild):
+[create-rsbuild](https://www.npmjs.com/package/create-rsbuild) lets you quickly create an Rsbuild application. We recommend using [pnpm](https://pnpm.io/) as your package manager.
 
 import { PackageManagerTabs } from '@theme';
 
 <PackageManagerTabs
   command={{
+    pnpm: 'pnpm create rsbuild@latest',
     npm: 'npm create rsbuild@latest',
     yarn: 'yarn create rsbuild',
-    pnpm: 'pnpm create rsbuild@latest',
     bun: 'bun create rsbuild@latest',
     deno: 'deno init --npm rsbuild@latest',
   }}
 />
 
-Follow the prompts to choose options, such as whether to add optional tools like TypeScript and ESLint.
-
-By default, the scaffold initializes a Git repository in the generated project. Pass `--no-git` to skip Git initialization.
+Follow the prompts to complete the setup.
 
 After creating the application, do the following:
 
-- Run `npm install` (or your package manager's install command) to install dependencies.
-- Run `npm run dev` to start the dev server, which runs on `http://localhost:3000` by default.
+- Run `pnpm install` (or your package manager's install command) to install dependencies.
+- Run `pnpm run dev` to start the [dev server](/guide/basic/server).
 
 ### Templates
 
@@ -76,16 +74,16 @@ When creating an application, choose from the following templates provided by `c
 
 `create-rsbuild` can help you set up the following commonly used tools. Use the arrow keys to navigate and the space bar to select. Press Enter without selecting anything to skip these tools.
 
-| Tool                                                    | Use                                        |
-| ------------------------------------------------------- | ------------------------------------------ |
-| [Rstest](https://github.com/web-infra-dev/rstest)       | Testing                                    |
-| [Rslint](https://github.com/web-infra-dev/rslint)       | Linting                                    |
-| [ESLint](https://github.com/eslint/eslint)              | Linting                                    |
-| [Prettier](https://github.com/prettier/prettier)        | Formatting                                 |
-| [Biome](https://github.com/biomejs/biome)               | Linting and formatting                     |
-| [Storybook](https://storybook.js.org/)                  | Component development                      |
-| [Tailwind CSS](https://tailwindcss.com)                 | Styling                                    |
-| [React Compiler](/guide/framework/react#react-compiler) | Optimizing React apps, React template only |
+| Tool                                                    | Use                                          |
+| ------------------------------------------------------- | -------------------------------------------- |
+| [Rstest](https://github.com/web-infra-dev/rstest)       | Testing                                      |
+| [Rslint](https://github.com/web-infra-dev/rslint)       | Linting                                      |
+| [ESLint](https://github.com/eslint/eslint)              | Linting                                      |
+| [Prettier](https://github.com/prettier/prettier)        | Formatting                                   |
+| [Biome](https://github.com/biomejs/biome)               | Linting and formatting                       |
+| [Storybook](https://storybook.js.org/)                  | Component development                        |
+| [Tailwind CSS](https://tailwindcss.com)                 | Styling                                      |
+| [React Compiler](/guide/framework/react#react-compiler) | Optimizing React apps (React templates only) |
 
 ### Current directory
 
@@ -114,7 +112,7 @@ npx -y create-rsbuild@latest my-app --template react
 npx -y create-rsbuild@latest my-app -t react
 
 # Specify multiple tools
-npx -y create-rsbuild@latest my-app -t react --tools eslint,prettier
+npx -y create-rsbuild@latest my-app -t react --tools rslint,prettier
 ```
 
 All CLI flags supported by `create-rsbuild`:

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -30,28 +30,26 @@ Rsbuild 支持使用 [Node.js](https://nodejs.org/)、[Deno](https://deno.com/) 
 
 ## 创建 Rsbuild 应用 \{#create-an-rsbuild-application}
 
-使用 [create-rsbuild](https://www.npmjs.com/package/create-rsbuild) 创建 Rsbuild 应用：
+使用 [create-rsbuild](https://www.npmjs.com/package/create-rsbuild) 可以快速创建一个 Rsbuild 应用，推荐使用 [pnpm](https://pnpm.io/) 作为包管理器。
 
 import { PackageManagerTabs } from '@theme';
 
 <PackageManagerTabs
   command={{
+    pnpm: 'pnpm create rsbuild@latest',
     npm: 'npm create rsbuild@latest',
     yarn: 'yarn create rsbuild',
-    pnpm: 'pnpm create rsbuild@latest',
     bun: 'bun create rsbuild@latest',
     deno: 'deno init --npm rsbuild@latest',
   }}
 />
 
-按照提示操作，并按需选择 TypeScript、ESLint 等额外工具。
-
-脚手架默认会在生成的项目中初始化 Git 仓库。如需跳过 Git 初始化，请在创建命令中添加 `--no-git`。
+按照提示操作即可。
 
 创建完成后，执行以下步骤：
 
-- 执行 `npm install`（或其他包管理器的 install 命令）安装 npm 依赖。
-- 执行 `npm run dev` 启动开发服务器，服务器默认运行在 `localhost:3000`。
+- 执行 `pnpm install`（或其他包管理器的 install 命令）安装依赖。
+- 执行 `pnpm run dev` 启动 [开发服务器](/guide/basic/server)。
 
 ### 模板
 
@@ -76,16 +74,16 @@ import { PackageManagerTabs } from '@theme';
 
 `create-rsbuild` 可帮助设置以下常用工具。使用上下箭头和空格进行选择；如不需要这些工具，直接按回车跳过。
 
-| 工具                                                    | 用途                           |
-| ------------------------------------------------------- | ------------------------------ |
-| [Rstest](https://github.com/web-infra-dev/rstest)       | 测试                           |
-| [Rslint](https://github.com/web-infra-dev/rslint)       | 代码检查                       |
-| [ESLint](https://github.com/eslint/eslint)              | 代码检查                       |
-| [Prettier](https://github.com/prettier/prettier)        | 代码格式化                     |
-| [Biome](https://github.com/biomejs/biome)               | 代码检查和格式化               |
-| [Storybook](https://storybook.js.org/)                  | 组件开发                       |
-| [Tailwind CSS](https://tailwindcss.com)                 | 样式                           |
-| [React Compiler](/guide/framework/react#react-compiler) | 优化 React 应用，仅 React 模板 |
+| 工具                                                    | 用途                             |
+| ------------------------------------------------------- | -------------------------------- |
+| [Rstest](https://github.com/web-infra-dev/rstest)       | 测试                             |
+| [Rslint](https://github.com/web-infra-dev/rslint)       | 代码检查                         |
+| [ESLint](https://github.com/eslint/eslint)              | 代码检查                         |
+| [Prettier](https://github.com/prettier/prettier)        | 代码格式化                       |
+| [Biome](https://github.com/biomejs/biome)               | 代码检查和格式化                 |
+| [Storybook](https://storybook.js.org/)                  | 组件开发                         |
+| [Tailwind CSS](https://tailwindcss.com)                 | 样式                             |
+| [React Compiler](/guide/framework/react#react-compiler) | 优化 React 应用（仅 React 模板） |
 
 ### 当前目录
 
@@ -114,7 +112,7 @@ npx -y create-rsbuild@latest my-app --template react
 npx -y create-rsbuild@latest my-app -t react
 
 # 指定多个 tools
-npx -y create-rsbuild@latest my-app -t react --tools eslint,prettier
+npx -y create-rsbuild@latest my-app -t react --tools rslint,prettier
 ```
 
 `create-rsbuild` 完整的 CLI 选项如下：


### PR DESCRIPTION
## Summary

This PR updates the quick-start docs to recommend pnpm for creating and running an Rsbuild application. It also simplifies the setup instructions, updates the optional-tool example to use Rslint, and keeps the Chinese and English guides aligned.