### PR TITLE
chore(deps): upgrade create-toolkit to v2.2.3

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,8 +83,8 @@ catalogs:
       specifier: 1.14.7
       version: 1.14.7
     '@rstackjs/create-toolkit':
-      specifier: 2.2.1
-      version: 2.2.1
+      specifier: 2.2.3
+      version: 2.2.3
     '@rstackjs/load-config':
       specifier: ^0.1.2
       version: 0.1.2
@@ -1007,7 +1007,7 @@ importers:
     dependencies:
       '@rstackjs/create-toolkit':
         specifier: 'catalog:'
-        version: 2.2.1
+        version: 2.2.3
     devDependencies:
       '@rsbuild/core':
         specifier: workspace:*
@@ -2616,8 +2616,8 @@ packages:
       '@rspress/core':
         optional: true
 
-  '@rstackjs/create-toolkit@2.2.1':
-    resolution: {integrity: sha512-zH0wfbjU8caMuCNn9PWp49u4Y6XuB40RBkuwM8Vo40XGeqWs8RkP527ojmDIPqm4dL3ojRksHYsKy1ROGSXBoA==}
+  '@rstackjs/create-toolkit@2.2.3':
+    resolution: {integrity: sha512-0I1U/BGGLXBkvE+C9oDKYfmg1wjFMHCPQlG2BJF+f41kL0BmXZaQMa/m515lo8Q349otqyAEam4A5BMuxetTVw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   '@rstackjs/load-config@0.1.2':
@@ -6619,7 +6619,7 @@ snapshots:
     optionalDependencies:
       '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.8)(core-js@3.50.0)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@8.1.1)
 
-  '@rstackjs/create-toolkit@2.2.1': {}
+  '@rstackjs/create-toolkit@2.2.3': {}
 
   '@rstackjs/load-config@0.1.2(jiti@2.7.0)':
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,7 +41,7 @@ catalog:
   '@rspress/plugin-rss': '^2.0.19'
   '@rspress/plugin-sitemap': '^2.0.19'
   '@rstack-dev/doc-ui': '1.14.7'
-  '@rstackjs/create-toolkit': '2.2.1'
+  '@rstackjs/create-toolkit': '2.2.3'
   '@rstackjs/load-config': '^0.1.2'
   '@rstackjs/test-utils': '^0.2.0'
   '@rstest/core': '^0.11.6'

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -117,32 +117,25 @@ npx -y create-rsbuild@latest my-app -t react --tools rslint,prettier
 
 All CLI flags supported by `create-rsbuild`:
 
-```
+```text wrapCode
 Usage: create-rsbuild [dir] [options]
 
 Options:
-
-  -h, --help            display help for command
-  -d, --dir <dir>       create project in specified directory
-  -t, --template <tpl>  specify the template to use
-  --no-git              skip Git repository initialization
-  --tools <tool>        add additional tools, comma separated
-  --skill <skill>       add optional skills, comma separated
-  --override            override files in target directory
-  --packageName <name>  specify the package name
+  -h, --help                display help for command
+  -d, --dir <dir>           create project in specified directory
+  -t, --template <tpl>      specify the template to use
+  --no-git                  skip Git repository initialization
+  --tools <tool>            add additional tools, comma separated
+  --skill <skill>           add optional skills, comma separated
+  --override                override files in target directory
+  --package-name <name>     specify the package name
   --template-version <ver>  specify the npm template version
 
-Available templates:
+Available templates: vanilla-js, vanilla-ts, react-js, react-ts, vue-js, vue-ts, lit-js, lit-ts, preact-js, preact-ts, svelte-js, svelte-ts, solid-js, solid-ts
 
-  vanilla-js, vanilla-ts, react-js, react-ts, vue-js, vue-ts,
-  lit-js, lit-ts, preact-js, preact-ts, svelte-js, svelte-ts,
-  solid-js, solid-ts
+Optional tools: react-compiler, rstest, eslint, rslint, biome, prettier, tailwindcss, storybook
 
-Optional tools:
-  react-compiler, rstest, eslint, rslint, biome, prettier, tailwindcss, storybook
-
-Optional skills:
-  rsbuild-best-practices, rstest-best-practices, vercel-react-best-practices
+Optional skills: rsbuild-best-practices, rstest-best-practices, vercel-react-best-practices
 ```
 
 ## Use Rsbuild in monorepos

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -117,32 +117,25 @@ npx -y create-rsbuild@latest my-app -t react --tools rslint,prettier
 
 `create-rsbuild` 完整的 CLI 选项如下：
 
-```
+```text wrapCode
 Usage: create-rsbuild [dir] [options]
 
 Options:
-
-  -h, --help            display help for command
-  -d, --dir <dir>       create project in specified directory
-  -t, --template <tpl>  specify the template to use
-  --no-git              skip Git repository initialization
-  --tools <tool>        add additional tools, comma separated
-  --skill <skill>       add optional skills, comma separated
-  --override            override files in target directory
-  --packageName <name>  specify the package name
+  -h, --help                display help for command
+  -d, --dir <dir>           create project in specified directory
+  -t, --template <tpl>      specify the template to use
+  --no-git                  skip Git repository initialization
+  --tools <tool>            add additional tools, comma separated
+  --skill <skill>           add optional skills, comma separated
+  --override                override files in target directory
+  --package-name <name>     specify the package name
   --template-version <ver>  specify the npm template version
 
-Available templates:
+Available templates: vanilla-js, vanilla-ts, react-js, react-ts, vue-js, vue-ts, lit-js, lit-ts, preact-js, preact-ts, svelte-js, svelte-ts, solid-js, solid-ts
 
-  vanilla-js, vanilla-ts, react-js, react-ts, vue-js, vue-ts,
-  lit-js, lit-ts, preact-js, preact-ts, svelte-js, svelte-ts,
-  solid-js, solid-ts
+Optional tools: react-compiler, rstest, eslint, rslint, biome, prettier, tailwindcss, storybook
 
-Optional tools:
-  react-compiler, rstest, eslint, rslint, biome, prettier, tailwindcss, storybook
-
-Optional skills:
-  rsbuild-best-practices, rstest-best-practices, vercel-react-best-practices
+Optional skills: rsbuild-best-practices, rstest-best-practices, vercel-react-best-practices
 ```
 
 ## 在 Monorepo 中使用 Rsbuild \{#use-rsbuild-in-monorepos}


### PR DESCRIPTION
## Summary

This PR upgrades `@rstackjs/create-toolkit` to v2.2.3 so `create-rsbuild` uses the improved CLI help output.

It updates the English and Chinese Quick Start examples to match the aligned output and kebab-case `--package-name` flag.

## Related Links

- https://github.com/rstackjs/create-toolkit/releases/tag/v2.2.3
- https://github.com/rstackjs/rstack-cli/pull/302