### PR TITLE
test(core): consolidate defineConfig type tests

### DIFF
--- a/e2e/type-tests/resolution-bundler/defineConfig.ts
+++ b/e2e/type-tests/resolution-bundler/defineConfig.ts
@@ -6,23 +6,6 @@ import {
   type RsbuildConfigSyncFn,
 } from '@rsbuild/core';
 
-defineConfig({
-  mode: 'production',
-});
-
-defineConfig(() => ({
-  mode: 'production',
-}));
-
-defineConfig(async () => ({
-  mode: 'production',
-}));
-
-// @ts-expect-error invalid mode
-defineConfig(async () => ({
-  mode: 'invalid',
-}));
-
 export const objectConfig: RsbuildConfig = defineConfig({
   mode: 'production',
 });
@@ -33,6 +16,11 @@ export const syncConfig: RsbuildConfigSyncFn = defineConfig(() => ({
 
 export const asyncConfig: RsbuildConfigAsyncFn = defineConfig(async () => ({
   mode: 'production',
+}));
+
+// @ts-expect-error invalid mode
+defineConfig(async () => ({
+  mode: 'invalid',
 }));
 
 declare const dynamicDefinition: RsbuildConfigDefinition;

--- a/e2e/type-tests/resolution-nodenext/defineConfig.ts
+++ b/e2e/type-tests/resolution-nodenext/defineConfig.ts
@@ -6,23 +6,6 @@ import {
   type RsbuildConfigSyncFn,
 } from '@rsbuild/core';
 
-defineConfig({
-  mode: 'production',
-});
-
-defineConfig(() => ({
-  mode: 'production',
-}));
-
-defineConfig(async () => ({
-  mode: 'production',
-}));
-
-// @ts-expect-error invalid mode
-defineConfig(async () => ({
-  mode: 'invalid',
-}));
-
 export const objectConfig: RsbuildConfig = defineConfig({
   mode: 'production',
 });
@@ -33,6 +16,11 @@ export const syncConfig: RsbuildConfigSyncFn = defineConfig(() => ({
 
 export const asyncConfig: RsbuildConfigAsyncFn = defineConfig(async () => ({
   mode: 'production',
+}));
+
+// @ts-expect-error invalid mode
+defineConfig(async () => ({
+  mode: 'invalid',
 }));
 
 declare const dynamicDefinition: RsbuildConfigDefinition;


### PR DESCRIPTION
## Summary

This PR consolidates the duplicated `defineConfig` type-test calls introduced in #8248. The existing object, sync callback, and async callback cases now also assert their public return types, while invalid-mode and dynamic-definition coverage remains unchanged.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8248