### PR TITLE
test(core): add Baseline query e2e test

### DIFF
--- a/e2e/cases/browserslist/baseline-query/index.test.ts
+++ b/e2e/cases/browserslist/baseline-query/index.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
+
+test('should transform syntax with a Baseline query', async ({ build }) => {
+  const rsbuild = await build();
+  const indexFile = getFileContent(rsbuild.getDistFiles(), 'index.js');
+
+  expect(indexFile).not.toContain('?.');
+});

--- a/e2e/cases/browserslist/baseline-query/index.test.ts
+++ b/e2e/cases/browserslist/baseline-query/index.test.ts
@@ -6,4 +6,5 @@ test('should transform syntax with a Baseline query', async ({ build }) => {
   const indexFile = getFileContent(rsbuild.getDistFiles(), 'index.js');
 
   expect(indexFile).not.toContain('?.');
+  expect(indexFile).toContain('value === null || value === void 0 ? void 0 : value.message');
 });

--- a/e2e/cases/browserslist/baseline-query/rsbuild.config.ts
+++ b/e2e/cases/browserslist/baseline-query/rsbuild.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from '@rsbuild/core';
 
 export default defineConfig({
   output: {
+    minify: false,
     overrideBrowserslist: ['baseline widely available on 2022-01-01'],
   },
 });

--- a/e2e/cases/browserslist/baseline-query/rsbuild.config.ts
+++ b/e2e/cases/browserslist/baseline-query/rsbuild.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    overrideBrowserslist: ['baseline widely available on 2022-01-01'],
+  },
+});

--- a/e2e/cases/browserslist/baseline-query/src/index.js
+++ b/e2e/cases/browserslist/baseline-query/src/index.js
@@ -1,0 +1,3 @@
+const getMessage = (value) => value?.message;
+
+console.log(getMessage);


### PR DESCRIPTION
## Summary

Rspack's browserslist-rs dependency now supports Baseline queries. This PR adds an e2e case using `baseline widely available on 2022-01-01` and verifies that optional chaining is transformed for the resolved browser targets.