### PR TITLE
test(core): add basic web ESM e2e tests

### DIFF
--- a/e2e/cases/web-esm/basic/index.test.ts
+++ b/e2e/cases/web-esm/basic/index.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
+
+test('should output and run basic web ESM bundles', async ({ page, runBothServe }) => {
+  const pageErrors: string[] = [];
+  page.on('pageerror', (error) => pageErrors.push(error.message));
+
+  await runBothServe(async ({ result }) => {
+    await expect(page.locator('#test')).toHaveText('Hello Web ESM!');
+    await expect(page.locator('#test')).toHaveCSS('color', 'rgb(255, 0, 0)');
+
+    const html = getFileContent(result.getDistFiles(), 'index.html');
+    expect(html).toContain('<script type="module" src="');
+  });
+
+  expect(pageErrors).toEqual([]);
+});

--- a/e2e/cases/web-esm/basic/rsbuild.config.ts
+++ b/e2e/cases/web-esm/basic/rsbuild.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    module: true,
+  },
+});

--- a/e2e/cases/web-esm/basic/src/index.js
+++ b/e2e/cases/web-esm/basic/src/index.js
@@ -1,0 +1,7 @@
+import { message } from './message';
+import './style.css';
+
+const testElement = document.createElement('div');
+testElement.id = 'test';
+testElement.textContent = message;
+document.body.appendChild(testElement);

--- a/e2e/cases/web-esm/basic/src/message.js
+++ b/e2e/cases/web-esm/basic/src/message.js
@@ -1,0 +1,1 @@
+export const message = 'Hello Web ESM!';

--- a/e2e/cases/web-esm/basic/src/style.css
+++ b/e2e/cases/web-esm/basic/src/style.css
@@ -1,0 +1,3 @@
+#test {
+  color: red;
+}

--- a/e2e/cases/web-esm/script-loading/index.test.ts
+++ b/e2e/cases/web-esm/script-loading/index.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
+
+test('should override blocking script loading for web ESM bundles', async ({ runBoth }) => {
+  await runBoth(({ result }) => {
+    const html = getFileContent(result.getDistFiles(), 'index.html');
+    expect(html).toContain('<script type="module" src="');
+  });
+});

--- a/e2e/cases/web-esm/script-loading/rsbuild.config.ts
+++ b/e2e/cases/web-esm/script-loading/rsbuild.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    module: true,
+  },
+  html: {
+    scriptLoading: 'blocking',
+  },
+});

--- a/e2e/cases/web-esm/script-loading/src/index.js
+++ b/e2e/cases/web-esm/script-loading/src/index.js
@@ -1,0 +1,1 @@
+console.log('Hello Web ESM!');


### PR DESCRIPTION
## Summary

This PR establishes dedicated Web ESM end-to-end coverage for `output.module`. It verifies basic bundles in development and production and ensures ESM output overrides blocking script loading.