### PR TITLE
test(core): add web ESM chunk e2e tests

### DIFF
--- a/e2e/cases/web-esm/async-chunks/index.test.ts
+++ b/e2e/cases/web-esm/async-chunks/index.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@e2e/helper';
+import { findFile } from '@rstackjs/test-utils';
+
+test('should load async JS, CSS, and assets in web ESM bundles', async ({ page, runBothServe }) => {
+  const pageErrors: string[] = [];
+  page.on('pageerror', (error) => pageErrors.push(error.message));
+
+  await runBothServe(async ({ mode, result }) => {
+    await expect(page.locator('#async')).toHaveCount(0);
+    await page.locator('#load').click();
+
+    await expect(page.locator('#async')).toHaveText('Async chunk loaded!');
+    await expect(page.locator('#async')).toHaveCSS('color', 'rgb(255, 0, 0)');
+
+    const image = page.locator('#async-image');
+    await expect(image).toHaveAttribute('src', /\/static\/image\//);
+    await expect
+      .poll(() =>
+        image.evaluate((element: HTMLImageElement) => element.complete && element.naturalWidth > 0),
+      )
+      .toBe(true);
+
+    if (mode === 'build') {
+      const files = result.getDistFiles();
+      expect(findFile(files, 'static/js/async/async.js')).toBeTruthy();
+      expect(findFile(files, 'static/css/async/async.css')).toBeTruthy();
+      expect(findFile(files, 'static/image/image.png')).toBeTruthy();
+    }
+  });
+
+  expect(pageErrors).toEqual([]);
+});

--- a/e2e/cases/web-esm/async-chunks/rsbuild.config.ts
+++ b/e2e/cases/web-esm/async-chunks/rsbuild.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    module: true,
+  },
+});

--- a/e2e/cases/web-esm/async-chunks/src/async.css
+++ b/e2e/cases/web-esm/async-chunks/src/async.css
@@ -1,0 +1,3 @@
+#async {
+  color: red;
+}

--- a/e2e/cases/web-esm/async-chunks/src/async.js
+++ b/e2e/cases/web-esm/async-chunks/src/async.js
@@ -1,0 +1,14 @@
+import imageUrl from '@e2e/assets/image.png?url';
+import './async.css';
+
+export const renderAsyncContent = () => {
+  const content = document.createElement('div');
+  content.id = 'async';
+  content.textContent = 'Async chunk loaded!';
+
+  const image = document.createElement('img');
+  image.id = 'async-image';
+  image.src = imageUrl;
+
+  document.body.append(content, image);
+};

--- a/e2e/cases/web-esm/async-chunks/src/index.js
+++ b/e2e/cases/web-esm/async-chunks/src/index.js
@@ -1,0 +1,8 @@
+const loadButton = document.createElement('button');
+loadButton.id = 'load';
+loadButton.textContent = 'Load async chunk';
+loadButton.addEventListener('click', async () => {
+  const { renderAsyncContent } = await import(/* rspackChunkName: "async" */ './async');
+  renderAsyncContent();
+});
+document.body.appendChild(loadButton);

--- a/e2e/cases/web-esm/initial-chunks/index.test.ts
+++ b/e2e/cases/web-esm/initial-chunks/index.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@e2e/helper';
+import { findFile, getFileContent } from '@rstackjs/test-utils';
+
+test('should load split and runtime chunks in web ESM bundles', async ({ page, runBothServe }) => {
+  const pageErrors: string[] = [];
+  page.on('pageerror', (error) => pageErrors.push(error.message));
+
+  await runBothServe(async ({ mode, result }) => {
+    await expect(page.locator('#test')).toHaveText('Initial chunks loaded!');
+
+    if (mode === 'build') {
+      const files = result.getDistFiles();
+      const initialJsFiles = Object.keys(files).filter(
+        (filename) =>
+          filename.endsWith('.js') &&
+          filename.includes('/static/js/') &&
+          !filename.includes('/async/'),
+      );
+
+      expect(initialJsFiles).toHaveLength(3);
+      expect(findFile(files, 'static/js/index.js')).toBeTruthy();
+      expect(findFile(files, 'static/js/shared.js')).toBeTruthy();
+      expect(findFile(files, 'static/js/runtime.js')).toBeTruthy();
+
+      const html = getFileContent(files, 'index.html');
+      expect(html.match(/<script type="module"/g)).toHaveLength(3);
+    }
+  });
+
+  expect(pageErrors).toEqual([]);
+});

--- a/e2e/cases/web-esm/initial-chunks/rsbuild.config.ts
+++ b/e2e/cases/web-esm/initial-chunks/rsbuild.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    module: true,
+  },
+  splitChunks: {
+    chunks: 'all',
+    minSize: 0,
+    cacheGroups: {
+      shared: {
+        test: /shared/,
+        name: 'shared',
+        enforce: true,
+      },
+    },
+  },
+  tools: {
+    rspack: {
+      optimization: {
+        runtimeChunk: 'single',
+      },
+    },
+  },
+});

--- a/e2e/cases/web-esm/initial-chunks/src/index.js
+++ b/e2e/cases/web-esm/initial-chunks/src/index.js
@@ -1,0 +1,6 @@
+import { message } from './shared';
+
+const testElement = document.createElement('div');
+testElement.id = 'test';
+testElement.textContent = message;
+document.body.appendChild(testElement);

--- a/e2e/cases/web-esm/initial-chunks/src/shared.js
+++ b/e2e/cases/web-esm/initial-chunks/src/shared.js
@@ -1,0 +1,1 @@
+export const message = 'Initial chunks loaded!';


### PR DESCRIPTION
## Summary

This PR expands Web ESM end-to-end coverage for chunk loading. It verifies dynamic JavaScript, CSS, and asset loading, as well as split chunks with a separate runtime chunk, in both development and production.