### PR TITLE
chore(deps): update dependency rstack to ^0.6.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -317,8 +317,8 @@ catalogs:
       specifier: ^1.0.4
       version: 1.0.4
     rstack:
-      specifier: ^0.6.0
-      version: 0.6.0
+      specifier: ^0.6.1
+      version: 0.6.1
     sass:
       specifier: ^1.102.0
       version: 1.102.0
@@ -407,7 +407,7 @@ importers:
         version: 1.1.5
       rstack:
         specifier: 'catalog:'
-        version: 0.6.0(@module-federation/runtime-tools@2.8.2)(@rspress/core@2.0.19)(core-js@3.50.0)(jiti@2.7.0)(typescript@6.0.3)
+        version: 0.6.1(@module-federation/runtime-tools@2.8.2)(@rspress/core@2.0.19)(core-js@3.50.0)(jiti@2.7.0)(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1348,7 +1348,7 @@ importers:
         version: 0.6.0
       rstack:
         specifier: 'catalog:'
-        version: 0.6.0(@module-federation/runtime-tools@2.8.2)(@rspress/core@2.0.19)(core-js@3.50.0)(jiti@2.7.0)(typescript@6.0.3)
+        version: 0.6.1(@module-federation/runtime-tools@2.8.2)(@rspress/core@2.0.19)(core-js@3.50.0)(jiti@2.7.0)(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1420,7 +1420,7 @@ importers:
         version: 1.0.4(@rspress/core@2.0.19)
       rstack:
         specifier: 'catalog:'
-        version: 0.6.0(@module-federation/runtime-tools@2.8.2)(@rspress/core@2.0.19)(core-js@3.50.0)(jiti@2.7.0)(typescript@6.0.3)
+        version: 0.6.1(@module-federation/runtime-tools@2.8.2)(@rspress/core@2.0.19)(core-js@3.50.0)(jiti@2.7.0)(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -2308,16 +2308,6 @@ packages:
       core-js:
         optional: true
 
-  '@rsbuild/core@2.1.12':
-    resolution: {integrity: sha512-xRqNHj/svDqeUzXPahmN4BdxEFCU1rxnVdjxyVV7WgsFfH+L3yAoQMJtIXVGhr00IQseDKkc3eonMF3NGrFj2Q==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      core-js: '>= 3.0.0'
-    peerDependenciesMeta:
-      core-js:
-        optional: true
-
   '@rsbuild/core@2.1.13':
     resolution: {integrity: sha512-Z+6MzmjOio4+bFZQ24k+7ge/oNCOdXIunAssrswTNE8AIf6mcyXpJZevRXRiOEMZasRPA8VNyh+9JngQLg729Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2654,88 +2644,88 @@ packages:
       '@rspress/core':
         optional: true
 
-  '@rstackjs/cli-darwin-arm64@0.6.0':
-    resolution: {integrity: sha512-Aa8QZre8VRKd3LT4mt/WW/h52zj+AgV3L8iaPzBAPHQTTWgFrZSt9yiEuV5+XWCYQVtmF0UDEfDVI7/qtzMZdg==}
+  '@rstackjs/cli-darwin-arm64@0.6.1':
+    resolution: {integrity: sha512-eXNU3W/e6kzSUQbuEX6p8WqRakEg9JDGbkKt0QW5H3VeAHmpSUir4L9cidLdXtSsa4/jcpIxE3IBAajwDg+cOA==}
     engines: {node: '>=22.12.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@rstackjs/cli-darwin-x64@0.6.0':
-    resolution: {integrity: sha512-TukyEJpyLsq9u0c7f/iFuZ/dC7fawB9bIlbLJLgU6ywNI9RlFN9XsKqiod4RG5QsWshSnUeZZl4JhdsadsX/3w==}
+  '@rstackjs/cli-darwin-x64@0.6.1':
+    resolution: {integrity: sha512-tqP0c+Clpf++pZFRe+hbk4V9cT1TG3EwHLOregACgE2rNKKEzxLdRF8zcPR3RzCQa7fo2zk29CWXcMVwaAf90A==}
     engines: {node: '>=22.12.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@rstackjs/cli-linux-arm64-gnu@0.6.0':
-    resolution: {integrity: sha512-Gm7YwHEj9a7VeoluVGeAGARXCM3JWcxCiALkXhBPfeykVs1inQVsno5fDKnlNFK79rCQj/M6DjK25PcVptVecQ==}
+  '@rstackjs/cli-linux-arm64-gnu@0.6.1':
+    resolution: {integrity: sha512-Wc1HjeqZ0OMoAT9qa9A5sC5ZVDkn7QegmdQGAEuDSh45t2lVIV4mHxrGGA7k7xGc1MmsQcf6uZQzFpoG1MO3yA==}
     engines: {node: '>=22.12.0'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rstackjs/cli-linux-arm64-musl@0.6.0':
-    resolution: {integrity: sha512-ZN0PpkiNkoHXHoVI1NFHh8SnupMYoDxB6xyKZFa7Za1/RAweQ2Tl/kYw/48WNbiZO7HK6kzmuKMvWvT+o/s14w==}
+  '@rstackjs/cli-linux-arm64-musl@0.6.1':
+    resolution: {integrity: sha512-u9z5Zcm2B+NhEW1ci6rqG1RkyR6vp0iuhV3ifQd+GI0DPutni5HaxEqbNQjaQ6qKGGKBk1H63SpOg6v6ODUkTA==}
     engines: {node: '>=22.12.0'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rstackjs/cli-linux-ppc64-gnu@0.6.0':
-    resolution: {integrity: sha512-QXcSTV0wbH2eJx+414uIKrrsNFr+y7zSACTlVgCyZd8AfS68E/SPwnx5ArYyowmHewV4P/ze+UyYc0qkL6Y7lg==}
+  '@rstackjs/cli-linux-ppc64-gnu@0.6.1':
+    resolution: {integrity: sha512-JaQLyGpQojMlsYa3FICW6zXa7dbl78Elj+dAFjR2mg08H65M/CPxrodJy9Mg3It4smiKOdsoyQJbG1xvX+/cEQ==}
     engines: {node: '>=22.12.0'}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rstackjs/cli-linux-riscv64-gnu@0.6.0':
-    resolution: {integrity: sha512-j5TQ3+HaMl1lVmlWLPIm+Zl4RFR7NgsokPc4qk9a0jBLwdWQ40hkZ7eoWsWhVNtk33MTRx5a0YVDRJlXl2WYYg==}
+  '@rstackjs/cli-linux-riscv64-gnu@0.6.1':
+    resolution: {integrity: sha512-LIrlSBM/MhGK9z207XrrCTO7DUvl8oxIpylrYZtMLoOcpEJM8sdjdBl7g4c+ODJ00+Rjs1ROSRRDs196Jd3lJQ==}
     engines: {node: '>=22.12.0'}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@rstackjs/cli-linux-riscv64-musl@0.6.0':
-    resolution: {integrity: sha512-0Xi7eUsvzJxMs/RP1MH04Fj0lnR4uwEC2nIkCIo5k2aHDl6YYRrNmnbCphgbYkXihdpvFEm90rBkS8Bcp4QnEA==}
+  '@rstackjs/cli-linux-riscv64-musl@0.6.1':
+    resolution: {integrity: sha512-T873vnvFc4hci9MOjD7BAAgp0dw3ibjarLx5/XKnjJRGvWj+zbEbIVNo/CUDfZ8wRBTvP+3AjkIjxgBeLDt1kg==}
     engines: {node: '>=22.12.0'}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@rstackjs/cli-linux-s390x-gnu@0.6.0':
-    resolution: {integrity: sha512-s6m+zd49aS9Gf6mUjciSYS7mYDJRHyiCyke+n9t4TOZysHcdVwXYfrAsCQT3l7WksP15YmtgPATyrBoeg1bdww==}
+  '@rstackjs/cli-linux-s390x-gnu@0.6.1':
+    resolution: {integrity: sha512-Gr4R8WPe1c0aeCBrN7WmtOHZq3AU6quu/KX/L4VjkNIAOysf2GDpqnOJFM7spuQ2Fv9+/QCVcPzOCsi7j7/y6A==}
     engines: {node: '>=22.12.0'}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rstackjs/cli-linux-x64-gnu@0.6.0':
-    resolution: {integrity: sha512-omZN0q0AtQSFbpoo1WR2gFyR7m+7Jwcb9EgRMB1LtscKFluU8sMa69yzM428eOMyyACPPbJ15hSKkAHDWKWXjQ==}
+  '@rstackjs/cli-linux-x64-gnu@0.6.1':
+    resolution: {integrity: sha512-Ie1Yx+nY1oA8d1K6rcYZgg53dfNzlTkujqfo/7Lcycz/WOLw4DuASV7y0x4zzi/gyAA1G3qot7/EF4U19j9mEQ==}
     engines: {node: '>=22.12.0'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rstackjs/cli-linux-x64-musl@0.6.0':
-    resolution: {integrity: sha512-A9YQhdeB0Y5LjvE/GStA6//pkPkgyJw3AeKt+nLTxH/v1SPE5pSvZC2uttJEQgnh8QDpWkShjVjySuuPm4KGnQ==}
+  '@rstackjs/cli-linux-x64-musl@0.6.1':
+    resolution: {integrity: sha512-Wv/PmkADIMZ2f/5aSpaH4H6pOuvaxe6ia2HBhrpNt8GVtZcp/lvaqLf6NoJ9BuGFzfP8s6elHUbBwgEQRZZAEg==}
     engines: {node: '>=22.12.0'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rstackjs/cli-win32-arm64-msvc@0.6.0':
-    resolution: {integrity: sha512-0/pWi41FfSe+Nsh9yHsiMWHXjrE7VgkVCKtLHms+2CCIWjmHOm92PGnKUW/3+n/mnnEPXFs3lhLLZyeLrWkRCg==}
+  '@rstackjs/cli-win32-arm64-msvc@0.6.1':
+    resolution: {integrity: sha512-lJ1+vQBeioa1nMDq0w81t7T9N4iyG7Q/lL8gsUFffuSrdY4povxtVnAp/zZ6IF5/+Okv5ViUEB+wNeZc+cxoKg==}
     engines: {node: '>=22.12.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@rstackjs/cli-win32-ia32-msvc@0.6.0':
-    resolution: {integrity: sha512-26JtrzCvvkwMIk0C3EDcT0n0kS8APu5UnaV3clPw7o4uMrHakCA/DyXVHl6y0xHLhqPS30Lk8Ev3nIFORIunPw==}
+  '@rstackjs/cli-win32-ia32-msvc@0.6.1':
+    resolution: {integrity: sha512-OnpxOeLbBlVgt8i6HVQebPD0+pLmJs2ynQIgiWuJXy/zYeuAjMqxlS3wz1Uk2VU0PSy43RlkSMT37q81he3+iw==}
     engines: {node: '>=22.12.0'}
     cpu: [ia32]
     os: [win32]
 
-  '@rstackjs/cli-win32-x64-msvc@0.6.0':
-    resolution: {integrity: sha512-m3eBCq8n2WnhfX95/a/FYc9aIJTr30tt5BKLhAaPtzWM5P/EZ3FEgSlTYIi7NfVfDOR8Dys7XRKPWOe9SW+6jA==}
+  '@rstackjs/cli-win32-x64-msvc@0.6.1':
+    resolution: {integrity: sha512-QqriBafjLRNJeAzXxVvGc0NmsPH3YCIL3iLgHeD31fsGXMjk07U0jU+1lUrr6R3vRVZWzC/IEaQCU+5B8jjpAg==}
     engines: {node: '>=22.12.0'}
     cpu: [x64]
     os: [win32]
@@ -3170,74 +3160,74 @@ packages:
   '@vue/shared@3.5.41':
     resolution: {integrity: sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==}
 
-  '@yuku-parser/binding-android-arm64@0.8.4':
-    resolution: {integrity: sha512-+HIMmv08Zrh9ugIAEMnKBMMePOl7CDxrjc8Vui1+GG2TJHM1yI1+3wo1pnXB6Nj2IiHugDkQw8ycUI6SA2EUkQ==}
+  '@yuku-parser/binding-android-arm64@0.8.5':
+    resolution: {integrity: sha512-BJtJvyf/Ma3v57uebPbe7VMUjNwTa3KW0fJn4awBBXyen8aS/i0gUbCDEsjGPY4GvAT41AggcYSep37V5VPENg==}
     cpu: [arm64]
     os: [android]
 
-  '@yuku-parser/binding-darwin-arm64@0.8.4':
-    resolution: {integrity: sha512-Elf/B/2m3OsyvxoQnBk8Dtu+9csHkzBNs5Yv9GbHjT3x0kVKNWjFusyZgm41VwxcPDqdpRi8tWxNX7OqXkmf/A==}
+  '@yuku-parser/binding-darwin-arm64@0.8.5':
+    resolution: {integrity: sha512-CEzkjuxNjufVmSRlSm1qYGaoRpbp0g03saC8Tz6BesbmBUuP8MSqJa2BSskMbvYkRhKUN4OFCoPJ0XJf7ARTZQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@yuku-parser/binding-darwin-x64@0.8.4':
-    resolution: {integrity: sha512-CjZuMoXnL5XUkVpDqh4WDPwpAw8CwmtHHnTerGkS45So/sNuwkXdyIAEqqIZfaLopi5W/V9NApAT2md9XizjsQ==}
+  '@yuku-parser/binding-darwin-x64@0.8.5':
+    resolution: {integrity: sha512-HS7wYfYUi3fTYNrzLNnZUia5DVo/Kf5NRmbh2rNVDKzMUEUfXI7xWdh0OOqIqYI3SsA5AcZOCI357uYb0+2B9Q==}
     cpu: [x64]
     os: [darwin]
 
-  '@yuku-parser/binding-freebsd-x64@0.8.4':
-    resolution: {integrity: sha512-ibLKORdz71iI4Vs+fyFgvwQ51P5XcxJIyQLa8cSEWqwptRdo+BTcZHIQEcZnFDPUuvmJ19RRH9CoiJdfhr7pZw==}
+  '@yuku-parser/binding-freebsd-x64@0.8.5':
+    resolution: {integrity: sha512-Iq/XcdT3qjV+mxzb6hE4oSlst/+wrJxSsgKu3FkVkV1bxb0UfITfedws/wI356KVr+BM9CeamNkdbchHV4pJlw==}
     cpu: [x64]
     os: [freebsd]
 
-  '@yuku-parser/binding-linux-arm-gnu@0.8.4':
-    resolution: {integrity: sha512-Fo3r5fYhGDcFnl+KN+L9PgtiQPS4AIE1n1mG1o5jZ11p7g5yZ/1EjLFmSHAUsoXreun8KjTsFjEL7P1Sb93PZQ==}
+  '@yuku-parser/binding-linux-arm-gnu@0.8.5':
+    resolution: {integrity: sha512-vbI/zeUdJEZ8BKUEfOD8ngtPR5/9XdONpRRosw73kOtA1GyipTF1rj75ozLHIVCEybdCB/GSlQ6OjjhuEAKrGA==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-parser/binding-linux-arm-musl@0.8.4':
-    resolution: {integrity: sha512-BEB31vUEgXPWf7WkoMPSzzJhpC/wWCBXyysRCCPsw47BJ/OtbQsvJbxX9fFDuSRLy3kbyIV/WbdUTgbQ9COxiw==}
+  '@yuku-parser/binding-linux-arm-musl@0.8.5':
+    resolution: {integrity: sha512-3K4kOkOxWbUKoRja+vn7Srn8Nyc66Fr66oFWO+pFA/0KpVtlIGpKY+/KL8QIQdM7swTh+82OVkuFKeFEweVFLg==}
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
-  '@yuku-parser/binding-linux-arm64-gnu@0.8.4':
-    resolution: {integrity: sha512-xGLCRcHn9xVz7JVNyyKtiNJSf503qtUmih9XVSsghgzOmiKUMnHObs69OMMwXN3788tg1jsl11fNjjQlB8idMA==}
+  '@yuku-parser/binding-linux-arm64-gnu@0.8.5':
+    resolution: {integrity: sha512-aj2pI9eT3ZAj8mWrC+utYUJwyxSd6ozthHjJfGtcY3MnZuQ4qbO7wm15BMqDgCSrg7az3tnONy1ftVQTWV9inA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-parser/binding-linux-arm64-musl@0.8.4':
-    resolution: {integrity: sha512-3kNRi8NJT2q6FQRVCUFHIQ99+kXdi8cVJEEUi6+xtFqpMgNrZNnbgAj28ILsDC7zmclaU+v47eUCeJoKLSCbww==}
+  '@yuku-parser/binding-linux-arm64-musl@0.8.5':
+    resolution: {integrity: sha512-+T2buVRNtY0QwhUeo8t47HmEpgh7tXMx8htMEdT7O0HHv3eFitwvyuVSdYNOpxo52Sc/0wJ6F4UbZni75aD4Pg==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@yuku-parser/binding-linux-x64-gnu@0.8.4':
-    resolution: {integrity: sha512-isi62oMy94Z3OXwGs2l2rkqRiRyqLmfHeTRHpA/uWZbsNhnm7IdVvkF7e7wHNKAtd5jwGzOqYSroxKv2fOm7Cw==}
+  '@yuku-parser/binding-linux-x64-gnu@0.8.5':
+    resolution: {integrity: sha512-uIoy1uplNUqjq3GW6z+Ea8UCQkLKRPlM4FvqAhYMDwBazkVpE1mNvMqaQqf57ZP8mGTeOf4OF6CuUlenR2ttqg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-parser/binding-linux-x64-musl@0.8.4':
-    resolution: {integrity: sha512-9RsEw2xYHqU/pjSRBTOupWN3sF8uz9stjJdARfz6o0llvF+yfrj5QHmTiocGGBeAI80fvKmDtr2RIQClUzAPcA==}
+  '@yuku-parser/binding-linux-x64-musl@0.8.5':
+    resolution: {integrity: sha512-27doVJjvYevPWcakDCpfgZfDAlyhfyY3BwHf5TKtponCrSYBMzrBpD8ChYB1M7B6YOm0M5U9kEA0k1sB6CD4Ow==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@yuku-parser/binding-win32-arm64@0.8.4':
-    resolution: {integrity: sha512-VEZHo9rEGOBKR20sA3vCO00aQvwWND5aLu7YxeX+YupMZJh9hd1f17AbClJN37Q2iL1PCHht+wDTOKX6tZYqXg==}
+  '@yuku-parser/binding-win32-arm64@0.8.5':
+    resolution: {integrity: sha512-UIlSKhOLWZUQyDVQzYWAkHQGWnwNw5IxR/YYT2UCy64HLMQGGIxhb3qa/7Rf6yki50FrLx1O9PWgBKXCq7Zxxg==}
     cpu: [arm64]
     os: [win32]
 
-  '@yuku-parser/binding-win32-x64@0.8.4':
-    resolution: {integrity: sha512-PeH3VzN1feGjPtDpVEAqf000fPT+nxtw/696LKp/5Z9RJi/MaXpB636QC+5QtrAPSoEnIkyEe+c+mq2QLZPWBA==}
+  '@yuku-parser/binding-win32-x64@0.8.5':
+    resolution: {integrity: sha512-helhS0Pt0TwsW9Z5L3V5o27qrnTrmaUTgSpymVUJYlZJgW6Nagk7nS5P3Ez4b1OZXMwc5y5CR6m1niuzL/yYfQ==}
     cpu: [x64]
     os: [win32]
 
-  '@yuku-toolchain/types@0.8.4':
-    resolution: {integrity: sha512-p7JE8flrj7ijZ/qLjHi4UwKqMarMD6zumbKXhrjp2I2iLJOuTYiQyci2U36VlXcUlNyzsY7E/mLnKCHotbzJVw==}
+  '@yuku-toolchain/types@0.8.7':
+    resolution: {integrity: sha512-2Z53dNxAJL6UvFoIrDZvYf3zlO8s4VJK4O2hhaB4mXVwwpX/7ajtss3cmfqKvamlNLWyt9FSWs4eoYdlbxpnHA==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -4926,8 +4916,8 @@ packages:
     peerDependencies:
       '@rspress/core': ^2.0.0
 
-  rstack@0.6.0:
-    resolution: {integrity: sha512-FRaooqevAPtC/y2QcH7E0AKK7gFcsnuBKYXr+7XLEo60OA6IW7rSo1LV2OyZ6LZhg47B5Yt2p3RldirdLuLrMw==}
+  rstack@0.6.1:
+    resolution: {integrity: sha512-9JGpdjpVryOJAOfdF0mYnNtlIe3RUAhdmq9DUcdYz/1M5SBEvmOtyX1aV2gUkEmu56EY7YLbGZJC9anPX5bmCg==}
     engines: {node: '>=22.12.0'}
     hasBin: true
     peerDependencies:
@@ -5487,11 +5477,11 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  yuku-ast@0.8.4:
-    resolution: {integrity: sha512-s7EWfWIQkaGmsGnyr/BU0jli9YTN5TvrKIsSmALyRD9elumDQInuhv0BrVObENKVCxr9W3Ikmnx5u02KvfuUmw==}
+  yuku-ast@0.8.7:
+    resolution: {integrity: sha512-h6+4bDfyootiMB9vckk5uKo5r5j0GHrkr17FQTDNfEsFT3DWlN9uu1HJwQwc64pgmLCI945fWM3lbTIqxjT3GQ==}
 
-  yuku-parser@0.8.4:
-    resolution: {integrity: sha512-sw41wouvT5rUmLIp87hmvm5vtF+MRSI3x6yjq6xqpYmtkQj+Ht6N7xRQ8lMhLv8N7JAzughGj0Rfi0jQRSu9HQ==}
+  yuku-parser@0.8.5:
+    resolution: {integrity: sha512-t843J9IdYYpcDaW7o3aDPXpTM72FsvkIDYEHtigyGFCvC3EhiIaSGM5WVNZl3lxTv1Dfis6IW3S/yBsBIaCiWw==}
 
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
@@ -6435,15 +6425,6 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/core@2.1.12(@module-federation/runtime-tools@2.8.2)(core-js@3.50.0)':
-    dependencies:
-      '@rspack/core': 2.1.10(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
-      '@swc/helpers': 0.5.23
-    optionalDependencies:
-      core-js: 3.50.0
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-
   '@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.8.2)(core-js@3.50.0)':
     dependencies:
       '@rspack/core': 2.1.10(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
@@ -6452,7 +6433,6 @@ snapshots:
       core-js: 3.50.0
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
-    optional: true
 
   '@rsbuild/plugin-check-syntax@2.0.1(@rsbuild/core@packages+core)':
     dependencies:
@@ -6463,12 +6443,12 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': link:packages/core
 
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.12)(@rspack/core@2.1.10)':
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.13)(@rspack/core@2.1.10)':
     dependencies:
       '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.10)(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.12(@module-federation/runtime-tools@2.8.2)(core-js@3.50.0)
+      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.8.2)(core-js@3.50.0)
     transitivePeerDependencies:
       - '@rspack/core'
 
@@ -6493,8 +6473,8 @@ snapshots:
 
   '@rslib/core@1.0.0-beta.3(@module-federation/runtime-tools@2.8.2)(core-js@3.50.0)(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/core': 2.1.12(@module-federation/runtime-tools@2.8.2)(core-js@3.50.0)
-      rsbuild-plugin-dts: 1.0.0-beta.3(@rsbuild/core@2.1.12)(typescript@6.0.3)
+      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.8.2)(core-js@3.50.0)
+      rsbuild-plugin-dts: 1.0.0-beta.3(@rsbuild/core@2.1.13)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -6683,8 +6663,8 @@ snapshots:
     dependencies:
       '@mdx-js/mdx': 3.1.1(supports-color@8.1.1)
       '@mdx-js/react': 3.1.1(@types/react@19.2.18)(react@19.2.8)
-      '@rsbuild/core': 2.1.12(@module-federation/runtime-tools@2.8.2)(core-js@3.50.0)
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.12)(@rspack/core@2.1.10)
+      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.8.2)(core-js@3.50.0)
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.13)(@rspack/core@2.1.10)
       '@rspress/shared': 2.0.19(@module-federation/runtime-tools@2.8.2)(core-js@3.50.0)(supports-color@8.1.1)
       '@shikijs/rehype': 4.3.0
       '@types/mdast': 4.0.4
@@ -6755,7 +6735,7 @@ snapshots:
 
   '@rspress/shared@2.0.19(@module-federation/runtime-tools@2.8.2)(core-js@3.50.0)(supports-color@8.1.1)':
     dependencies:
-      '@rsbuild/core': 2.1.12(@module-federation/runtime-tools@2.8.2)(core-js@3.50.0)
+      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.8.2)(core-js@3.50.0)
       '@shikijs/rehype': 4.3.0
       '@types/react': 19.2.18
       mdast-util-mdx-jsx: 3.2.0(supports-color@8.1.1)
@@ -6769,43 +6749,43 @@ snapshots:
     optionalDependencies:
       '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.10)(core-js@3.50.0)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@8.1.1)
 
-  '@rstackjs/cli-darwin-arm64@0.6.0':
+  '@rstackjs/cli-darwin-arm64@0.6.1':
     optional: true
 
-  '@rstackjs/cli-darwin-x64@0.6.0':
+  '@rstackjs/cli-darwin-x64@0.6.1':
     optional: true
 
-  '@rstackjs/cli-linux-arm64-gnu@0.6.0':
+  '@rstackjs/cli-linux-arm64-gnu@0.6.1':
     optional: true
 
-  '@rstackjs/cli-linux-arm64-musl@0.6.0':
+  '@rstackjs/cli-linux-arm64-musl@0.6.1':
     optional: true
 
-  '@rstackjs/cli-linux-ppc64-gnu@0.6.0':
+  '@rstackjs/cli-linux-ppc64-gnu@0.6.1':
     optional: true
 
-  '@rstackjs/cli-linux-riscv64-gnu@0.6.0':
+  '@rstackjs/cli-linux-riscv64-gnu@0.6.1':
     optional: true
 
-  '@rstackjs/cli-linux-riscv64-musl@0.6.0':
+  '@rstackjs/cli-linux-riscv64-musl@0.6.1':
     optional: true
 
-  '@rstackjs/cli-linux-s390x-gnu@0.6.0':
+  '@rstackjs/cli-linux-s390x-gnu@0.6.1':
     optional: true
 
-  '@rstackjs/cli-linux-x64-gnu@0.6.0':
+  '@rstackjs/cli-linux-x64-gnu@0.6.1':
     optional: true
 
-  '@rstackjs/cli-linux-x64-musl@0.6.0':
+  '@rstackjs/cli-linux-x64-musl@0.6.1':
     optional: true
 
-  '@rstackjs/cli-win32-arm64-msvc@0.6.0':
+  '@rstackjs/cli-win32-arm64-msvc@0.6.1':
     optional: true
 
-  '@rstackjs/cli-win32-ia32-msvc@0.6.0':
+  '@rstackjs/cli-win32-ia32-msvc@0.6.1':
     optional: true
 
-  '@rstackjs/cli-win32-x64-msvc@0.6.0':
+  '@rstackjs/cli-win32-x64-msvc@0.6.1':
     optional: true
 
   '@rstackjs/create-toolkit@2.2.3': {}
@@ -7276,43 +7256,43 @@ snapshots:
 
   '@vue/shared@3.5.41': {}
 
-  '@yuku-parser/binding-android-arm64@0.8.4':
+  '@yuku-parser/binding-android-arm64@0.8.5':
     optional: true
 
-  '@yuku-parser/binding-darwin-arm64@0.8.4':
+  '@yuku-parser/binding-darwin-arm64@0.8.5':
     optional: true
 
-  '@yuku-parser/binding-darwin-x64@0.8.4':
+  '@yuku-parser/binding-darwin-x64@0.8.5':
     optional: true
 
-  '@yuku-parser/binding-freebsd-x64@0.8.4':
+  '@yuku-parser/binding-freebsd-x64@0.8.5':
     optional: true
 
-  '@yuku-parser/binding-linux-arm-gnu@0.8.4':
+  '@yuku-parser/binding-linux-arm-gnu@0.8.5':
     optional: true
 
-  '@yuku-parser/binding-linux-arm-musl@0.8.4':
+  '@yuku-parser/binding-linux-arm-musl@0.8.5':
     optional: true
 
-  '@yuku-parser/binding-linux-arm64-gnu@0.8.4':
+  '@yuku-parser/binding-linux-arm64-gnu@0.8.5':
     optional: true
 
-  '@yuku-parser/binding-linux-arm64-musl@0.8.4':
+  '@yuku-parser/binding-linux-arm64-musl@0.8.5':
     optional: true
 
-  '@yuku-parser/binding-linux-x64-gnu@0.8.4':
+  '@yuku-parser/binding-linux-x64-gnu@0.8.5':
     optional: true
 
-  '@yuku-parser/binding-linux-x64-musl@0.8.4':
+  '@yuku-parser/binding-linux-x64-musl@0.8.5':
     optional: true
 
-  '@yuku-parser/binding-win32-arm64@0.8.4':
+  '@yuku-parser/binding-win32-arm64@0.8.5':
     optional: true
 
-  '@yuku-parser/binding-win32-x64@0.8.4':
+  '@yuku-parser/binding-win32-x64@0.8.5':
     optional: true
 
-  '@yuku-toolchain/types@0.8.4': {}
+  '@yuku-toolchain/types@0.8.7': {}
 
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
@@ -9253,10 +9233,10 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.4
       fsevents: 2.3.3
 
-  rsbuild-plugin-dts@1.0.0-beta.3(@rsbuild/core@2.1.12)(typescript@6.0.3):
+  rsbuild-plugin-dts@1.0.0-beta.3(@rsbuild/core@2.1.13)(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.1.12(@module-federation/runtime-tools@2.8.2)(core-js@3.50.0)
+      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.8.2)(core-js@3.50.0)
     optionalDependencies:
       typescript: 6.0.3
 
@@ -9295,30 +9275,30 @@ snapshots:
     dependencies:
       '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.10)(core-js@3.50.0)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@8.1.1)
 
-  rstack@0.6.0(@module-federation/runtime-tools@2.8.2)(@rspress/core@2.0.19)(core-js@3.50.0)(jiti@2.7.0)(typescript@6.0.3):
+  rstack@0.6.1(@module-federation/runtime-tools@2.8.2)(@rspress/core@2.0.19)(core-js@3.50.0)(jiti@2.7.0)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)(core-js@3.50.0)
+      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.8.2)(core-js@3.50.0)
       '@rslib/core': 1.0.0-beta.3(@module-federation/runtime-tools@2.8.2)(core-js@3.50.0)(typescript@6.0.3)
       '@rslint/core': 0.8.0(jiti@2.7.0)
       '@rstest/core': 0.11.6(@module-federation/runtime-tools@2.8.2)(core-js@3.50.0)
       prettier: 3.9.6
       tinypool: 2.1.0
-      yuku-parser: 0.8.4
+      yuku-parser: 0.8.5
     optionalDependencies:
       '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.10)(core-js@3.50.0)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@8.1.1)
-      '@rstackjs/cli-darwin-arm64': 0.6.0
-      '@rstackjs/cli-darwin-x64': 0.6.0
-      '@rstackjs/cli-linux-arm64-gnu': 0.6.0
-      '@rstackjs/cli-linux-arm64-musl': 0.6.0
-      '@rstackjs/cli-linux-ppc64-gnu': 0.6.0
-      '@rstackjs/cli-linux-riscv64-gnu': 0.6.0
-      '@rstackjs/cli-linux-riscv64-musl': 0.6.0
-      '@rstackjs/cli-linux-s390x-gnu': 0.6.0
-      '@rstackjs/cli-linux-x64-gnu': 0.6.0
-      '@rstackjs/cli-linux-x64-musl': 0.6.0
-      '@rstackjs/cli-win32-arm64-msvc': 0.6.0
-      '@rstackjs/cli-win32-ia32-msvc': 0.6.0
-      '@rstackjs/cli-win32-x64-msvc': 0.6.0
+      '@rstackjs/cli-darwin-arm64': 0.6.1
+      '@rstackjs/cli-darwin-x64': 0.6.1
+      '@rstackjs/cli-linux-arm64-gnu': 0.6.1
+      '@rstackjs/cli-linux-arm64-musl': 0.6.1
+      '@rstackjs/cli-linux-ppc64-gnu': 0.6.1
+      '@rstackjs/cli-linux-riscv64-gnu': 0.6.1
+      '@rstackjs/cli-linux-riscv64-musl': 0.6.1
+      '@rstackjs/cli-linux-s390x-gnu': 0.6.1
+      '@rstackjs/cli-linux-x64-gnu': 0.6.1
+      '@rstackjs/cli-linux-x64-musl': 0.6.1
+      '@rstackjs/cli-win32-arm64-msvc': 0.6.1
+      '@rstackjs/cli-win32-ia32-msvc': 0.6.1
+      '@rstackjs/cli-win32-x64-msvc': 0.6.1
     transitivePeerDependencies:
       - '@microsoft/api-extractor'
       - '@module-federation/runtime-tools'
@@ -9809,27 +9789,27 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  yuku-ast@0.8.4:
+  yuku-ast@0.8.7:
     dependencies:
-      '@yuku-toolchain/types': 0.8.4
+      '@yuku-toolchain/types': 0.8.7
 
-  yuku-parser@0.8.4:
+  yuku-parser@0.8.5:
     dependencies:
-      '@yuku-toolchain/types': 0.8.4
-      yuku-ast: 0.8.4
+      '@yuku-toolchain/types': 0.8.7
+      yuku-ast: 0.8.7
     optionalDependencies:
-      '@yuku-parser/binding-android-arm64': 0.8.4
-      '@yuku-parser/binding-darwin-arm64': 0.8.4
-      '@yuku-parser/binding-darwin-x64': 0.8.4
-      '@yuku-parser/binding-freebsd-x64': 0.8.4
-      '@yuku-parser/binding-linux-arm-gnu': 0.8.4
-      '@yuku-parser/binding-linux-arm-musl': 0.8.4
-      '@yuku-parser/binding-linux-arm64-gnu': 0.8.4
-      '@yuku-parser/binding-linux-arm64-musl': 0.8.4
-      '@yuku-parser/binding-linux-x64-gnu': 0.8.4
-      '@yuku-parser/binding-linux-x64-musl': 0.8.4
-      '@yuku-parser/binding-win32-arm64': 0.8.4
-      '@yuku-parser/binding-win32-x64': 0.8.4
+      '@yuku-parser/binding-android-arm64': 0.8.5
+      '@yuku-parser/binding-darwin-arm64': 0.8.5
+      '@yuku-parser/binding-darwin-x64': 0.8.5
+      '@yuku-parser/binding-freebsd-x64': 0.8.5
+      '@yuku-parser/binding-linux-arm-gnu': 0.8.5
+      '@yuku-parser/binding-linux-arm-musl': 0.8.5
+      '@yuku-parser/binding-linux-arm64-gnu': 0.8.5
+      '@yuku-parser/binding-linux-arm64-musl': 0.8.5
+      '@yuku-parser/binding-linux-x64-gnu': 0.8.5
+      '@yuku-parser/binding-linux-x64-musl': 0.8.5
+      '@yuku-parser/binding-win32-arm64': 0.8.5
+      '@yuku-parser/binding-win32-x64': 0.8.5
 
   zimmerframe@1.1.4: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -119,7 +119,7 @@ catalog:
   'rspack-merge': '1.0.1'
   'rspack-vue-loader': '^17.6.2'
   'rspress-plugin-font-open-sans': '^1.0.4'
-  'rstack': '^0.6.0'
+  'rstack': '^0.6.1'
   'sass': '^1.102.0'
   'sass-embedded': '^1.102.0'
   'sass-loader': '^16.0.8'

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -11,8 +11,6 @@ define.fmt({
     'e2e/cases/syntax-es/using-declaration/src/index.ts',
     // Preserve uppercase DOCTYPE in create-rsbuild templates.
     'packages/create-rsbuild/**/*.html',
-    // Keep the package-manager-generated layout stable.
-    'pnpm-lock.yaml',
   ],
 });
 
@@ -21,10 +19,8 @@ define.staged({
   '*.{js,jsx,ts,tsx,mjs,cjs}': ['rs lint --type-check', 'rs fmt'],
 });
 
-define.lint(async () => {
+define.lint(async ({ globalIgnores, js, ts }) => {
   const { default: globals } = await import('globals');
-  const { globalIgnores, js, ts } = await import('rstack/lint');
-
   return [
     globalIgnores([
       'e2e/cases/browser-logs/skip-build-error/src/index.js',


### PR DESCRIPTION
## Summary

This PR upgrades Rstack CLI to 0.6.1 and adopts the new injected lint helpers in the shared configuration.
It also relies on Rstack's built-in pnpm lockfile ignore to keep formatter behavior unchanged.

## Related Links

https://github.com/rstackjs/rstack-cli/releases/tag/v0.6.1