### PR TITLE
test(core): add module worker async chunk e2e test

### DIFF
--- a/e2e/cases/workers/worker-query-module-dynamic-import/index.test.ts
+++ b/e2e/cases/workers/worker-query-module-dynamic-import/index.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@e2e/helper';
+import { findFile } from '@rstackjs/test-utils';
+
+test('should support dynamic imports inside module worker query imports', async ({
+  page,
+  runBothServe,
+}) => {
+  await runBothServe(async ({ mode, result }) => {
+    await expect(page.locator('#worker')).toHaveText('worker: async msg');
+
+    if (mode === 'build') {
+      expect(findFile(result.getDistFiles(), 'static/js/async/worker-async.js')).toBeTruthy();
+    }
+  });
+});

--- a/e2e/cases/workers/worker-query-module-dynamic-import/rsbuild.config.ts
+++ b/e2e/cases/workers/worker-query-module-dynamic-import/rsbuild.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    module: true,
+  },
+});

--- a/e2e/cases/workers/worker-query-module-dynamic-import/src/async-message.ts
+++ b/e2e/cases/workers/worker-query-module-dynamic-import/src/async-message.ts
@@ -1,0 +1,1 @@
+export const getMessage = (name: string, message: string): string => `${name}: async ${message}`;

--- a/e2e/cases/workers/worker-query-module-dynamic-import/src/chunk-worker.ts
+++ b/e2e/cases/workers/worker-query-module-dynamic-import/src/chunk-worker.ts
@@ -1,0 +1,7 @@
+self.onmessage = async ({ data }) => {
+  const { getMessage } = await import(/* rspackChunkName: "worker-async" */ './async-message');
+
+  self.postMessage({
+    text: getMessage(self.name, data),
+  });
+};

--- a/e2e/cases/workers/worker-query-module-dynamic-import/src/index.ts
+++ b/e2e/cases/workers/worker-query-module-dynamic-import/src/index.ts
@@ -1,0 +1,15 @@
+import ModuleWorker from './chunk-worker?worker';
+
+document.body.innerHTML = '<div id="worker"></div>';
+
+const worker = new ModuleWorker({ name: 'worker' });
+
+worker.addEventListener('message', ({ data }) => {
+  const element = document.querySelector('#worker');
+  if (element) {
+    element.textContent = data.text;
+  }
+  worker.terminate();
+});
+
+worker.postMessage('msg');


### PR DESCRIPTION
## Summary

This PR adds dedicated end-to-end coverage for async chunk loading inside module workers when `output.module` is enabled. The new case verifies worker dynamic imports in development and production without changing the existing static module worker coverage.