### PR TITLE
test(core): add web ESM multiple entries e2e test

### DIFF
--- a/e2e/cases/web-esm/multiple-entries/index.test.ts
+++ b/e2e/cases/web-esm/multiple-entries/index.test.ts
@@ -1,0 +1,46 @@
+import { expect, gotoPage, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
+
+const entries = [
+  {
+    name: 'index',
+    message: 'Index entry loaded!',
+    otherEntry: 'other',
+  },
+  {
+    name: 'other',
+    message: 'Other entry loaded!',
+    otherEntry: 'index',
+  },
+];
+
+test('should load multiple entries with shared chunks in web ESM bundles', async ({
+  page,
+  runBothServe,
+}) => {
+  const pageErrors: string[] = [];
+  page.on('pageerror', (error) => pageErrors.push(error.message));
+
+  await runBothServe(async ({ mode, result }) => {
+    for (const { name, message } of entries) {
+      await gotoPage(page, result, name);
+      await expect(page.locator('#test')).toHaveText(message);
+    }
+
+    if (mode === 'build') {
+      const files = result.getDistFiles();
+
+      for (const { name, otherEntry } of entries) {
+        const html = getFileContent(files, `${name}.html`);
+
+        expect(html.match(/<script type="module"/g)).toHaveLength(3);
+        expect(html).toContain(`/static/js/${name}`);
+        expect(html).toContain('/static/js/shared');
+        expect(html).toContain('/static/js/runtime');
+        expect(html).not.toContain(`/static/js/${otherEntry}`);
+      }
+    }
+  });
+
+  expect(pageErrors).toEqual([]);
+});

--- a/e2e/cases/web-esm/multiple-entries/rsbuild.config.ts
+++ b/e2e/cases/web-esm/multiple-entries/rsbuild.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  source: {
+    entry: {
+      index: './src/index',
+      other: './src/other',
+    },
+  },
+  output: {
+    module: true,
+  },
+  splitChunks: {
+    chunks: 'all',
+    minSize: 0,
+    cacheGroups: {
+      shared: {
+        test: /shared/,
+        name: 'shared',
+        enforce: true,
+      },
+    },
+  },
+  tools: {
+    rspack: {
+      optimization: {
+        runtimeChunk: 'single',
+      },
+    },
+  },
+});

--- a/e2e/cases/web-esm/multiple-entries/src/index.js
+++ b/e2e/cases/web-esm/multiple-entries/src/index.js
@@ -1,0 +1,6 @@
+import { getMessage } from './shared';
+
+const testElement = document.createElement('div');
+testElement.id = 'test';
+testElement.textContent = getMessage('Index');
+document.body.appendChild(testElement);

--- a/e2e/cases/web-esm/multiple-entries/src/other.js
+++ b/e2e/cases/web-esm/multiple-entries/src/other.js
@@ -1,0 +1,6 @@
+import { getMessage } from './shared';
+
+const testElement = document.createElement('div');
+testElement.id = 'test';
+testElement.textContent = getMessage('Other');
+document.body.appendChild(testElement);

--- a/e2e/cases/web-esm/multiple-entries/src/shared.js
+++ b/e2e/cases/web-esm/multiple-entries/src/shared.js
@@ -1,0 +1,1 @@
+export const getMessage = (entry) => `${entry} entry loaded!`;


### PR DESCRIPTION
## Summary

This PR adds web ESM coverage for multiple entry points. It verifies that each generated HTML file loads its own entry while sharing module runtime and split chunks in both development and production.