### PR TITLE
test(core): add web ESM inline scripts e2e test

### DIFF
--- a/e2e/cases/web-esm/inline-scripts/index.test.ts
+++ b/e2e/cases/web-esm/inline-scripts/index.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
+
+test('should inline scripts in web ESM bundles', async ({
+  page,
+  runBothServe,
+}) => {
+  const pageErrors: string[] = [];
+  page.on('pageerror', (error) => pageErrors.push(error.message));
+
+  await runBothServe(async ({ mode, result }) => {
+    await expect(page.locator('#test')).toHaveText('Inline scripts loaded!');
+
+    const files = result.getDistFiles();
+    const html = getFileContent(files, 'index.html');
+
+    if (mode === 'dev') {
+      expect(html).toContain('<script type="module" src="');
+      return;
+    }
+
+    expect(html.match(/<script type="module">/g)).toHaveLength(1);
+    expect(html).not.toContain('<script type="module" src="');
+    expect(
+      Object.keys(files).filter((filename) => filename.endsWith('.js')),
+    ).toEqual([]);
+  });
+
+  expect(pageErrors).toEqual([]);
+});

--- a/e2e/cases/web-esm/inline-scripts/rsbuild.config.ts
+++ b/e2e/cases/web-esm/inline-scripts/rsbuild.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    module: true,
+    inlineScripts: true,
+  },
+});

--- a/e2e/cases/web-esm/inline-scripts/src/index.js
+++ b/e2e/cases/web-esm/inline-scripts/src/index.js
@@ -1,0 +1,6 @@
+import { message } from './shared';
+
+const testElement = document.createElement('div');
+testElement.id = 'test';
+testElement.textContent = message;
+document.body.appendChild(testElement);

--- a/e2e/cases/web-esm/inline-scripts/src/shared.js
+++ b/e2e/cases/web-esm/inline-scripts/src/shared.js
@@ -1,0 +1,1 @@
+export const message = 'Inline scripts loaded!';


### PR DESCRIPTION
## Summary

This PR adds web ESM coverage for `output.inlineScripts`. It verifies that a single initial ESM bundle runs in development and production, is inlined with `type="module"` in production, and does not leave a JavaScript asset in the output.