### PR TITLE
refactor(core): use default loader for dynamic imports

### DIFF
--- a/packages/core/src/server/runner/cjs.ts
+++ b/packages/core/src/server/runner/cjs.ts
@@ -107,17 +107,10 @@ export class CommonJsRunner extends BasicRunner {
       const args = Object.keys(currentModuleScope);
       const argValues = args.map((arg) => currentModuleScope[arg]);
       this.preExecute(file.content, file);
-      const dynamicImport = new Function(
-        'specifier',
-        'return import(specifier)',
-      );
       const fn = vm.compileFunction(file.content, args, {
         filename: file.path,
         // Specify how the modules should be loaded during the evaluation of this script when `import()` is called.
-        importModuleDynamically: async (specifier) => {
-          const result = await dynamicImport(specifier);
-          return result;
-        },
+        importModuleDynamically: vm.constants.USE_MAIN_CONTEXT_DEFAULT_LOADER,
       });
 
       fn.call(m.exports, ...argValues);


### PR DESCRIPTION
## Summary

`CommonJsRunner` currently forwards dynamic `import()` calls from `vm.compileFunction` through a `new Function` wrapper.

This PR uses `vm.constants.USE_MAIN_CONTEXT_DEFAULT_LOADER` so Node.js handles dynamic imports through the main-context default ESM loader, using the compiled filename as the referrer.

## Related Links

- https://nodejs.org/download/release/v20.19.0/docs/api/vm.html#vmconstantsuse_main_context_default_loader
- https://nodejs.org/download/release/v20.19.0/docs/api/vm.html#support-of-dynamic-import-in-compilation-apis
- https://github.com/web-infra-dev/rsbuild/pull/8282
