### PR TITLE
test(core): add web ESM base path e2e test

### DIFF
--- a/e2e/cases/web-esm/base-path/index.test.ts
+++ b/e2e/cases/web-esm/base-path/index.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@e2e/helper';
+import { getFileContent } from '@rstackjs/test-utils';
+
+test('should load web ESM bundles under a base path', async ({
+  page,
+  runBothServe,
+}) => {
+  const pageErrors: string[] = [];
+  page.on('pageerror', (error) => pageErrors.push(error.message));
+
+  await runBothServe(async ({ result }) => {
+    expect(new URL(page.url()).pathname).toContain('/base/');
+
+    const html = getFileContent(result.getDistFiles(), 'index.html');
+    expect(html).toMatch(/<script type="module" src="\/base\/static\/js\//);
+
+    await page.locator('#load').click();
+    await expect(page.locator('#async')).toHaveText('Base path loaded!');
+    await expect(page.locator('#async')).toHaveCSS('color', 'rgb(255, 0, 0)');
+
+    const image = page.locator('#async-image');
+    await expect(image).toHaveAttribute('src', /\/base\/static\/image\//);
+    await expect
+      .poll(() =>
+        image.evaluate(
+          (element: HTMLImageElement) =>
+            element.complete && element.naturalWidth > 0,
+        ),
+      )
+      .toBe(true);
+  });
+
+  expect(pageErrors).toEqual([]);
+});

--- a/e2e/cases/web-esm/base-path/rsbuild.config.ts
+++ b/e2e/cases/web-esm/base-path/rsbuild.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  server: {
+    base: '/base',
+  },
+  output: {
+    module: true,
+  },
+});

--- a/e2e/cases/web-esm/base-path/src/async.css
+++ b/e2e/cases/web-esm/base-path/src/async.css
@@ -1,0 +1,3 @@
+#async {
+  color: red;
+}

--- a/e2e/cases/web-esm/base-path/src/async.js
+++ b/e2e/cases/web-esm/base-path/src/async.js
@@ -1,0 +1,14 @@
+import imageUrl from '@e2e/assets/image.png?url';
+import './async.css';
+
+export const renderAsyncContent = () => {
+  const content = document.createElement('div');
+  content.id = 'async';
+  content.textContent = 'Base path loaded!';
+
+  const image = document.createElement('img');
+  image.id = 'async-image';
+  image.src = imageUrl;
+
+  document.body.append(content, image);
+};

--- a/e2e/cases/web-esm/base-path/src/index.js
+++ b/e2e/cases/web-esm/base-path/src/index.js
@@ -1,0 +1,8 @@
+const loadButton = document.createElement('button');
+loadButton.id = 'load';
+loadButton.textContent = 'Load async chunk';
+loadButton.addEventListener('click', async () => {
+  const { renderAsyncContent } = await import('./async');
+  renderAsyncContent();
+});
+document.body.appendChild(loadButton);


### PR DESCRIPTION
## Summary

This PR adds end-to-end coverage for web ESM applications deployed under a non-root base path. It verifies that initial module scripts and dynamically imported JavaScript, CSS, and image assets load correctly in both development and preview.