### PR TITLE
test(server): cover native import in CJS bundle

### DIFF
--- a/e2e/cases/server/load-bundle-cjs-native-import/index.test.ts
+++ b/e2e/cases/server/load-bundle-cjs-native-import/index.test.ts
@@ -9,8 +9,7 @@ test('should load a CJS bundle containing native import()', async ({
   const port = await getRandomPort();
   execCli(`dev --port ${port}`, {
     env: {
-      NODE_OPTIONS:
-        `${process.env.NODE_OPTIONS ?? ''} --experimental-vm-modules`.trim(),
+      NODE_OPTIONS: '--experimental-vm-modules',
     },
   });
   await logHelper.expectBuildEnd();

--- a/e2e/cases/server/load-bundle-cjs-native-import/index.test.ts
+++ b/e2e/cases/server/load-bundle-cjs-native-import/index.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@e2e/helper';
+import { getRandomPort } from '@rstackjs/test-utils';
+
+test('should load a CJS bundle containing native import()', async ({
+  execCli,
+  logHelper,
+  request,
+}) => {
+  const port = await getRandomPort();
+  execCli(`dev --port ${port}`, {
+    env: {
+      NODE_OPTIONS:
+        `${process.env.NODE_OPTIONS ?? ''} --experimental-vm-modules`.trim(),
+    },
+  });
+  await logHelper.expectBuildEnd();
+
+  const response = await request.get(`http://localhost:${port}/check`);
+  expect(response.status()).toBe(200);
+  expect(await response.text()).toBe('index.js');
+});

--- a/e2e/cases/server/load-bundle-cjs-native-import/rsbuild.config.ts
+++ b/e2e/cases/server/load-bundle-cjs-native-import/rsbuild.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  server: {
+    setup: ({ action, server }) => {
+      if (action !== 'dev') {
+        return;
+      }
+
+      server.middlewares.use('/check', async (_req, res) => {
+        const getFilename =
+          await server.environments.node.loadBundle<() => Promise<string>>(
+            'index',
+          );
+
+        res.end(await getFilename());
+      });
+    },
+  },
+  environments: {
+    node: {
+      output: {
+        target: 'node',
+        module: false,
+        externals: {
+          'node:path': 'import node:path',
+        },
+      },
+      source: {
+        entry: {
+          index: './src/index.server.cjs',
+        },
+      },
+    },
+  },
+});

--- a/e2e/cases/server/load-bundle-cjs-native-import/src/index.server.cjs
+++ b/e2e/cases/server/load-bundle-cjs-native-import/src/index.server.cjs
@@ -1,0 +1,5 @@
+module.exports = async function getFilename() {
+  const path = await import('node:path');
+
+  return path.basename('/tmp/index.js');
+};


### PR DESCRIPTION
## Summary

This PR adds an isolated e2e case for loading a CommonJS server bundle that retains a native `import()` expression. The case starts Rsbuild with `--experimental-vm-modules` so it passes against the current `main` runner and continues to cover the loader update in #8282.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8282