### PR TITLE
test(core): add web ESM externals e2e test

### DIFF
--- a/e2e/cases/web-esm/externals/index.test.ts
+++ b/e2e/cases/web-esm/externals/index.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@e2e/helper';
+
+test('should resolve externals with an import map in web ESM bundles', async ({
+  page,
+  runBothServe,
+}) => {
+  const pageErrors: string[] = [];
+  page.on('pageerror', (error) => pageErrors.push(error.message));
+
+  await runBothServe(async () => {
+    await expect(page.locator('#root')).toHaveText('External module loaded!');
+
+    const importMap = await page
+      .locator('script[type="importmap"]')
+      .textContent();
+    expect(JSON.parse(importMap!)).toEqual({
+      imports: {
+        'external-module': '/external.js',
+      },
+    });
+  });
+
+  expect(pageErrors).toEqual([]);
+});

--- a/e2e/cases/web-esm/externals/public/external.js
+++ b/e2e/cases/web-esm/externals/public/external.js
@@ -1,0 +1,1 @@
+export const message = 'External module loaded!';

--- a/e2e/cases/web-esm/externals/rsbuild.config.ts
+++ b/e2e/cases/web-esm/externals/rsbuild.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    module: true,
+    externals: {
+      'external-module': 'external-module',
+    },
+  },
+  html: {
+    tags: [
+      {
+        tag: 'script',
+        attrs: {
+          type: 'importmap',
+        },
+        children: JSON.stringify({
+          imports: {
+            'external-module': '/external.js',
+          },
+        }),
+        append: false,
+      },
+    ],
+  },
+});

--- a/e2e/cases/web-esm/externals/src/index.js
+++ b/e2e/cases/web-esm/externals/src/index.js
@@ -1,0 +1,3 @@
+import { message } from 'external-module';
+
+document.querySelector('#root').textContent = message;

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -53,6 +53,7 @@ icss
 idents
 iife
 imagex
+importmap
 inlines
 jfif
 Jiahan


### PR DESCRIPTION
## Summary

This PR adds browser-level coverage for ESM externals resolved through an import map. It verifies that `output.module` preserves a bare module import and that the mapped public ESM module runs in both development and preview.