### PR TITLE
chore: enable no-unnecessary-type-assertion rule

### DIFF
--- a/e2e/cases/server/viewing-served-files/index.test.ts
+++ b/e2e/cases/server/viewing-served-files/index.test.ts
@@ -22,7 +22,7 @@ test('should show assets on /rsbuild-dev-server path', async ({
   );
   for (const href of hrefList) {
     const status = await page.evaluate(async (url) => {
-      const response = await fetch(url as string);
+      const response = await fetch(url);
       return response.status;
     }, href);
 
@@ -61,7 +61,7 @@ test('should show assets on /rsbuild-dev-server path with server.base and assetP
   );
   for (const href of hrefList) {
     const status = await page.evaluate(async (url) => {
-      const response = await fetch(url as string);
+      const response = await fetch(url);
       return response.status;
     }, href);
 
@@ -116,7 +116,7 @@ test('should show assets on /rsbuild-dev-server path with environments', async (
   );
   for (const href of hrefList) {
     const status = await page.evaluate(async (url) => {
-      const response = await fetch(url as string);
+      const response = await fetch(url);
       return response.status;
     }, href);
 

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -65,7 +65,7 @@ define.lint(async ({ globalIgnores, js, ts }) => {
         '@typescript-eslint/no-misused-promises': 'off',
         '@typescript-eslint/restrict-template-expressions': 'off',
         '@typescript-eslint/no-unsafe-return': 'off',
-        '@typescript-eslint/no-unnecessary-type-assertion': 'off',
+        '@typescript-eslint/no-unnecessary-type-assertion': 'error',
         '@typescript-eslint/no-explicit-any': 'off',
       },
     },


### PR DESCRIPTION
## Summary

This PR enables `@typescript-eslint/no-unnecessary-type-assertion` to prevent redundant type assertions. It removes the three existing unnecessary assertions reported by the rule.