### PR TITLE
chore: enable no-unsafe-return rule

### DIFF
--- a/packages/core/src/helpers/vendors.ts
+++ b/packages/core/src/helpers/vendors.ts
@@ -16,4 +16,4 @@ export const require: NodeJS.Require = createRequire(import.meta.url);
  */
 export const requireCompiledPackage = <T extends keyof CompiledPackages>(
   name: T,
-): CompiledPackages[T] => require(`${COMPILED_PATH}/${name}/index.js`);
+) => require(`${COMPILED_PATH}/${name}/index.js`) as CompiledPackages[T];

--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -134,9 +134,11 @@ async function loadUserPostcssrc(
 }
 
 const isPostcssPluginCreator = (
-  plugin: AcceptedPlugin,
+  plugin: unknown,
 ): plugin is PluginCreator<unknown> =>
-  typeof plugin === 'function' && (plugin as PluginCreator<unknown>).postcss;
+  typeof plugin === 'function' &&
+  'postcss' in plugin &&
+  Boolean(plugin.postcss);
 
 const getPostcssLoaderOptions = async ({
   config,
@@ -189,7 +191,7 @@ const getPostcssLoaderOptions = async ({
 
     // initialize the plugin to avoid multiple initialization
     // https://github.com/web-infra-dev/rsbuild/issues/3618
-    options.plugins = options.plugins.map((plugin) =>
+    options.plugins = options.plugins.map((plugin: unknown) =>
       isPostcssPluginCreator(plugin) ? plugin() : plugin,
     );
 

--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -72,12 +72,10 @@ export function normalizeFilePath(filePath: string): string {
 }
 
 /** Load previous build file sizes from snapshots */
-async function loadPrevSnapshots(
-  snapshotPath: string,
-): Promise<SizeSnapshots | null> {
+async function loadPrevSnapshots(snapshotPath: string) {
   try {
     const content = await fs.promises.readFile(snapshotPath, 'utf-8');
-    return JSON.parse(content);
+    return JSON.parse(content) as SizeSnapshots;
   } catch {
     // Cache doesn't exist or is invalid
     return null;

--- a/packages/core/src/server/runner/cjs.ts
+++ b/packages/core/src/server/runner/cjs.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import type { Module } from 'node:vm';
 import { require } from '../../helpers';
 import { BasicRunner } from './basic';
 import type {
@@ -79,7 +80,7 @@ export class CommonJsRunner extends BasicRunner {
       // rslint-disable-next-line @typescript-eslint/no-require-imports
       return require(
         resolvedPath.startsWith('node:') ? resolvedPath.slice(5) : resolvedPath,
-      );
+      ) as unknown;
     };
   }
 
@@ -115,7 +116,7 @@ export class CommonJsRunner extends BasicRunner {
       const dynamicImport = new Function(
         'specifier',
         'return import(specifier)',
-      );
+      ) as (specifier: string) => Promise<Module>;
       const fn = vm.compileFunction(file.content, args, {
         filename: file.path,
         // Specify how the modules should be loaded during the evaluation of this script when `import()` is called.

--- a/packages/core/src/server/runner/esm.ts
+++ b/packages/core/src/server/runner/esm.ts
@@ -99,7 +99,9 @@ export class EsmRunner extends CommonJsRunner {
         const ns = esm.namespace as {
           default: unknown;
         };
-        return ns.default && ns.default instanceof Promise ? ns.default : ns;
+        return ns.default && ns.default instanceof Promise
+          ? (ns.default as Promise<unknown>)
+          : ns;
       })();
     };
   }

--- a/packages/core/src/types/shim.d.ts
+++ b/packages/core/src/types/shim.d.ts
@@ -1,4 +1,0 @@
-declare module 'launch-editor-middleware' {
-  const plugin: any;
-  export = plugin;
-}

--- a/packages/plugin-sass/src/helpers.ts
+++ b/packages/plugin-sass/src/helpers.ts
@@ -55,7 +55,7 @@ type ResolveUrlJoinItem = {
  *
  * reference: https://github.com/bholloway/resolve-url-loader/blob/e2695cde68f325f617825e168173df92236efb93/packages/resolve-url-loader/docs/advanced-features.md
  */
-export const getResolveUrlJoinFn = (): ((...args: unknown[]) => void) => {
+export const getResolveUrlJoinFn = () => {
   const {
     createJoinFunction,
     asGenerator,
@@ -69,11 +69,11 @@ export const getResolveUrlJoinFn = (): ((...args: unknown[]) => void) => {
       if (!item.uri.startsWith('.')) {
         return [null];
       }
-      return defaultJoinGenerator(item, ...rest);
+      return defaultJoinGenerator(item, ...rest) as unknown;
     },
   );
   return createJoinFunction(
     'rsbuild-resolve-join-fn',
     createJoinImplementation(rsbuildGenerator),
-  );
+  ) as (...args: unknown[]) => void;
 };

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -64,7 +64,6 @@ define.lint(async ({ globalIgnores, js, ts }) => {
         '@typescript-eslint/no-floating-promises': 'off',
         '@typescript-eslint/no-misused-promises': 'off',
         '@typescript-eslint/restrict-template-expressions': 'off',
-        '@typescript-eslint/no-unsafe-return': 'error',
         '@typescript-eslint/no-unnecessary-type-assertion': 'off',
         '@typescript-eslint/no-explicit-any': 'off',
       },

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -64,7 +64,7 @@ define.lint(async ({ globalIgnores, js, ts }) => {
         '@typescript-eslint/no-floating-promises': 'off',
         '@typescript-eslint/no-misused-promises': 'off',
         '@typescript-eslint/restrict-template-expressions': 'off',
-        '@typescript-eslint/no-unsafe-return': 'off',
+        '@typescript-eslint/no-unsafe-return': 'error',
         '@typescript-eslint/no-unnecessary-type-assertion': 'off',
         '@typescript-eslint/no-explicit-any': 'off',
       },


### PR DESCRIPTION
## Summary

This PR enables `@typescript-eslint/no-unsafe-return` to prevent `any` values from leaking through typed return values. It narrows the existing unsafe boundaries and removes an obsolete `launch-editor-middleware` type shim now that the dependency ships its own declarations.