### PR TITLE
fix: HMR client crash on legacy browsers where URL lacks searchParams

### DIFF
--- a/packages/core/src/client/hmr.ts
+++ b/packages/core/src/client/hmr.ts
@@ -120,7 +120,7 @@ export function init(
       config.protocol || (location.protocol === 'https:' ? 'wss' : 'ws');
     const pathname = config.path;
 
-    if (typeof URL !== 'undefined') {
+    if (typeof URL !== 'undefined' && 'searchParams' in URL.prototype) {
       const url = new URL('http://localhost');
       url.port = String(port);
       url.hostname = hostname;
@@ -130,7 +130,7 @@ export function init(
       return url.toString();
     }
 
-    // compatible with IE11
+    // compatible with IE 11 and legacy WebKit where URL lacks searchParams
     const colon = protocol.indexOf(':') === -1 ? ':' : '';
     return `${protocol}${colon}//${hostname}:${port}${pathname}?token=${token}`;
   }


### PR DESCRIPTION
## Summary

Some legacy embedded browsers (e.g. PS4 WebKit, Cobalt on Nintendo Switch) ship a global `URL` constructor without `URLSearchParams` support — `url.searchParams` is `undefined` on instances. The HMR client currently guards only on `typeof URL !== 'undefined'`, so on those browsers `formatURL()` throws a `TypeError` at `url.searchParams.append('token', token)` during `init()`. Since `init()` runs at the top of the dev client entry chunk, the whole chunk fails to execute and the page cannot boot against the dev server on those devices at all.

This PR extends the guard with a `'searchParams' in URL.prototype` feature check, so such browsers fall through to the existing string-concatenation fallback (the same path used for IE 11), which already produces an equivalent WebSocket URL including the `token` query parameter.

We have been carrying exactly this fix as a one-line `pnpm patch` on `@rsbuild/core` since 1.2.x, and it is verified working on the affected devices (dev server boots and HMR connects via the string-URL fallback).

## Related Links

- The `dev.client.webSocketTransport` / `resolveWebSocketUrl` hook (#7770) cannot be used as a workaround, because it is applied in `getSocketURL()` only after `formatURL()` has already thrown.