### PR TITLE
perf(core): enable native watcher by default

### DIFF
--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -33,6 +33,7 @@ export const pluginBasic = (): RsbuildPlugin => ({
 
         chain.experiments({
           ...chain.get('experiments'),
+          nativeWatcher: true,
           sourceImport: true,
         });
 

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -10,6 +10,7 @@ exports[`default bundler > should use Rspack by default 1`] = `
     ],
   },
   "experiments": {
+    "nativeWatcher": true,
     "sourceImport": true,
   },
   "infrastructureLogging": {

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -33,6 +33,7 @@ exports[`should apply default plugins correctly 1`] = `
   "context": "<ROOT>",
   "devtool": "cheap-module-source-map",
   "experiments": {
+    "nativeWatcher": true,
     "sourceImport": true,
   },
   "infrastructureLogging": {
@@ -602,6 +603,7 @@ exports[`should apply default plugins correctly in production 1`] = `
   "context": "<ROOT>",
   "devtool": false,
   "experiments": {
+    "nativeWatcher": true,
     "sourceImport": true,
   },
   "infrastructureLogging": {
@@ -1201,6 +1203,7 @@ exports[`should apply default plugins correctly when target is node 1`] = `
   "context": "<ROOT>",
   "devtool": "cheap-module-source-map",
   "experiments": {
+    "nativeWatcher": true,
     "sourceImport": true,
   },
   "infrastructureLogging": {
@@ -1757,6 +1760,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
   "context": "<ROOT>",
   "devtool": "cheap-module-source-map",
   "experiments": {
+    "nativeWatcher": true,
     "sourceImport": true,
   },
   "infrastructureLogging": {

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -6,6 +6,7 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
     "context": "<ROOT>",
     "devtool": "eval-source-map",
     "experiments": {
+      "nativeWatcher": true,
       "sourceImport": true,
     },
     "infrastructureLogging": {
@@ -572,6 +573,7 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
     "context": "<ROOT>",
     "devtool": "eval",
     "experiments": {
+      "nativeWatcher": true,
       "sourceImport": true,
     },
     "infrastructureLogging": {

--- a/website/docs/en/guide/optimization/build-performance.mdx
+++ b/website/docs/en/guide/optimization/build-performance.mdx
@@ -77,16 +77,18 @@ export default {
 
 > See [dev.lazyCompilation](/config/dev/lazy-compilation) for more information.
 
-### Enable native watcher
+### Native watcher
 
-Enabling Rspack's [native watcher](https://rspack.rs/config/experiments#experimentsnativewatcher) improves HMR performance in development mode.
+Starting with Rsbuild 2.2.0, Rspack's [native watcher](https://rspack.rs/config/experiments#experimentsnativewatcher) is enabled by default to improve HMR performance in development mode.
+
+If a plugin requires Watchpack compatibility, you can disable the native watcher:
 
 ```ts title="rsbuild.config.ts"
 export default {
   tools: {
     rspack: {
       experiments: {
-        nativeWatcher: true,
+        nativeWatcher: false,
       },
     },
   },

--- a/website/docs/zh/guide/optimization/build-performance.mdx
+++ b/website/docs/zh/guide/optimization/build-performance.mdx
@@ -77,16 +77,18 @@ export default {
 
 > 请参考 [dev.lazyCompilation](/config/dev/lazy-compilation) 了解更多。
 
-### 开启 native watcher
+### Native watcher
 
-启用 Rspack 的 [native watcher](https://rspack.rs/zh/config/experiments#experimentsnativewatcher) 可以提升开发模式下的 HMR 性能。
+从 Rsbuild 2.2.0 开始，Rspack 的 [native watcher](https://rspack.rs/zh/config/experiments#experimentsnativewatcher) 默认启用，以提升开发模式下的 HMR 性能。
+
+如果使用的插件需要兼容 Watchpack，你可以禁用 native watcher：
 
 ```ts title="rsbuild.config.ts"
 export default {
   tools: {
     rspack: {
       experiments: {
-        nativeWatcher: true,
+        nativeWatcher: false,
       },
     },
   },


### PR DESCRIPTION
## Summary

This PR enables Rspack's native watcher by default in Rsbuild to improve file watching performance and stability when processing frequent file changes.

Users can opt out through `tools.rspack.experiments.nativeWatcher` when Watchpack compatibility is required.

## Performance

Measured locally with [rstackjs/build-tools-performance](https://github.com/rstackjs/build-tools-performance) using Rspack 2.1.10, Rsbuild 2.1.13, and Node.js 24.19.0.

| Case | Rspack CLI HMR | Change | Rsbuild HMR | Change |
| --- | ---: | ---: | ---: | ---: |
| react-1k | 79 ms → 74 ms | -6.3% | 92 ms → 72 ms | -21.7% |
| react-5k | 75 ms → 59 ms | -21.3% | 65 ms → 60 ms | -7.7% |
| react-10k | 85 ms → 73 ms | -14.1% | 88 ms → 74 ms | -15.9% |
| Cross-case mean | 79.7 ms → 68.7 ms | **-13.8%** | 81.7 ms → 68.7 ms | **-15.9%** |

All six tool/case comparisons showed faster HMR with the native watcher, with improvements ranging from 6.3% to 21.7%.

## Related Links

- https://rspack.rs/config/experiments#experimentsnativewatcher