### PR TITLE
feat(plugin-babel): add modifyBabelLoaders helper

### DIFF
--- a/packages/plugin-babel/src/helper.ts
+++ b/packages/plugin-babel/src/helper.ts
@@ -14,6 +14,7 @@ import type {
 } from './types.js';
 
 export const BABEL_JS_RULE = 'babel-js';
+const BABEL_JS_RULE_REGEXP = /^babel-js(?:-\d+)?$/;
 
 export const getBabelRuleId = (chain: RspackChain): string => {
   let id = BABEL_JS_RULE;
@@ -22,6 +23,16 @@ export const getBabelRuleId = (chain: RspackChain): string => {
     id = `${BABEL_JS_RULE}-${++index}`;
   }
   return id;
+};
+
+const isBabelRuleId = (id: string) => BABEL_JS_RULE_REGEXP.test(id);
+
+const getBabelRules = (chain: RspackChain) => {
+  const ruleIds = Object.keys(chain.module.rules.entries()).filter(
+    isBabelRuleId,
+  );
+
+  return ruleIds.map((id) => chain.module.rules.get(id));
 };
 
 export const castArray = <T>(arr?: T | T[]): T[] => {
@@ -189,20 +200,7 @@ export const applyUserBabelConfig = (
   return defaultOptions;
 };
 
-type BabelRule = RspackChain.Rule<unknown>;
-
-const walkRules = <Parent>(
-  rules: RspackChain.Rule<Parent>[],
-  callback: (rule: BabelRule) => void,
-): void => {
-  for (const rule of rules) {
-    callback(rule);
-    walkRules(rule.rules.values(), callback);
-    walkRules(rule.oneOfs.values(), callback);
-  }
-};
-
-/** Modify every Babel loader configured in the Rspack chain. */
+/** Modify Babel loaders in Rsbuild's known Babel rules. */
 export const modifyBabelLoaders = ({
   chain,
   CHAIN_ID,
@@ -210,10 +208,17 @@ export const modifyBabelLoaders = ({
   modifyRule,
 }: ModifyBabelLoadersOptions): void => {
   const babelUseId = CHAIN_ID.USE.BABEL;
+  const rules = [
+    chain.module.rules
+      .get(CHAIN_ID.RULE.JS)
+      .oneOfs.get(CHAIN_ID.ONE_OF.JS_MAIN),
+    chain.module.rules.get(CHAIN_ID.RULE.JS_DATA_URI),
+    ...getBabelRules(chain),
+  ].filter(Boolean);
 
-  walkRules(chain.module.rules.values(), (rule) => {
+  for (const rule of rules) {
     if (!rule.uses.has(babelUseId)) {
-      return;
+      continue;
     }
 
     if (modifyOptions) {
@@ -223,7 +228,7 @@ export const modifyBabelLoaders = ({
     }
 
     modifyRule?.(rule, { babelUseId });
-  });
+  }
 };
 
 export const modifyBabelLoaderOptions = ({

--- a/packages/plugin-babel/src/helper.ts
+++ b/packages/plugin-babel/src/helper.ts
@@ -7,13 +7,13 @@ import type {
   BabelLoaderOptions,
   BabelPlugin,
   BabelTransformOptions,
+  ModifyBabelLoadersOptions,
   PluginBabelOptions,
   PresetEnvOptions,
   PresetReactOptions,
 } from './types.js';
 
 export const BABEL_JS_RULE = 'babel-js';
-const BABEL_JS_RULE_REGEXP = /^babel-js(?:-\d+)?$/;
 
 export const getBabelRuleId = (chain: RspackChain): string => {
   let id = BABEL_JS_RULE;
@@ -22,16 +22,6 @@ export const getBabelRuleId = (chain: RspackChain): string => {
     id = `${BABEL_JS_RULE}-${++index}`;
   }
   return id;
-};
-
-const isBabelRuleId = (id: string) => BABEL_JS_RULE_REGEXP.test(id);
-
-const getBabelRules = (chain: RspackChain) => {
-  const ruleIds = Object.keys(chain.module.rules.entries()).filter(
-    isBabelRuleId,
-  );
-
-  return ruleIds.map((id) => chain.module.rules.get(id));
 };
 
 export const castArray = <T>(arr?: T | T[]): T[] => {
@@ -199,6 +189,43 @@ export const applyUserBabelConfig = (
   return defaultOptions;
 };
 
+type BabelRule = RspackChain.Rule<unknown>;
+
+const walkRules = <Parent>(
+  rules: RspackChain.Rule<Parent>[],
+  callback: (rule: BabelRule) => void,
+): void => {
+  for (const rule of rules) {
+    callback(rule);
+    walkRules(rule.rules.values(), callback);
+    walkRules(rule.oneOfs.values(), callback);
+  }
+};
+
+/** Modify every Babel loader configured in the Rspack chain. */
+export const modifyBabelLoaders = ({
+  chain,
+  CHAIN_ID,
+  modifyOptions,
+  modifyRule,
+}: ModifyBabelLoadersOptions): void => {
+  const babelUseId = CHAIN_ID.USE.BABEL;
+
+  walkRules(chain.module.rules.values(), (rule) => {
+    if (!rule.uses.has(babelUseId)) {
+      return;
+    }
+
+    if (modifyOptions) {
+      rule
+        .use(babelUseId)
+        .tap((options) => modifyOptions(options as BabelTransformOptions));
+    }
+
+    modifyRule?.(rule, { babelUseId });
+  });
+};
+
 export const modifyBabelLoaderOptions = ({
   chain,
   CHAIN_ID,
@@ -208,19 +235,9 @@ export const modifyBabelLoaderOptions = ({
   CHAIN_ID: ChainIdentifier;
   modifier: (config: BabelTransformOptions) => BabelTransformOptions;
 }): void => {
-  const rules = [
-    chain.module.rules
-      .get(CHAIN_ID.RULE.JS)
-      .oneOfs.get(CHAIN_ID.ONE_OF.JS_MAIN),
-    chain.module.rules.get(CHAIN_ID.RULE.JS_DATA_URI),
-    ...getBabelRules(chain),
-  ].filter(Boolean);
-
-  for (const rule of rules) {
-    if (rule.uses.has(CHAIN_ID.USE.BABEL)) {
-      rule
-        .use(CHAIN_ID.USE.BABEL)
-        .tap((options) => modifier(options as BabelTransformOptions));
-    }
-  }
+  modifyBabelLoaders({
+    chain,
+    CHAIN_ID,
+    modifyOptions: modifier,
+  });
 };

--- a/packages/plugin-babel/src/index.ts
+++ b/packages/plugin-babel/src/index.ts
@@ -1,4 +1,8 @@
-export { getBabelUtils, modifyBabelLoaderOptions } from './helper.js';
+export {
+  getBabelUtils,
+  modifyBabelLoaderOptions,
+  modifyBabelLoaders,
+} from './helper.js';
 export {
   getDefaultBabelOptions,
   PLUGIN_BABEL_NAME,
@@ -7,6 +11,7 @@ export {
 export type {
   BabelConfigUtils,
   BabelTransformOptions,
+  ModifyBabelLoadersOptions,
   PluginBabelOptions,
   PresetEnvBuiltIns,
   PresetEnvOptions,

--- a/packages/plugin-babel/src/types.ts
+++ b/packages/plugin-babel/src/types.ts
@@ -2,9 +2,24 @@ import type {
   PluginItem as BabelPlugin,
   TransformOptions as BabelTransformOptions,
 } from '@babel/core';
-import type { ConfigChainWithContext } from '@rsbuild/core';
+import type {
+  ChainIdentifier,
+  ConfigChainWithContext,
+  RspackChain,
+} from '@rsbuild/core';
 
 export type { BabelPlugin, BabelTransformOptions };
+
+type BabelRule = RspackChain.Rule<unknown>;
+
+export type ModifyBabelLoadersOptions = {
+  chain: RspackChain;
+  CHAIN_ID: ChainIdentifier;
+  /** Modify the options of each Babel loader. */
+  modifyOptions?: (config: BabelTransformOptions) => BabelTransformOptions;
+  /** Modify each rule that contains a Babel loader. */
+  modifyRule?: (rule: BabelRule, context: { babelUseId: string }) => void;
+};
 
 export type PresetEnvTargets = string | string[] | Record<string, string>;
 export type PresetEnvBuiltIns = 'usage' | 'entry' | false;

--- a/packages/plugin-babel/src/types.ts
+++ b/packages/plugin-babel/src/types.ts
@@ -17,7 +17,7 @@ export type ModifyBabelLoadersOptions = {
   CHAIN_ID: ChainIdentifier;
   /** Modify the options of each Babel loader. */
   modifyOptions?: (config: BabelTransformOptions) => BabelTransformOptions;
-  /** Modify each rule that contains a Babel loader. */
+  /** Modify each matched rule that contains a Babel loader. */
   modifyRule?: (rule: BabelRule, context: { babelUseId: string }) => void;
 };
 

--- a/packages/plugin-babel/tests/index.test.ts
+++ b/packages/plugin-babel/tests/index.test.ts
@@ -153,9 +153,6 @@ describe('plugins/babel', () => {
   });
 
   it('should modify Babel loaders in known rules', async () => {
-    let modifiedOptionsCount = 0;
-    let modifiedRuleCount = 0;
-
     const rsbuild = await createRsbuild({
       cwd: import.meta.dirname,
       config: {
@@ -166,46 +163,29 @@ describe('plugins/babel', () => {
             name: 'test:modify-babel-loaders',
             setup(api) {
               api.modifyBundlerChain((chain, { CHAIN_ID }) => {
-                const babelLoader = chain.module.rules
-                  .get(CHAIN_ID.RULE.JS)
-                  .oneOfs.get(CHAIN_ID.ONE_OF.JS_MAIN)
-                  .uses.get(CHAIN_ID.USE.BABEL)
-                  .get('loader');
-
                 chain.module.rules
                   .get(CHAIN_ID.RULE.JS_DATA_URI)
                   .use(CHAIN_ID.USE.BABEL)
-                  .loader(babelLoader)
+                  .loader('babel-loader')
                   .options({ comments: true });
 
                 chain.module
                   .rule('nested-rules')
-                  .test(/nested-rules/)
                   .rule('babel')
                   .use(CHAIN_ID.USE.BABEL)
-                  .loader(babelLoader)
-                  .options({ comments: true });
-
-                chain.module
-                  .rule('nested-one-ofs')
-                  .test(/nested-one-ofs/)
-                  .oneOf('babel')
-                  .use(CHAIN_ID.USE.BABEL)
-                  .loader(babelLoader)
+                  .loader('babel-loader')
                   .options({ comments: true });
 
                 modifyBabelLoaders({
                   chain,
                   CHAIN_ID,
                   modifyOptions(options) {
-                    modifiedOptionsCount++;
                     return {
                       ...options,
                       comments: false,
                     };
                   },
                   modifyRule(rule, { babelUseId }) {
-                    modifiedRuleCount++;
                     rule
                       .use('test-loader')
                       .after(babelUseId)
@@ -225,10 +205,8 @@ describe('plugins/babel', () => {
     const configs = await rsbuild.initConfigs();
     const rules = JSON.stringify(configs[0].module?.rules);
 
-    expect(modifiedOptionsCount).toBe(3);
-    expect(modifiedRuleCount).toBe(3);
     expect(rules.match(/test-loader/g)).toHaveLength(3);
     expect(rules.match(/"comments":false/g)).toHaveLength(3);
-    expect(rules.match(/"comments":true/g)).toHaveLength(2);
+    expect(rules.match(/"comments":true/g)).toHaveLength(1);
   });
 });

--- a/packages/plugin-babel/tests/index.test.ts
+++ b/packages/plugin-babel/tests/index.test.ts
@@ -152,7 +152,7 @@ describe('plugins/babel', () => {
     expect(matchRules(configs[0], 'a.js')).toMatchSnapshot();
   });
 
-  it('should modify Babel loaders in nested rules', async () => {
+  it('should modify Babel loaders in known rules', async () => {
     let modifiedOptionsCount = 0;
     let modifiedRuleCount = 0;
 
@@ -172,13 +172,19 @@ describe('plugins/babel', () => {
                   .uses.get(CHAIN_ID.USE.BABEL)
                   .get('loader');
 
+                chain.module.rules
+                  .get(CHAIN_ID.RULE.JS_DATA_URI)
+                  .use(CHAIN_ID.USE.BABEL)
+                  .loader(babelLoader)
+                  .options({ comments: true });
+
                 chain.module
                   .rule('nested-rules')
                   .test(/nested-rules/)
                   .rule('babel')
                   .use(CHAIN_ID.USE.BABEL)
                   .loader(babelLoader)
-                  .options({});
+                  .options({ comments: true });
 
                 chain.module
                   .rule('nested-one-ofs')
@@ -186,7 +192,7 @@ describe('plugins/babel', () => {
                   .oneOf('babel')
                   .use(CHAIN_ID.USE.BABEL)
                   .loader(babelLoader)
-                  .options({});
+                  .options({ comments: true });
 
                 modifyBabelLoaders({
                   chain,
@@ -219,9 +225,10 @@ describe('plugins/babel', () => {
     const configs = await rsbuild.initConfigs();
     const rules = JSON.stringify(configs[0].module?.rules);
 
-    expect(modifiedOptionsCount).toBe(4);
-    expect(modifiedRuleCount).toBe(4);
-    expect(rules.match(/test-loader/g)).toHaveLength(4);
-    expect(rules.match(/"comments":false/g)).toHaveLength(4);
+    expect(modifiedOptionsCount).toBe(3);
+    expect(modifiedRuleCount).toBe(3);
+    expect(rules.match(/test-loader/g)).toHaveLength(3);
+    expect(rules.match(/"comments":false/g)).toHaveLength(3);
+    expect(rules.match(/"comments":true/g)).toHaveLength(2);
   });
 });

--- a/packages/plugin-babel/tests/index.test.ts
+++ b/packages/plugin-babel/tests/index.test.ts
@@ -1,6 +1,6 @@
 import { createRsbuild } from '@rsbuild/core';
 import { matchRules } from '@scripts/test-helper';
-import { pluginBabel } from '../src';
+import { modifyBabelLoaders, pluginBabel } from '../src';
 
 describe('plugins/babel', () => {
   it('babel-loader should works with builtin:swc-loader', async () => {
@@ -150,5 +150,78 @@ describe('plugins/babel', () => {
 
     const configs = await rsbuild.initConfigs();
     expect(matchRules(configs[0], 'a.js')).toMatchSnapshot();
+  });
+
+  it('should modify Babel loaders in nested rules', async () => {
+    let modifiedOptionsCount = 0;
+    let modifiedRuleCount = 0;
+
+    const rsbuild = await createRsbuild({
+      cwd: import.meta.dirname,
+      config: {
+        plugins: [
+          pluginBabel(),
+          pluginBabel({ include: /standalone/ }),
+          {
+            name: 'test:modify-babel-loaders',
+            setup(api) {
+              api.modifyBundlerChain((chain, { CHAIN_ID }) => {
+                const babelLoader = chain.module.rules
+                  .get(CHAIN_ID.RULE.JS)
+                  .oneOfs.get(CHAIN_ID.ONE_OF.JS_MAIN)
+                  .uses.get(CHAIN_ID.USE.BABEL)
+                  .get('loader');
+
+                chain.module
+                  .rule('nested-rules')
+                  .test(/nested-rules/)
+                  .rule('babel')
+                  .use(CHAIN_ID.USE.BABEL)
+                  .loader(babelLoader)
+                  .options({});
+
+                chain.module
+                  .rule('nested-one-ofs')
+                  .test(/nested-one-ofs/)
+                  .oneOf('babel')
+                  .use(CHAIN_ID.USE.BABEL)
+                  .loader(babelLoader)
+                  .options({});
+
+                modifyBabelLoaders({
+                  chain,
+                  CHAIN_ID,
+                  modifyOptions(options) {
+                    modifiedOptionsCount++;
+                    return {
+                      ...options,
+                      comments: false,
+                    };
+                  },
+                  modifyRule(rule, { babelUseId }) {
+                    modifiedRuleCount++;
+                    rule
+                      .use('test-loader')
+                      .after(babelUseId)
+                      .loader('test-loader');
+                  },
+                });
+              });
+            },
+          },
+        ],
+        performance: {
+          buildCache: false,
+        },
+      },
+    });
+
+    const configs = await rsbuild.initConfigs();
+    const rules = JSON.stringify(configs[0].module?.rules);
+
+    expect(modifiedOptionsCount).toBe(4);
+    expect(modifiedRuleCount).toBe(4);
+    expect(rules.match(/test-loader/g)).toHaveLength(4);
+    expect(rules.match(/"comments":false/g)).toHaveLength(4);
   });
 });


### PR DESCRIPTION
## Summary

This PR adds `modifyBabelLoaders` so integrations can update Babel loader options and their corresponding rules through one helper. It preserves the existing rule matching scope (`JS_MAIN`, `JS_DATA_URI`, and top-level `babel-js(-n)` rules) and keeps `modifyBabelLoaderOptions` as a backward-compatible wrapper.