### PR TITLE
release: @rsbuild/plugin-babel v2.1.0

### DIFF
--- a/packages/create-rsbuild/template-solid-js/package.json
+++ b/packages/create-rsbuild/template-solid-js/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "^2.1.13",
-    "@rsbuild/plugin-babel": "^2.0.1",
+    "@rsbuild/plugin-babel": "^2.1.0",
     "@rsbuild/plugin-solid": "^1.2.2"
   }
 }

--- a/packages/create-rsbuild/template-solid-ts/package.json
+++ b/packages/create-rsbuild/template-solid-ts/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "^2.1.13",
-    "@rsbuild/plugin-babel": "^2.0.1",
+    "@rsbuild/plugin-babel": "^2.1.0",
     "@rsbuild/plugin-solid": "^1.2.2",
     "@types/node": "^24.13.3",
     "typescript": "^6.0.3"

--- a/packages/plugin-babel/CHANGELOG.md
+++ b/packages/plugin-babel/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @rsbuild/plugin-babel
 
+## 2.1.0 (2026-08-18)
+
+### New features
+
+- feat(plugin-babel): add modifyBabelLoaders helper by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/8297
+
+### Performance
+
+- perf(plugin-babel): avoid redundant path join by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/8124
+
 ## 2.0.1 (2026-07-02)
 
 ### Bug fixes

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-babel",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Babel plugin for Rsbuild",
   "homepage": "https://rsbuild.rs",
   "bugs": {


### PR DESCRIPTION
## Summary

Release `@rsbuild/plugin-babel` v2.1.0.

## Changes

- https://github.com/web-infra-dev/rsbuild/pull/8124
- https://github.com/web-infra-dev/rsbuild/pull/8297