### PR TITLE
docs(plugin-babel): document modifyBabelLoaders

### DIFF
--- a/website/docs/en/plugins/list/plugin-babel.mdx
+++ b/website/docs/en/plugins/list/plugin-babel.mdx
@@ -426,6 +426,66 @@ DEBUG=rsbuild pnpm build
 
 Then open the generated `rspack.config.web.mjs` file and search for the `babel-loader` keyword to see the complete `babel-loader` configuration.
 
+## Helper functions
+
+This helper is intended for Rsbuild plugins and framework integrations.
+
+### modifyBabelLoaders
+
+- **Type:**
+
+```ts
+function modifyBabelLoaders(options: ModifyBabelLoadersOptions): void;
+
+type ModifyBabelLoadersOptions = {
+  chain: RspackChain;
+  CHAIN_ID: ChainIdentifier;
+  modifyOptions?: (options: BabelTransformOptions) => BabelTransformOptions;
+  modifyRule?: (
+    rule: RspackChain.Rule<unknown>,
+    context: { babelUseId: string },
+  ) => void;
+};
+```
+
+- **Version:** `>= 2.1.0`
+
+`modifyBabelLoaders` allows you to modify Babel loader options and their containing rules.
+
+- `modifyOptions` updates the current `babel-loader` options and must return the final options.
+- `modifyRule` updates the matched rule. If both callbacks are provided, it runs after `modifyOptions`. Use `babelUseId` to access the Babel loader in that rule.
+
+Call it from the [`modifyBundlerChain`](/plugins/dev/hooks#modifybundlerchain) hook of a custom Rsbuild plugin:
+
+```ts title="rsbuild.config.ts"
+import { defineConfig, type RsbuildPlugin } from '@rsbuild/core';
+import { modifyBabelLoaders, pluginBabel } from '@rsbuild/plugin-babel';
+
+const pluginCustomizeBabel = (): RsbuildPlugin => ({
+  name: 'customize-babel',
+  setup(api) {
+    api.modifyBundlerChain((chain, { CHAIN_ID }) => {
+      modifyBabelLoaders({
+        chain,
+        CHAIN_ID,
+        modifyOptions(options) {
+          options.plugins ??= [];
+          options.plugins.push('babel-plugin-example');
+          return options;
+        },
+        modifyRule(rule) {
+          rule.exclude.add(/[\\/]node_modules[\\/]/);
+        },
+      });
+    });
+  },
+});
+
+export default defineConfig({
+  plugins: [pluginBabel(), pluginCustomizeBabel()],
+});
+```
+
 ## FAQ
 
 ### Compilation freezes

--- a/website/docs/en/plugins/list/plugin-babel.mdx
+++ b/website/docs/en/plugins/list/plugin-babel.mdx
@@ -428,7 +428,7 @@ Then open the generated `rspack.config.web.mjs` file and search for the `babel-l
 
 ## Helper functions
 
-This helper is intended for Rsbuild plugins and framework integrations.
+`@rsbuild/plugin-babel` provides helper functions for plugin developers and framework authors.
 
 ### modifyBabelLoaders
 
@@ -452,7 +452,7 @@ type ModifyBabelLoadersOptions = {
 
 `modifyBabelLoaders` allows you to modify Babel loader options and their containing rules.
 
-- `modifyOptions` updates the current `babel-loader` options and must return the final options.
+- `modifyOptions` updates the current `babel-loader` options and needs to return the final options.
 - `modifyRule` updates the matched rule. If both callbacks are provided, it runs after `modifyOptions`. Use `babelUseId` to access the Babel loader in that rule.
 
 Call it from the [`modifyBundlerChain`](/plugins/dev/hooks#modifybundlerchain) hook of a custom Rsbuild plugin:

--- a/website/docs/zh/plugins/list/plugin-babel.mdx
+++ b/website/docs/zh/plugins/list/plugin-babel.mdx
@@ -427,7 +427,7 @@ DEBUG=rsbuild pnpm build
 
 ## 辅助函数 \{#helper-functions}
 
-该辅助函数主要面向 Rsbuild 插件和框架集成。
+`@rsbuild/plugin-babel` 提供了一些面向插件开发者和框架作者的辅助函数。
 
 ### modifyBabelLoaders
 
@@ -451,7 +451,7 @@ type ModifyBabelLoadersOptions = {
 
 `modifyBabelLoaders` 用于修改 Babel loader 选项及其所在的 rule。
 
-- `modifyOptions` 修改当前的 `babel-loader` 选项，并且必须返回最终选项。
+- `modifyOptions` 修改当前的 `babel-loader` 选项，并且需要返回最终选项。
 - `modifyRule` 修改匹配的 rule。如果同时提供两个回调，它会在 `modifyOptions` 之后执行。可以通过 `babelUseId` 访问该 rule 中的 Babel loader。
 
 在自定义 Rsbuild 插件的 [`modifyBundlerChain`](/plugins/dev/hooks#modifybundlerchain) 钩子中调用此函数：

--- a/website/docs/zh/plugins/list/plugin-babel.mdx
+++ b/website/docs/zh/plugins/list/plugin-babel.mdx
@@ -425,6 +425,66 @@ DEBUG=rsbuild pnpm build
 
 然后打开生成的 `rspack.config.web.mjs`，搜索 `babel-loader` 关键词，即可看到完整的 `babel-loader` 配置内容。
 
+## 辅助函数 \{#helper-functions}
+
+该辅助函数主要面向 Rsbuild 插件和框架集成。
+
+### modifyBabelLoaders
+
+- **类型：**
+
+```ts
+function modifyBabelLoaders(options: ModifyBabelLoadersOptions): void;
+
+type ModifyBabelLoadersOptions = {
+  chain: RspackChain;
+  CHAIN_ID: ChainIdentifier;
+  modifyOptions?: (options: BabelTransformOptions) => BabelTransformOptions;
+  modifyRule?: (
+    rule: RspackChain.Rule<unknown>,
+    context: { babelUseId: string },
+  ) => void;
+};
+```
+
+- **版本：** `>= 2.1.0`
+
+`modifyBabelLoaders` 用于修改 Babel loader 选项及其所在的 rule。
+
+- `modifyOptions` 修改当前的 `babel-loader` 选项，并且必须返回最终选项。
+- `modifyRule` 修改匹配的 rule。如果同时提供两个回调，它会在 `modifyOptions` 之后执行。可以通过 `babelUseId` 访问该 rule 中的 Babel loader。
+
+在自定义 Rsbuild 插件的 [`modifyBundlerChain`](/plugins/dev/hooks#modifybundlerchain) 钩子中调用此函数：
+
+```ts title="rsbuild.config.ts"
+import { defineConfig, type RsbuildPlugin } from '@rsbuild/core';
+import { modifyBabelLoaders, pluginBabel } from '@rsbuild/plugin-babel';
+
+const pluginCustomizeBabel = (): RsbuildPlugin => ({
+  name: 'customize-babel',
+  setup(api) {
+    api.modifyBundlerChain((chain, { CHAIN_ID }) => {
+      modifyBabelLoaders({
+        chain,
+        CHAIN_ID,
+        modifyOptions(options) {
+          options.plugins ??= [];
+          options.plugins.push('babel-plugin-example');
+          return options;
+        },
+        modifyRule(rule) {
+          rule.exclude.add(/[\\/]node_modules[\\/]/);
+        },
+      });
+    });
+  },
+});
+
+export default defineConfig({
+  plugins: [pluginBabel(), pluginCustomizeBabel()],
+});
+```
+
 ## 常见问题
 
 ### 编译卡死


### PR DESCRIPTION
## Summary

This PR adds English and Chinese documentation for `modifyBabelLoaders`, covering its callbacks and usage in custom Rsbuild plugins.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/8297