### PR TITLE
chore(lint): enable Rstest rules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,6 @@
   "mdx.validate.validateFileLinks": "ignore",
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   // Temporary workaround until we switch to the Rstack VS Code extension.
-  "prettier.printWidth": 100,
   "prettier.singleQuote": true,
   "js/ts.tsdk.path": "node_modules/typescript/lib",
   "json.schemas": [

--- a/packages/core/tests/__snapshots__/asset.test.ts.snap
+++ b/packages/core/tests/__snapshots__/asset.test.ts.snap
@@ -42,48 +42,6 @@ exports[`plugin-asset > should add image rules correctly 1`] = `
 ]
 `;
 
-exports[`plugin-asset > should add image rules correctly 2`] = `
-[
-  {
-    "oneOf": [
-      {
-        "generator": {
-          "filename": "[name].[contenthash:10][ext]",
-        },
-        "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
-        "type": "asset/resource",
-      },
-      {
-        "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
-        "type": "asset/inline",
-      },
-      {
-        "type": "asset/source",
-        "with": {
-          "type": "text",
-        },
-      },
-      {
-        "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
-        "type": "asset/source",
-      },
-      {
-        "generator": {
-          "filename": "[name].[contenthash:10][ext]",
-        },
-        "parser": {
-          "dataUrlCondition": {
-            "maxSize": 4096,
-          },
-        },
-        "type": "asset",
-      },
-    ],
-    "test": /\\\\\\.\\(\\?:png\\|jpg\\|jpeg\\|pjpeg\\|pjp\\|gif\\|bmp\\|webp\\|ico\\|apng\\|avif\\|tif\\|tiff\\|jfif\\|cur\\|jxl\\)\\$/i,
-  },
-]
-`;
-
 exports[`plugin-asset > should add media rules correctly 1`] = `
 [
   {
@@ -164,6 +122,48 @@ exports[`plugin-asset > should add other asset rules correctly 1`] = `
       },
     ],
     "test": /\\\\\\.\\(\\?:webmanifest\\|pdf\\|txt\\)\\$/i,
+  },
+]
+`;
+
+exports[`plugin-asset > should allow setting distPath.image to an empty string 1`] = `
+[
+  {
+    "oneOf": [
+      {
+        "generator": {
+          "filename": "[name].[contenthash:10][ext]",
+        },
+        "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
+        "type": "asset/resource",
+      },
+      {
+        "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
+        "type": "asset/inline",
+      },
+      {
+        "type": "asset/source",
+        "with": {
+          "type": "text",
+        },
+      },
+      {
+        "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
+        "type": "asset/source",
+      },
+      {
+        "generator": {
+          "filename": "[name].[contenthash:10][ext]",
+        },
+        "parser": {
+          "dataUrlCondition": {
+            "maxSize": 4096,
+          },
+        },
+        "type": "asset",
+      },
+    ],
+    "test": /\\\\\\.\\(\\?:png\\|jpg\\|jpeg\\|pjpeg\\|pjp\\|gif\\|bmp\\|webp\\|ico\\|apng\\|avif\\|tif\\|tiff\\|jfif\\|cur\\|jxl\\)\\$/i,
   },
 ]
 `;

--- a/packages/core/tests/asset.test.ts
+++ b/packages/core/tests/asset.test.ts
@@ -38,7 +38,7 @@ describe('plugin-asset', () => {
     expect(matchRules(config, 'a.png')).toMatchSnapshot();
   });
 
-  test('should add image rules correctly', async () => {
+  test('should allow setting distPath.image to an empty string', async () => {
     const rsbuild = await createRsbuild({
       config: {
         output: {

--- a/packages/create-rsbuild/template-rstest/vanilla-js/tests/dom.test.js
+++ b/packages/create-rsbuild/template-rstest/vanilla-js/tests/dom.test.js
@@ -1,7 +1,7 @@
 import { expect, test } from '@rstest/core';
 import { screen } from '@testing-library/dom';
 
-test('test dom', () => {
+test('renders content', () => {
   document.body.innerHTML = `
     <span data-testid="not-empty"><span data-testid="empty"></span></span>
     <div data-testid="visible">Visible Example</div>

--- a/packages/create-rsbuild/template-rstest/vanilla-ts/tests/dom.test.ts
+++ b/packages/create-rsbuild/template-rstest/vanilla-ts/tests/dom.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@rstest/core';
 import { screen } from '@testing-library/dom';
 
-test('test dom', () => {
+test('renders content', () => {
   document.body.innerHTML = `
     <span data-testid="not-empty"><span data-testid="empty"></span></span>
     <div data-testid="visible">Visible Example</div>

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -18,7 +18,7 @@ define.staged({
   '*.{js,jsx,ts,tsx,mjs,cjs}': ['rs lint --type-check', 'rs fmt'],
 });
 
-define.lint(async ({ globalIgnores, js, ts }) => {
+define.lint(async ({ globalIgnores, js, rstestPlugin, ts }) => {
   const { default: globals } = await import('globals');
   return [
     globalIgnores([
@@ -27,6 +27,10 @@ define.lint(async ({ globalIgnores, js, ts }) => {
     ]),
     js.configs.recommended,
     ts.configs.recommendedTypeChecked,
+    {
+      files: ['**/*.test.{ts,tsx}'],
+      ...rstestPlugin.configs.recommended,
+    },
     {
       files: ['**/*.{js,jsx,cjs,mjs}'],
       languageOptions: {


### PR DESCRIPTION
## Summary

This PR enables Rstest's recommended lint rules for TypeScript test files so invalid test patterns are caught by repository checks. It applies the rules to both `.test.ts` and `.test.tsx` files and updates the existing violations. It also removes the obsolete VS Code print-width override now that the repository uses Prettier's default.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/371