### PR TITLE
release: @rsbuild/plugin-solid v2.0.0-beta.1

### DIFF
--- a/packages/create-rsbuild/template-solid-js/package.json
+++ b/packages/create-rsbuild/template-solid-js/package.json
@@ -15,6 +15,6 @@
   "devDependencies": {
     "@rsbuild/core": "^2.1.13",
     "@rsbuild/plugin-babel": "^2.1.0",
-    "@rsbuild/plugin-solid": "^2.0.0-beta.0"
+    "@rsbuild/plugin-solid": "^2.0.0-beta.1"
   }
 }

--- a/packages/create-rsbuild/template-solid-ts/package.json
+++ b/packages/create-rsbuild/template-solid-ts/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@rsbuild/core": "^2.1.13",
     "@rsbuild/plugin-babel": "^2.1.0",
-    "@rsbuild/plugin-solid": "^2.0.0-beta.0",
+    "@rsbuild/plugin-solid": "^2.0.0-beta.1",
     "@types/node": "^24.13.3",
     "typescript": "^6.0.3"
   }

--- a/packages/plugin-solid/CHANGELOG.md
+++ b/packages/plugin-solid/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @rsbuild/plugin-solid
 
+## 2.0.0-beta.1 (2026-08-18)
+
+### New features
+
+- feat(plugin-solid): support Solid v2 RC by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/8301
+
 ## 1.2.2 (2026-06-05)
 
 ### Bug fixes

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-solid",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "description": "Solid plugin for Rsbuild",
   "homepage": "https://rsbuild.rs",
   "bugs": {


### PR DESCRIPTION
## Summary

Release `@rsbuild/plugin-solid` v2.0.0-beta.1.

## Changes

- https://github.com/web-infra-dev/rsbuild/pull/8301