### PR TITLE
fix(create-rsbuild): correct Solid JSX import source

### DIFF
--- a/packages/create-rsbuild/template-solid-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-solid-ts/tsconfig.json
@@ -6,7 +6,7 @@
     "noEmit": true,
     "skipLibCheck": true,
     "types": ["@rsbuild/core/types", "node"],
-    "jsxImportSource": "solid-js",
+    "jsxImportSource": "@solidjs/web",
     "useDefineForClassFields": true,
 
     /* modules */


### PR DESCRIPTION
## Summary

Fix the Solid TypeScript template to use `@solidjs/web` as its JSX import source. Solid 2 exposes the JSX runtime and types from `@solidjs/web`, so generated projects can type-check correctly.