### PR TITLE
docs: update build performance optimization guide

### DIFF
--- a/website/docs/en/guide/optimization/build-performance.mdx
+++ b/website/docs/en/guide/optimization/build-performance.mdx
@@ -138,10 +138,6 @@ These methods improve performance in production mode.
 
 Enable Rspack's experimental [`experiments.fasterModuleConcatenation`](https://rspack.rs/config/experiments#experimentsfastermoduleconcatenation) option to speed up module concatenation in production builds.
 
-:::tip
-`experiments.fasterModuleConcatenation` is supported in Rsbuild v2.2.0 and later.
-:::
-
 ```ts title="rsbuild.config.ts"
 export default {
   tools: {
@@ -153,3 +149,7 @@ export default {
   },
 };
 ```
+
+:::tip
+`experiments.fasterModuleConcatenation` is supported in Rsbuild v2.2.0 and later.
+:::

--- a/website/docs/en/guide/optimization/build-performance.mdx
+++ b/website/docs/en/guide/optimization/build-performance.mdx
@@ -138,6 +138,10 @@ These methods improve performance in production mode.
 
 Enable Rspack's experimental [`experiments.fasterModuleConcatenation`](https://rspack.rs/config/experiments#experimentsfastermoduleconcatenation) option to speed up module concatenation in production builds.
 
+:::tip
+`experiments.fasterModuleConcatenation` is supported in Rsbuild v2.2.0 and later.
+:::
+
 ```ts title="rsbuild.config.ts"
 export default {
   tools: {

--- a/website/docs/en/guide/optimization/build-performance.mdx
+++ b/website/docs/en/guide/optimization/build-performance.mdx
@@ -77,24 +77,6 @@ export default {
 
 > See [dev.lazyCompilation](/config/dev/lazy-compilation) for more information.
 
-### Native watcher
-
-Starting with Rsbuild 2.2.0, Rspack's [native watcher](https://rspack.rs/config/experiments#experimentsnativewatcher) is enabled by default to improve HMR performance in development mode.
-
-If a plugin requires Watchpack compatibility, you can disable the native watcher:
-
-```ts title="rsbuild.config.ts"
-export default {
-  tools: {
-    rspack: {
-      experiments: {
-        nativeWatcher: false,
-      },
-    },
-  },
-};
-```
-
 ### Source map format
 
 To provide a good debugging experience, Rsbuild uses the `cheap-module-source-map` format in development mode by default. This is a high-quality source map format that comes with some performance overhead.
@@ -147,3 +129,23 @@ last 1 safari version
 ```
 
 Note that this can lead to differences in build output between development and production modes.
+
+## Production optimization
+
+These methods improve performance in production mode.
+
+### Enable faster module concatenation
+
+Enable Rspack's experimental [`experiments.fasterModuleConcatenation`](https://rspack.rs/config/experiments#experimentsfastermoduleconcatenation) option to speed up module concatenation in production builds.
+
+```ts title="rsbuild.config.ts"
+export default {
+  tools: {
+    rspack: {
+      experiments: {
+        fasterModuleConcatenation: true,
+      },
+    },
+  },
+};
+```

--- a/website/docs/zh/guide/optimization/build-performance.mdx
+++ b/website/docs/zh/guide/optimization/build-performance.mdx
@@ -138,6 +138,10 @@ last 1 safari version
 
 开启 Rspack 的实验性 [`experiments.fasterModuleConcatenation`](https://rspack.rs/zh/config/experiments#experimentsfastermoduleconcatenation) 配置，可以提升生产模式下的模块合并速度。
 
+:::tip
+`experiments.fasterModuleConcatenation` 配置在 Rsbuild v2.2.0 及以上版本中支持。
+:::
+
 ```ts title="rsbuild.config.ts"
 export default {
   tools: {

--- a/website/docs/zh/guide/optimization/build-performance.mdx
+++ b/website/docs/zh/guide/optimization/build-performance.mdx
@@ -138,10 +138,6 @@ last 1 safari version
 
 开启 Rspack 的实验性 [`experiments.fasterModuleConcatenation`](https://rspack.rs/zh/config/experiments#experimentsfastermoduleconcatenation) 配置，可以提升生产模式下的模块合并速度。
 
-:::tip
-`experiments.fasterModuleConcatenation` 配置在 Rsbuild v2.2.0 及以上版本中支持。
-:::
-
 ```ts title="rsbuild.config.ts"
 export default {
   tools: {
@@ -153,3 +149,7 @@ export default {
   },
 };
 ```
+
+:::tip
+`experiments.fasterModuleConcatenation` 配置在 Rsbuild v2.2.0 及以上版本中支持。
+:::

--- a/website/docs/zh/guide/optimization/build-performance.mdx
+++ b/website/docs/zh/guide/optimization/build-performance.mdx
@@ -77,24 +77,6 @@ export default {
 
 > 请参考 [dev.lazyCompilation](/config/dev/lazy-compilation) 了解更多。
 
-### Native watcher
-
-从 Rsbuild 2.2.0 开始，Rspack 的 [native watcher](https://rspack.rs/zh/config/experiments#experimentsnativewatcher) 默认启用，以提升开发模式下的 HMR 性能。
-
-如果使用的插件需要兼容 Watchpack，你可以禁用 native watcher：
-
-```ts title="rsbuild.config.ts"
-export default {
-  tools: {
-    rspack: {
-      experiments: {
-        nativeWatcher: false,
-      },
-    },
-  },
-};
-```
-
 ### Source map 格式
 
 为了提供良好的调试体验，Rsbuild 在开发模式下默认使用 `cheap-module-source-map` 格式 source map，这是一种高质量的 source map 格式，会带来一定的性能开销。
@@ -147,3 +129,23 @@ last 1 safari version
 ```
 
 注意，这项优化方法会导致开发模式与生产模式的构建产物存在一定差异。
+
+## 生产模式优化
+
+以下是针对生产构建进行提速的方法。
+
+### 开启更快的模块合并
+
+开启 Rspack 的实验性 [`experiments.fasterModuleConcatenation`](https://rspack.rs/zh/config/experiments#experimentsfastermoduleconcatenation) 配置，可以提升生产模式下的模块合并速度。
+
+```ts title="rsbuild.config.ts"
+export default {
+  tools: {
+    rspack: {
+      experiments: {
+        fasterModuleConcatenation: true,
+      },
+    },
+  },
+};
+```


### PR DESCRIPTION
## Summary

The native watcher no longer needs opt-in guidance because Rsbuild enables it by default. This PR replaces that section with a production optimization guide for Rspack's experimental `experiments.fasterModuleConcatenation` option, supported in Rsbuild v2.2.0 and later, in both English and Chinese.

## Related Links

- https://rspack.rs/config/experiments#experimentsfastermoduleconcatenation