### PR TITLE
fix(core): handle server startup errors

### DIFF
--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -1,3 +1,4 @@
+import { once } from 'node:events';
 import type { Server } from 'node:http';
 import type { Http2SecureServer } from 'node:http2';
 import { color, pick } from '../helpers';
@@ -390,41 +391,33 @@ export async function createDevServer<
 
       context.hooks.onCloseDevServer.tap(serverTerminator);
 
-      return new Promise<StartDevServerResult>((resolve) => {
-        httpServer.listen(
-          {
-            host,
-            port,
-          },
-          async (err?: Error) => {
-            if (err) {
-              throw err;
-            }
-
-            // OPTIONS request fallback middleware
-            // Should register this middleware as the last
-            // see: https://github.com/web-infra-dev/rsbuild/pull/2867
-            middlewares.use(optionsFallbackMiddleware);
-
-            // 404 fallback middleware should be the last middleware
-            middlewares.use(notFoundMiddleware);
-
-            if (state.devMiddlewares) {
-              httpServer.on('upgrade', state.devMiddlewares.onUpgrade);
-            }
-
-            logger.debug('listen dev server done');
-
-            await devServer.afterListen();
-
-            resolve({
-              port,
-              urls: urls.map((item) => item.url),
-              server: devServer,
-            });
-          },
-        );
+      httpServer.listen({
+        host,
+        port,
       });
+      await once(httpServer, 'listening');
+
+      // OPTIONS request fallback middleware
+      // Should register this middleware as the last
+      // see: https://github.com/web-infra-dev/rsbuild/pull/2867
+      middlewares.use(optionsFallbackMiddleware);
+
+      // 404 fallback middleware should be the last middleware
+      middlewares.use(notFoundMiddleware);
+
+      if (state.devMiddlewares) {
+        httpServer.on('upgrade', state.devMiddlewares.onUpgrade);
+      }
+
+      logger.debug('listen dev server done');
+
+      await devServer.afterListen();
+
+      return {
+        port,
+        urls: urls.map((item) => item.url),
+        server: devServer,
+      };
     },
     afterListen: async () => {
       await context.hooks.onAfterStartDevServer.callBatch({

--- a/packages/core/src/server/previewServer.ts
+++ b/packages/core/src/server/previewServer.ts
@@ -1,3 +1,4 @@
+import { once } from 'node:events';
 import fs from 'node:fs';
 import { isWebTarget } from '../helpers';
 import { isVerbose } from '../logger';
@@ -247,48 +248,44 @@ export async function startPreviewServer(
   middlewares.use(optionsFallbackMiddleware);
   middlewares.use(notFoundMiddleware);
 
-  return new Promise<StartPreviewServerResult>((resolve) => {
-    httpServer.listen(
-      {
-        host,
-        port,
-      },
-      async () => {
-        await context.hooks.onAfterStartPreviewServer.callBatch({
-          port,
-          routes,
-          environments: context.environments,
-        });
-
-        registerCleanup(closeServer);
-        printUrls();
-
-        if (cliShortcutsEnabled) {
-          const shortcutsOptions =
-            typeof config.dev.cliShortcuts === 'boolean'
-              ? {}
-              : config.dev.cliShortcuts;
-
-          await setupCliShortcuts({
-            openPage,
-            closeServer,
-            printUrls,
-            help: shortcutsOptions.help,
-            customShortcuts: shortcutsOptions.custom,
-            logger,
-          });
-        }
-
-        if (!getPortSilently && portTip) {
-          logger.info(portTip);
-        }
-
-        resolve({
-          port,
-          urls: urls.map((item) => item.url),
-          server: previewServer,
-        });
-      },
-    );
+  httpServer.listen({
+    host,
+    port,
   });
+  await once(httpServer, 'listening');
+
+  await context.hooks.onAfterStartPreviewServer.callBatch({
+    port,
+    routes,
+    environments: context.environments,
+  });
+
+  registerCleanup(closeServer);
+  printUrls();
+
+  if (cliShortcutsEnabled) {
+    const shortcutsOptions =
+      typeof config.dev.cliShortcuts === 'boolean'
+        ? {}
+        : config.dev.cliShortcuts;
+
+    await setupCliShortcuts({
+      openPage,
+      closeServer,
+      printUrls,
+      help: shortcutsOptions.help,
+      customShortcuts: shortcutsOptions.custom,
+      logger,
+    });
+  }
+
+  if (!getPortSilently && portTip) {
+    logger.info(portTip);
+  }
+
+  return {
+    port,
+    urls: urls.map((item) => item.url),
+    server: previewServer,
+  };
 }


### PR DESCRIPTION
## Summary

The Node.js `server.listen()` callback is only a `listening` listener: it receives no error argument and does not await returned Promises. As a result, failures from after-start hooks or CLI shortcut setup could become unhandled rejections and leave dev or preview startup pending.

This PR waits for the server's `listening` event with `events.once()` and keeps post-listen work in the surrounding async flow, allowing listen and setup errors to propagate to callers.