### PR TITLE
fix(core): clean up servers after startup failure

### DIFF
--- a/e2e/cases/plugin-api/plugin-hooks/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-hooks/index.test.ts
@@ -1,5 +1,27 @@
+import net from 'node:net';
 import { expect, recordPluginHooks, test } from '@e2e/helper';
-import { createRsbuild } from '@rsbuild/core';
+import {
+  createRsbuild,
+  type RsbuildDevServer,
+  type RsbuildPlugin,
+  type RsbuildPreviewServer,
+} from '@rsbuild/core';
+import { getRandomPort } from '@rstackjs/test-utils';
+
+const HOST = '127.0.0.1';
+
+const expectPortAvailable = async (port: number) => {
+  const server = net.createServer();
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen({ host: HOST, port }, resolve);
+  });
+
+  await new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
+};
 
 test('should run plugin hooks correctly when running build', async ({
   build,
@@ -119,4 +141,73 @@ test('should run plugin hooks correctly when running preview', async () => {
     'BeforeStartPreviewServer',
     'AfterStartPreviewServer',
   ]);
+});
+
+test('should close dev server when onAfterStartDevServer throws', async () => {
+  const port = await getRandomPort();
+  let devServer: RsbuildDevServer | undefined;
+  let closeHookCalled = false;
+  const plugin: RsbuildPlugin = {
+    name: 'throw-in-after-start-dev-server',
+    setup(api) {
+      api.onBeforeStartDevServer(({ server }) => {
+        devServer = server;
+      });
+      api.onAfterStartDevServer(() => {
+        throw new Error('Failed to start dev server');
+      });
+      api.onCloseDevServer(() => {
+        closeHookCalled = true;
+      });
+    },
+  };
+  const rsbuild = await createRsbuild({
+    cwd: import.meta.dirname,
+    config: {
+      server: { host: HOST, port },
+      plugins: [plugin],
+    },
+  });
+
+  try {
+    await expect(
+      rsbuild.startDevServer({ getPortSilently: true }),
+    ).rejects.toThrow('Failed to start dev server');
+    expect(closeHookCalled).toBe(true);
+    await expectPortAvailable(port);
+  } finally {
+    await devServer?.close();
+  }
+});
+
+test('should close preview server when onAfterStartPreviewServer throws', async () => {
+  const port = await getRandomPort();
+  let previewServer: RsbuildPreviewServer | undefined;
+  const plugin: RsbuildPlugin = {
+    name: 'throw-in-after-start-preview-server',
+    setup(api) {
+      api.onBeforeStartPreviewServer(({ server }) => {
+        previewServer = server;
+      });
+      api.onAfterStartPreviewServer(() => {
+        throw new Error('Failed to start preview server');
+      });
+    },
+  };
+  const rsbuild = await createRsbuild({
+    cwd: import.meta.dirname,
+    config: {
+      server: { host: HOST, port },
+      plugins: [plugin],
+    },
+  });
+
+  try {
+    await expect(
+      rsbuild.preview({ checkDistDir: false, getPortSilently: true }),
+    ).rejects.toThrow('Failed to start preview server');
+    await expectPortAvailable(port);
+  } finally {
+    await previewServer?.close();
+  }
 });

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -391,33 +391,43 @@ export async function createDevServer<
 
       context.hooks.onCloseDevServer.tap(serverTerminator);
 
-      httpServer.listen({
-        host,
-        port,
-      });
-      await once(httpServer, 'listening');
+      try {
+        httpServer.listen({
+          host,
+          port,
+        });
+        await once(httpServer, 'listening');
 
-      // OPTIONS request fallback middleware
-      // Should register this middleware as the last
-      // see: https://github.com/web-infra-dev/rsbuild/pull/2867
-      middlewares.use(optionsFallbackMiddleware);
+        // OPTIONS request fallback middleware
+        // Should register this middleware as the last
+        // see: https://github.com/web-infra-dev/rsbuild/pull/2867
+        middlewares.use(optionsFallbackMiddleware);
 
-      // 404 fallback middleware should be the last middleware
-      middlewares.use(notFoundMiddleware);
+        // 404 fallback middleware should be the last middleware
+        middlewares.use(notFoundMiddleware);
 
-      if (state.devMiddlewares) {
-        httpServer.on('upgrade', state.devMiddlewares.onUpgrade);
+        if (state.devMiddlewares) {
+          httpServer.on('upgrade', state.devMiddlewares.onUpgrade);
+        }
+
+        logger.debug('listen dev server done');
+
+        await devServer.afterListen();
+
+        return {
+          port,
+          urls: urls.map((item) => item.url),
+          server: devServer,
+        };
+      } catch (error) {
+        try {
+          await closeServer();
+        } catch (closeError) {
+          logger.error('Failed to close dev server after startup error.');
+          logger.error(closeError);
+        }
+        throw error;
       }
-
-      logger.debug('listen dev server done');
-
-      await devServer.afterListen();
-
-      return {
-        port,
-        urls: urls.map((item) => item.url),
-        server: devServer,
-      };
     },
     afterListen: async () => {
       await context.hooks.onAfterStartDevServer.callBatch({

--- a/packages/core/src/server/previewServer.ts
+++ b/packages/core/src/server/previewServer.ts
@@ -248,44 +248,54 @@ export async function startPreviewServer(
   middlewares.use(optionsFallbackMiddleware);
   middlewares.use(notFoundMiddleware);
 
-  httpServer.listen({
-    host,
-    port,
-  });
-  await once(httpServer, 'listening');
-
-  await context.hooks.onAfterStartPreviewServer.callBatch({
-    port,
-    routes,
-    environments: context.environments,
-  });
-
-  registerCleanup(closeServer);
-  printUrls();
-
-  if (cliShortcutsEnabled) {
-    const shortcutsOptions =
-      typeof config.dev.cliShortcuts === 'boolean'
-        ? {}
-        : config.dev.cliShortcuts;
-
-    await setupCliShortcuts({
-      openPage,
-      closeServer,
-      printUrls,
-      help: shortcutsOptions.help,
-      customShortcuts: shortcutsOptions.custom,
-      logger,
+  try {
+    httpServer.listen({
+      host,
+      port,
     });
-  }
+    await once(httpServer, 'listening');
 
-  if (!getPortSilently && portTip) {
-    logger.info(portTip);
-  }
+    await context.hooks.onAfterStartPreviewServer.callBatch({
+      port,
+      routes,
+      environments: context.environments,
+    });
 
-  return {
-    port,
-    urls: urls.map((item) => item.url),
-    server: previewServer,
-  };
+    registerCleanup(closeServer);
+    printUrls();
+
+    if (cliShortcutsEnabled) {
+      const shortcutsOptions =
+        typeof config.dev.cliShortcuts === 'boolean'
+          ? {}
+          : config.dev.cliShortcuts;
+
+      await setupCliShortcuts({
+        openPage,
+        closeServer,
+        printUrls,
+        help: shortcutsOptions.help,
+        customShortcuts: shortcutsOptions.custom,
+        logger,
+      });
+    }
+
+    if (!getPortSilently && portTip) {
+      logger.info(portTip);
+    }
+
+    return {
+      port,
+      urls: urls.map((item) => item.url),
+      server: previewServer,
+    };
+  } catch (error) {
+    try {
+      await closeServer();
+    } catch (closeError) {
+      logger.error('Failed to close preview server after startup error.');
+      logger.error(closeError);
+    }
+    throw error;
+  }
 }


### PR DESCRIPTION
## Summary

Server startup could leave an already-listening HTTP server and, in dev mode, compiler and watcher resources alive when an `onAfterStart*Server` hook failed. This behavior predates #8307; this PR closes the corresponding server resources before rethrowing the original startup error.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/8307