### PR TITLE
feat(plugin-solid): apply dev option to compiler transforms

### DIFF
--- a/packages/plugin-solid/src/index.ts
+++ b/packages/plugin-solid/src/index.ts
@@ -1,6 +1,6 @@
 import { createRequire } from 'node:module';
 import path from 'node:path';
-import type { RsbuildPlugin } from '@rsbuild/core';
+import type { RsbuildMode, RsbuildPlugin } from '@rsbuild/core';
 import { modifyBabelLoaders } from '@rsbuild/plugin-babel';
 import type { SolidPresetOptions } from './types.js';
 
@@ -8,7 +8,7 @@ const require = createRequire(import.meta.url);
 
 export type PluginSolidOptions = {
   /**
-   * Whether to resolve Solid's development runtime.
+   * Whether to enable Solid's development runtime and compiler transforms.
    * @default `true` in development mode, `false` in production mode
    */
   dev?: boolean;
@@ -29,6 +29,7 @@ export type PluginSolidOptions = {
   };
   /**
    * Options passed to `babel-preset-solid`.
+   * `solid.dev` overrides compiler transforms without changing runtime resolution.
    * @see https://npmjs.com/package/babel-preset-solid
    */
   solid?: SolidPresetOptions;
@@ -44,6 +45,7 @@ export const PLUGIN_SOLID_NAME = 'rsbuild:solid';
 
 export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
   const { dev, solid, solidPresetOptions, ssr } = options;
+  const isDevModeEnabled = (mode: RsbuildMode) => dev ?? mode === 'development';
 
   return {
     name: PLUGIN_SOLID_NAME,
@@ -51,13 +53,13 @@ export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
     setup(api) {
       api.modifyEnvironmentConfig((config) => {
         const conditionNames = config.resolve.conditionNames ?? ['...'];
-        const useDevRuntime = dev ?? config.mode === 'development';
+        const useDevMode = isDevModeEnabled(config.mode);
 
         // Prefer Solid-specific exports while preserving user conditions or Rspack defaults.
         config.resolve.conditionNames = [
           ...new Set([
             'solid',
-            ...(useDevRuntime ? ['development'] : []),
+            ...(useDevMode ? ['development'] : []),
             ...conditionNames,
           ]),
         ];
@@ -66,6 +68,7 @@ export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
       api.modifyBundlerChain(
         (chain, { CHAIN_ID, environment, isProd, target }) => {
           const environmentConfig = environment.config;
+          const useDevMode = isDevModeEnabled(environmentConfig.mode);
           const usingHMR =
             options.refresh?.disabled !== true &&
             !isProd &&
@@ -77,11 +80,14 @@ export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
             CHAIN_ID,
             modifyOptions: (babelOptions) => {
               // Apply SSR defaults before user options so explicit values can override them.
-              const defaultPresetOptions: SolidPresetOptions = ssr
-                ? target === 'node'
-                  ? { generate: 'ssr', hydratable: true }
-                  : { generate: 'dom', hydratable: true }
-                : {};
+              const defaultPresetOptions: SolidPresetOptions = {
+                dev: useDevMode,
+                ...(ssr
+                  ? target === 'node'
+                    ? { generate: 'ssr', hydratable: true }
+                    : { generate: 'dom', hydratable: true }
+                  : {}),
+              };
 
               babelOptions.presets = [
                 [

--- a/packages/plugin-solid/src/types.ts
+++ b/packages/plugin-solid/src/types.ts
@@ -11,6 +11,11 @@ export type SolidPresetOptions = {
    */
   moduleName?: string;
   /**
+   * Whether to generate development-only runtime checks and metadata.
+   * @default false
+   */
+  dev?: boolean;
+  /**
    * The output mode of the compiler.
    * Can be:
    * - "dom" is standard output

--- a/packages/plugin-solid/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-solid/tests/__snapshots__/index.test.ts.snap
@@ -94,6 +94,7 @@ exports[`plugin-solid > should allow deprecated solidPresetOptions alias 1`] = `
               [
                 "<PNPM_INNER>/babel-preset-solid/index.js",
                 {
+                  "dev": false,
                   "generate": "ssr",
                   "hydratable": true,
                 },
@@ -202,6 +203,7 @@ exports[`plugin-solid > should allow solid options to override ssr defaults 1`] 
               [
                 "<PNPM_INNER>/babel-preset-solid/index.js",
                 {
+                  "dev": false,
                   "generate": "universal",
                   "hydratable": false,
                 },
@@ -310,6 +312,7 @@ exports[`plugin-solid > should allow to configure solid options 1`] = `
               [
                 "<PNPM_INNER>/babel-preset-solid/index.js",
                 {
+                  "dev": false,
                   "generate": "ssr",
                   "hydratable": true,
                 },
@@ -420,7 +423,9 @@ exports[`plugin-solid > should apply solid preset correctly 1`] = `
             "presets": [
               [
                 "<PNPM_INNER>/babel-preset-solid/index.js",
-                {},
+                {
+                  "dev": false,
+                },
               ],
             ],
           },
@@ -529,6 +534,7 @@ exports[`plugin-solid > should use hydratable dom output for ssr option on web t
               [
                 "<PNPM_INNER>/babel-preset-solid/index.js",
                 {
+                  "dev": false,
                   "generate": "dom",
                   "hydratable": true,
                 },
@@ -637,6 +643,7 @@ exports[`plugin-solid > should use ssr output for ssr option on node target 1`] 
               [
                 "<PNPM_INNER>/babel-preset-solid/index.js",
                 {
+                  "dev": false,
                   "generate": "ssr",
                   "hydratable": true,
                 },

--- a/packages/plugin-solid/tests/index.test.ts
+++ b/packages/plugin-solid/tests/index.test.ts
@@ -32,20 +32,24 @@ describe('plugin-solid', () => {
     expect(config[0].resolve?.conditionNames).toEqual(['solid', '...']);
   });
 
-  it('should add development resolve condition in development mode', async () => {
+  it('should enable Solid development mode in development mode', async () => {
     const rsbuild = await createRsbuild({
       config: {
         ...rsbuildConfig,
         mode: 'development',
-        plugins: [pluginSolid()],
+        plugins: [pluginSolid(), pluginBabel()],
       },
     });
     const config = await rsbuild.initConfigs();
+
     expect(config[0].resolve?.conditionNames).toEqual([
       'solid',
       'development',
       '...',
     ]);
+    expect(JSON.stringify(matchRules(config[0], 'a.tsx')[0])).toContain(
+      '"dev":true',
+    );
   });
 
   it('should preserve user resolve condition names', async () => {
@@ -68,44 +72,75 @@ describe('plugin-solid', () => {
     ]);
   });
 
-  it('should allow disabling solid development condition', async () => {
+  it('should allow disabling Solid development mode', async () => {
     const rsbuild = await createRsbuild({
       config: {
         ...rsbuildConfig,
         mode: 'development',
-        plugins: [pluginSolid({ dev: false })],
+        plugins: [pluginSolid({ dev: false }), pluginBabel()],
       },
     });
     const config = await rsbuild.initConfigs();
+
     expect(config[0].resolve?.conditionNames).toEqual(['solid', '...']);
+    expect(JSON.stringify(matchRules(config[0], 'a.tsx')[0])).toContain(
+      '"dev":false',
+    );
   });
 
-  it('should not add development condition in production mode by default', async () => {
+  it('should disable Solid development mode in production by default', async () => {
     const rsbuild = await createRsbuild({
       config: {
         ...rsbuildConfig,
         mode: 'production',
-        plugins: [pluginSolid()],
+        plugins: [pluginSolid(), pluginBabel()],
       },
     });
     const config = await rsbuild.initConfigs();
+
     expect(config[0].resolve?.conditionNames).toEqual(['solid', '...']);
+    expect(JSON.stringify(matchRules(config[0], 'a.tsx')[0])).toContain(
+      '"dev":false',
+    );
   });
 
-  it('should allow forcing solid development condition in production mode', async () => {
+  it('should allow forcing Solid development mode in production mode', async () => {
     const rsbuild = await createRsbuild({
       config: {
         ...rsbuildConfig,
         mode: 'production',
-        plugins: [pluginSolid({ dev: true })],
+        plugins: [pluginSolid({ dev: true }), pluginBabel()],
       },
     });
     const config = await rsbuild.initConfigs();
+
     expect(config[0].resolve?.conditionNames).toEqual([
       'solid',
       'development',
       '...',
     ]);
+    expect(JSON.stringify(matchRules(config[0], 'a.tsx')[0])).toContain(
+      '"dev":true',
+    );
+  });
+
+  it('should allow solid.dev to override compiler development mode', async () => {
+    const rsbuild = await createRsbuild({
+      config: {
+        ...rsbuildConfig,
+        mode: 'development',
+        plugins: [
+          pluginSolid({ dev: false, solid: { dev: true } }),
+          pluginBabel(),
+        ],
+      },
+    });
+    const config = await rsbuild.initConfigs();
+
+    expect(config[0].resolve?.conditionNames).toEqual(['solid', '...']);
+    expect(JSON.stringify(matchRules(config[0], 'a.tsx')[0])).toContain(
+      '"dev":true',
+    );
   });
 
   it('should allow disabling solid refresh via refresh.disabled', async () => {


### PR DESCRIPTION
## Summary

The `dev` option previously selected Solid's development runtime without configuring matching compiler transforms. This PR applies the same environment-aware development mode to both runtime resolution and `babel-preset-solid`, while allowing `solid.dev` to explicitly override compiler behavior.