### PR TITLE
chore(lint): enable no-misused-promises rule

### DIFF
--- a/packages/core/src/restart.ts
+++ b/packages/core/src/restart.ts
@@ -165,6 +165,7 @@ export function watchFilesForRestart({
           ? new Set(events)
           : DEFAULT_WATCH_FILE_EVENTS;
         for (const event of watchEvents) {
+          // rslint-disable-next-line @typescript-eslint/no-misused-promises -- Chokidar does not consume listener return values.
           watcher.on(event, (filePath) => onWatchEvent(event, filePath, cwd));
         }
         return watcher;

--- a/packages/core/src/server/assets-middleware/middleware.ts
+++ b/packages/core/src/server/assets-middleware/middleware.ts
@@ -499,6 +499,7 @@ export function createAssetsMiddleware(
       onFinished(res, cleanup);
     }
 
+    // rslint-disable-next-line @typescript-eslint/no-misused-promises -- `ready` does not consume callback return values.
     ready(processRequest);
   };
 }

--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -404,6 +404,7 @@ export class SocketServer {
       socket.isAlive = true;
     });
 
+    // rslint-disable-next-line @typescript-eslint/no-misused-promises -- ws does not consume listener return values.
     socket.on('message', async (data) => {
       try {
         const payload: ClientMessage = JSON.parse(

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -66,7 +66,6 @@ define.lint(async ({ globalIgnores, js, rstestPlugin, ts }) => {
         '@typescript-eslint/require-await': 'off',
         '@typescript-eslint/no-unsafe-call': 'off',
         '@typescript-eslint/no-floating-promises': 'off',
-        '@typescript-eslint/no-misused-promises': 'off',
         '@typescript-eslint/restrict-template-expressions': 'off',
         '@typescript-eslint/no-explicit-any': 'off',
       },


### PR DESCRIPTION
## Summary

The `@typescript-eslint/no-misused-promises` rule was disabled globally, so Promise-returning callbacks were not reviewed consistently. This PR enables the rule and documents the three intentional callback exceptions with scoped Rslint suppressions, without changing runtime behavior.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/8307