### PR TITLE
docs: clarify Baseline browser targets

### DIFF
--- a/website/docs/en/blog/v2-0.mdx
+++ b/website/docs/en/blog/v2-0.mdx
@@ -253,7 +253,7 @@ Starting from 2.0, the minimum supported Node.js versions for Rsbuild are `20.19
 
 Rsbuild 2.0 updates its default targets so build output targets more modern browsers and Node.js versions.
 
-For web output, the default browserslist now aligns with the widely available range defined by [Baseline](https://web-platform-dx.github.io/web-features/). Specifically, it uses the target set for [2025-05-01](https://browsersl.ist/#q=baseline+widely+available+on+2025-05-01), which represents the Web platform capabilities widely supported by mainstream browsers at that point.
+For web output, the default browserslist now matches the [`baseline widely available on 2025-05-01`](https://browsersl.ist/#q=baseline+widely+available+on+2025-05-01) query. This query is based on the [Baseline Widely Available](https://web-platform-dx.github.io/baseline/) feature set as of [May 1, 2025](https://web-platform-dx.github.io/supported-browsers/?widelyAvailableOnDate=2025-05-01).
 
 The default values change as follows:
 

--- a/website/docs/en/guide/advanced/browserslist.mdx
+++ b/website/docs/en/guide/advanced/browserslist.mdx
@@ -53,7 +53,7 @@ firefox >= 104
 safari >= 16
 ```
 
-> This browser range matches [Baseline](https://web-platform-dx.github.io/web-features/) widely available as of [2025-05-01](https://browsersl.ist/#q=baseline+widely+available+on+2025-05-01).
+> By default, Rsbuild targets these browser versions and newer. This range matches the [`baseline widely available on 2025-05-01`](https://browsersl.ist/#q=baseline+widely+available+on+2025-05-01) query. The query is based on the [Baseline Widely Available](https://web-platform-dx.github.io/baseline/) feature set as of [May 1, 2025](https://web-platform-dx.github.io/supported-browsers/?widelyAvailableOnDate=2025-05-01).
 
 ### Node target
 

--- a/website/docs/en/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/en/guide/upgrade/v1-to-v2.mdx
@@ -52,11 +52,11 @@ See the [Rspack v2 upgrade guide](https://github.com/web-infra-dev/rspack/discus
 
 ## Default browserslist updated
 
-In Rsbuild 2.0, the default browserslist have been updated to better reflect the modern web platform baseline.
+Rsbuild 2.0 updates the default browserslist to target newer browsers.
 
 ### Web target
 
-The default web browserslist has moved to a more modern [baseline](https://web-platform-dx.github.io/web-features/), the new default corresponds to [`baseline widely available on 2025-05-01`](https://browsersl.ist/#q=baseline+widely+available+on+2025-05-01):
+The default web browserslist now matches the [`baseline widely available on 2025-05-01`](https://browsersl.ist/#q=baseline+widely+available+on+2025-05-01) query. This query is based on the [Baseline Widely Available](https://web-platform-dx.github.io/baseline/) feature set as of [May 1, 2025](https://web-platform-dx.github.io/supported-browsers/?widelyAvailableOnDate=2025-05-01). The minimum versions have changed as follows:
 
 - Chrome 87 → 107
 - Edge 88 → 107

--- a/website/docs/zh/blog/v2-0.mdx
+++ b/website/docs/zh/blog/v2-0.mdx
@@ -253,7 +253,7 @@ rsbuild --host
 
 Rsbuild 2.0 调整了默认的目标环境，使产物面向更现代的浏览器和 Node.js 版本。
 
-对于 Web 产物，默认的 browserslist 现在对齐到 [Baseline](https://web-platform-dx.github.io/web-features/) 的广泛可用范围。这里选取的是 [2025-05-01](https://browsersl.ist/#q=baseline+widely+available+on+2025-05-01) 对应的目标集，表示截至该时间点已被主流浏览器广泛支持的 Web 平台能力。
+对于 Web 产物，默认的 browserslist 现在与 [`baseline widely available on 2025-05-01`](https://browsersl.ist/#q=baseline+widely+available+on+2025-05-01) 查询结果一致。该查询基于 [2025 年 5 月 1 日](https://web-platform-dx.github.io/supported-browsers/?widelyAvailableOnDate=2025-05-01) 的 [Baseline 广泛可用](https://web-platform-dx.github.io/baseline/) 特性集。
 
 默认值变化如下：
 

--- a/website/docs/zh/guide/advanced/browserslist.mdx
+++ b/website/docs/zh/guide/advanced/browserslist.mdx
@@ -53,7 +53,7 @@ firefox >= 104
 safari >= 16
 ```
 
-> 该浏览器范围对应 [Baseline](https://web-platform-dx.github.io/web-features/) 在 [2025-05-01](https://browsersl.ist/#q=baseline+widely+available+on+2025-05-01) 达到广泛可用状态。
+> Rsbuild 默认以上述浏览器版本及更高版本为构建目标。该范围与 [`baseline widely available on 2025-05-01`](https://browsersl.ist/#q=baseline+widely+available+on+2025-05-01) 查询结果一致。该查询基于 [2025 年 5 月 1 日](https://web-platform-dx.github.io/supported-browsers/?widelyAvailableOnDate=2025-05-01) 的 [Baseline 广泛可用](https://web-platform-dx.github.io/baseline/) 特性集。
 
 ### Node 产物
 

--- a/website/docs/zh/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/zh/guide/upgrade/v1-to-v2.mdx
@@ -52,11 +52,11 @@ Rsbuild v2 现在依赖 [@rspack/core](https://www.npmjs.com/package/@rspack/cor
 
 ## 默认 browserslist 更新
 
-在 Rsbuild 2.0 中，默认的 browserslist 已进行更新，以更好地反映现代 Web 平台的基线水平。
+Rsbuild 2.0 更新了默认 browserslist，使构建产物面向更现代的浏览器。
 
 ### Web 产物
 
-默认的 Web browserslist 已升级到更现代的 [Baseline](https://web-platform-dx.github.io/web-features/)。新的默认值对应于 [`baseline widely available on 2025-05-01`](https://browsersl.ist/#q=baseline+widely+available+on+2025-05-01)：
+默认的 Web browserslist 现在与 [`baseline widely available on 2025-05-01`](https://browsersl.ist/#q=baseline+widely+available+on+2025-05-01) 查询结果一致。该查询基于 [2025 年 5 月 1 日](https://web-platform-dx.github.io/supported-browsers/?widelyAvailableOnDate=2025-05-01) 的 [Baseline 广泛可用](https://web-platform-dx.github.io/baseline/) 特性集。最低版本变化如下：
 
 - Chrome 87 → 107
 - Edge 88 → 107


### PR DESCRIPTION
## Summary

Clarify how the default web browser targets map to the Baseline Widely Available query.
Update the related links and keep the English and Chinese docs aligned.