### PR TITLE
docs: clarify Solid dev option behavior

### DIFF
--- a/website/docs/en/plugins/list/plugin-solid.mdx
+++ b/website/docs/en/plugins/list/plugin-solid.mdx
@@ -61,7 +61,7 @@ Solid v2 support is currently in beta. To use Solid v2, install the beta version
 
 The Solid plugin adds `solid` to Rsbuild's [resolve.conditionNames](/config/resolve/condition-names). This allows package exports to resolve Solid-specific entries when they are available.
 
-In development mode, the plugin also adds `development` to resolve Solid's development runtime. You can disable this behavior with [`dev: false`](#dev).
+In development mode, the plugin also adds `development` to resolve Solid's development runtime and enables development-only compiler transforms. You can disable both behaviors with [`dev: false`](#dev).
 
 If you configure `resolve.conditionNames`, the plugin preserves your configured values and prepends these Solid conditions.
 
@@ -71,7 +71,9 @@ To customize the compilation behavior of Solid, use the following options.
 
 ### dev
 
-Whether to resolve Solid's development runtime in development mode. Set it to `false` to disable the `development` condition, or set it to `true` to force the `development` condition in production mode.
+Whether to enable Solid's development runtime and development-only compiler transforms. Set it to `false` to disable both behaviors in development mode, or set it to `true` to enable them in production mode.
+
+If `solid.dev` is explicitly configured, it overrides the `dev` setting for compiler transforms without affecting runtime resolution.
 
 - **Type:** `boolean`
 - **Default:** `true` in development mode, `false` in production mode

--- a/website/docs/zh/plugins/list/plugin-solid.mdx
+++ b/website/docs/zh/plugins/list/plugin-solid.mdx
@@ -57,7 +57,7 @@ Solid v2 支持目前处于 beta 阶段。要使用 Solid v2，请安装 `@rsbui
 
 Solid 插件会将 `solid` 添加到 Rsbuild 的 [resolve.conditionNames](/config/resolve/condition-names) 中，使 package exports 可以解析到 Solid 专属的入口。
 
-在开发模式下，插件还会添加 `development`，用于解析 Solid 的开发环境运行时。你可以通过 [`dev: false`](#dev) 关闭该行为。
+在开发模式下，插件还会添加 `development`，用于解析 Solid 的开发环境运行时，并启用开发环境编译转换。你可以通过 [`dev: false`](#dev) 同时关闭这两项行为。
 
 如果你配置了 `resolve.conditionNames`，插件会保留已有配置，并在前面添加这些 Solid 条件。
 
@@ -67,7 +67,9 @@ Solid 插件会将 `solid` 添加到 Rsbuild 的 [resolve.conditionNames](/confi
 
 ### dev
 
-是否在开发模式下解析 Solid 的开发环境运行时。设置为 `false` 可以禁用 `development` condition，设置为 `true` 可以在生产模式下强制启用 `development` condition。
+是否启用 Solid 的开发环境运行时和编译转换。设置为 `false` 可以在开发模式下同时禁用两者，设置为 `true` 可以在生产模式下同时启用两者。
+
+如果显式配置 `solid.dev`，它会覆盖编译转换的 `dev` 设置，但不会影响运行时解析。
 
 - **类型：** `boolean`
 - **默认值：** 开发模式下为 `true`，生产模式下为 `false`


### PR DESCRIPTION
## Summary

This PR clarifies that the Solid plugin's `dev` option controls both development runtime resolution and compiler transforms. It also documents that `solid.dev` only overrides compiler transforms without changing runtime resolution.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/8311