### PR TITLE
fix(core): correctly resolve server port 0

### DIFF
--- a/e2e/cases/server/custom-server/index.test.ts
+++ b/e2e/cases/server/custom-server/index.test.ts
@@ -4,7 +4,6 @@ test('should support a custom dev server', async ({ page }) => {
   const { startDevServer } = await import('./scripts/server.js' as string);
   const { config, close } = await startDevServer(import.meta.dirname);
 
-  expect(config.port).toBeGreaterThan(0);
   await gotoPage(page, config);
 
   const locator = page.locator('#test');

--- a/e2e/cases/server/custom-server/index.test.ts
+++ b/e2e/cases/server/custom-server/index.test.ts
@@ -4,6 +4,7 @@ test('should support a custom dev server', async ({ page }) => {
   const { startDevServer } = await import('./scripts/server.js' as string);
   const { config, close } = await startDevServer(import.meta.dirname);
 
+  expect(config.port).toBeGreaterThan(0);
   await gotoPage(page, config);
 
   const locator = page.locator('#test');

--- a/e2e/cases/server/custom-server/scripts/server.js
+++ b/e2e/cases/server/custom-server/scripts/server.js
@@ -1,17 +1,14 @@
 import { createConnectHandler } from '@e2e/helper/server';
-import { getRandomPort } from '@rstackjs/test-utils';
 import { createAdaptorServer } from '@hono/node-server';
 import { createRsbuild } from '@rsbuild/core';
 import { Hono } from 'hono';
 
 export async function startDevServer(fixtures) {
-  const customServerPort = await getRandomPort();
-
   const rsbuild = await createRsbuild({
     cwd: fixtures,
     config: {
       server: {
-        port: customServerPort,
+        port: 0,
         htmlFallback: false,
         middlewareMode: true,
       },

--- a/e2e/cases/server/port/index.test.ts
+++ b/e2e/cases/server/port/index.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@e2e/helper';
 import { getRandomPort } from '@rstackjs/test-utils';
+import type { RsbuildPlugin } from '@rsbuild/core';
 
 test('should set the port via server.port', async ({ page, dev }) => {
   const errors: string[] = [];
@@ -20,4 +21,50 @@ test('should set the port via server.port', async ({ page, dev }) => {
   await expect(locator).toHaveText('Hello Rsbuild!');
 
   expect(errors).toEqual([]);
+});
+
+test('should resolve server.port 0 to the actual port', async ({
+  page,
+  dev,
+}) => {
+  let hookPort: number | undefined;
+  const plugin: RsbuildPlugin = {
+    name: 'test-port',
+    setup(api) {
+      api.onAfterStartDevServer(({ port }) => {
+        hookPort = port;
+      });
+    },
+  };
+
+  const rsbuild = await dev({
+    config: {
+      server: {
+        port: 0,
+        strictPort: true,
+      },
+      dev: {
+        assetPrefix: true,
+      },
+      plugins: [plugin],
+    },
+  });
+
+  expect(rsbuild.port).toBeGreaterThan(0);
+  expect(rsbuild.server?.port).toBe(rsbuild.port);
+  expect(rsbuild.instance.context.devServer?.port).toBe(rsbuild.port);
+  expect(hookPort).toBe(rsbuild.port);
+  expect(rsbuild.urls).toContain(`http://localhost:${rsbuild.port}`);
+
+  const address = rsbuild.server?.httpServer?.address();
+  expect(
+    address && typeof address !== 'string' ? address.port : undefined,
+  ).toBe(rsbuild.port);
+
+  const scriptSrc = await page
+    .locator('script[src]')
+    .first()
+    .getAttribute('src');
+  expect(scriptSrc).toContain(`http://localhost:${rsbuild.port}/`);
+  await expect(page.locator('#test')).toHaveText('Hello Rsbuild!');
 });

--- a/e2e/cases/server/preview/index.test.ts
+++ b/e2e/cases/server/preview/index.test.ts
@@ -1,7 +1,7 @@
 import { basename } from 'node:path';
 import { expect, test } from '@e2e/helper';
 import { findFile, getRandomPort } from '@rstackjs/test-utils';
-import type { RsbuildPlugin } from '@rsbuild/core';
+import type { RsbuildPlugin, RsbuildPreviewServer } from '@rsbuild/core';
 
 test('should preview dist files correctly', async ({ page, buildPreview }) => {
   await buildPreview();
@@ -35,6 +35,46 @@ test('should allow plugin to modify preview server config', async ({
 
   const rootEl = page.locator('#root');
   await expect(rootEl).toHaveText('Hello Rsbuild!');
+});
+
+test('should resolve server.port 0 for preview server', async ({
+  page,
+  buildPreview,
+}) => {
+  let hookPort: number | undefined;
+  let previewServer: RsbuildPreviewServer | undefined;
+  const plugin: RsbuildPlugin = {
+    name: 'test-port',
+    setup(api) {
+      api.onBeforeStartPreviewServer(({ server }) => {
+        previewServer = server;
+      });
+      api.onAfterStartPreviewServer(({ port }) => {
+        hookPort = port;
+      });
+    },
+  };
+
+  const result = await buildPreview({
+    config: {
+      server: {
+        port: 0,
+        strictPort: true,
+      },
+      plugins: [plugin],
+    },
+  });
+
+  expect(result.port).toBeGreaterThan(0);
+  expect(previewServer?.port).toBe(result.port);
+  expect(hookPort).toBe(result.port);
+
+  const address = previewServer?.httpServer?.address();
+  expect(
+    address && typeof address !== 'string' ? address.port : undefined,
+  ).toBe(result.port);
+
+  await expect(page.locator('#root')).toHaveText('Hello Rsbuild!');
 });
 
 test('should serve multi-environment assets before returned setup middleware', async ({

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -455,6 +455,10 @@ export const getPort = async ({
         server.unref();
         server.on('error', reject);
         server.listen({ port, host }, () => {
+          const address = server.address();
+          if (address && typeof address !== 'string') {
+            port = address.port;
+          }
           found = true;
           server.close(resolve);
         });
@@ -476,7 +480,7 @@ export const getPort = async ({
     );
   }
 
-  if (port !== original) {
+  if (original !== 0 && port !== original) {
     if (strictPort) {
       throw new Error(
         `${color.dim('[rsbuild:server]')} Port ${color.yellow(
@@ -502,7 +506,7 @@ export const resolvePort = async (
     strictPort,
   });
   const portTip =
-    port !== originalPort
+    originalPort !== 0 && port !== originalPort
       ? `port ${originalPort} is in use, ${color.yellow(`using port ${port}.`)}`
       : undefined;
   return {

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -455,9 +455,11 @@ export const getPort = async ({
         server.unref();
         server.on('error', reject);
         server.listen({ port, host }, () => {
-          const address = server.address();
-          if (address && typeof address !== 'string') {
-            port = address.port;
+          if (port === 0) {
+            const address = server.address();
+            if (address && typeof address !== 'string') {
+              port = address.port;
+            }
           }
           found = true;
           server.close(resolve);

--- a/packages/core/tests/server.test.ts
+++ b/packages/core/tests/server.test.ts
@@ -9,9 +9,10 @@ import {
   joinUrlPath,
   printServerURLs,
   removeBasePath,
+  resolvePort,
 } from '../src/server/helper';
 import { createHttpServer } from '../src/server/httpServer';
-import type { Connect } from '../src/types';
+import type { Connect, NormalizedConfig } from '../src/types';
 import { logger } from '../src';
 
 beforeEach(() => {
@@ -48,6 +49,19 @@ const networkUrls = [
     url: 'http://198.51.100.20:3000',
   },
 ];
+
+test('should resolve port 0 to an available port', async () => {
+  const result = await resolvePort({
+    server: {
+      host: '127.0.0.1',
+      port: 0,
+      strictPort: true,
+    },
+  } as NormalizedConfig);
+
+  expect(result.port).toBeGreaterThan(0);
+  expect(result.portTip).toBeUndefined();
+});
 
 test('should format routes correctly', () => {
   expect(


### PR DESCRIPTION
## Summary

`server.port: 0` currently propagates `0` even though the operating system selects a different listening port, producing invalid URLs and API results. This PR reads the assigned port before closing the probe server and propagates it through dev, preview, and middleware-mode servers. It also treats port `0` as an ephemeral-port request instead of an occupied fixed port when `strictPort` or port fallback messages are used.