### PR TITLE
fix(cli): support --port 0

### DIFF
--- a/e2e/cases/cli/port-zero/index.test.ts
+++ b/e2e/cases/cli/port-zero/index.test.ts
@@ -1,9 +1,5 @@
 import { expect, gotoPage, test } from '@e2e/helper';
 
-const cliEnv = {
-  TEST_CLI_PORT_ZERO: 'true',
-};
-
 const getPortFromLogs = (logs: string[]): number => {
   const match = logs.join('\n').match(/http:\/\/localhost:(\d+)/);
   if (!match) {
@@ -17,7 +13,7 @@ test('should support --port 0 for dev server', async ({
   execCli,
   logHelper,
 }) => {
-  execCli('dev --port 0', { env: cliEnv });
+  execCli('dev --port 0');
   await logHelper.expectBuildEnd();
 
   const port = getPortFromLogs(logHelper.logs);
@@ -36,7 +32,7 @@ test('should support --port 0 for preview server', async ({
   await build();
   logHelper.clearLogs();
 
-  execCli('preview --port 0', { env: cliEnv });
+  execCli('preview --port 0');
   await logHelper.expectLog('➜  Local:');
 
   const port = getPortFromLogs(logHelper.logs);

--- a/e2e/cases/cli/port-zero/index.test.ts
+++ b/e2e/cases/cli/port-zero/index.test.ts
@@ -1,0 +1,47 @@
+import { expect, gotoPage, test } from '@e2e/helper';
+
+const cliEnv = {
+  TEST_CLI_PORT_ZERO: 'true',
+};
+
+const getPortFromLogs = (logs: string[]): number => {
+  const match = logs.join('\n').match(/http:\/\/localhost:(\d+)/);
+  if (!match) {
+    throw new Error('Failed to find server port in logs.');
+  }
+  return Number(match[1]);
+};
+
+test('should support --port 0 for dev server', async ({
+  page,
+  execCli,
+  logHelper,
+}) => {
+  execCli('dev --port 0', { env: cliEnv });
+  await logHelper.expectBuildEnd();
+
+  const port = getPortFromLogs(logHelper.logs);
+  expect(port).toBeGreaterThan(0);
+
+  await gotoPage(page, { port });
+  await expect(page.locator('#test')).toHaveText('Hello Rsbuild!');
+});
+
+test('should support --port 0 for preview server', async ({
+  page,
+  build,
+  execCli,
+  logHelper,
+}) => {
+  await build();
+  logHelper.clearLogs();
+
+  execCli('preview --port 0', { env: cliEnv });
+  await logHelper.expectLog('➜  Local:');
+
+  const port = getPortFromLogs(logHelper.logs);
+  expect(port).toBeGreaterThan(0);
+
+  await gotoPage(page, { port });
+  await expect(page.locator('#test')).toHaveText('Hello Rsbuild!');
+});

--- a/e2e/cases/cli/port-zero/rsbuild.config.ts
+++ b/e2e/cases/cli/port-zero/rsbuild.config.ts
@@ -1,22 +1,7 @@
-import { defineConfig, type RsbuildPlugin } from '@rsbuild/core';
-
-const plugin: RsbuildPlugin = {
-  name: 'test-cli-port-zero',
-  setup(api) {
-    api.modifyRsbuildConfig((config) => {
-      if (
-        process.env.TEST_CLI_PORT_ZERO === 'true' &&
-        config.server?.port !== 0
-      ) {
-        throw new Error('Expected CLI to preserve port 0.');
-      }
-    });
-  },
-};
+import { defineConfig } from '@rsbuild/core';
 
 export default defineConfig({
   server: {
-    port: 3000,
+    port: -1,
   },
-  plugins: [plugin],
 });

--- a/e2e/cases/cli/port-zero/rsbuild.config.ts
+++ b/e2e/cases/cli/port-zero/rsbuild.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, type RsbuildPlugin } from '@rsbuild/core';
+
+const plugin: RsbuildPlugin = {
+  name: 'test-cli-port-zero',
+  setup(api) {
+    api.modifyRsbuildConfig((config) => {
+      if (
+        process.env.TEST_CLI_PORT_ZERO === 'true' &&
+        config.server?.port !== 0
+      ) {
+        throw new Error('Expected CLI to preserve port 0.');
+      }
+    });
+  },
+};
+
+export default defineConfig({
+  server: {
+    port: 3000,
+  },
+  plugins: [plugin],
+});

--- a/e2e/cases/cli/port-zero/src/index.js
+++ b/e2e/cases/cli/port-zero/src/index.js
@@ -1,0 +1,5 @@
+const testEl = document.createElement('div');
+testEl.id = 'test';
+testEl.innerHTML = 'Hello Rsbuild!';
+
+document.body.appendChild(testEl);

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -81,7 +81,7 @@ const loadConfig = async (root: string) => {
     config.server.host = options.host;
   }
 
-  if (options.port) {
+  if (options.port !== undefined) {
     config.server.port = options.port;
   }
 


### PR DESCRIPTION
## Summary

`--port 0` is parsed as numeric zero but was ignored by CLI config merging because of a truthy check, causing dev and preview to use the configured or default port. This PR preserves zero-valued port arguments so both commands can use an operating-system-assigned port.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8315#discussion_r3809770632