### PR TITLE
fix(core): support dynamic ports in module federation

### DIFF
--- a/e2e/cases/module-federation/v1-basic/index.test.ts
+++ b/e2e/cases/module-federation/v1-basic/index.test.ts
@@ -137,6 +137,34 @@ test('should allow remote module to perform HMR', async ({ page, devOnly }) => {
   await expect(page.locator('#button')).toHaveText('Button from remote (HMR)');
 });
 
+test('should allow remote module with a dynamic port to perform HMR', async ({
+  page,
+  devOnly,
+}) => {
+  writeButtonCode();
+
+  const remoteApp = await devOnly({
+    cwd: remote,
+    config: {
+      server: {
+        port: 0,
+      },
+    },
+  });
+
+  process.env.REMOTE_PORT = remoteApp.port.toString();
+
+  const hostApp = await devOnly({
+    cwd: host,
+  });
+
+  await gotoPage(page, hostApp);
+  await expect(page.locator('#button')).toHaveText('Button from remote');
+
+  writeButtonCode('Button from remote (HMR)');
+  await expect(page.locator('#button')).toHaveText('Button from remote (HMR)');
+});
+
 test('should transform module federation runtime with SWC', async ({
   build,
 }) => {

--- a/packages/core/src/plugins/moduleFederation.ts
+++ b/packages/core/src/plugins/moduleFederation.ts
@@ -28,9 +28,10 @@ export function pluginModuleFederation(): RsbuildPlugin {
 
           // For remote modules, Rsbuild should send the ws request to the provider's dev server.
           // This allows the provider to do HMR when the provider module is loaded in the consumer's page.
-          if (config.server?.port && !config.dev.client?.port) {
+          if (config.server?.port !== undefined && !config.dev.client?.port) {
             config.dev.client ||= {};
-            config.dev.client.port = config.server.port;
+            config.dev.client.port =
+              config.server.port === 0 ? '<port>' : config.server.port;
           }
 
           // Change the default assetPrefix to `true` for remote modules.


### PR DESCRIPTION
## Summary

- resolve Module Federation provider HMR connections against dynamically assigned server ports
- add end-to-end coverage for remote HMR with `server.port: 0`

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8315