### PR TITLE
feat(plugin-solid): add granular refresh option

### DIFF
--- a/packages/plugin-solid/src/index.ts
+++ b/packages/plugin-solid/src/index.ts
@@ -26,6 +26,12 @@ export type PluginSolidOptions = {
      * @default false
      */
     disabled?: boolean;
+    /**
+     * Whether to emit per-component metadata so edits only remount components
+     * whose code changed.
+     * @default true
+     */
+    granular?: boolean;
   };
   /**
    * Options passed to `babel-preset-solid`.
@@ -105,12 +111,18 @@ export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
             },
             modifyRule: usingHMR
               ? (rule, { babelUseId }) => {
-                  rule
+                  const refreshUse = rule
                     .use('solid-refresh')
                     .after(babelUseId)
                     .loader(
                       path.join(import.meta.dirname, 'refreshLoader.mjs'),
                     );
+
+                  if (typeof options.refresh?.granular === 'boolean') {
+                    refreshUse.options({
+                      granular: options.refresh.granular,
+                    });
+                  }
                 }
               : undefined,
           });

--- a/packages/plugin-solid/tests/index.test.ts
+++ b/packages/plugin-solid/tests/index.test.ts
@@ -159,6 +159,19 @@ describe('plugin-solid', () => {
     ).toEqual(false);
   });
 
+  it('should configure granular solid refresh', async () => {
+    const rsbuild = await createRsbuild({
+      config: {
+        ...rsbuildConfig,
+        plugins: [pluginSolid({ refresh: { granular: false } }), pluginBabel()],
+      },
+    });
+    const config = await rsbuild.initConfigs();
+    const rule = matchRules(config[0], 'a.tsx')[0];
+
+    expect(JSON.stringify(rule)).toContain('"granular":false');
+  });
+
   it('should use hydratable dom output for ssr option on web target', async () => {
     const rsbuild = await createRsbuild({
       config: {

--- a/website/docs/en/plugins/list/plugin-solid.mdx
+++ b/website/docs/en/plugins/list/plugin-solid.mdx
@@ -87,7 +87,7 @@ pluginSolid({
 
 ### refresh.disabled
 
-Whether to disable [Solid Refresh](https://github.com/solidjs/solid-refresh) for HMR in development mode. This only controls Solid Refresh injection and does not disable Rsbuild HMR.
+Whether to disable Solid Refresh for HMR in development mode. This only controls the refresh transform and does not disable Rsbuild HMR.
 
 - **Type:** `boolean`
 - **Default:** `false`
@@ -97,6 +97,23 @@ Whether to disable [Solid Refresh](https://github.com/solidjs/solid-refresh) for
 pluginSolid({
   refresh: {
     disabled: true,
+  },
+});
+```
+
+### refresh.granular
+
+Whether to emit per-component metadata so edits only remount components whose code changed.
+
+- **Type:** `boolean`
+- **Default:** `true`
+- **Version:** `>= 2.0.0`
+- **Example:**
+
+```ts
+pluginSolid({
+  refresh: {
+    granular: false,
   },
 });
 ```

--- a/website/docs/zh/plugins/list/plugin-solid.mdx
+++ b/website/docs/zh/plugins/list/plugin-solid.mdx
@@ -83,7 +83,7 @@ pluginSolid({
 
 ### refresh.disabled
 
-是否在开发模式下禁用 [Solid Refresh](https://github.com/solidjs/solid-refresh) HMR。该选项只控制 Solid Refresh 注入，不会禁用 Rsbuild HMR。
+是否在开发模式下禁用 Solid Refresh HMR。该选项只控制 refresh 转换，不会禁用 Rsbuild HMR。
 
 - **类型：** `boolean`
 - **默认值：** `false`
@@ -93,6 +93,23 @@ pluginSolid({
 pluginSolid({
   refresh: {
     disabled: true,
+  },
+});
+```
+
+### refresh.granular
+
+是否生成组件级元数据，使代码变更时仅重新挂载实际发生变化的组件。
+
+- **类型：** `boolean`
+- **默认值：** `true`
+- **版本：** `>= 2.0.0`
+- **示例：**
+
+```ts
+pluginSolid({
+  refresh: {
+    granular: false,
   },
 });
 ```


### PR DESCRIPTION
## Summary

This PR exposes `refresh.granular` so users can disable per-component refresh metadata while keeping Solid Refresh enabled. The compiler default is preserved when the option is omitted, and the Solid Refresh documentation is updated for the current transform.