### PR TITLE
chore(lint): enable no-floating-promises rule

### DIFF
--- a/e2e/cases/overlay/type-errors/index.test.ts
+++ b/e2e/cases/overlay/type-errors/index.test.ts
@@ -35,6 +35,6 @@ test('should display type errors on overlay correctly', async ({
   await expectErrorOverlay(page);
 
   // The error overlay should be rendered after reloading the page
-  page.reload();
+  await page.reload();
   await expectErrorOverlay(page);
 });

--- a/e2e/cases/print-file-size/diff/index.test.ts
+++ b/e2e/cases/print-file-size/diff/index.test.ts
@@ -24,7 +24,7 @@ test('should print file size diff as expected', async ({
   expect(extractFileSizeLogs(rsbuild1.logs)).toMatchSnapshot();
   rsbuild1.clearLogs();
 
-  editFile(
+  await editFile(
     join(srcDir, 'index.js'),
     () => `import "./App.css";
 import React from 'react';
@@ -38,7 +38,7 @@ console.log(ReactDOM);
   expect(extractFileSizeLogs(rsbuild2.logs)).toMatchSnapshot();
   rsbuild2.clearLogs();
 
-  editFile(join(srcDir, 'index.js'), () => `import "./App.css";`);
+  await editFile(join(srcDir, 'index.js'), () => `import "./App.css";`);
 
   const rsbuild3 = await build({ config });
   expect(extractFileSizeLogs(rsbuild3.logs)).toMatchSnapshot();

--- a/e2e/cases/server/multi-server/index.test.ts
+++ b/e2e/cases/server/multi-server/index.test.ts
@@ -70,10 +70,10 @@ test('multiple rsbuild dev servers should work correctly', async ({ page }) => {
     server.listen(port, () => resolve());
   });
 
-  page.goto(`http://localhost:${port}/app1`);
+  await page.goto(`http://localhost:${port}/app1`);
   await expect(page.innerHTML('#test')).resolves.toBe('Hello Rsbuild1!');
 
-  page.goto(`http://localhost:${port}/app2`);
+  await page.goto(`http://localhost:${port}/app2`);
   await expect(page.innerHTML('#test')).resolves.toBe('Hello Rsbuild2!');
 
   await rsbuildServer1.close();

--- a/e2e/cases/server/public-dir/publicDir.test.ts
+++ b/e2e/cases/server/public-dir/publicDir.test.ts
@@ -365,9 +365,7 @@ test('should reload page when publicDir file changes', async ({
 
   await fse.outputFile(file, 'test');
   // check the page is reloaded
-  await new Promise((resolve) => {
-    page.waitForURL(page.url()).then(resolve);
-  });
+  await page.waitForURL(page.url());
 
   // reset file
   await fse.outputFile(file, 'a');
@@ -392,9 +390,7 @@ test('should reload page when custom publicDir file changes', async ({
 
   await fse.outputFile(file, 'test');
   // check the page is reloaded
-  await new Promise((resolve) => {
-    page.waitForURL(page.url()).then(resolve);
-  });
+  await page.waitForURL(page.url());
 
   // reset file
   await fse.outputFile(file, 'a111');

--- a/e2e/type-tests/resolution-bundler/index.ts
+++ b/e2e/type-tests/resolution-bundler/index.ts
@@ -15,7 +15,7 @@ const plugins = [
   pluginSolid(),
 ];
 
-createRsbuild({
+void createRsbuild({
   config: {
     plugins,
   },

--- a/e2e/type-tests/resolution-nodenext/index.ts
+++ b/e2e/type-tests/resolution-nodenext/index.ts
@@ -15,7 +15,7 @@ const plugins = [
   pluginSolid(),
 ];
 
-createRsbuild({
+void createRsbuild({
   config: {
     plugins,
   },

--- a/packages/core/src/client/overlay.ts
+++ b/packages/core/src/client/overlay.ts
@@ -18,7 +18,7 @@ class ErrorOverlay extends HTMLElement {
       if (e.target) {
         const { file } = (e.target as HTMLLinkElement).dataset;
         if (file) {
-          fetch(`/__open-in-editor?file=${encodeURIComponent(file)}`);
+          void fetch(`/__open-in-editor?file=${encodeURIComponent(file)}`);
         }
       }
       e.stopPropagation();

--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -349,7 +349,7 @@ export function initPluginAPI({
   const onExit: typeof hooks.onExit.tap = (cb) => {
     if (!onExitListened) {
       exitHook((exitCode) => {
-        hooks.onExit.callBatch({ exitCode });
+        void hooks.onExit.callBatch({ exitCode });
       });
       onExitListened = true;
     }

--- a/packages/core/src/plugins/rspackProfile.ts
+++ b/packages/core/src/plugins/rspackProfile.ts
@@ -129,7 +129,7 @@ export const pluginRspackProfile = (): RsbuildPlugin => ({
         return;
       }
 
-      rspack.experiments.globalTrace.cleanup();
+      void rspack.experiments.globalTrace.cleanup();
 
       if (!isTerminalTraceOutput(traceOutput)) {
         const profileMessage = 'profile file saved to';

--- a/packages/core/src/plugins/server.ts
+++ b/packages/core/src/plugins/server.ts
@@ -12,11 +12,11 @@ export const pluginServer = (): RsbuildPlugin => ({
   name: 'rsbuild:server',
 
   setup(api) {
-    const onStartServer: OnAfterStartDevServerFn = ({ port, routes }) => {
+    const onStartServer: OnAfterStartDevServerFn = async ({ port, routes }) => {
       const config = api.getNormalizedConfig();
       if (config.server.open) {
         const protocol = config.server.https ? 'https' : 'http';
-        open({
+        await open({
           port,
           routes,
           config,

--- a/packages/core/src/server/cliShortcuts.ts
+++ b/packages/core/src/server/cliShortcuts.ts
@@ -105,7 +105,7 @@ export async function setupCliShortcuts({
 
     for (const shortcut of shortcuts) {
       if (input === shortcut.key) {
-        shortcut.action();
+        void shortcut.action();
         return;
       }
     }

--- a/packages/core/src/server/gracefulShutdown.ts
+++ b/packages/core/src/server/gracefulShutdown.ts
@@ -41,14 +41,14 @@ export const setupGracefulShutdown = (): (() => void) => {
   // or manually via 'kill -15 <pid>' or 'kill -TERM <pid>' command.
   // Add 128 to signal number as per POSIX convention for signal-terminated processes.
   const onSigterm = () => {
-    handleTermination(constants.signals.SIGTERM + 128);
+    void handleTermination(constants.signals.SIGTERM + 128);
   };
   process.once('SIGTERM', onSigterm);
 
   // Listen for CTRL+D (stdin end) in non-CI environments
   const isCI = process.env.CI === 'true';
   const onStdinEnd = () => {
-    handleTermination(0);
+    void handleTermination(0);
   };
   if (!isCI) {
     process.stdin.on('end', onStdinEnd);

--- a/packages/core/src/server/open.ts
+++ b/packages/core/src/server/open.ts
@@ -234,7 +234,7 @@ export async function open({
      * It can prevent opening the same URL multiple times.
      */
     if (!openedURLs.includes(url)) {
-      openBrowser(url, logger);
+      await openBrowser(url, logger);
       openedURLs.push(url);
     }
   }

--- a/packages/create-rsbuild/src/index.ts
+++ b/packages/create-rsbuild/src/index.ts
@@ -105,7 +105,7 @@ function mapRslintTemplate(templateName: string): RslintTemplateName {
 
 const root = path.join(import.meta.dirname, '..');
 
-create({
+await create({
   root,
   name: 'rsbuild',
   templates: [

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -65,7 +65,6 @@ define.lint(async ({ globalIgnores, js, rstestPlugin, ts }) => {
         '@typescript-eslint/no-unsafe-argument': 'off',
         '@typescript-eslint/require-await': 'off',
         '@typescript-eslint/no-unsafe-call': 'off',
-        '@typescript-eslint/no-floating-promises': 'off',
         '@typescript-eslint/restrict-template-expressions': 'off',
         '@typescript-eslint/no-explicit-any': 'off',
       },


### PR DESCRIPTION
## Summary

This PR enables `@typescript-eslint/no-floating-promises` to catch unintentionally unhandled promises. Existing call sites now await work that affects execution order and explicitly mark intentional fire-and-forget operations.