### PR TITLE
test(plugin-solid): cover SSR and hydration

### DIFF
--- a/e2e/cases/plugin-solid/ssr/index.test.ts
+++ b/e2e/cases/plugin-solid/ssr/index.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@e2e/helper';
+
+test('should render and hydrate a Solid app', async ({ page, devOnly }) => {
+  const rsbuild = await devOnly();
+
+  const response = await page.goto(`http://localhost:${rsbuild.port}`);
+  expect(await response?.text()).toContain('<button');
+
+  const button = page.locator('#button');
+  await expect(button).toHaveText('count: 0');
+
+  await button.click();
+  await expect(button).toHaveText('count: 1');
+});

--- a/e2e/cases/plugin-solid/ssr/rsbuild.config.ts
+++ b/e2e/cases/plugin-solid/ssr/rsbuild.config.ts
@@ -1,0 +1,77 @@
+import {
+  defineConfig,
+  type RequestHandler,
+  type RsbuildDevServer,
+} from '@rsbuild/core';
+import { pluginBabel } from '@rsbuild/plugin-babel';
+import { pluginSolid } from '@rsbuild/plugin-solid';
+
+const serverRender =
+  ({ environments }: RsbuildDevServer): RequestHandler =>
+  async (_req, res) => {
+    const bundle = await environments.node.loadBundle<{
+      render: () => {
+        app: string;
+        hydrationScript: string;
+      };
+    }>('index');
+    const { app, hydrationScript } = bundle.render();
+    const template = await environments.web.getTransformedHtml('index');
+
+    res.writeHead(200, {
+      'Content-Type': 'text/html',
+    });
+    res.end(
+      template
+        .replace('<!--hydration-script-->', hydrationScript)
+        .replace('<!--app-content-->', app),
+    );
+  };
+
+export default defineConfig({
+  plugins: [
+    pluginBabel({
+      include: /\.(?:jsx|tsx)$/,
+    }),
+    pluginSolid({ ssr: true }),
+  ],
+  server: {
+    setup: ({ action, server }) => {
+      if (action !== 'dev') {
+        return;
+      }
+
+      const render = serverRender(server);
+
+      server.middlewares.use((req, res, next) => {
+        if (req.method === 'GET' && req.url === '/') {
+          return render(req, res, next);
+        }
+
+        next();
+      });
+    },
+  },
+  environments: {
+    web: {
+      source: {
+        entry: {
+          index: './src/index',
+        },
+      },
+    },
+    node: {
+      output: {
+        target: 'node',
+      },
+      source: {
+        entry: {
+          index: './src/index.server',
+        },
+      },
+    },
+  },
+  html: {
+    template: './template.html',
+  },
+});

--- a/e2e/cases/plugin-solid/ssr/src/App.jsx
+++ b/e2e/cases/plugin-solid/ssr/src/App.jsx
@@ -1,0 +1,13 @@
+import { createSignal } from 'solid-js';
+
+const App = () => {
+  const [count, setCount] = createSignal(0);
+
+  return (
+    <button id="button" type="button" onClick={() => setCount(count() + 1)}>
+      count: {count()}
+    </button>
+  );
+};
+
+export default App;

--- a/e2e/cases/plugin-solid/ssr/src/index.jsx
+++ b/e2e/cases/plugin-solid/ssr/src/index.jsx
@@ -1,0 +1,4 @@
+import { hydrate } from '@solidjs/web';
+import App from './App';
+
+hydrate(() => <App />, document.getElementById('root'));

--- a/e2e/cases/plugin-solid/ssr/src/index.server.jsx
+++ b/e2e/cases/plugin-solid/ssr/src/index.server.jsx
@@ -1,0 +1,7 @@
+import { generateHydrationScript, renderToString } from '@solidjs/web';
+import App from './App';
+
+export const render = () => ({
+  app: renderToString(() => <App />),
+  hydrationScript: generateHydrationScript(),
+});

--- a/e2e/cases/plugin-solid/ssr/template.html
+++ b/e2e/cases/plugin-solid/ssr/template.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Solid SSR</title>
+    <!--hydration-script-->
+  </head>
+  <body>
+    <div id="root"><!--app-content--></div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

This PR adds an end-to-end Solid SSR case to verify that the Node output can render an application and the web output can hydrate it. The fixture includes Solid's hydration initialization script and confirms that the hydrated application remains interactive.