### PR TITLE
docs: document dynamic server ports

### DIFF
--- a/website/docs/en/config/server/port.mdx
+++ b/website/docs/en/config/server/port.mdx
@@ -38,3 +38,17 @@ export default {
   },
 };
 ```
+
+## Dynamic port
+
+- **Version:** `>= 2.2.0`
+
+Set `server.port` to `0` to let the operating system assign an available port:
+
+```ts title="rsbuild.config.ts"
+export default {
+  server: {
+    port: 0,
+  },
+};
+```

--- a/website/docs/zh/config/server/port.mdx
+++ b/website/docs/zh/config/server/port.mdx
@@ -38,3 +38,17 @@ export default {
   },
 };
 ```
+
+## 动态端口
+
+- **版本：** `>= 2.2.0`
+
+将 `server.port` 设置为 `0`，让操作系统自动分配一个可用端口：
+
+```ts title="rsbuild.config.ts"
+export default {
+  server: {
+    port: 0,
+  },
+};
+```


### PR DESCRIPTION
## Summary

Document how to use `server.port: 0` to let the operating system assign an available port. Note that this behavior is supported in Rsbuild 2.2.0 or later.