### PR TITLE
chore(lint): enable require-await rule

### DIFF
--- a/e2e/cases/cli/custom-config/index.test.ts
+++ b/e2e/cases/cli/custom-config/index.test.ts
@@ -28,9 +28,7 @@ test('should support custom config to find absolute path', async ({
   expect(outputFiles.length > 1).toBeTruthy();
 });
 
-test('should throw error when custom config not found', async ({
-  execCliSync,
-}) => {
+test('should throw error when custom config not found', ({ execCliSync }) => {
   expect(() => {
     execCliSync('build --config ./custom-not-found.config.js', {
       // only capture stderr output

--- a/e2e/cases/cli/custom-env-dir/index.test.ts
+++ b/e2e/cases/cli/custom-env-dir/index.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { expect, test } from '@e2e/helper';
 
-test('should support a custom env directory', async ({ execCliSync }) => {
+test('should support a custom env directory', ({ execCliSync }) => {
   execCliSync('build --env-dir env');
   const content = fs.readFileSync(
     path.join(import.meta.dirname, 'dist/static/js/index.js'),

--- a/e2e/cases/cli/custom-env-prefix/index.test.ts
+++ b/e2e/cases/cli/custom-env-prefix/index.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { expect, test } from '@e2e/helper';
 
-test('should allow to custom env prefix via loadEnv method', async ({
+test('should allow to custom env prefix via loadEnv method', ({
   execCliSync,
 }) => {
   execCliSync('build');

--- a/e2e/cases/cli/load-import-meta-env/index.test.ts
+++ b/e2e/cases/cli/load-import-meta-env/index.test.ts
@@ -11,21 +11,21 @@ test.beforeEach(async () => {
   await fse.remove(prodLocalFile);
 });
 
-test('should load .env config and allow rsbuild.config.ts to read env vars', async ({
+test('should load .env config and allow rsbuild.config.ts to read env vars', ({
   execCliSync,
 }) => {
   execCliSync('build');
   expect(fs.existsSync(path.join(import.meta.dirname, 'dist/1'))).toBeTruthy();
 });
 
-test('should load .env.local with higher priority', async ({ execCliSync }) => {
+test('should load .env.local with higher priority', ({ execCliSync }) => {
   fse.outputFileSync(localFile, 'FOO=2');
 
   execCliSync('build');
   expect(fs.existsSync(path.join(import.meta.dirname, 'dist/2'))).toBeTruthy();
 });
 
-test('should load .env.production.local with higher priority', async ({
+test('should load .env.production.local with higher priority', ({
   execCliSync,
 }) => {
   fse.outputFileSync(localFile, 'FOO=2');
@@ -35,9 +35,7 @@ test('should load .env.production.local with higher priority', async ({
   expect(fs.existsSync(path.join(import.meta.dirname, 'dist/3'))).toBeTruthy();
 });
 
-test('should support specifying env mode via --env-mode', async ({
-  execCliSync,
-}) => {
+test('should support specifying env mode via --env-mode', ({ execCliSync }) => {
   execCliSync('build --env-mode test');
   expect(fs.existsSync(path.join(import.meta.dirname, 'dist/5'))).toBeTruthy();
 });

--- a/e2e/cases/cli/load-node-env/index.test.ts
+++ b/e2e/cases/cli/load-node-env/index.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { expect, test } from '@e2e/helper';
 
 // see: https://github.com/web-infra-dev/rsbuild/issues/2904
-test('should load .env config and set NODE_ENV as expected', async ({
+test('should load .env config and set NODE_ENV as expected', ({
   execCliSync,
 }) => {
   execCliSync('build');

--- a/e2e/cases/cli/load-process-env/index.test.ts
+++ b/e2e/cases/cli/load-process-env/index.test.ts
@@ -11,20 +11,20 @@ test.beforeEach(async () => {
   await fse.remove(prodLocalFile);
 });
 
-test('should load .env config and allow rsbuild.config.ts to read env vars', async ({
+test('should load .env config and allow rsbuild.config.ts to read env vars', ({
   execCliSync,
 }) => {
   execCliSync('build');
   expect(fs.existsSync(path.join(import.meta.dirname, 'dist/1'))).toBeTruthy();
 });
 
-test('should load .env.local with higher priority', async ({ execCliSync }) => {
+test('should load .env.local with higher priority', ({ execCliSync }) => {
   fse.outputFileSync(localFile, 'FOO=2');
   execCliSync('build');
   expect(fs.existsSync(path.join(import.meta.dirname, 'dist/2'))).toBeTruthy();
 });
 
-test('should load .env.production.local with higher priority', async ({
+test('should load .env.production.local with higher priority', ({
   execCliSync,
 }) => {
   fse.outputFileSync(localFile, 'FOO=2');
@@ -33,9 +33,7 @@ test('should load .env.production.local with higher priority', async ({
   expect(fs.existsSync(path.join(import.meta.dirname, 'dist/3'))).toBeTruthy();
 });
 
-test('should support specifying env mode via --env-mode', async ({
-  execCliSync,
-}) => {
+test('should support specifying env mode via --env-mode', ({ execCliSync }) => {
   execCliSync('build --env-mode test');
   expect(fs.existsSync(path.join(import.meta.dirname, 'dist/5'))).toBeTruthy();
 });

--- a/e2e/cases/cli/log-level/index.test.ts
+++ b/e2e/cases/cli/log-level/index.test.ts
@@ -1,25 +1,21 @@
 import { stripVTControlCharacters as stripAnsi } from 'node:util';
 import { expect, test } from '@e2e/helper';
 
-test('should run build command with log level: info', async ({
-  execCliSync,
-}) => {
+test('should run build command with log level: info', ({ execCliSync }) => {
   const stdout = stripAnsi(execCliSync('build --logLevel info'));
   expect(stdout).toContain('Rsbuild v');
   expect(stdout).toContain('build started...');
   expect(stdout).toContain('built in');
 });
 
-test('should run build command with log level: warn', async ({
-  execCliSync,
-}) => {
+test('should run build command with log level: warn', ({ execCliSync }) => {
   const stdout = stripAnsi(execCliSync('build --logLevel warn'));
   expect(stdout).not.toContain('Rsbuild v');
   expect(stdout).not.toContain('build started...');
   expect(stdout).not.toContain('built in');
 });
 
-test('should always print verbose logs when debug mode is enabled', async ({
+test('should always print verbose logs when debug mode is enabled', ({
   execCliSync,
 }) => {
   const stdout = stripAnsi(

--- a/e2e/cases/cli/no-env/index.test.ts
+++ b/e2e/cases/cli/no-env/index.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { expect, test } from '@e2e/helper';
 
-test('should disable loading env files', async ({ execCliSync }) => {
+test('should disable loading env files', ({ execCliSync }) => {
   execCliSync('build --no-env');
   const content = fs.readFileSync(
     path.join(import.meta.dirname, 'dist/static/js/index.js'),

--- a/e2e/cases/cli/public-env-vars/index.test.ts
+++ b/e2e/cases/cli/public-env-vars/index.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { expect, test } from '@e2e/helper';
 
-test('should inject public env vars to client', async ({ execCliSync }) => {
+test('should inject public env vars to client', ({ execCliSync }) => {
   execCliSync('build');
 
   const content = fs.readFileSync(

--- a/e2e/cases/cli/source-map/index.test.ts
+++ b/e2e/cases/cli/source-map/index.test.ts
@@ -27,7 +27,7 @@ test('should disable source map from CLI', async ({
   expect(outputFiles.some((file) => file.endsWith('.js.map'))).toBeFalsy();
 });
 
-test('should reject source map type from CLI', async ({ execCliSync }) => {
+test('should reject source map type from CLI', ({ execCliSync }) => {
   expect(() => {
     execCliSync('build --source-map hidden-source-map', {
       stdio: ['ignore', 'ignore', 'pipe'],

--- a/e2e/cases/cli/unknown-option/index.test.ts
+++ b/e2e/cases/cli/unknown-option/index.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@e2e/helper';
 
-test('should exit with error code 1 when unknown options are provided', async ({
+test('should exit with error code 1 when unknown options are provided', ({
   execCliSync,
 }) => {
   try {

--- a/e2e/cases/cli/watch-files/index.test.ts
+++ b/e2e/cases/cli/watch-files/index.test.ts
@@ -5,7 +5,7 @@ import { getRandomPort } from '@rstackjs/test-utils';
 
 const tempConfig = path.join(import.meta.dirname, 'test-temp-config.ts');
 
-test.beforeEach(async () => {
+test.beforeEach(() => {
   fs.writeFileSync(tempConfig, 'export default 1;');
 });
 

--- a/e2e/cases/css/css-layers/index.test.ts
+++ b/e2e/cases/css/css-layers/index.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@e2e/helper';
 import { getFileContent } from '@rstackjs/test-utils';
 
 test('should bundle CSS layers as expected', async ({ runBoth }) => {
-  await runBoth(async ({ mode, result }) => {
+  await runBoth(({ mode, result }) => {
     const files = result.getDistFiles();
     const content = getFileContent(files, 'index.css');
 

--- a/e2e/cases/css/css-modules-export-locals/index.test.ts
+++ b/e2e/cases/css/css-modules-export-locals/index.test.ts
@@ -7,7 +7,7 @@ declare global {
   }
 }
 
-const expectCSSContext = async (rsbuild: BuildResult) => {
+const expectCSSContext = (rsbuild: BuildResult) => {
   const files = rsbuild.getDistFiles();
   const content = getFileContent(files, 'index.css');
   expect(content).toMatch(
@@ -29,7 +29,7 @@ test('should compile CSS Modules with exportLocalsConvention camelCaseOnly', asy
     },
   });
 
-  await expectCSSContext(rsbuild);
+  expectCSSContext(rsbuild);
 
   const styles = await page.evaluate(() => window.styles);
   expect(Object.keys(styles)).toEqual([
@@ -53,7 +53,7 @@ test('should compile CSS Modules with exportLocalsConvention camelCase', async (
     },
   });
 
-  await expectCSSContext(rsbuild);
+  expectCSSContext(rsbuild);
 
   const styles = await page.evaluate(() => window.styles);
   expect(Object.keys(styles)).toEqual([
@@ -79,7 +79,7 @@ test('should compile CSS Modules with exportLocalsConvention dashes', async ({
     },
   });
 
-  await expectCSSContext(rsbuild);
+  expectCSSContext(rsbuild);
 
   const styles = await page.evaluate(() => window.styles);
   expect(Object.keys(styles)).toEqual([
@@ -104,7 +104,7 @@ test('should compile CSS Modules with exportLocalsConvention dashesOnly', async 
     },
   });
 
-  await expectCSSContext(rsbuild);
+  expectCSSContext(rsbuild);
 
   const styles = await page.evaluate(() => window.styles);
   expect(Object.keys(styles)).toEqual([
@@ -128,7 +128,7 @@ test('should compile CSS Modules with exportLocalsConvention asIs', async ({
     },
   });
 
-  await expectCSSContext(rsbuild);
+  expectCSSContext(rsbuild);
 
   const styles = await page.evaluate(() => window.styles);
   expect(Object.keys(styles)).toEqual([

--- a/e2e/cases/css/lightningcss-prefixes/index.test.ts
+++ b/e2e/cases/css/lightningcss-prefixes/index.test.ts
@@ -4,7 +4,7 @@ import { getFileContent } from '@rstackjs/test-utils';
 test('should add vendor prefixes by current browserslist', async ({
   runBoth,
 }) => {
-  await runBoth(async ({ mode, result }) => {
+  await runBoth(({ mode, result }) => {
     const files = result.getDistFiles();
 
     if (mode === 'build') {

--- a/e2e/cases/html/html-loader/index.test.ts
+++ b/e2e/cases/html/html-loader/index.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@e2e/helper';
 
 test('should allow to use html-loader', async ({ runBoth }) => {
-  await runBoth(async ({ result }) => {
+  await runBoth(({ result }) => {
     const files = result.getDistFiles();
     const filenames = Object.keys(files);
 

--- a/e2e/cases/html/template/index.test.ts
+++ b/e2e/cases/html/template/index.test.ts
@@ -42,10 +42,10 @@ test('should set template via async function correctly', async ({ build }) => {
         },
       },
       html: {
-        async template({ entryName }) {
-          return entryName === 'index'
-            ? './static/index.html'
-            : './static/foo.html';
+        template({ entryName }) {
+          return Promise.resolve(
+            entryName === 'index' ? './static/index.html' : './static/foo.html',
+          );
         },
         templateParameters: {
           foo: 'foo',
@@ -138,12 +138,12 @@ test('should allow templateParameters to be an async function', async ({
             ? './static/foo.html'
             : './static/index.html';
         },
-        async templateParameters(defaultValue, { entryName }) {
-          return {
+        templateParameters(defaultValue, { entryName }) {
+          return Promise.resolve({
             ...defaultValue,
             foo: `${entryName}-foo`,
             type: `${entryName}-type`,
-          };
+          });
         },
       },
     },

--- a/e2e/cases/manifest/environments/index.test.ts
+++ b/e2e/cases/manifest/environments/index.test.ts
@@ -151,7 +151,7 @@ test('should allow to access manifest data in environment API', async ({
           if (action !== 'dev') {
             return;
           }
-          server.middlewares.use(async (_req, _res, next) => {
+          server.middlewares.use((_req, _res, next) => {
             webManifest = server.environments.web.context.manifest;
             nodeManifest = server.environments.node.context.manifest;
             next();

--- a/e2e/cases/manifest/generate/index.test.ts
+++ b/e2e/cases/manifest/generate/index.test.ts
@@ -21,7 +21,7 @@ const config: RsbuildConfig = {
 
 test('should generate custom manifest data', async ({ runBoth }) => {
   await runBoth(
-    async ({ result }) => {
+    ({ result }) => {
       const files = result.getDistFiles();
       const manifestContent = getFileContent(files, 'my-manifest.json');
       const manifest = JSON.parse(manifestContent);

--- a/e2e/cases/manifest/integrity/index.test.ts
+++ b/e2e/cases/manifest/integrity/index.test.ts
@@ -17,7 +17,7 @@ const checkManifestIntegrity = (rsbuild: {
 };
 
 test('should generate manifest file with integrity', async ({ runBoth }) => {
-  await runBoth(async ({ result }) => {
+  await runBoth(({ result }) => {
     checkManifestIntegrity(result);
   });
 });
@@ -26,7 +26,7 @@ test('should generate manifest file with integrity when html plugin is disabled'
   runBoth,
 }) => {
   await runBoth(
-    async ({ result }) => {
+    ({ result }) => {
       checkManifestIntegrity(result);
     },
     {

--- a/e2e/cases/performance/remove-console/index.test.ts
+++ b/e2e/cases/performance/remove-console/index.test.ts
@@ -2,7 +2,7 @@ import type { BuildResult } from '@e2e/helper';
 import { expect, test } from '@e2e/helper';
 import { getFileContent } from '@rstackjs/test-utils';
 
-const expectConsoleType = async (
+const expectConsoleType = (
   rsbuild: Awaited<BuildResult>,
   consoleType: Record<string, boolean>,
 ) => {
@@ -23,7 +23,7 @@ test('should remove specified console correctly', async ({ build }) => {
     },
   });
 
-  await expectConsoleType(rsbuild, {
+  expectConsoleType(rsbuild, {
     log: false,
     warn: false,
     debug: true,
@@ -40,7 +40,7 @@ test('should remove all console correctly', async ({ build }) => {
     },
   });
 
-  await expectConsoleType(rsbuild, {
+  expectConsoleType(rsbuild, {
     log: false,
     warn: false,
     debug: false,

--- a/e2e/cases/plugin-api/plugin-before-start-dev-server-hook/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-before-start-dev-server-hook/index.test.ts
@@ -8,7 +8,7 @@ test('should run onBeforeStartDevServer hooks and add custom middleware', async 
   const plugin: RsbuildPlugin = {
     name: 'test-plugin',
     setup(api) {
-      api.onBeforeStartDevServer(async ({ server }) => {
+      api.onBeforeStartDevServer(({ server }) => {
         server.middlewares.use((req, res, next) => {
           if (req.url === '/test.html') {
             res.end('Hello, world!');

--- a/e2e/cases/plugin-tailwindcss/source-directive/index.test.ts
+++ b/e2e/cases/plugin-tailwindcss/source-directive/index.test.ts
@@ -4,7 +4,7 @@ import { getFileContent } from '@rstackjs/test-utils';
 test('should generate Tailwind utilities from @source files', async ({
   runBoth,
 }) => {
-  await runBoth(async ({ result }) => {
+  await runBoth(({ result }) => {
     const indexCss = getFileContent(result.getDistFiles(), 'index.css');
     expect(indexCss).toContain('.font-bold');
     expect(indexCss).not.toContain('.underline{');

--- a/e2e/cases/plugin-tailwindcss/source-function/index.test.ts
+++ b/e2e/cases/plugin-tailwindcss/source-function/index.test.ts
@@ -4,7 +4,7 @@ import { getFileContent } from '@rstackjs/test-utils';
 test('should generate Tailwind utilities from source() files', async ({
   runBoth,
 }) => {
-  await runBoth(async ({ result }) => {
+  await runBoth(({ result }) => {
     const indexCss = getFileContent(result.getDistFiles(), 'index.css');
     expect(indexCss).toContain('.font-bold');
     expect(indexCss).not.toContain('.underline{');

--- a/e2e/cases/polyfill/core-js-browserslist/index.test.ts
+++ b/e2e/cases/polyfill/core-js-browserslist/index.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@e2e/helper';
 import { getPolyfillContent } from '../helper';
 
 test('should read browserslist correctly', async ({ runBoth }) => {
-  await runBoth(async ({ mode, result }) => {
+  await runBoth(({ mode, result }) => {
     const files = result.getDistFiles({ sourceMaps: true });
     const content = getPolyfillContent(files);
 

--- a/e2e/cases/server/cors/index.test.ts
+++ b/e2e/cases/server/cors/index.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@e2e/helper';
 import { defaultAllowedOrigins } from '@rsbuild/core';
 
-test('should expose `defaultAllowedOrigins`', async () => {
+test('should expose `defaultAllowedOrigins`', () => {
   expect(defaultAllowedOrigins).toBeInstanceOf(RegExp);
 });
 

--- a/e2e/cases/swc/jsc-target/index.test.ts
+++ b/e2e/cases/swc/jsc-target/index.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@e2e/helper';
 import { getFileContent } from '@rstackjs/test-utils';
 
 test('should configure jsc.target correctly', async ({ runBoth }) => {
-  await runBoth(async ({ result }) => {
+  await runBoth(({ result }) => {
     const files = result.getDistFiles();
     const content = getFileContent(files, 'index.js');
     expect(content).not.toContain('...baz');

--- a/e2e/helper/jsApi.ts
+++ b/e2e/helper/jsApi.ts
@@ -226,13 +226,13 @@ export async function build({
     server = result.server;
   }
 
-  const getIndexBundle = async () => {
+  const getIndexBundle = () => {
     const [name, content] =
       Object.entries(getOutputFiles()).find(
         ([file]) => file.includes('index') && file.endsWith('.js'),
       ) || [];
     assert(name && content);
-    return content;
+    return Promise.resolve(content);
   };
 
   if (page) {

--- a/e2e/helper/utils.ts
+++ b/e2e/helper/utils.ts
@@ -114,7 +114,7 @@ export const recordPluginHooks = () => {
   return { plugin, hooks };
 };
 
-export async function mapSourceMapPositions(
+export function mapSourceMapPositions(
   rawSourceMap: string,
   generatedPositions: {
     line: number;
@@ -129,7 +129,7 @@ export async function mapSourceMapPositions(
     }),
   );
 
-  return originalPositions;
+  return Promise.resolve(originalPositions);
 }
 
 export const enableDebugMode = () => {

--- a/e2e/type-tests/resolution-bundler/defineConfig.ts
+++ b/e2e/type-tests/resolution-bundler/defineConfig.ts
@@ -14,11 +14,13 @@ export const syncConfig: RsbuildConfigSyncFn = defineConfig(() => ({
   mode: 'production',
 }));
 
+// rslint-disable-next-line @typescript-eslint/require-await -- Test async config types.
 export const asyncConfig: RsbuildConfigAsyncFn = defineConfig(async () => ({
   mode: 'production',
 }));
 
 // @ts-expect-error invalid mode
+// rslint-disable-next-line @typescript-eslint/require-await -- Test async config types.
 defineConfig(async () => ({
   mode: 'invalid',
 }));

--- a/e2e/type-tests/resolution-nodenext/defineConfig.ts
+++ b/e2e/type-tests/resolution-nodenext/defineConfig.ts
@@ -14,11 +14,13 @@ export const syncConfig: RsbuildConfigSyncFn = defineConfig(() => ({
   mode: 'production',
 }));
 
+// rslint-disable-next-line @typescript-eslint/require-await -- Test async config types.
 export const asyncConfig: RsbuildConfigAsyncFn = defineConfig(async () => ({
   mode: 'production',
 }));
 
 // @ts-expect-error invalid mode
+// rslint-disable-next-line @typescript-eslint/require-await -- Test async config types.
 defineConfig(async () => ({
   mode: 'invalid',
 }));

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -63,7 +63,6 @@ define.lint(async ({ globalIgnores, js, rstestPlugin, ts }) => {
         '@typescript-eslint/no-unsafe-member-access': 'off',
         '@typescript-eslint/no-unsafe-assignment': 'off',
         '@typescript-eslint/no-unsafe-argument': 'off',
-        '@typescript-eslint/require-await': 'off',
         '@typescript-eslint/no-unsafe-call': 'off',
         '@typescript-eslint/restrict-template-expressions': 'off',
         '@typescript-eslint/no-explicit-any': 'off',


### PR DESCRIPTION
## Summary

This PR enables the `@typescript-eslint/require-await` rule to prevent unnecessary async functions. Existing violations are converted to synchronous functions, while intentional async type fixtures use targeted Rslint suppressions.