### PR TITLE
chore(vscode): use Rstack extension as default formatter

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["rstack.rslint", "rstack.rstest", "unifiedjs.vscode-mdx"]
+  "recommendations": ["rstack.rstack", "unifiedjs.vscode-mdx"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,9 +14,7 @@
     "**/.DS_Store": true
   },
   "mdx.validate.validateFileLinks": "ignore",
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
-  // Temporary workaround until we switch to the Rstack VS Code extension.
-  "prettier.singleQuote": true,
+  "editor.defaultFormatter": "rstack.rstack",
   "js/ts.tsdk.path": "node_modules/typescript/lib",
   "json.schemas": [
     {
@@ -29,12 +27,18 @@
     }
   ],
   "[typescript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "rstack.rstack"
   },
   "[javascript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "rstack.rstack"
   },
   "[mdx]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "rstack.rstack"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "rstack.rstack"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "rstack.rstack"
   }
 }


### PR DESCRIPTION
## Summary

Use the unified Rstack VS Code extension as the default formatter and remove recommendations for the standalone Rslint and Rstest extensions. This also adds explicit JSON and JSONC formatter settings and removes the temporary Prettier workaround.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/378