### PR TITLE
fix(plugin-solid): skip refresh for node_modules

### DIFF
--- a/packages/plugin-solid/src/refreshLoader.ts
+++ b/packages/plugin-solid/src/refreshLoader.ts
@@ -10,6 +10,11 @@ const solidRefreshLoader: Rspack.LoaderDefinition<SolidRefreshLoaderOptions> =
     const callback = this.async();
     const { granular } = this.getOptions();
 
+    if (/[\\/]node_modules[\\/]/.test(this.resourcePath)) {
+      callback(null, source, sourceMap);
+      return;
+    }
+
     try {
       const result = await transformRefreshAsync(String(source), {
         filename: this.resourcePath,

--- a/packages/plugin-solid/src/refreshLoader.ts
+++ b/packages/plugin-solid/src/refreshLoader.ts
@@ -1,6 +1,8 @@
 import { transformRefreshAsync } from '@dom-expressions/compiler';
 import type { Rspack } from '@rsbuild/core';
 
+const NODE_MODULES_REGEX = /[\\/]node_modules[\\/]/;
+
 export type SolidRefreshLoaderOptions = {
   granular?: boolean;
 };
@@ -10,7 +12,7 @@ const solidRefreshLoader: Rspack.LoaderDefinition<SolidRefreshLoaderOptions> =
     const callback = this.async();
     const { granular } = this.getOptions();
 
-    if (/[\\/]node_modules[\\/]/.test(this.resourcePath)) {
+    if (NODE_MODULES_REGEX.test(this.resourcePath)) {
       callback(null, source, sourceMap);
       return;
     }


### PR DESCRIPTION
## Summary

Skip the Solid refresh transform for files inside `node_modules`. This prevents dependency modules from receiving application HMR boundaries and aligns the behavior with the official Solid plugin.

## Related Links

- https://github.com/solidjs/solid-vite-plugin/blob/63fe297157536cc809a25ca183400f6e9125b8f5/src/index.ts#L1019-L1073