### PR TITLE
test: fix Rstest lint violations

### DIFF
--- a/e2e/cases/server/print-urls/index.test.ts
+++ b/e2e/cases/server/print-urls/index.test.ts
@@ -1,6 +1,6 @@
 import os, { type NetworkInterfaceInfo } from 'node:os';
-import { mock } from 'node:test';
 import { expect, NETWORK_LOG_REGEX, test } from '@e2e/helper';
+import { rs } from 'rstack/test';
 
 const createIpv4 = (
   address: string,
@@ -38,11 +38,11 @@ test('should print server urls correctly by default', async ({
 });
 
 test('should print names for multiple network urls', async ({ devOnly }) => {
-  const networkInterfaces = mock.method(os, 'networkInterfaces', () => ({
+  const networkInterfaces = rs.spyOn(os, 'networkInterfaces').mockReturnValue({
     lo: [createIpv4('127.0.0.1', true)],
     xray_tun: [createIpv4('192.0.2.10')],
     'Wi-Fi': [createIpv4('198.51.100.20')],
-  }));
+  });
 
   try {
     const rsbuild = await devOnly({
@@ -62,15 +62,15 @@ test('should print names for multiple network urls', async ({ devOnly }) => {
     await rsbuild.expectLog('➜  Network (xray_tun):');
     await rsbuild.expectLog('➜  Network (Wi-Fi):');
   } finally {
-    networkInterfaces.mock.restore();
+    networkInterfaces.mockRestore();
   }
 });
 
 test('should omit name for a single network url', async ({ devOnly }) => {
-  const networkInterfaces = mock.method(os, 'networkInterfaces', () => ({
+  const networkInterfaces = rs.spyOn(os, 'networkInterfaces').mockReturnValue({
     lo: [createIpv4('127.0.0.1', true)],
     'Wi-Fi': [createIpv4('198.51.100.20')],
-  }));
+  });
 
   try {
     const rsbuild = await devOnly({
@@ -86,7 +86,7 @@ test('should omit name for a single network url', async ({ devOnly }) => {
     );
     rsbuild.expectNoLog('(Wi-Fi)');
   } finally {
-    networkInterfaces.mock.restore();
+    networkInterfaces.mockRestore();
   }
 });
 

--- a/packages/core/tests/swc.test.ts
+++ b/packages/core/tests/swc.test.ts
@@ -6,114 +6,136 @@ const defaultCwd = path.join(import.meta.dirname, '..');
 
 describe('plugin-swc', () => {
   it('should disable preset-env for non-web targets', async () => {
-    await matchConfigSnapshot({
-      output: {
-        polyfill: 'entry',
-        target: 'node',
-      },
-    });
+    await expect(
+      getMatchedRules({
+        output: {
+          polyfill: 'entry',
+          target: 'node',
+        },
+      }),
+    ).resolves.toMatchSnapshot();
   });
 
   it('should disable preset-env mode', async () => {
-    await matchConfigSnapshot({
-      output: {
-        polyfill: 'off',
-      },
-    });
+    await expect(
+      getMatchedRules({
+        output: {
+          polyfill: 'off',
+        },
+      }),
+    ).resolves.toMatchSnapshot();
   });
 
   it('should enable preset-env in usage mode', async () => {
-    await matchConfigSnapshot({
-      output: {
-        polyfill: 'usage',
-      },
-    });
+    await expect(
+      getMatchedRules({
+        output: {
+          polyfill: 'usage',
+        },
+      }),
+    ).resolves.toMatchSnapshot();
   });
 
   it('should enable preset-env in entry mode', async () => {
-    await matchConfigSnapshot({
-      output: {
-        polyfill: 'entry',
-      },
-    });
+    await expect(
+      getMatchedRules({
+        output: {
+          polyfill: 'entry',
+        },
+      }),
+    ).resolves.toMatchSnapshot();
   });
 
   it('should apply overrideBrowserslist', async () => {
-    await matchConfigSnapshot({
-      output: {
-        overrideBrowserslist: ['chrome 98'],
-      },
-    });
+    await expect(
+      getMatchedRules({
+        output: {
+          overrideBrowserslist: ['chrome 98'],
+        },
+      }),
+    ).resolves.toMatchSnapshot();
   });
 
   it('should use the correct core-js version', async () => {
-    await matchConfigSnapshot({
-      output: {
-        polyfill: 'entry',
-      },
-    });
+    await expect(
+      getMatchedRules({
+        output: {
+          polyfill: 'entry',
+        },
+      }),
+    ).resolves.toMatchSnapshot();
 
-    await matchConfigSnapshot({
-      output: {
-        polyfill: 'entry',
-        target: 'node',
-      },
-    });
+    await expect(
+      getMatchedRules({
+        output: {
+          polyfill: 'entry',
+          target: 'node',
+        },
+      }),
+    ).resolves.toMatchSnapshot();
   });
 
   it('should apply pluginImport', async () => {
-    await matchConfigSnapshot({
-      source: {
-        transformImport: [
-          {
-            libraryName: 'foo',
-          },
-        ],
-      },
-    });
+    await expect(
+      getMatchedRules({
+        source: {
+          transformImport: [
+            {
+              libraryName: 'foo',
+            },
+          ],
+        },
+      }),
+    ).resolves.toMatchSnapshot();
   });
 
   it('should disable pluginImport when it returns undefined', async () => {
-    await matchConfigSnapshot({
-      source: {
-        transformImport: () => {},
-      },
-    });
+    await expect(
+      getMatchedRules({
+        source: {
+          transformImport: () => {},
+        },
+      }),
+    ).resolves.toMatchSnapshot();
   });
 
   it('should apply pluginImport correctly with ConfigChain', async () => {
-    await matchConfigSnapshot({
-      source: {
-        transformImport: [
-          {
-            libraryName: 'foo1',
-          },
-          // ignore foo1
-          () => [],
-          {
-            libraryName: 'foo',
-          },
-          {
-            libraryName: 'baz',
-          },
-          {
-            libraryName: 'bar',
-          },
-          // ignore baz
-          (value) => value.filter((v) => v.libraryName !== 'baz'),
-        ],
-      },
-    });
+    await expect(
+      getMatchedRules({
+        source: {
+          transformImport: [
+            {
+              libraryName: 'foo1',
+            },
+            // ignore foo1
+            () => [],
+            {
+              libraryName: 'foo',
+            },
+            {
+              libraryName: 'baz',
+            },
+            {
+              libraryName: 'bar',
+            },
+            // ignore baz
+            (value) => value.filter((v) => v.libraryName !== 'baz'),
+          ],
+        },
+      }),
+    ).resolves.toMatchSnapshot();
   });
 
   it('should apply decorators version 2023-11', async () => {
-    await matchConfigSnapshot({
-      source: {
-        decorators: {
-          version: '2023-11',
+    await expect(
+      getMatchedRules({
+        source: {
+          decorators: {
+            version: '2023-11',
+          },
         },
-      },
-    });
+      }),
+    ).resolves.toMatchSnapshot();
   });
 
   it('should allow using `tools.swc` to configure swc-loader options', async () => {
@@ -205,7 +227,7 @@ describe('plugin-swc', () => {
   });
 });
 
-async function matchConfigSnapshot(config: RsbuildConfig) {
+async function getMatchedRules(config: RsbuildConfig) {
   config.source ||= {};
   config.source.entry = {
     main: './src/index.js',
@@ -216,7 +238,5 @@ async function matchConfigSnapshot(config: RsbuildConfig) {
     cwd: defaultCwd,
   });
   const rspackConfigs = await rsbuild.initConfigs();
-  expect(
-    rspackConfigs.map((rspackConfig) => matchRules(rspackConfig, 'a.js')),
-  ).toMatchSnapshot();
+  return rspackConfigs.map((rspackConfig) => matchRules(rspackConfig, 'a.js'));
 }

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -64,8 +64,6 @@ define.lint(({ globals, globalIgnores, js, rstestPlugin, ts }) => [
       '@typescript-eslint/no-unsafe-call': 'off',
       '@typescript-eslint/restrict-template-expressions': 'off',
       '@typescript-eslint/no-explicit-any': 'off',
-      'rstest/expect-expect': 'off',
-      'rstest/no-import-node-test': 'off',
     },
   },
 ]);


### PR DESCRIPTION
## Summary

Rstest's recommended lint rules exposed tests that relied on Node's test mock API and hid snapshot assertions inside a helper. This PR removes the rule overrides, migrates the URL tests to `rs.spyOn`, and moves the SWC snapshot assertions into their test bodies so both rules remain enabled.