### PR TITLE
fix(core): reuse dynamic port after restart

### DIFF
--- a/e2e/cases/javascript-api/restart-preserve-options/index.test.ts
+++ b/e2e/cases/javascript-api/restart-preserve-options/index.test.ts
@@ -1,7 +1,12 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { expect, test } from '@e2e/helper';
-import { createRsbuild, type RestartContext } from '@rsbuild/core';
+import {
+  createRsbuild,
+  type RestartContext,
+  type RestartFn,
+  type StartDevServerResult,
+} from '@rsbuild/core';
 import { getRandomPort } from '@rstackjs/test-utils';
 
 const watchedFile = path.join(import.meta.dirname, 'test-temp-watch.txt');
@@ -58,6 +63,72 @@ test('should preserve startDevServer options after restart', async () => {
         },
       });
   } finally {
+    await server.close();
+  }
+});
+
+test('should preserve a dynamically assigned port after restart', async () => {
+  let restartContext: RestartContext | undefined;
+  let restartResult: StartDevServerResult | undefined;
+
+  async function createInstance() {
+    return createRsbuild({
+      cwd: import.meta.dirname,
+      config: {
+        dev: {
+          watchFiles: {
+            paths: watchedFile,
+            type: 'restart',
+          },
+        },
+        server: {
+          port: 0,
+        },
+      },
+      restart,
+    });
+  }
+
+  const restart: RestartFn = async (context) => {
+    restartContext = context;
+    if (context.action !== 'dev') {
+      return false;
+    }
+
+    const rsbuild = await createInstance();
+    restartResult = await rsbuild.startDevServer(context.options);
+    return true;
+  };
+
+  const rsbuild = await createInstance();
+  const { port, server } = await rsbuild.startDevServer({
+    getPortSilently: true,
+  });
+  let version = 1;
+
+  try {
+    await expect
+      .poll(
+        () => {
+          if (!restartContext) {
+            fs.writeFileSync(watchedFile, String(++version));
+          }
+          return restartContext;
+        },
+        { timeout: 5_000 },
+      )
+      .toEqual({
+        action: 'dev',
+        event: 'change',
+        filePath: watchedFile,
+        options: {
+          getPortSilently: true,
+        },
+      });
+
+    await expect.poll(() => restartResult?.port).toBe(port);
+  } finally {
+    await restartResult?.server.close();
     await server.close();
   }
 });

--- a/packages/core/src/helpers/restartManager.ts
+++ b/packages/core/src/helpers/restartManager.ts
@@ -6,11 +6,19 @@ type Cleanup = () => MaybePromise<void>;
 export type RestartManager = {
   /** Whether a restart executor is available. */
   readonly canRestart: boolean;
+  /** Get the port used before a restart. */
+  getPort(): number | undefined;
+  /** Set the port to reuse after a restart. */
+  setPort(port: number): void;
   /** Register a cleanup callback and return a function that unregisters it. */
   registerCleanup(cleanup: Cleanup): () => void;
   /** Handle a restart request and return whether the restart succeeded. */
   requestRestart(context: RestartContext): Promise<boolean>;
 };
+
+// Replacement instances use the same restart callback, so its identity can be
+// used to share the last port without exposing a public option.
+const restartPorts = new WeakMap<RestartFn, number>();
 
 export const createRestartManager = ({
   onRestart,
@@ -23,6 +31,14 @@ export const createRestartManager = ({
 
   return {
     canRestart: Boolean(restart),
+    getPort() {
+      return restart ? restartPorts.get(restart) : undefined;
+    },
+    setPort(port) {
+      if (restart) {
+        restartPorts.set(restart, port);
+      }
+    },
     registerCleanup(cleanup) {
       cleanups.add(cleanup);
 

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -109,7 +109,12 @@ export async function createDevServer<
   const { logger } = context;
   logger.debug('create dev server');
 
-  const { port, portTip } = await resolvePort(config);
+  const isDynamicPort = config.server.port === 0;
+  const lastPort = isDynamicPort ? context.restartManager.getPort() : undefined;
+  const { port, portTip } = await resolvePort(config, lastPort);
+  if (isDynamicPort) {
+    context.restartManager.setPort(port);
+  }
   const { middlewareMode, host } = config.server;
   const isHttps = Boolean(config.server.https);
   const routes = getRoutes(context);

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -497,15 +497,17 @@ export const getPort = async ({
 
 export const resolvePort = async (
   config: NormalizedConfig,
+  lastPort?: number,
 ): Promise<{
   port: number;
   portTip: string | undefined;
 }> => {
   const { host, port: originalPort, strictPort } = config.server;
+  const preferredPort = originalPort === 0 ? lastPort : undefined;
   const port = await getPort({
     host,
-    port: originalPort,
-    strictPort,
+    port: preferredPort ?? originalPort,
+    strictPort: preferredPort === undefined && strictPort,
   });
   const portTip =
     originalPort !== 0 && port !== originalPort


### PR DESCRIPTION
## Summary

When `server.port` is `0`, restarting could allocate a different port and disrupt integrations that rely on a stable address. This PR keeps the dynamically assigned port in core restart state and preferentially reuses it for replacement server instances, providing consistent behavior for both CLI and JS API users. If the previous port is unavailable, Rsbuild still falls back to another available port, with no public API changes.