### PR TITLE
fix(core): isolate dynamic ports across restart instances

### DIFF
--- a/e2e/cases/javascript-api/restart-preserve-options/index.test.ts
+++ b/e2e/cases/javascript-api/restart-preserve-options/index.test.ts
@@ -67,11 +67,22 @@ test('should preserve startDevServer options after restart', async () => {
   }
 });
 
-test('should preserve a dynamically assigned port after restart', async () => {
-  let restartContext: RestartContext | undefined;
+test('should preserve a dynamically assigned port with a new restart callback', async () => {
+  let restarting = false;
   let restartResult: StartDevServerResult | undefined;
 
   async function createInstance() {
+    const restart: RestartFn = async (context) => {
+      if (context.action !== 'dev') {
+        return false;
+      }
+
+      restarting = true;
+      const rsbuild = await createInstance();
+      restartResult = await rsbuild.startDevServer(context.options);
+      return true;
+    };
+
     return createRsbuild({
       cwd: import.meta.dirname,
       config: {
@@ -89,17 +100,6 @@ test('should preserve a dynamically assigned port after restart', async () => {
     });
   }
 
-  const restart: RestartFn = async (context) => {
-    restartContext = context;
-    if (context.action !== 'dev') {
-      return false;
-    }
-
-    const rsbuild = await createInstance();
-    restartResult = await rsbuild.startDevServer(context.options);
-    return true;
-  };
-
   const rsbuild = await createInstance();
   const { port, server } = await rsbuild.startDevServer({
     getPortSilently: true,
@@ -110,23 +110,14 @@ test('should preserve a dynamically assigned port after restart', async () => {
     await expect
       .poll(
         () => {
-          if (!restartContext) {
+          if (!restarting) {
             fs.writeFileSync(watchedFile, String(++version));
           }
-          return restartContext;
+          return restartResult?.port;
         },
         { timeout: 5_000 },
       )
-      .toEqual({
-        action: 'dev',
-        event: 'change',
-        filePath: watchedFile,
-        options: {
-          getPortSilently: true,
-        },
-      });
-
-    await expect.poll(() => restartResult?.port).toBe(port);
+      .toBe(port);
   } finally {
     await restartResult?.server.close();
     await server.close();

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -307,7 +307,7 @@ export async function createRsbuild(
       },
       createCompiler,
       config,
-      { ...options },
+      options,
     );
 
     return server.listen();

--- a/packages/core/src/helpers/restartManager.ts
+++ b/packages/core/src/helpers/restartManager.ts
@@ -6,19 +6,18 @@ type Cleanup = () => MaybePromise<void>;
 export type RestartManager = {
   /** Whether a restart executor is available. */
   readonly canRestart: boolean;
-  /** Get the port used before a restart. */
-  getPort(): number | undefined;
-  /** Set the port to reuse after a restart. */
+  /** Store the dynamic port for the next restart. */
   setPort(port: number): void;
+  /** Consume the dynamic port associated with restart options. */
+  inheritPort(options?: object): number | undefined;
   /** Register a cleanup callback and return a function that unregisters it. */
   registerCleanup(cleanup: Cleanup): () => void;
   /** Handle a restart request and return whether the restart succeeded. */
   requestRestart(context: RestartContext): Promise<boolean>;
 };
 
-// Replacement instances use the same restart callback, so its identity can be
-// used to share the last port without exposing a public option.
-const restartPorts = new WeakMap<RestartFn, number>();
+// The options object temporarily links the current and replacement managers.
+const restartPorts = new WeakMap<object, number>();
 
 export const createRestartManager = ({
   onRestart,
@@ -28,16 +27,19 @@ export const createRestartManager = ({
   restart?: RestartFn;
 }): RestartManager => {
   let cleanups = new Set<Cleanup>();
+  let port: number | undefined;
 
   return {
     canRestart: Boolean(restart),
-    getPort() {
-      return restart ? restartPorts.get(restart) : undefined;
+    setPort(nextPort) {
+      port = nextPort;
     },
-    setPort(port) {
-      if (restart) {
-        restartPorts.set(restart, port);
+    inheritPort(options) {
+      const inheritedPort = options ? restartPorts.get(options) : undefined;
+      if (options) {
+        restartPorts.delete(options);
       }
+      return inheritedPort;
     },
     registerCleanup(cleanup) {
       cleanups.add(cleanup);
@@ -80,7 +82,17 @@ export const createRestartManager = ({
         throw firstError;
       }
 
-      return restart(context);
+      if (context.action !== 'dev' || port === undefined) {
+        return restart(context);
+      }
+
+      // Expose the port only while the replacement task is being created.
+      restartPorts.set(context.options, port);
+      try {
+        return await restart(context);
+      } finally {
+        restartPorts.delete(context.options);
+      }
     },
   };
 };

--- a/packages/core/src/helpers/restartManager.ts
+++ b/packages/core/src/helpers/restartManager.ts
@@ -16,7 +16,9 @@ export type RestartManager = {
   requestRestart(context: RestartContext): Promise<boolean>;
 };
 
-// The options object temporarily links the current and replacement managers.
+// During a dynamic-port restart, the current manager associates its assigned
+// port with the restart options object. The replacement manager consumes that
+// entry when creating the new server, preserving the port across the restart.
 const restartPorts = new WeakMap<object, number>();
 
 export const createRestartManager = ({

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -110,7 +110,9 @@ export async function createDevServer<
   logger.debug('create dev server');
 
   const isDynamicPort = config.server.port === 0;
-  const lastPort = isDynamicPort ? context.restartManager.getPort() : undefined;
+  const lastPort = isDynamicPort
+    ? context.restartManager.inheritPort(devServerOptions)
+    : undefined;
   const { port, portTip } = await resolvePort(config, lastPort);
   if (isDynamicPort) {
     context.restartManager.setPort(port);

--- a/packages/core/tests/restartHook.test.ts
+++ b/packages/core/tests/restartHook.test.ts
@@ -39,4 +39,23 @@ describe('restartManager', () => {
 
     expect(callback).not.toHaveBeenCalled();
   });
+
+  test('should isolate ports when managers share a restart callback', async () => {
+    const inheritedPorts: (number | undefined)[] = [];
+    const restart = rstest.fn(({ options }) => {
+      const manager = createRestartManager({ onRestart: () => {} });
+      inheritedPorts.push(manager.inheritPort(options));
+      return true;
+    });
+    const first = createRestartManager({ onRestart: () => {}, restart });
+    const second = createRestartManager({ onRestart: () => {}, restart });
+
+    first.setPort(3000);
+    second.setPort(4000);
+
+    await first.requestRestart({ action: 'dev', options: {} });
+    await second.requestRestart({ action: 'dev', options: {} });
+
+    expect(inheritedPorts).toEqual([3000, 4000]);
+  });
 });


### PR DESCRIPTION
## Summary

The dynamic port state introduced in #8330 was keyed by restart callback identity, so replacement instances with new callbacks could lose the port while instances sharing a callback could overwrite each other. This PR transfers the port through the exact restart options object, isolating state per replacement task for both CLI and JS API users without changing the public API.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/8330