### PR TITLE
revert: enable native watcher by default

### DIFF
--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -33,7 +33,6 @@ export const pluginBasic = (): RsbuildPlugin => ({
 
         chain.experiments({
           ...chain.get('experiments'),
-          nativeWatcher: true,
           sourceImport: true,
         });
 

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -10,7 +10,6 @@ exports[`default bundler > should use Rspack by default 1`] = `
     ],
   },
   "experiments": {
-    "nativeWatcher": true,
     "sourceImport": true,
   },
   "infrastructureLogging": {

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -33,7 +33,6 @@ exports[`should apply default plugins correctly 1`] = `
   "context": "<ROOT>",
   "devtool": "cheap-module-source-map",
   "experiments": {
-    "nativeWatcher": true,
     "sourceImport": true,
   },
   "infrastructureLogging": {
@@ -603,7 +602,6 @@ exports[`should apply default plugins correctly in production 1`] = `
   "context": "<ROOT>",
   "devtool": false,
   "experiments": {
-    "nativeWatcher": true,
     "sourceImport": true,
   },
   "infrastructureLogging": {
@@ -1203,7 +1201,6 @@ exports[`should apply default plugins correctly when target is node 1`] = `
   "context": "<ROOT>",
   "devtool": "cheap-module-source-map",
   "experiments": {
-    "nativeWatcher": true,
     "sourceImport": true,
   },
   "infrastructureLogging": {
@@ -1760,7 +1757,6 @@ exports[`tools.rspack > should match snapshot 1`] = `
   "context": "<ROOT>",
   "devtool": "cheap-module-source-map",
   "experiments": {
-    "nativeWatcher": true,
     "sourceImport": true,
   },
   "infrastructureLogging": {

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -6,7 +6,6 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
     "context": "<ROOT>",
     "devtool": "eval-source-map",
     "experiments": {
-      "nativeWatcher": true,
       "sourceImport": true,
     },
     "infrastructureLogging": {
@@ -573,7 +572,6 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
     "context": "<ROOT>",
     "devtool": "eval",
     "experiments": {
-      "nativeWatcher": true,
       "sourceImport": true,
     },
     "infrastructureLogging": {

--- a/website/docs/en/guide/optimization/build-performance.mdx
+++ b/website/docs/en/guide/optimization/build-performance.mdx
@@ -77,6 +77,22 @@ export default {
 
 > See [dev.lazyCompilation](/config/dev/lazy-compilation) for more information.
 
+### Enable native watcher
+
+Enabling Rspack's [native watcher](https://rspack.rs/config/experiments#experimentsnativewatcher) improves HMR performance in development mode.
+
+```ts title="rsbuild.config.ts"
+export default {
+  tools: {
+    rspack: {
+      experiments: {
+        nativeWatcher: true,
+      },
+    },
+  },
+};
+```
+
 ### Source map format
 
 To provide a good debugging experience, Rsbuild uses the `cheap-module-source-map` format in development mode by default. This is a high-quality source map format that comes with some performance overhead.

--- a/website/docs/zh/guide/optimization/build-performance.mdx
+++ b/website/docs/zh/guide/optimization/build-performance.mdx
@@ -77,6 +77,22 @@ export default {
 
 > 请参考 [dev.lazyCompilation](/config/dev/lazy-compilation) 了解更多。
 
+### 开启 native watcher
+
+启用 Rspack 的 [native watcher](https://rspack.rs/zh/config/experiments#experimentsnativewatcher) 可以提升开发模式下的 HMR 性能。
+
+```ts title="rsbuild.config.ts"
+export default {
+  tools: {
+    rspack: {
+      experiments: {
+        nativeWatcher: true,
+      },
+    },
+  },
+};
+```
+
 ### Source map 格式
 
 为了提供良好的调试体验，Rsbuild 在开发模式下默认使用 `cheap-module-source-map` 格式 source map，这是一种高质量的 source map 格式，会带来一定的性能开销。


### PR DESCRIPTION
## Summary

This PR reverts #8296 and restores Rspack's native watcher as an opt-in experiment.

The native watcher currently does not support a function-valued `watchOptions.ignored`, causing`rsbuild-plugin-rsc` test files to fail during watch startup in ecosystem CI. It also does not yet support `compiler.fileTimestamps`, so enabling it by default is premature.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8296
- https://github.com/rstackjs/rstack-ecosystem-ci/actions/runs/32146764819/job/95742301969