### PR TITLE
chore(ci): allow ecosystem CI to update PR comments

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -43,8 +43,7 @@ jobs:
     if: github.repository == 'web-infra-dev/rsbuild' && github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
-      issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Trigger Ecosystem CI
         uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@4b0ec855ccbd27595a0df4781ed58b77e64d25ee # v0.3.5


### PR DESCRIPTION
## Summary

The manual ecosystem CI action needs to find a pull request and create or update its status comment. This PR replaces separate issue-write and pull-request-read permissions with `pull-requests: write`, matching the action's PR API usage while retaining read access.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8332