### PR TITLE
fix(core): use output.target to decide HMR client injection

### DIFF
--- a/e2e/cases/hmr/browserslist-target/index.test.ts
+++ b/e2e/cases/hmr/browserslist-target/index.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@e2e/helper';
+
+test('should inject HMR client into each entry when target is browserslist', async ({
+  devOnly,
+}) => {
+  const rsbuild = await devOnly({
+    config: {
+      source: {
+        entry: {
+          foo: './src/foo.js',
+          bar: './src/bar.js',
+        },
+      },
+    },
+  });
+
+  const files = rsbuild.getDistFiles();
+  const filenames = Object.keys(files);
+  const fooJs = filenames.find((name) => name.endsWith('foo.js'));
+  const barJs = filenames.find((name) => name.endsWith('bar.js'));
+
+  expect(files[fooJs!].includes('hmr.js')).toBeTruthy();
+  expect(files[barJs!].includes('hmr.js')).toBeTruthy();
+});

--- a/e2e/cases/hmr/browserslist-target/rsbuild.config.ts
+++ b/e2e/cases/hmr/browserslist-target/rsbuild.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  tools: {
+    htmlPlugin: false,
+    rspack: (config, { mergeConfig }) =>
+      mergeConfig(config, {
+        target: 'browserslist:last 2 chrome versions',
+      }),
+  },
+});

--- a/e2e/cases/hmr/browserslist-target/src/bar.js
+++ b/e2e/cases/hmr/browserslist-target/src/bar.js
@@ -1,0 +1,1 @@
+console.log('bar');

--- a/e2e/cases/hmr/browserslist-target/src/foo.js
+++ b/e2e/cases/hmr/browserslist-target/src/foo.js
@@ -1,0 +1,1 @@
+console.log('foo');

--- a/packages/core/src/server/assets-middleware/index.ts
+++ b/packages/core/src/server/assets-middleware/index.ts
@@ -61,14 +61,6 @@ const normalizeLiveReload = (liveReload: LiveReload): NormalizedLiveReload => {
   };
 };
 
-export const isClientCompiler = (compiler: Compiler): boolean => {
-  const { target } = compiler.options;
-  if (target) {
-    return Array.isArray(target) ? target.includes('web') : target === 'web';
-  }
-  return false;
-};
-
 const isNodeCompiler = (compiler: Compiler) => {
   const { target } = compiler.options;
   if (target) {
@@ -191,7 +183,7 @@ function applyHMREntry({
   resolvedPort: number;
 }) {
   if (
-    !isClientCompiler(compiler) ||
+    config.output.target !== 'web' ||
     (!config.dev.hmr && !config.dev.liveReload)
   ) {
     return;

--- a/packages/core/tests/server.test.ts
+++ b/packages/core/tests/server.test.ts
@@ -1,7 +1,5 @@
 import os from 'node:os';
-import { rspack } from '@rspack/core';
 import { defaultAllowedOrigins } from '../src/defaultConfig';
-import { isClientCompiler } from '../src/server/assets-middleware';
 import {
   formatRoutes,
   getAddressUrls,
@@ -688,36 +686,6 @@ test('should limit printed server routes correctly', () => {
       -  foo      http://localhost:3000/foo
       -  bar      http://localhost:3000/bar"
   `);
-});
-
-describe('dev server', () => {
-  test('should detect client compilers correctly', () => {
-    expect(isClientCompiler(rspack({}))).toBeTruthy();
-
-    expect(
-      isClientCompiler(
-        rspack({
-          target: ['web', 'es5'],
-        }),
-      ),
-    ).toBeTruthy();
-
-    expect(
-      isClientCompiler(
-        rspack({
-          target: 'node',
-        }),
-      ),
-    ).toBeFalsy();
-
-    expect(
-      isClientCompiler(
-        rspack({
-          target: ['node'],
-        }),
-      ),
-    ).toBeFalsy();
-  });
 });
 
 test('should use Http2SecureServer when https and proxy are both enabled', async () => {


### PR DESCRIPTION
## Summary

- Use Rsbuild's own `output.target` to decide if the dev HMR client should be added to the entries
- Before this, the check only looked for the literal `'web'` in `compiler.options.target`
- If the target is set through `tools.rspack` (for example `target: 'browserslist:...'`), it no longer contains `'web'`, so the HMR client was never added and you had to refresh by hand

## Use case

My app sets the Rspack target through `tools.rspack` to a browserslist query. The HMR runtime was in the bundle, but the HMR client entry was never added, so changes did not show up without a manual refresh.

`output.target` is already normalized to `web`, `node`, or `web-worker`, so it is a safer check than the raw Rspack target.

## Changes

- Replace `isClientCompiler(compiler)` with `config.output.target !== 'web'`
- Remove `isClientCompiler` and its unit test
- Add e2e case `cases/hmr/browserslist-target` that fails on main and passes with this change

## Test plan

- [x] `pnpm e2e cases/hmr/browserslist-target` fails on main, passes with this change
- [x] `pnpm e2e hmr` (22 files, 29 tests)
- [x] core unit tests, lint and type check