### PR TITLE
docs: remove faster module concatenation guide

### DIFF
--- a/website/docs/en/guide/optimization/build-performance.mdx
+++ b/website/docs/en/guide/optimization/build-performance.mdx
@@ -145,27 +145,3 @@ last 1 safari version
 ```
 
 Note that this can lead to differences in build output between development and production modes.
-
-## Production optimization
-
-These methods improve performance in production mode.
-
-### Enable faster module concatenation
-
-Enable Rspack's experimental [`experiments.fasterModuleConcatenation`](https://rspack.rs/config/experiments#experimentsfastermoduleconcatenation) option to speed up module concatenation in production builds.
-
-```ts title="rsbuild.config.ts"
-export default {
-  tools: {
-    rspack: {
-      experiments: {
-        fasterModuleConcatenation: true,
-      },
-    },
-  },
-};
-```
-
-:::tip
-`experiments.fasterModuleConcatenation` is supported in Rsbuild v2.2.0 and later.
-:::

--- a/website/docs/zh/guide/optimization/build-performance.mdx
+++ b/website/docs/zh/guide/optimization/build-performance.mdx
@@ -145,27 +145,3 @@ last 1 safari version
 ```
 
 注意，这项优化方法会导致开发模式与生产模式的构建产物存在一定差异。
-
-## 生产模式优化
-
-以下是针对生产构建进行提速的方法。
-
-### 开启更快的模块合并
-
-开启 Rspack 的实验性 [`experiments.fasterModuleConcatenation`](https://rspack.rs/zh/config/experiments#experimentsfastermoduleconcatenation) 配置，可以提升生产模式下的模块合并速度。
-
-```ts title="rsbuild.config.ts"
-export default {
-  tools: {
-    rspack: {
-      experiments: {
-        fasterModuleConcatenation: true,
-      },
-    },
-  },
-};
-```
-
-:::tip
-`experiments.fasterModuleConcatenation` 配置在 Rsbuild v2.2.0 及以上版本中支持。
-:::


### PR DESCRIPTION
## Summary

Rspack has removed the experimental `fasterModuleConcatenation` option after reverting the optimization. This PR removes the obsolete guidance from the English and Chinese build performance docs.

## Related Links

- https://github.com/web-infra-dev/rspack/pull/15262