### PR TITLE
perf(core): optimize manifest entry grouping

### DIFF
--- a/packages/core/src/plugins/manifest.ts
+++ b/packages/core/src/plugins/manifest.ts
@@ -63,9 +63,6 @@ const generateManifest =
     const manifestEntries: ManifestData['entries'] = {};
 
     for (const [entryName, chunkFiles] of chunkEntries) {
-      // Preserve the existing reverse file order without copying on every insertion.
-      chunkFiles.reverse();
-
       const assets = new Set<string>();
       const initialJS: string[] = [];
       const initialCSS: string[] = [];

--- a/packages/core/src/plugins/manifest.ts
+++ b/packages/core/src/plugins/manifest.ts
@@ -44,10 +44,12 @@ const generateManifest =
         const entryNames = recursiveChunkEntryNames(file.chunk);
 
         for (const entryName of entryNames) {
-          chunkEntries.set(entryName, [
-            file,
-            ...(chunkEntries.get(entryName) || []),
-          ]);
+          const chunkFiles = chunkEntries.get(entryName);
+          if (chunkFiles) {
+            chunkFiles.push(file);
+          } else {
+            chunkEntries.set(entryName, [file]);
+          }
         }
       }
 
@@ -61,6 +63,9 @@ const generateManifest =
     const manifestEntries: ManifestData['entries'] = {};
 
     for (const [entryName, chunkFiles] of chunkEntries) {
+      // Preserve the existing reverse file order without copying on every insertion.
+      chunkFiles.reverse();
+
       const assets = new Set<string>();
       const initialJS: string[] = [];
       const initialCSS: string[] = [];


### PR DESCRIPTION
## Summary

This PR reduces manifest entry grouping from quadratic to linear time by appending chunk files in place. Async files and auxiliary assets now follow the file order provided by Rspack instead of reversing it; initial chunk order remains sourced from `entrypoint.getFiles()`.

## Performance

Isolated grouping benchmark on Node.js v24.12.0 (darwin-arm64), using one entry with 4,000 file descriptors, 20 warmups, and 50 samples:

| | Median | P95 |
| --- | ---: | ---: |
| Before | 25.210 ms | 25.788 ms |
| After | 0.028 ms | 0.038 ms |
| Delta | -25.182 ms (-99.9%) | -25.750 ms (-99.9%) |

This measures only the manifest grouping algorithm, not end-to-end build time.