### PR TITLE
test: migrate module federation tests to splitChunks

### DIFF
--- a/packages/core/tests/__snapshots__/moduleFederation.test.ts.snap
+++ b/packages/core/tests/__snapshots__/moduleFederation.test.ts.snap
@@ -26,7 +26,7 @@ exports[`plugin-module-federation > should set environment module federation con
 ]
 `;
 
-exports[`plugin-module-federation > should set module federation and environment chunkSplit config correctly 1`] = `
+exports[`plugin-module-federation > should set module federation and environment splitChunks config correctly 1`] = `
 [
   ModuleFederationPlugin {
     "_options": {

--- a/packages/core/tests/moduleFederation.test.ts
+++ b/packages/core/tests/moduleFederation.test.ts
@@ -5,11 +5,6 @@ describe('plugin-module-federation', () => {
   it('should set module federation config', async () => {
     const rsbuild = await createRsbuild({
       config: {
-        performance: {
-          chunkSplit: {
-            strategy: 'split-by-experience',
-          },
-        },
         moduleFederation: {
           options: {
             name: 'remote',
@@ -39,11 +34,6 @@ describe('plugin-module-federation', () => {
   it('should set environment module federation config correctly', async () => {
     const rsbuild = await createRsbuild({
       config: {
-        performance: {
-          chunkSplit: {
-            strategy: 'split-by-experience',
-          },
-        },
         environments: {
           web: {
             moduleFederation: {
@@ -77,7 +67,7 @@ describe('plugin-module-federation', () => {
     ).toMatchSnapshot();
   });
 
-  it('should set module federation and environment chunkSplit config correctly', async () => {
+  it('should set module federation and environment splitChunks config correctly', async () => {
     const rsbuild = await createRsbuild({
       config: {
         moduleFederation: {
@@ -100,19 +90,9 @@ describe('plugin-module-federation', () => {
           },
         },
         environments: {
-          web: {
-            performance: {
-              chunkSplit: {
-                strategy: 'split-by-experience',
-              },
-            },
-          },
+          web: {},
           web1: {
-            performance: {
-              chunkSplit: {
-                strategy: 'all-in-one',
-              },
-            },
+            splitChunks: false,
           },
         },
       },


### PR DESCRIPTION
## Summary

`performance.chunkSplit` is deprecated in Rsbuild v2, but the Module Federation unit tests still used it outside the dedicated legacy coverage. This PR migrates those tests to equivalent `splitChunks` settings while leaving legacy compatibility tests unchanged; snapshot payloads remain identical.

## Related Links

- https://rsbuild.rs/guide/upgrade/v1-to-v2#migrate-performancechunksplit
- https://github.com/web-infra-dev/rsbuild/pull/7077