### PR TITLE
perf(core): optimize resource hint file collection

### DIFF
--- a/packages/core/src/rspack-plugins/resource-hints/HtmlResourceHintsPlugin.ts
+++ b/packages/core/src/rspack-plugins/resource-hints/HtmlResourceHintsPlugin.ts
@@ -192,26 +192,24 @@ function generateLinks(
           }),
         );
 
-  // Flatten the list of files.
-  const allFiles = htmlChunks
-    .reduce(
-      (accumulated: string[], chunk) =>
-        accumulated.concat([
-          ...chunk.files,
-          // related assets are inside auxiliaryFiles
-          ...(chunk.auxiliaryFiles || []),
-        ]),
-      [],
-    )
-    // source map and hot-update files should always be excluded
-    .filter((file) => {
-      if (isDev && file.endsWith('.hot-update.js')) {
-        return false;
-      }
-      return !file.endsWith('.map');
-    });
+  const uniqueFiles = new Set<string>();
 
-  const uniqueFiles = new Set<string>(allFiles);
+  for (const chunk of htmlChunks) {
+    // Related assets are inside auxiliaryFiles.
+    for (const files of [chunk.files, chunk.auxiliaryFiles ?? []]) {
+      for (const file of files) {
+        // Exclude source maps and development hot-update files.
+        if (
+          (isDev && file.endsWith('.hot-update.js')) ||
+          file.endsWith('.map')
+        ) {
+          continue;
+        }
+        uniqueFiles.add(file);
+      }
+    }
+  }
+
   const filteredFiles = applyFilter(
     [...uniqueFiles],
     options.include,


### PR DESCRIPTION
## Summary

Resource hint generation currently creates multiple intermediate arrays while flattening, filtering, and deduplicating chunk files. This PR filters chunk and auxiliary files directly into a `Set` in one pass, preserving the generated output.

## Performance

Isolated file-collection benchmark on Node.js v24.12.0 (darwin-arm64), using 1,000 chunks with 8 chunk files and 4 auxiliary files each, development filtering enabled, 20 warmups, and 50 samples:

| | Median | P95 |
| --- | ---: | ---: |
| Before | 3.207 ms | 3.738 ms |
| After | 0.592 ms | 0.898 ms |
| Delta | -2.615 ms (-81.5%) | -2.840 ms (-76.0%) |

This measures only resource hint file collection, not end-to-end build time.