### PR TITLE
perf(core): cache loadBundle stats projection

### DIFF
--- a/packages/core/src/server/environment.ts
+++ b/packages/core/src/server/environment.ts
@@ -8,18 +8,32 @@ export type ServerUtils = {
   environment: EnvironmentContext;
 };
 
+type StatsProjection = Pick<
+  Rspack.StatsCompilation,
+  'chunks' | 'entrypoints' | 'outputPath'
+>;
+
+// Avoid repeated `toJson` calls across entries without retaining old compilations.
+const statsProjectionCache = new WeakMap<Rspack.Stats, StatsProjection>();
+
 export const loadBundle = async <T>(
   stats: Rspack.Stats,
   entryName: string,
   utils: ServerUtils,
 ): Promise<T> => {
-  const { chunks, entrypoints, outputPath } = stats.toJson({
-    all: false,
-    chunks: true,
-    entrypoints: true,
-    ids: true,
-    outputPath: true,
-  });
+  let statsProjection = statsProjectionCache.get(stats);
+  if (!statsProjection) {
+    statsProjection = stats.toJson({
+      all: false,
+      chunks: true,
+      entrypoints: true,
+      ids: true,
+      outputPath: true,
+    });
+    statsProjectionCache.set(stats, statsProjection);
+  }
+
+  const { chunks, entrypoints, outputPath } = statsProjection;
 
   if (!entrypoints?.[entryName]) {
     throw new Error(


### PR DESCRIPTION
## Summary

Loading different entries from the same compilation currently serializes the same stats subset for every entry. This PR caches that projection in a `WeakMap` keyed by `Stats`, avoiding repeated `toJson` calls while allowing previous compilations to be garbage-collected.

## Performance

Benchmark using a real Rspack `Stats` from a 50-entry compilation on Node.js v24.12.0 (darwin-arm64), with 10 warmups and 30 samples:

| | Median | P95 |
| --- | ---: | ---: |
| Before | 35.199 ms | 37.803 ms |
| After | 1.018 ms | 1.125 ms |
| Delta | -34.181 ms (-97.1%) | -36.678 ms (-97.0%) |

The number of stats projections per sample drops from 50 to 1. This measures only the stats projection stage, not complete bundle execution.