### PR TITLE
perf(core): speed up runner output file lookups

### DIFF
--- a/packages/core/src/server/environment.ts
+++ b/packages/core/src/server/environment.ts
@@ -8,32 +8,36 @@ export type ServerUtils = {
   environment: EnvironmentContext;
 };
 
-type StatsProjection = Pick<
+type LoadBundleStats = Pick<
   Rspack.StatsCompilation,
   'chunks' | 'entrypoints' | 'outputPath'
->;
+> & {
+  outputFilePaths?: Set<string>;
+};
 
-// Avoid repeated `toJson` calls across entries without retaining old compilations.
-const statsProjectionCache = new WeakMap<Rspack.Stats, StatsProjection>();
+// Reuse stats data across entries without retaining old compilations.
+const loadBundleStatsCache = new WeakMap<Rspack.Stats, LoadBundleStats>();
 
 export const loadBundle = async <T>(
   stats: Rspack.Stats,
   entryName: string,
   utils: ServerUtils,
 ): Promise<T> => {
-  let statsProjection = statsProjectionCache.get(stats);
-  if (!statsProjection) {
-    statsProjection = stats.toJson({
-      all: false,
-      chunks: true,
-      entrypoints: true,
-      ids: true,
-      outputPath: true,
-    });
-    statsProjectionCache.set(stats, statsProjection);
+  let loadBundleStats = loadBundleStatsCache.get(stats);
+  if (!loadBundleStats) {
+    loadBundleStats = {
+      ...stats.toJson({
+        all: false,
+        chunks: true,
+        entrypoints: true,
+        ids: true,
+        outputPath: true,
+      }),
+    };
+    loadBundleStatsCache.set(stats, loadBundleStats);
   }
 
-  const { chunks, entrypoints, outputPath } = statsProjection;
+  const { chunks, entrypoints, outputPath } = loadBundleStats;
 
   if (!entrypoints?.[entryName]) {
     throw new Error(
@@ -71,16 +75,23 @@ export const loadBundle = async <T>(
     );
   }
 
-  const allChunkFiles =
-    chunks?.flatMap((c) => c.files).map((file) => join(outputPath!, file!)) ||
-    [];
+  let { outputFilePaths } = loadBundleStats;
+  if (!outputFilePaths) {
+    outputFilePaths = new Set<string>();
+    for (const chunk of chunks || []) {
+      for (const file of chunk.files!) {
+        outputFilePaths.add(join(outputPath!, file));
+      }
+    }
+    loadBundleStats.outputFilePaths = outputFilePaths;
+  }
 
   const res = await run<T>({
     bundlePath: files[0],
     dist: outputPath!,
     compilerOptions: stats.compilation.options,
     readFileSync: utils.readFileSync,
-    isBundleOutput: (modulePath: string) => allChunkFiles.includes(modulePath),
+    isBundleOutput: (modulePath: string) => outputFilePaths.has(modulePath),
   });
 
   return res;

--- a/packages/core/src/server/environment.ts
+++ b/packages/core/src/server/environment.ts
@@ -91,7 +91,7 @@ export const loadBundle = async <T>(
     dist: outputPath!,
     compilerOptions: stats.compilation.options,
     readFileSync: utils.readFileSync,
-    isBundleOutput: (modulePath: string) => outputFilePaths.has(modulePath),
+    isOutputFile: (modulePath: string) => outputFilePaths.has(modulePath),
   });
 
   return res;

--- a/packages/core/src/server/runner/basic.ts
+++ b/packages/core/src/server/runner/basic.ts
@@ -34,7 +34,8 @@ const getSubPath = (p: string) => {
 
 export interface IBasicRunnerOptions {
   name: string;
-  isBundleOutput: (modulePath: string) => boolean;
+  /** Whether the module path is an output file of the current compilation. */
+  isOutputFile: (modulePath: string) => boolean;
   readFileSync: (path: string) => string;
   dist: string;
   compilerOptions: CompilerOptions;
@@ -105,7 +106,7 @@ export abstract class BasicRunner implements Runner {
       ? path.join(currentDirectory, modulePath)
       : modulePath;
 
-    if (!this._options.isBundleOutput(joinedPath)) {
+    if (!this._options.isOutputFile(joinedPath)) {
       return null;
     }
     return {

--- a/packages/core/src/server/runner/basic.ts
+++ b/packages/core/src/server/runner/basic.ts
@@ -4,9 +4,9 @@ import type {
   BasicGlobalContext,
   BasicModuleScope,
   BasicRunnerFile,
-  CompilerOptions,
   ModuleObject,
   Runner,
+  RunnerFactoryOptions,
   RunnerRequirer,
 } from './type';
 
@@ -32,20 +32,15 @@ const getSubPath = (p: string) => {
   return '';
 };
 
-export interface IBasicRunnerOptions {
+export interface BasicRunnerOptions extends RunnerFactoryOptions {
   name: string;
-  /** Whether the module path is an output file of the current compilation. */
-  isOutputFile: (modulePath: string) => boolean;
-  readFileSync: (path: string) => string;
-  dist: string;
-  compilerOptions: CompilerOptions;
 }
 
 export abstract class BasicRunner implements Runner {
   protected globalContext: BasicGlobalContext | null = null;
   protected baseModuleScope: BasicModuleScope | null = null;
   protected requirers: Map<string, RunnerRequirer> = new Map();
-  constructor(protected _options: IBasicRunnerOptions) {}
+  constructor(protected _options: BasicRunnerOptions) {}
 
   run(file: string): Promise<unknown> {
     if (!this.globalContext) {

--- a/packages/core/src/server/runner/type.ts
+++ b/packages/core/src/server/runner/type.ts
@@ -46,7 +46,8 @@ export type RunnerFactoryOptions = {
   dist: string;
   compilerOptions: CompilerOptions;
   readFileSync: (path: string) => string;
-  isBundleOutput: (modulePath: string) => boolean;
+  /** Whether the module path is an output file of the current compilation. */
+  isOutputFile: (modulePath: string) => boolean;
 };
 
 export interface RunnerFactory {

--- a/packages/core/tests/environment.test.ts
+++ b/packages/core/tests/environment.test.ts
@@ -1,7 +1,5 @@
-import { join } from 'node:path';
 import {
   createCacheableFunction,
-  loadBundle,
   type ServerUtils,
 } from '../src/server/environment';
 import type { Rspack } from '../src/types';
@@ -48,71 +46,4 @@ test('should retry after a pending call rejects', async () => {
   await expect(first).rejects.toBe(error);
   await expect(cacheableGetter(stats, 'index', utils)).resolves.toBe('result');
   expect(getter).toHaveBeenCalledTimes(2);
-});
-
-test('should cache bundle outputs and handle output hits and misses', async () => {
-  const outputPath = join(process.cwd(), 'dist');
-  const getSharedFiles = rstest.fn(() => ['shared.js']);
-  const toJson = rstest.fn(() => ({
-    chunks: [
-      { entry: true, id: 'first', files: ['first.js'] },
-      { entry: true, id: 'second', files: ['second.js'] },
-      {
-        entry: false,
-        id: 'shared',
-        get files() {
-          return getSharedFiles();
-        },
-      },
-    ],
-    entrypoints: {
-      first: { chunks: ['first'] },
-      second: { chunks: ['second'] },
-    },
-    outputPath,
-  }));
-  const bundleStats = {
-    compilation: {
-      options: {
-        target: 'node',
-        output: { module: false },
-      },
-    },
-    toJson,
-  } as unknown as Rspack.Stats;
-  const sources = new Map([
-    [
-      join(outputPath, 'first.js'),
-      `module.exports = {
-        bundled: require('./shared.js'),
-        external: require('node:path').basename('/external/file.js'),
-      };`,
-    ],
-    [join(outputPath, 'second.js'), `module.exports = require('./shared.js');`],
-    [join(outputPath, 'shared.js'), `module.exports = 'shared';`],
-  ]);
-  const bundleUtils = {
-    environment: {},
-    readFileSync: (fileName: string) => {
-      const source = sources.get(fileName);
-      if (source === undefined) {
-        throw new Error(`Unexpected read: ${fileName}`);
-      }
-      return source;
-    },
-  } as ServerUtils;
-
-  await expect(
-    loadBundle<{ bundled: string; external: string }>(
-      bundleStats,
-      'first',
-      bundleUtils,
-    ),
-  ).resolves.toEqual({ bundled: 'shared', external: 'file.js' });
-  await expect(
-    loadBundle<string>(bundleStats, 'second', bundleUtils),
-  ).resolves.toBe('shared');
-
-  expect(toJson).toHaveBeenCalledTimes(1);
-  expect(getSharedFiles).toHaveBeenCalledTimes(1);
 });

--- a/packages/core/tests/environment.test.ts
+++ b/packages/core/tests/environment.test.ts
@@ -1,5 +1,7 @@
+import { join } from 'node:path';
 import {
   createCacheableFunction,
+  loadBundle,
   type ServerUtils,
 } from '../src/server/environment';
 import type { Rspack } from '../src/types';
@@ -46,4 +48,71 @@ test('should retry after a pending call rejects', async () => {
   await expect(first).rejects.toBe(error);
   await expect(cacheableGetter(stats, 'index', utils)).resolves.toBe('result');
   expect(getter).toHaveBeenCalledTimes(2);
+});
+
+test('should cache bundle outputs and handle output hits and misses', async () => {
+  const outputPath = join(process.cwd(), 'dist');
+  const getSharedFiles = rstest.fn(() => ['shared.js']);
+  const toJson = rstest.fn(() => ({
+    chunks: [
+      { entry: true, id: 'first', files: ['first.js'] },
+      { entry: true, id: 'second', files: ['second.js'] },
+      {
+        entry: false,
+        id: 'shared',
+        get files() {
+          return getSharedFiles();
+        },
+      },
+    ],
+    entrypoints: {
+      first: { chunks: ['first'] },
+      second: { chunks: ['second'] },
+    },
+    outputPath,
+  }));
+  const bundleStats = {
+    compilation: {
+      options: {
+        target: 'node',
+        output: { module: false },
+      },
+    },
+    toJson,
+  } as unknown as Rspack.Stats;
+  const sources = new Map([
+    [
+      join(outputPath, 'first.js'),
+      `module.exports = {
+        bundled: require('./shared.js'),
+        external: require('node:path').basename('/external/file.js'),
+      };`,
+    ],
+    [join(outputPath, 'second.js'), `module.exports = require('./shared.js');`],
+    [join(outputPath, 'shared.js'), `module.exports = 'shared';`],
+  ]);
+  const bundleUtils = {
+    environment: {},
+    readFileSync: (fileName: string) => {
+      const source = sources.get(fileName);
+      if (source === undefined) {
+        throw new Error(`Unexpected read: ${fileName}`);
+      }
+      return source;
+    },
+  } as ServerUtils;
+
+  await expect(
+    loadBundle<{ bundled: string; external: string }>(
+      bundleStats,
+      'first',
+      bundleUtils,
+    ),
+  ).resolves.toEqual({ bundled: 'shared', external: 'file.js' });
+  await expect(
+    loadBundle<string>(bundleStats, 'second', bundleUtils),
+  ).resolves.toBe('shared');
+
+  expect(toJson).toHaveBeenCalledTimes(1);
+  expect(getSharedFiles).toHaveBeenCalledTimes(1);
 });


### PR DESCRIPTION
## Summary

`loadBundle` checks each resolved module against all emitted files, making runner lookups linear in the number of outputs. This PR caches absolute output file paths as a `Set` per compilation so lookups are constant-time and shared across entries.