### PR TITLE
perf(core): optimize manifest HTML file lookup

### DIFF
--- a/packages/core/src/plugins/manifest.ts
+++ b/packages/core/src/plugins/manifest.ts
@@ -31,11 +31,16 @@ const generateManifest =
     { compilation },
   ) => {
     const chunkEntries = new Map<string, FileDescriptor[]>();
+    const filePathByName = new Map<string, string>();
     const licenseMap = new Map<string, string>();
     const publicPath = getPublicPathFromCompiler(compilation);
     const integrity: Record<string, string> = {};
 
     const allFiles = files.map((file) => {
+      if (!filePathByName.has(file.name)) {
+        filePathByName.set(file.name, file.path);
+      }
+
       if (file.integrity) {
         integrity[file.path] = file.integrity;
       }
@@ -118,7 +123,7 @@ const generateManifest =
         entryManifest.assets = Array.from(assets);
       }
 
-      const htmlPath = files.find((f) => f.name === htmlPaths[entryName])?.path;
+      const htmlPath = filePathByName.get(htmlPaths[entryName]);
 
       if (htmlPath) {
         entryManifest.html = [htmlPath];


### PR DESCRIPTION
## Summary

This PR avoids rescanning all manifest files for every entry by building a first-match `name → path` index during the existing file traversal. It preserves `Array.find` behavior for duplicate names and changes HTML lookup complexity from O(entries × files) to O(entries + files).

## Benchmark

The benchmark simulates a large multipage build using the same ordering as `rspack-manifest-plugin`: chunk-backed files are collected before ordinary assets, with HTML files in the later asset phase. The fixture contains 100 entries and 10,000 emitted files, including 2 initial and 6 async chunks per entry, 100 shared async chunks, static assets, source maps, license files, integrity data, and 5 duplicate HTML names.

Measured on Node.js v24.12.0 with 30 warmups and 50 samples. The metric is the complete simulated `generateManifest` wall time, and the 450,515-byte manifests are deeply equal with first-match behavior preserved.

| Metric | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Median | 12.60 ms | 1.43 ms | 11.17 ms (88.67%, 8.82×) |
| P95 | 13.24 ms | 1.63 ms | 11.61 ms (87.67%, 8.11×) |