### PR TITLE
perf(core): avoid repeated HTML tag sorting

### DIFF
--- a/packages/core/src/rspack-plugins/RsbuildHtmlPlugin.ts
+++ b/packages/core/src/rspack-plugins/RsbuildHtmlPlugin.ts
@@ -103,6 +103,12 @@ const getTagPriority = (tag: HtmlTag, tagConfig: TagConfig) => {
   return priority;
 };
 
+const sortTags = (tags: HtmlTag[], tagConfig: TagConfig) =>
+  tags.sort(
+    (tag1, tag2) =>
+      getTagPriority(tag1, tagConfig) - getTagPriority(tag2, tagConfig),
+  );
+
 /**
  * `HtmlTagObject` -> `HtmlBasicTag`
  */
@@ -203,17 +209,25 @@ const applyTagConfig = (
     publicPath: data.publicPath,
   };
 
+  // Defer sorting consecutive static tags to avoid repeatedly sorting the
+  // entire array. Flush before function configs so they receive sorted tags.
+  let shouldSort = false;
+
   for (const item of tagConfig.tags) {
     if (isFunction(item)) {
+      if (shouldSort) {
+        tags = sortTags(tags, tagConfig);
+      }
       tags = item(tags, context) || tags;
     } else {
       tags.push(item);
     }
 
-    tags = tags.sort(
-      (tag1, tag2) =>
-        getTagPriority(tag1, tagConfig) - getTagPriority(tag2, tagConfig),
-    );
+    shouldSort = true;
+  }
+
+  if (shouldSort) {
+    tags = sortTags(tags, tagConfig);
   }
 
   const [headTags, bodyTags] = partition(


### PR DESCRIPTION
## Summary

`html.tags` sorted the complete tag array after every descriptor, causing repeated work for consecutive static tags. This PR defers sorting until the next function descriptor or the end of the list, while ensuring function descriptors receive sorted tags.

Benchmark environment: Node.js v24.12.0 on macOS arm64, build cache and minification disabled, one warmup, and 5–7 measured builds. Values below are the median total time spent in the complete `RsbuildHtmlPlugin` `alterAssetTagGroups` hook across all entries; the baseline column shows the range from two independent runs.

| Scenario | Baseline | After | Change vs baseline midpoint |
| --- | ---: | ---: | ---: |
| 8 entries × 20 static tags | 0.244–0.306 ms | 0.180 ms | -34.7% |
| 32 entries × 200 static tags | 18.615–20.597 ms | 3.020 ms | -84.6% |
| 32 entries × 200 static tags, 3 function boundaries | 18.305–18.595 ms | 2.716 ms | -85.3% |
| 32 entries × 1000 static tags | 371.606–377.895 ms | 12.207 ms | -96.7% |

In the small-entry benchmark fixture, full build median time also decreased from 35.659 ms to 20.944 ms for the 32 × 200 case and from 405.689 ms to 43.305 ms for the 32 × 1000 case.