### PR TITLE
feat(create-rsbuild): add Octane templates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,6 +27,15 @@
       "enabled": false
     },
     {
+      "description": "Keep TypeScript 5 in the Octane template because @tsrx/typescript-plugin currently supports TypeScript ^5.9.3.",
+      "matchManagers": ["npm"],
+      "matchFileNames": [
+        "packages/create-rsbuild/template-octane-ts/package.json"
+      ],
+      "matchPackageNames": ["typescript"],
+      "enabled": false
+    },
+    {
       "groupName": "Rspress",
       "groupSlug": "rspress",
       "matchPackageNames": ["/rspress/"]

--- a/e2e/cases/create-rsbuild/jsTemplates.test.ts
+++ b/e2e/cases/create-rsbuild/jsTemplates.test.ts
@@ -8,6 +8,12 @@ test('should create react project as expected', async () => {
   expect(pkgJson.devDependencies['@rsbuild/plugin-react']).toBeTruthy();
 });
 
+test('should create octane project as expected', async () => {
+  const { pkgJson } = await createAndValidate(import.meta.dirname, 'octane');
+  expect(pkgJson.dependencies.octane).toBeTruthy();
+  expect(pkgJson.devDependencies['@octanejs/rsbuild-plugin']).toBeTruthy();
+});
+
 test('should create preact project as expected', async () => {
   const { pkgJson } = await createAndValidate(import.meta.dirname, 'preact');
   expect(pkgJson.dependencies.preact).toBeTruthy();

--- a/e2e/cases/create-rsbuild/tsTemplates.test.ts
+++ b/e2e/cases/create-rsbuild/tsTemplates.test.ts
@@ -8,6 +8,13 @@ test('should create react-ts project as expected', async () => {
   expect(pkgJson.devDependencies['@rsbuild/plugin-react']).toBeTruthy();
 });
 
+test('should create octane project as expected', async () => {
+  const { pkgJson } = await createAndValidate(import.meta.dirname, 'octane-ts');
+  expect(pkgJson.dependencies.octane).toBeTruthy();
+  expect(pkgJson.devDependencies['@octanejs/rsbuild-plugin']).toBeTruthy();
+  expect(pkgJson.devDependencies['@tsrx/typescript-plugin']).toBeTruthy();
+});
+
 test('should create preact-ts project as expected', async () => {
   const { pkgJson } = await createAndValidate(import.meta.dirname, 'preact-ts');
   expect(pkgJson.dependencies.preact).toBeTruthy();

--- a/packages/create-rsbuild/src/index.ts
+++ b/packages/create-rsbuild/src/index.ts
@@ -41,6 +41,7 @@ async function getTemplateName({ template }: Argv) {
         { value: 'svelte', label: 'Svelte' },
         { value: 'solid', label: 'Solid' },
         { value: 'solid2', label: 'Solid 2 (RC)' },
+        { value: 'octane', label: 'Octane' },
       ],
     }),
   );
@@ -113,6 +114,8 @@ await create({
     'vanilla-ts',
     'react-js',
     'react-ts',
+    'octane-js',
+    'octane-ts',
     'vue-js',
     'vue-ts',
     'lit-js',

--- a/packages/create-rsbuild/template-octane-js/package.json
+++ b/packages/create-rsbuild/template-octane-js/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "rsbuild-octane-js",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rsbuild build",
+    "dev": "rsbuild",
+    "preview": "rsbuild preview"
+  },
+  "dependencies": {
+    "octane": "^0.1.44"
+  },
+  "devDependencies": {
+    "@octanejs/rsbuild-plugin": "^0.1.39",
+    "@rsbuild/core": "^2.2.0-beta.2"
+  }
+}

--- a/packages/create-rsbuild/template-octane-js/pnpm-workspace.yaml
+++ b/packages/create-rsbuild/template-octane-js/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/packages/create-rsbuild/template-octane-js/rsbuild.config.js
+++ b/packages/create-rsbuild/template-octane-js/rsbuild.config.js
@@ -1,0 +1,8 @@
+// @ts-check
+import { defineConfig } from '@rsbuild/core';
+import { pluginOctane } from '@octanejs/rsbuild-plugin';
+
+// Docs: https://rsbuild.rs/config/
+export default defineConfig({
+  plugins: [pluginOctane()],
+});

--- a/packages/create-rsbuild/template-octane-js/src/App.css
+++ b/packages/create-rsbuild/template-octane-js/src/App.css
@@ -1,0 +1,26 @@
+body {
+  margin: 0;
+  color: #fff;
+  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
+  background-image: linear-gradient(to bottom, #020917, #101725);
+}
+
+.content {
+  display: flex;
+  min-height: 100vh;
+  line-height: 1.1;
+  text-align: center;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.content h1 {
+  font-size: 3.6rem;
+  font-weight: 700;
+}
+
+.content p {
+  font-size: 1.2rem;
+  font-weight: 400;
+  opacity: 0.5;
+}

--- a/packages/create-rsbuild/template-octane-js/src/App.tsrx
+++ b/packages/create-rsbuild/template-octane-js/src/App.tsrx
@@ -1,0 +1,8 @@
+import './App.css';
+
+export function App() @{
+  <div class="content">
+    <h1>Rsbuild with Octane</h1>
+    <p>Start building amazing things with Rsbuild.</p>
+  </div>
+}

--- a/packages/create-rsbuild/template-octane-js/src/index.js
+++ b/packages/create-rsbuild/template-octane-js/src/index.js
@@ -1,0 +1,7 @@
+import { createRoot } from 'octane';
+import { App } from './App.tsrx';
+
+const rootEl = document.getElementById('root');
+if (rootEl) {
+  createRoot(rootEl).render(App);
+}

--- a/packages/create-rsbuild/template-octane-ts/package.json
+++ b/packages/create-rsbuild/template-octane-ts/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "rsbuild-octane-ts",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rsbuild build",
+    "dev": "rsbuild",
+    "preview": "rsbuild preview",
+    "typecheck": "tsrx-tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "octane": "^0.1.44"
+  },
+  "devDependencies": {
+    "@octanejs/rsbuild-plugin": "^0.1.39",
+    "@rsbuild/core": "^2.2.0-beta.2",
+    "@tsrx/typescript-plugin": "^0.3.124",
+    "@types/node": "^24.13.3",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/create-rsbuild/template-octane-ts/pnpm-workspace.yaml
+++ b/packages/create-rsbuild/template-octane-ts/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/packages/create-rsbuild/template-octane-ts/rsbuild.config.ts
+++ b/packages/create-rsbuild/template-octane-ts/rsbuild.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginOctane } from '@octanejs/rsbuild-plugin';
+
+// Docs: https://rsbuild.rs/config/
+export default defineConfig({
+  plugins: [pluginOctane()],
+});

--- a/packages/create-rsbuild/template-octane-ts/src/App.css
+++ b/packages/create-rsbuild/template-octane-ts/src/App.css
@@ -1,0 +1,26 @@
+body {
+  margin: 0;
+  color: #fff;
+  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
+  background-image: linear-gradient(to bottom, #020917, #101725);
+}
+
+.content {
+  display: flex;
+  min-height: 100vh;
+  line-height: 1.1;
+  text-align: center;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.content h1 {
+  font-size: 3.6rem;
+  font-weight: 700;
+}
+
+.content p {
+  font-size: 1.2rem;
+  font-weight: 400;
+  opacity: 0.5;
+}

--- a/packages/create-rsbuild/template-octane-ts/src/App.tsrx
+++ b/packages/create-rsbuild/template-octane-ts/src/App.tsrx
@@ -1,0 +1,8 @@
+import './App.css';
+
+export function App() @{
+  <div class="content">
+    <h1>Rsbuild with Octane</h1>
+    <p>Start building amazing things with Rsbuild.</p>
+  </div>
+}

--- a/packages/create-rsbuild/template-octane-ts/src/index.ts
+++ b/packages/create-rsbuild/template-octane-ts/src/index.ts
@@ -1,0 +1,7 @@
+import { createRoot } from 'octane';
+import { App } from './App.tsrx';
+
+const rootEl = document.getElementById('root');
+if (rootEl) {
+  createRoot(rootEl).render(App);
+}

--- a/packages/create-rsbuild/template-octane-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-octane-ts/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "compilerOptions": {
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "jsx": "react-jsx",
+    "jsxImportSource": "octane",
+    "target": "ES2020",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["@rsbuild/core/types", "node"],
+    "useDefineForClassFields": true,
+
+    /* modules */
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "moduleResolution": "bundler",
+    "verbatimModuleSyntax": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+
+    /* type checking */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "plugins": [
+      {
+        "name": "@tsrx/typescript-plugin"
+      }
+    ]
+  },
+  "include": ["src"]
+}

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -87,6 +87,7 @@ nosniff
 nosources
 ntqry
 nuxt
+octanejs
 oklab
 onclosetag
 onopentag
@@ -158,6 +159,7 @@ treeshaking
 tsbuildinfo
 tsdoc
 tsgo
+tsrx
 twoslash
 TYPELESS
 uncompiled


### PR DESCRIPTION
## Summary

Add JavaScript and TypeScript Octane templates to create-rsbuild, following Octane's official Rsbuild integration. 

Keep the TypeScript template on TypeScript 5 and document its Renovate exclusion because the current `@tsrx/typescript-plugin` supports TypeScript 5.9.

## Related Links

- https://octanejs.dev/docs/build-tools#rsbuild