### PR TITLE
docs: remove outdated CodeSandbox links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.en-US.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.en-US.yml
@@ -38,7 +38,7 @@ body:
     id: repro
     attributes:
       label: Reproduce link
-      description: 'Please provide a minimal reproduction of the issue. You can create a GitHub repo and use `npm create rsbuild@latest` as a starter. Or fork from the the [rsbuild-codesandbox-example](https://codesandbox.io/p/github/rstackjs/rsbuild-codesandbox-example).'
+      description: 'Please provide a minimal reproduction of the issue. You can create a GitHub repo and use `npm create rsbuild@latest` as a starter.'
       placeholder: paste link here
     validations:
       required: true

--- a/website/docs/en/blog/v1-0.mdx
+++ b/website/docs/en/blog/v1-0.mdx
@@ -93,7 +93,7 @@ As shown, the API style of the Rsbuild plugin is similar to esbuild, it can be d
 
 ## How to use 1.0
 
-- If you haven't used Rsbuild before, you can experience it through the [CodeSandbox example](https://codesandbox.io/p/github/rstackjs/rsbuild-codesandbox-example) or refer to the [Quick start](/guide/start/quick-start) to use Rsbuild.
+- If you haven't used Rsbuild before, refer to the [Quick start](/guide/start/quick-start) to get started.
 - If you are using Rsbuild 0.7 or earlier, please note that 1.0 includes some breaking changes. You can refer to the [Upgrading from 0.x to v1](/guide/upgrade/v0-to-v1) document to upgrade.
 - Rsbuild also provides migration guides for projects that use webpack, CRA, Vue CLI, etc. See [Migrate from Existing Projects](/guide/start/quick-start#migrate-from-existing-projects).
 

--- a/website/docs/en/guide/start/index.mdx
+++ b/website/docs/en/guide/start/index.mdx
@@ -8,7 +8,7 @@ Rsbuild is a modern build tool for web applications, powered by [Rspack](https:/
 
 It delivers fast builds and optimized production output, while keeping configuration simple, consistent, and extensible through plugins.
 
-## 🚀 Performance
+## Performance
 
 Powered by Rspack's Rust-based architecture, Rsbuild delivers blazing-fast performance to speed up your development workflow.
 
@@ -20,7 +20,7 @@ import { BenchmarkGraph } from '@components/Benchmark';
 
 > 📊 Benchmark results from [build-tools-performance](https://github.com/rstackjs/build-tools-performance).
 
-## 💡 Comparisons
+## Comparisons
 
 Rsbuild is comparable to [Vite](https://vitejs.dev/), [Create React App](https://github.com/facebook/create-react-app), and [Vue CLI](https://github.com/vuejs/vue-cli). Each of these tools includes a built-in dev server, command-line tools, and sensible defaults for an out-of-the-box experience.
 
@@ -42,7 +42,7 @@ Rsbuild has many similarities to Vite, as both aim to improve the frontend devel
 - **Ecosystem compatibility**: Rsbuild is compatible with most webpack plugins and all Rspack plugins, while Vite is compatible with Rollup plugins. If you're using many plugins and loaders from the webpack ecosystem, migration to Rsbuild is more straightforward.
 - **Module Federation**: The Rsbuild team works closely with the [Module Federation](/guide/advanced/module-federation) development team, providing first-class support for Module Federation to help you develop large web applications with micro-frontend architecture.
 
-## 🔥 Features
+## Features
 
 Rsbuild has the following features:
 
@@ -56,7 +56,7 @@ Rsbuild has the following features:
 
 - **Framework agnostic**: Rsbuild is not coupled to any frontend UI framework. It supports frameworks like React, Vue, Svelte, Solid, and Preact through plugins, with plans to support more UI frameworks from the community in the future.
 
-## 🦀 Rstack
+## Rstack
 
 Rsbuild is part of Rstack, the fast, unified JavaScript toolchain for developers and agents.
 
@@ -78,7 +78,7 @@ Rstack includes the following tools:
 | [Rstest](https://github.com/web-infra-dev/rstest)     | Testing framework        | <a href="https://npmjs.com/package/@rstest/core"><img src="https://img.shields.io/npm/v/@rstest/core?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>     |
 | [Rslint](https://github.com/web-infra-dev/rslint)     | Linter                   | <a href="https://npmjs.com/package/@rslint/core"><img src="https://img.shields.io/npm/v/@rslint/core?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>     |
 
-## 🔗 Links
+## Links
 
 - [awesome-rstack](https://github.com/rstackjs/awesome-rstack): A curated list of awesome things related to Rstack.
 - [agent-skills](https://github.com/rstackjs/agent-skills): A collection of Agent Skills for Rstack.
@@ -87,11 +87,15 @@ Rstack includes the following tools:
 - [rsbuild-plugin-template](https://github.com/rstackjs/rsbuild-plugin-template): Use this template to create your own Rsbuild plugin.
 - [rstack-design-resources](https://github.com/rstackjs/rstack-design-resources): Design resources for Rstack.
 
-## 🧑‍💻 Community
+## Community
 
 Come and chat with us on [Discord](https://discord.gg/XsaKEEk4mW)! The Rstack team and users are active there, and we're always looking for contributions.
 
-## ✨ Next step
+## Online example
+
+Try Rsbuild online with the [StackBlitz example](https://stackblitz.com/~/github.com/rstackjs/rsbuild-stackblitz-example).
+
+## Next step
 
 Next, you may want to:
 

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -4,13 +4,6 @@ description: 'Get started with Rsbuild by creating a project, starting the dev s
 
 # Quick start
 
-## Online examples
-
-We provide online Rsbuild examples that showcase Rspack's build performance and Rsbuild's development experience:
-
-- [StackBlitz example](https://stackblitz.com/~/github.com/rstackjs/rsbuild-stackblitz-example)
-- [CodeSandbox example](https://codesandbox.io/p/github/rstackjs/rsbuild-codesandbox-example)
-
 ## Environment preparation
 
 Rsbuild supports using [Node.js](https://nodejs.org/), [Deno](https://deno.com/), or [Bun](https://bun.sh/) as the JavaScript runtime.

--- a/website/docs/zh/blog/v1-0.mdx
+++ b/website/docs/zh/blog/v1-0.mdx
@@ -93,7 +93,7 @@ Rsbuild 的插件生态正在不断发展，目前社区中已经有超过 50 �
 
 ## 如何使用 1.0
 
-- 如果你还未使用过 Rsbuild，可以通过 [CodeSandbox 示例](https://codesandbox.io/p/github/rstackjs/rsbuild-codesandbox-example) 来体验，也可以参考 [快速上手](/zh/guide/start/quick-start) 来接入 Rsbuild。
+- 如果你还未使用过 Rsbuild，可以参考 [快速上手](/zh/guide/start/quick-start) 来接入 Rsbuild。
 - 如果你正在使用 Rsbuild 0.7 或更早的版本，请留意 1.0 版本包含一些不兼容更新，可参考 [从 Rsbuild 0.x 迁移](/zh/guide/upgrade/v0-to-v1) 文档进行升级。
 - Rsbuild 也提供了 webpack、CRA、Vue CLI 等项目的迁移指南，详见 [从现有项目迁移](/zh/guide/start/quick-start#migrate-from-existing-projects)。
 

--- a/website/docs/zh/guide/start/index.mdx
+++ b/website/docs/zh/guide/start/index.mdx
@@ -8,7 +8,7 @@ Rsbuild 是一个由 [Rspack](https://rspack.rs/zh/) 驱动的现代 Web 应用�
 
 它提供快速的构建体验和高度优化的构建产物，同时保持配置简单一致，并支持通过插件进行扩展。
 
-## 🚀 性能
+## 性能
 
 基于 Rspack 的 Rust 架构，Rsbuild 能够提供极致的构建性能，为你带来全新的开发体验。
 
@@ -20,7 +20,7 @@ import { BenchmarkGraph } from '@components/Benchmark';
 
 > 📊 Benchmark 结果来自 [build-tools-performance](https://github.com/rstackjs/build-tools-performance)。
 
-## 💡 对比其他工具
+## 对比其他工具
 
 Rsbuild 是与 [Vite](https://vitejs.dev/)、[Create React App](https://github.com/facebook/create-react-app) 或 [Vue CLI](https://github.com/vuejs/vue-cli) 相似的构建工具，它们都默认包含了开发服务器、命令行工具和合理的构建配置，以此来提供开箱即用的体验。
 
@@ -42,7 +42,7 @@ Rsbuild 与 Vite 有许多相似之处，它们皆致力于提升前端的开发
 - **生态兼容性**：Rsbuild 兼容大部分的 webpack 插件和所有 Rspack 插件，而 Vite 则是兼容 Rollup 插件。如果你目前更多地使用了 webpack 生态的插件和 loaders，那么迁移到 Rsbuild 会更容易。
 - **模块联邦**：Rsbuild 团队与 [Module Federation](/guide/advanced/module-federation) 的开发团队密切合作，并为 Module Federation 提供一流的支持，帮助你开发微前端架构的大型 Web 应用。
 
-## 🔥 特性
+## 特性
 
 Rsbuild 具备以下特性：
 
@@ -56,7 +56,7 @@ Rsbuild 具备以下特性：
 
 - **框架无关**：Rsbuild 不与前端 UI 框架耦合，并通过插件来支持 React、Vue、Svelte、Solid、Preact 等框架，未来也计划支持社区中更多的 UI 框架。
 
-## 🦀 Rstack
+## Rstack
 
 Rsbuild 是 Rstack 的一员。Rstack 是为开发者与 Agent 打造的高性能、一体化 JavaScript 工具链。
 
@@ -78,7 +78,7 @@ Rstack 包含以下工具：
 | [Rstest](https://github.com/web-infra-dev/rstest)     | 测试框架       | <a href="https://npmjs.com/package/@rstest/core"><img src="https://img.shields.io/npm/v/@rstest/core?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>     |
 | [Rslint](https://github.com/web-infra-dev/rslint)     | 代码检查工具   | <a href="https://npmjs.com/package/@rslint/core"><img src="https://img.shields.io/npm/v/@rslint/core?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>     |
 
-## 🔗 链接
+## 链接
 
 - [awesome-rstack](https://github.com/rstackjs/awesome-rstack)：与 Rstack 相关的精彩内容列表。
 - [agent-skills](https://github.com/rstackjs/agent-skills)：Rstack 的 Agent Skills 合集。
@@ -87,13 +87,17 @@ Rstack 包含以下工具：
 - [rsbuild-plugin-template](https://github.com/rstackjs/rsbuild-plugin-template)：使用此模板创建你的 Rsbuild 插件。
 - [rstack-design-resources](https://github.com/rstackjs/rstack-design-resources)：Rstack 的设计资源。
 
-## 🧑‍💻 社区
+## 社区
 
 欢迎加入我们的 [Discord](https://discord.gg/XsaKEEk4mW) 交流频道！Rstack 团队和用户都在那里活跃，并且我们一直期待着各种贡献。
 
 你也可以加入 [飞书群](https://applink.feishu.cn/client/chat/chatter/add_by_link?link_token=3c3vca77-bfc0-4ef5-b62b-9c5c9c92f1b4) 与大家一起交流。
 
-## ✨ 下一步
+## 在线示例
+
+通过 [StackBlitz 示例](https://stackblitz.com/~/github.com/rstackjs/rsbuild-stackblitz-example) 在线体验 Rsbuild。
+
+## 下一步
 
 你可能想要：
 

--- a/website/docs/zh/guide/start/index.mdx
+++ b/website/docs/zh/guide/start/index.mdx
@@ -8,7 +8,7 @@ Rsbuild 是一个由 [Rspack](https://rspack.rs/zh/) 驱动的现代 Web 应用�
 
 它提供快速的构建体验和高度优化的构建产物，同时保持配置简单一致，并支持通过插件进行扩展。
 
-## 性能
+## 性能 \{#performance}
 
 基于 Rspack 的 Rust 架构，Rsbuild 能够提供极致的构建性能，为你带来全新的开发体验。
 
@@ -20,7 +20,7 @@ import { BenchmarkGraph } from '@components/Benchmark';
 
 > 📊 Benchmark 结果来自 [build-tools-performance](https://github.com/rstackjs/build-tools-performance)。
 
-## 对比其他工具
+## 对比其他工具 \{#comparisons}
 
 Rsbuild 是与 [Vite](https://vitejs.dev/)、[Create React App](https://github.com/facebook/create-react-app) 或 [Vue CLI](https://github.com/vuejs/vue-cli) 相似的构建工具，它们都默认包含了开发服务器、命令行工具和合理的构建配置，以此来提供开箱即用的体验。
 
@@ -42,7 +42,7 @@ Rsbuild 与 Vite 有许多相似之处，它们皆致力于提升前端的开发
 - **生态兼容性**：Rsbuild 兼容大部分的 webpack 插件和所有 Rspack 插件，而 Vite 则是兼容 Rollup 插件。如果你目前更多地使用了 webpack 生态的插件和 loaders，那么迁移到 Rsbuild 会更容易。
 - **模块联邦**：Rsbuild 团队与 [Module Federation](/guide/advanced/module-federation) 的开发团队密切合作，并为 Module Federation 提供一流的支持，帮助你开发微前端架构的大型 Web 应用。
 
-## 特性
+## 特性 \{#features}
 
 Rsbuild 具备以下特性：
 
@@ -78,7 +78,7 @@ Rstack 包含以下工具：
 | [Rstest](https://github.com/web-infra-dev/rstest)     | 测试框架       | <a href="https://npmjs.com/package/@rstest/core"><img src="https://img.shields.io/npm/v/@rstest/core?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>     |
 | [Rslint](https://github.com/web-infra-dev/rslint)     | 代码检查工具   | <a href="https://npmjs.com/package/@rslint/core"><img src="https://img.shields.io/npm/v/@rslint/core?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>     |
 
-## 链接
+## 链接 \{#links}
 
 - [awesome-rstack](https://github.com/rstackjs/awesome-rstack)：与 Rstack 相关的精彩内容列表。
 - [agent-skills](https://github.com/rstackjs/agent-skills)：Rstack 的 Agent Skills 合集。
@@ -87,17 +87,17 @@ Rstack 包含以下工具：
 - [rsbuild-plugin-template](https://github.com/rstackjs/rsbuild-plugin-template)：使用此模板创建你的 Rsbuild 插件。
 - [rstack-design-resources](https://github.com/rstackjs/rstack-design-resources)：Rstack 的设计资源。
 
-## 社区
+## 社区 \{#community}
 
 欢迎加入我们的 [Discord](https://discord.gg/XsaKEEk4mW) 交流频道！Rstack 团队和用户都在那里活跃，并且我们一直期待着各种贡献。
 
 你也可以加入 [飞书群](https://applink.feishu.cn/client/chat/chatter/add_by_link?link_token=3c3vca77-bfc0-4ef5-b62b-9c5c9c92f1b4) 与大家一起交流。
 
-## 在线示例
+## 在线示例 \{#online-example}
 
 通过 [StackBlitz 示例](https://stackblitz.com/~/github.com/rstackjs/rsbuild-stackblitz-example) 在线体验 Rsbuild。
 
-## 下一步
+## 下一步 \{#next-step}
 
 你可能想要：
 

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -4,13 +4,6 @@ description: '快速开始使用 Rsbuild，包括创建项目、启动开发服�
 
 # 快速上手
 
-## 在线示例
-
-我们提供了基于 Rsbuild 的在线示例，通过示例项目，你可以直观感受 Rspack 的构建性能和 Rsbuild 的开发体验：
-
-- [StackBlitz 示例](https://stackblitz.com/~/github.com/rstackjs/rsbuild-stackblitz-example)
-- [CodeSandbox 示例](https://codesandbox.io/p/github/rstackjs/rsbuild-codesandbox-example)
-
 ## 环境准备
 
 Rsbuild 支持使用 [Node.js](https://nodejs.org/)、[Deno](https://deno.com/) 或 [Bun](https://bun.sh/) 作为 JavaScript 运行时。


### PR DESCRIPTION
## Summary

CodeSandbox no longer supports opening repositories, leaving broken examples and reproduction links. This PR removes the outdated CodeSandbox references from the documentation and issue template, keeps StackBlitz as the online example on the introduction page, and simplifies the introduction headings.