### PR TITLE
perf(core): reduce plugin dependency sorting scans

### DIFF
--- a/packages/core/src/pluginManager.ts
+++ b/packages/core/src/pluginManager.ts
@@ -213,7 +213,7 @@ export const sortPluginsByDependencies = (
   const sortedPluginNames = new Set<string>();
 
   while (zeroEndPoints.length) {
-    const name = zeroEndPoints[0].instance.name;
+    const { name } = zeroEndPoints[0].instance;
     const pluginInstances = getPlugin(name);
     sortedPoint.push(...pluginInstances);
     sortedPluginNames.add(name);

--- a/packages/core/src/pluginManager.ts
+++ b/packages/core/src/pluginManager.ts
@@ -174,6 +174,7 @@ export const sortPluginsByDependencies = (
   plugins: PluginMeta[],
 ): PluginMeta[] => {
   let allLines: [string, string][] = [];
+  const pluginNames = new Set(plugins.map((item) => item.instance.name));
 
   function getPlugin(name: string) {
     const targets = plugins.filter((item) => item.instance.name === name);
@@ -188,7 +189,7 @@ export const sortPluginsByDependencies = (
   for (const plugin of plugins) {
     if (plugin.instance.pre) {
       for (const pre of plugin.instance.pre) {
-        if (pre && plugins.some((item) => item.instance.name === pre)) {
+        if (pre && pluginNames.has(pre)) {
           allLines.push([pre, plugin.instance.name]);
         }
       }
@@ -196,43 +197,42 @@ export const sortPluginsByDependencies = (
 
     if (plugin.instance.post) {
       for (const post of plugin.instance.post) {
-        if (post && plugins.some((item) => item.instance.name === post)) {
+        if (post && pluginNames.has(post)) {
           allLines.push([plugin.instance.name, post]);
         }
       }
     }
   }
 
-  // search the zero input plugin
+  let endPoints = new Set(allLines.map((line) => line[1]));
   let zeroEndPoints = plugins.filter(
-    (item) => !allLines.find((l) => l[1] === item.instance.name),
+    (item) => !endPoints.has(item.instance.name),
   );
 
   const sortedPoint: PluginMeta[] = [];
+  const sortedPluginNames = new Set<string>();
 
   while (zeroEndPoints.length) {
-    const zep = zeroEndPoints.shift()!;
-    const pluginInstances = getPlugin(zep.instance.name);
+    const name = zeroEndPoints[0].instance.name;
+    const pluginInstances = getPlugin(name);
     sortedPoint.push(...pluginInstances);
-    allLines = allLines.filter(
-      (l) => l[0] !== pluginInstances[0].instance.name,
-    );
+    sortedPluginNames.add(name);
+    allLines = allLines.filter((line) => line[0] !== name);
+    endPoints = new Set(allLines.map((line) => line[1]));
 
-    const restPoints = plugins.filter(
+    zeroEndPoints = plugins.filter(
       (item) =>
-        !sortedPoint.find((sp) => sp.instance.name === item.instance.name),
-    );
-    zeroEndPoints = restPoints.filter(
-      (item) => !allLines.find((l) => l[1] === item.instance.name),
+        !sortedPluginNames.has(item.instance.name) &&
+        !endPoints.has(item.instance.name),
     );
   }
 
   // if has ring, throw error
   if (allLines.length) {
     const restInRingPoints: Record<string, boolean> = {};
-    for (const l of allLines) {
-      restInRingPoints[l[0]] = true;
-      restInRingPoints[l[1]] = true;
+    for (const line of allLines) {
+      restInRingPoints[line[0]] = true;
+      restInRingPoints[line[1]] = true;
     }
 
     throw new Error(


### PR DESCRIPTION
## Summary

Plugin dependency sorting runs during both dev and build startup and repeatedly performs linear scans as the plugin count grows. This PR caches registered plugin names, remaining dependency endpoints, and sorted plugin names in `Set`s while preserving stable ordering and cycle reporting.

A temporary Rstest microbenchmark called `sortPluginsByDependencies` with chain-shaped dependency graphs after 20 warmups and measured the median of 5 samples on Node.js v24.12.0:

| Plugins | Before | After | Reduction |
| ---: | ---: | ---: | ---: |
| 32 | 83.299 μs | 36.081 μs | 47.218 μs (56.7%) |
| 64 | 597.350 μs | 135.318 μs | 462.032 μs (77.3%) |
| 128 | 3944.491 μs | 542.087 μs | 3402.404 μs (86.3%) |