### PR TITLE
fix(core): avoid hanging requests after fatal watch errors

### DIFF
--- a/e2e/cases/server/fatal-watch-error/index.test.ts
+++ b/e2e/cases/server/fatal-watch-error/index.test.ts
@@ -1,0 +1,108 @@
+import { join } from 'node:path';
+import type { Rspack } from '@rsbuild/core';
+import { expect, test } from '@e2e/helper';
+
+const createDeferred = () => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = () => done();
+  });
+  return { promise, resolve };
+};
+
+test('should respond to requests after a fatal rebuild error', async ({
+  copySrcDir,
+  devOnly,
+  editFile,
+}) => {
+  const rebuildStarted = createDeferred();
+  const requestQueued = createDeferred();
+  const triggerFatalError = createDeferred();
+  let compileCount = 0;
+  let shouldThrow = false;
+
+  const tempSrc = await copySrcDir();
+  const rsbuild = await devOnly({
+    config: {
+      server: {
+        setup: ({ action, server }) => {
+          if (action !== 'dev') {
+            return;
+          }
+
+          server.middlewares.use((req, _res, next) => {
+            if (req.headers['x-test-pending-request']) {
+              next();
+              // The built-in assets middleware queues the request synchronously.
+              requestQueued.resolve();
+              return;
+            }
+            next();
+          });
+        },
+      },
+      source: {
+        entry: {
+          index: join(tempSrc, 'index.js'),
+        },
+      },
+      tools: {
+        rspack(_config, { appendPlugins }) {
+          appendPlugins({
+            apply(compiler: Rspack.Compiler) {
+              compiler.hooks.watchRun.tap('ThrowOnFirstRebuild', () => {
+                compileCount++;
+                shouldThrow = compileCount === 2;
+              });
+
+              compiler.hooks.thisCompilation.tap(
+                'ThrowOnFirstRebuild',
+                (compilation) => {
+                  compilation.hooks.processAssets.tapPromise(
+                    'ThrowOnFirstRebuild',
+                    async () => {
+                      if (!shouldThrow) {
+                        return;
+                      }
+
+                      rebuildStarted.resolve();
+                      await triggerFatalError.promise;
+                      throw new Error('intentional fatal watch error');
+                    },
+                  );
+                },
+              );
+            },
+          });
+        },
+      },
+    },
+  });
+  const url = `http://localhost:${rsbuild.port}/`;
+
+  const initialResponse = await fetch(url);
+  expect(initialResponse.status).toBe(200);
+
+  rsbuild.clearLogs();
+  await editFile(join(tempSrc, 'index.js'), (code) =>
+    code.replace('Hello Rsbuild!', 'Hello Rsbuild 2!'),
+  );
+
+  await rebuildStarted.promise;
+  const pendingResponse = fetch(url, {
+    headers: {
+      'x-test-pending-request': 'true',
+    },
+    signal: AbortSignal.timeout(2_000),
+  });
+  await requestQueued.promise;
+  triggerFatalError.resolve();
+  await rsbuild.expectLog('intentional fatal watch error');
+
+  expect((await pendingResponse).status).toBe(200);
+
+  const subsequentResponse = await fetch(url, {
+    signal: AbortSignal.timeout(2_000),
+  });
+  expect(subsequentResponse.status).toBe(200);
+});

--- a/e2e/cases/server/fatal-watch-error/src/index.js
+++ b/e2e/cases/server/fatal-watch-error/src/index.js
@@ -1,0 +1,1 @@
+document.body.textContent = 'Hello Rsbuild!';

--- a/packages/core/src/createCompiler.ts
+++ b/packages/core/src/createCompiler.ts
@@ -181,6 +181,18 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
     context.buildState.hasErrors = false;
   });
 
+  const compilers = isMultiCompiler
+    ? (compiler as Rspack.MultiCompiler).compilers
+    : [compiler as Rspack.Compiler];
+
+  for (const item of compilers) {
+    item.hooks.failed.tap(HOOK_NAME, () => {
+      context.buildState.status = 'failed';
+      context.buildState.hasErrors = true;
+      isCompiling = false;
+    });
+  }
+
   if (context.action === 'build') {
     // When there are multiple compilers, we only need to print the start log once
     const firstCompiler = isMultiCompiler

--- a/packages/core/src/server/assets-middleware/index.ts
+++ b/packages/core/src/server/assets-middleware/index.ts
@@ -288,16 +288,19 @@ export const assetsMiddleware = async ({
   const compilers = isMultiCompiler(compiler) ? compiler.compilers : [compiler];
   const callbacks: (() => void)[] = [];
 
+  const flushCallbacks = () => {
+    for (const callback of callbacks.splice(0)) {
+      callback();
+    }
+  };
+
   compiler.hooks.done.tap('rsbuild-dev-middleware', () => {
     process.nextTick(() => {
       if (!(context.buildState.status === 'done')) {
         return;
       }
 
-      callbacks.forEach((callback) => {
-        callback();
-      });
-      callbacks.length = 0;
+      flushCallbacks();
     });
   });
 
@@ -313,7 +316,10 @@ export const assetsMiddleware = async ({
   const outputFileSystem = await setupOutputFileSystem(writeToDisk, compilers);
 
   const ready = (callback: () => void) => {
-    if (context.buildState.status === 'done') {
+    if (
+      context.buildState.status === 'done' ||
+      context.buildState.status === 'failed'
+    ) {
       callback();
     } else {
       callbacks.push(callback);
@@ -340,6 +346,13 @@ export const assetsMiddleware = async ({
 
       watching = compiler.watch(watchOptions, (error) => {
         if (error) {
+          context.buildState.status = 'failed';
+          context.buildState.hasErrors = true;
+
+          // Fatal compiler errors do not trigger the `done` hook. Release
+          // pending requests so the server can keep serving previous output.
+          process.nextTick(flushCallbacks);
+
           if (error.message?.includes('× Error:')) {
             error.message = error.message.replace('× Error:', '').trim();
           }

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -73,7 +73,7 @@ export type RsbuildContext = {
   callerName: string;
 };
 
-export type BuildStatus = 'idle' | 'building' | 'done';
+export type BuildStatus = 'idle' | 'building' | 'done' | 'failed';
 
 export type BuildState = {
   /**


### PR DESCRIPTION
## Summary

A fatal Rspack watch error does not trigger the `done` hook, leaving requests queued by the dev assets middleware indefinitely. This PR tracks fatal build failures and releases pending requests so the dev server can continue serving the previous output.

## Related Links

https://github.com/web-infra-dev/rspack/issues/15370