### PR TITLE
docs: fix malformed configuration examples

### DIFF
--- a/website/docs/en/config/output/css-modules.mdx
+++ b/website/docs/en/config/output/css-modules.mdx
@@ -274,19 +274,23 @@ export default {
 
 ### Function
 
-You can also pass a function to `modules.mode` that determines the mode based on the resource path, query, or fragment. This allows you to use different modes for different files.
+You can also pass a function to `cssModules.mode` that determines the mode based on the resource path, query, or fragment. This allows you to use different modes for different files.
 
 For example, to use local scoping for `.module.css` files and global styles for other files:
 
-```js
-modules: {
-  mode: (resourcePath) => {
-    if (/\.module\.\css$/.test(resourcePath)) {
-      return 'local';
-    }
-    return 'global';
-  };
-}
+```ts title="rsbuild.config.ts"
+export default {
+  output: {
+    cssModules: {
+      mode: (resourcePath) => {
+        if (/\.module\.css$/.test(resourcePath)) {
+          return 'local';
+        }
+        return 'global';
+      },
+    },
+  },
+};
 ```
 
 ## cssModules.namedExport

--- a/website/docs/en/guide/configuration/rspack.mdx
+++ b/website/docs/en/guide/configuration/rspack.mdx
@@ -132,7 +132,7 @@ export default {
 ```ts title="rsbuild.config.ts"
 export default {
   tools: {
-    bundlerChain: (chain, { env }) => {
+    bundlerChain: async (chain, { env }) => {
       const value = await fetchValue();
       chain.devtool(value);
     },
@@ -347,6 +347,7 @@ export default {
         // ...
       }
     },
+  },
 };
 ```
 

--- a/website/docs/zh/config/output/dist-path.mdx
+++ b/website/docs/zh/config/output/dist-path.mdx
@@ -42,7 +42,7 @@ const defaultDistPath = {
   wasm: 'static/wasm',
   image: 'static/image',
   media: 'static/media',
-  assets: 'static/assets';
+  assets: 'static/assets',
 };
 ```
 

--- a/website/docs/zh/guide/configuration/rspack.mdx
+++ b/website/docs/zh/guide/configuration/rspack.mdx
@@ -134,7 +134,7 @@ export default {
 ```ts title="rsbuild.config.ts"
 export default {
   tools: {
-    bundlerChain: (chain, { env }) => {
+    bundlerChain: async (chain, { env }) => {
       const value = await fetchValue();
       chain.devtool(value);
     },


### PR DESCRIPTION
## Summary

Several configuration examples contain invalid JavaScript or do not match the documented Rsbuild option shape, so copying them produces unusable configs. This PR fixes the CSS Modules function example, marks async `bundlerChain` callbacks in both locales, closes the environment-based config object, and corrects the Chinese `distPath` default object.