### PR TITLE
perf: set splitChunks minSize to 0 for Node.js builds

### DIFF
--- a/e2e/cases/manifest/node/index.test.ts
+++ b/e2e/cases/manifest/node/index.test.ts
@@ -9,11 +9,13 @@ test('should generate manifest file when target is node', async ({ build }) => {
   expect(manifestContent).toBeDefined();
 
   const manifest = JSON.parse(manifestContent);
-  expect(Object.keys(manifest.allFiles).length).toBe(1);
+  expect(manifest.allFiles).toEqual(['/index.js', expect.any(String)]);
+  const sharedChunk = manifest.allFiles[1];
+  expect(sharedChunk).toMatch(/^\/\d+\.js$/);
 
   expect(manifest.entries.index).toMatchObject({
     initial: {
-      js: ['/index.js'],
+      js: [sharedChunk, '/index.js'],
     },
   });
 });

--- a/packages/core/src/plugins/splitChunks.ts
+++ b/packages/core/src/plugins/splitChunks.ts
@@ -279,6 +279,7 @@ export const pluginSplitChunks = (): RsbuildPlugin => ({
           const { preset = 'none', ...rest } = splitChunks;
           chain.optimization.splitChunks({
             chunks: 'all',
+            minSize: 0,
             ...getSplitChunksByPreset(config, preset),
             ...rest,
           });

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -1689,6 +1689,7 @@ exports[`should apply default plugins correctly when target is node 1`] = `
     "minimize": false,
     "splitChunks": {
       "chunks": "all",
+      "minSize": 0,
     },
   },
   "output": {

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1066,6 +1066,7 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
       "minimize": false,
       "splitChunks": {
         "chunks": "all",
+        "minSize": 0,
       },
     },
     "output": {

--- a/packages/core/tests/splitChunks.test.ts
+++ b/packages/core/tests/splitChunks.test.ts
@@ -5,6 +5,41 @@ import {
 } from '../src/plugins/splitChunks';
 
 describe('plugin-split-chunks', () => {
+  it('should set minSize to 0 by default for Node.js builds', async () => {
+    const rsbuild = await createRsbuild({
+      config: {
+        output: {
+          target: 'node',
+        },
+      },
+    });
+
+    const config = await rsbuild.initConfigs();
+    expect(config[0].optimization?.splitChunks).toMatchObject({
+      chunks: 'all',
+      minSize: 0,
+    });
+  });
+
+  it('should allow overriding minSize for Node.js builds', async () => {
+    const rsbuild = await createRsbuild({
+      config: {
+        output: {
+          target: 'node',
+        },
+        splitChunks: {
+          minSize: 5000,
+        },
+      },
+    });
+
+    const config = await rsbuild.initConfigs();
+    expect(config[0].optimization?.splitChunks).toMatchObject({
+      chunks: 'all',
+      minSize: 5000,
+    });
+  });
+
   it('should set `default` preset by default', async () => {
     const rsbuild = await createRsbuild({
       config: {

--- a/website/docs/en/config/split-chunks.mdx
+++ b/website/docs/en/config/split-chunks.mdx
@@ -16,7 +16,7 @@ type SplitChunksConfig =
 
 - **Default:** depends on [output.target](/config/output/target):
   - When `output.target` is `'web'`, the default is `{ preset: 'default', chunks: 'all' }`
-  - When `output.target` is `'node'`, the default is `{ preset: 'none', chunks: 'all' }`
+  - When `output.target` is `'node'`, the default is `{ preset: 'none', chunks: 'all', minSize: 0 }`
   - When `output.target` is `'web-worker'`, the default is `false`
 - **Version:** `>= 2.0.0`
 
@@ -28,7 +28,8 @@ It is built on top of Rspack's [optimization.splitChunks](https://rspack.rs/plug
 
 When `output.target` is `'web'` or `'node'`, Rsbuild enables chunk splitting by default and sets `chunks` to `'all'`. This allows eligible modules in both initial and async chunks to be extracted into separate chunks, helping reduce duplicated code across output chunks.
 
-Apart from `chunks` and the splitting rules provided by the selected `preset` or Rsbuild plugins, unspecified options such as `minSize` and `minChunks` use the defaults from Rspack's [`optimization.splitChunks`](https://rspack.rs/plugins/webpack/split-chunks-plugin).
+- For web builds, unspecified options such as `minSize` and `minChunks` use the defaults from Rspack's [`optimization.splitChunks`](https://rspack.rs/plugins/webpack/split-chunks-plugin).
+- For Node.js builds, Rsbuild also sets `minSize` to `0` so that small shared modules can be extracted instead of being duplicated across chunks.
 
 Because Web Worker outputs do not support dynamic imports, Rsbuild disables chunk splitting by default when `output.target` is `'web-worker'`.
 
@@ -134,6 +135,6 @@ export default {
 
 ## Version history
 
-| Version | Changes                                                                                                   |
-| ------- | --------------------------------------------------------------------------------------------------------- |
-| v2.2.0  | When `output.target` is `'node'`, the default changed from `false` to `{ preset: 'none', chunks: 'all' }` |
+| Version | Changes                                                                                                               |
+| ------- | --------------------------------------------------------------------------------------------------------------------- |
+| v2.2.0  | When `output.target` is `'node'`, the default changed from `false` to `{ preset: 'none', chunks: 'all', minSize: 0 }` |

--- a/website/docs/zh/config/split-chunks.mdx
+++ b/website/docs/zh/config/split-chunks.mdx
@@ -16,7 +16,7 @@ type SplitChunksConfig =
 
 - **默认值：** 根据 [output.target](/config/output/target) 而定：
   - `output.target` 为 `'web'` 时，为 `{ preset: 'default', chunks: 'all' }`
-  - `output.target` 为 `'node'` 时，为 `{ preset: 'none', chunks: 'all' }`
+  - `output.target` 为 `'node'` 时，为 `{ preset: 'none', chunks: 'all', minSize: 0 }`
   - `output.target` 为 `'web-worker'` 时，为 `false`
 - **版本：** `>= 2.0.0`
 
@@ -28,7 +28,8 @@ type SplitChunksConfig =
 
 当 `output.target` 为 `'web'` 或 `'node'` 时，Rsbuild 默认启用 chunk 拆分，并将 `chunks` 设置为 `'all'`。因此，初始 chunk 和异步 chunk 中符合条件的模块都可以被提取到独立的 chunk 中，有助于减少不同输出 chunk 之间的重复代码。
 
-除了 `chunks` 及所选 `preset` 或 Rsbuild 插件提供的拆分规则，其余未指定的选项（如 `minSize` 和 `minChunks`）均沿用 Rspack [`optimization.splitChunks`](https://rspack.rs/zh/plugins/webpack/split-chunks-plugin) 的默认值。
+- 对于 Web 构建，其余未指定的选项（如 `minSize` 和 `minChunks`）均沿用 Rspack [`optimization.splitChunks`](https://rspack.rs/zh/plugins/webpack/split-chunks-plugin) 的默认值。
+- 对于 Node.js 构建，Rsbuild 还会将 `minSize` 设置为 `0`，使较小的共享模块也能被提取，避免这些模块重复出现在多个 chunk 中。
 
 由于 Web Worker 产物不支持 dynamic import，当 `output.target` 为 `'web-worker'` 时，Rsbuild 默认关闭 chunk 拆分。
 
@@ -135,6 +136,6 @@ export default {
 
 ## 版本历史 \{#version-history}
 
-| 版本   | 变更内容                                                                                     |
-| ------ | -------------------------------------------------------------------------------------------- |
-| v2.2.0 | 当 `output.target` 为 `'node'` 时，默认值从 `false` 改为 `{ preset: 'none', chunks: 'all' }` |
+| 版本   | 变更内容                                                                                                 |
+| ------ | -------------------------------------------------------------------------------------------------------- |
+| v2.2.0 | 当 `output.target` 为 `'node'` 时，默认值从 `false` 改为 `{ preset: 'none', chunks: 'all', minSize: 0 }` |


### PR DESCRIPTION
## Summary

Node.js builds do not have browser network-loading constraints, but a non-zero `splitChunks.minSize` can leave small shared modules duplicated across route chunks. This PR sets the default `minSize` to `0` for Node.js builds while preserving explicit user overrides; web and web-worker defaults are unchanged.

### Benchmark results

The following results were measured on an Apple M3 Max with Node.js 24.12.0. Build values are medians of 4 runs and runtime values are medians of 5 fresh Node.js processes per configuration.

#### Rspress: Rspack website

The benchmark contains 388 routes and uses `chunks: 'async'`. SSR renders use a concurrency of 32.

| minSize | Combined SSR output | JS files | Build | HTML first / warm | HTML peak RSS | Markdown first / warm | Markdown peak RSS |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 0 | 94.02 MiB | 997 | 15.55s | 1430 / 687ms | 566.0 MiB | 721 / 393ms | 330.5 MiB |
| 5 KB | 95.90 MiB | 950 | 15.69s | 1427 / 698ms | 577.4 MiB | 719 / 393ms | 334.0 MiB |
| 10 KB | 96.84 MiB | 938 | 15.63s | 1437 / 686ms | 582.7 MiB | 717 / 391ms | 337.0 MiB |
| 20 KB | 96.98 MiB | 932 | 15.57s | 1413 / 687ms | 581.1 MiB | 715 / 391ms | 337.2 MiB |

Compared with 5 KB, `minSize: 0` reduces the SSR output by about 2% and peak RSS by 1–2%, without a measurable build or SSR throughput regression.

#### TanStack Start synthetic benchmark

The benchmark contains 300 routes and 400 shared components, with each route importing 6 components. It uses `chunks: 'all'`; 5, 10, and 20 KB produced byte-identical server output, so they are grouped below.

| minSize | Server output | JS files | Component source copies | Build | First 300 routes | Warm 300 routes | Peak RSS |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 0 | 3.179 MB | 708 | 400 | 3.440s | 300.1ms | 68.8ms | 210.0 MiB |
| 5 / 10 / 20 KB | 5.430 MB | 308 | 1,800 | 3.345s | 254.5ms | 70.1ms | 216.4 MiB |

Here, `minSize: 0` reduces raw server output by 41.5%, removes 1,400 duplicated component copies, and lowers peak RSS by about 3%. The trade-off is 400 additional small chunks and about 45.6ms of one-time loading overhead while visiting all 300 routes (about 0.15ms per route); warm SSR performance is unchanged.

## Related Links

- https://github.com/childrentime/tanstack-start-rsbuild-ssr-chunk-duplication
- https://github.com/TanStack/router/issues/8113#issuecomment-5366808113
- https://github.com/web-infra-dev/rspack/tree/1f60d78659da7ea955fe2c26c03625f8aacc3ee2/website
