### PR TITLE
fix(core): refine HMR client target detection

### DIFF
--- a/e2e/cases/hmr/rspack-target-environment/index.test.ts
+++ b/e2e/cases/hmr/rspack-target-environment/index.test.ts
@@ -1,4 +1,3 @@
-// cspell:ignore nwjs
 import { expect, test } from '@e2e/helper';
 import type { Rspack } from '@rsbuild/core';
 import { findFile } from '@rstackjs/test-utils';

--- a/e2e/cases/hmr/rspack-target-environment/index.test.ts
+++ b/e2e/cases/hmr/rspack-target-environment/index.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from '@e2e/helper';
+import type { Rspack } from '@rsbuild/core';
+import { findFile } from '@rstackjs/test-utils';
+
+const targetCases: {
+  target: NonNullable<Rspack.Configuration['target']>;
+  injectHMRClient: boolean;
+}[] = [
+  {
+    target: 'browserslist:last 2 node versions',
+    injectHMRClient: false,
+  },
+  { target: 'webworker', injectHMRClient: false },
+  { target: 'electron-main', injectHMRClient: false },
+  { target: 'electron-preload', injectHMRClient: false },
+  { target: 'electron-renderer', injectHMRClient: true },
+  { target: 'nwjs', injectHMRClient: false },
+];
+
+for (const { target, injectHMRClient } of targetCases) {
+  test(`should ${injectHMRClient ? '' : 'not '}inject HMR client when Rspack target is ${target}`, async ({
+    devOnly,
+  }) => {
+    const rsbuild = await devOnly({
+      config: {
+        tools: {
+          htmlPlugin: false,
+          rspack: (config) => {
+            config.target = target;
+            return config;
+          },
+        },
+      },
+    });
+
+    const files = rsbuild.getDistFiles();
+    const indexJs = findFile(files, 'index.js');
+
+    expect(files[indexJs].includes('hmr.js')).toBe(injectHMRClient);
+  });
+}

--- a/e2e/cases/hmr/rspack-target-environment/index.test.ts
+++ b/e2e/cases/hmr/rspack-target-environment/index.test.ts
@@ -1,3 +1,4 @@
+// cspell:ignore nwjs
 import { expect, test } from '@e2e/helper';
 import type { Rspack } from '@rsbuild/core';
 import { findFile } from '@rstackjs/test-utils';

--- a/e2e/cases/hmr/rspack-target-environment/src/index.js
+++ b/e2e/cases/hmr/rspack-target-environment/src/index.js
@@ -1,0 +1,1 @@
+console.log('index');

--- a/packages/core/src/server/assets-middleware/index.ts
+++ b/packages/core/src/server/assets-middleware/index.ts
@@ -61,6 +61,22 @@ const normalizeLiveReload = (liveReload: LiveReload): NormalizedLiveReload => {
   };
 };
 
+const isWebPageCompiler = (compiler: Compiler): boolean => {
+  const { platform } = compiler;
+
+  // `output.target` only reflects Rsbuild's target. `tools.rspack` can override
+  // the final Rspack target, and Browserslist targets can resolve to either a
+  // browser or Node.js environment. The HMR client runs in a page context and
+  // its overlay requires `document`, so use Rspack's normalized capabilities.
+  // Do not exclude Node.js or Electron flags directly because hybrid targets,
+  // such as `electron-renderer`, support both web and Node.js APIs.
+  return Boolean(
+    platform.web &&
+    !platform.webworker &&
+    compiler.options.output.environment?.document,
+  );
+};
+
 const isNodeCompiler = (compiler: Compiler) => {
   const { target } = compiler.options;
   if (target) {
@@ -183,7 +199,7 @@ function applyHMREntry({
   resolvedPort: number;
 }) {
   if (
-    config.output.target !== 'web' ||
+    !isWebPageCompiler(compiler) ||
     (!config.dev.hmr && !config.dev.liveReload)
   ) {
     return;

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -87,6 +87,7 @@ nosniff
 nosources
 ntqry
 nuxt
+nwjs
 octanejs
 oklab
 onclosetag


### PR DESCRIPTION
## Summary

This PR makes HMR client injection follow Rspack's normalized web-page capabilities instead of Rsbuild's `output.target`, which can diverge when `tools.rspack` overrides the final target.

It keeps the client enabled for browser page targets such as `electron-renderer` while avoiding injection into Node.js, Web Worker, Electron main/preload, and NW.js outputs.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/8337