### PR TITLE
fix(core): use async chunks for single-entry Node.js builds

### DIFF
--- a/e2e/cases/manifest/node/index.test.ts
+++ b/e2e/cases/manifest/node/index.test.ts
@@ -9,13 +9,11 @@ test('should generate manifest file when target is node', async ({ build }) => {
   expect(manifestContent).toBeDefined();
 
   const manifest = JSON.parse(manifestContent);
-  expect(manifest.allFiles).toEqual(['/index.js', expect.any(String)]);
-  const sharedChunk = manifest.allFiles[1];
-  expect(sharedChunk).toMatch(/^\/\d+\.js$/);
+  expect(manifest.allFiles).toEqual(['/index.js']);
 
   expect(manifest.entries.index).toMatchObject({
     initial: {
-      js: [sharedChunk, '/index.js'],
+      js: ['/index.js'],
     },
   });
 });

--- a/e2e/cases/print-file-size/basic/__snapshots__/index.test.ts.snap
+++ b/e2e/cases/print-file-size/basic/__snapshots__/index.test.ts.snap
@@ -79,6 +79,5 @@ dist/static/js/lib-react.js   X.X kB   X.X kB
 File (node)                         Size
 dist/server/static/image/icon.png   X.X kB
 dist/server/index.js                X.X kB
-dist/server/517.js                  X.X kB
                            Total:   X.X kB"
 `;

--- a/e2e/cases/split-chunks/preset-per-package/index.test.ts
+++ b/e2e/cases/split-chunks/preset-per-package/index.test.ts
@@ -27,3 +27,23 @@ test('should generate chunks for each package when preset is "per-package"', asy
   expect(jsFiles.find((file) => file.includes('npm-react-dom'))).toBeTruthy();
   expect(jsFiles.find((file) => file.includes('npm-scheduler'))).toBeTruthy();
 });
+
+test('should generate package chunks for a single-entry Node.js build', async ({
+  build,
+}) => {
+  const rsbuild = await build({
+    config: {
+      output: {
+        target: 'node',
+      },
+    },
+  });
+
+  const files = rsbuild.getDistFiles();
+  const reactFile = findFile(
+    files,
+    (name) => name.includes('npm-react') && files[name].includes('React'),
+  );
+
+  expect(reactFile).toBeTruthy();
+});

--- a/packages/core/src/plugins/splitChunks.ts
+++ b/packages/core/src/plugins/splitChunks.ts
@@ -65,6 +65,7 @@ function resolveDefaultPreset(
 
 function resolvePerPackagePreset(): Rspack.OptimizationSplitChunksOptions {
   return {
+    chunks: 'all',
     minSize: 0,
     maxInitialRequests: Number.POSITIVE_INFINITY,
     cacheGroups: {

--- a/packages/core/src/plugins/splitChunks.ts
+++ b/packages/core/src/plugins/splitChunks.ts
@@ -278,7 +278,8 @@ export const pluginSplitChunks = (): RsbuildPlugin => ({
         } else {
           const { preset = 'none', ...rest } = splitChunks;
           chain.optimization.splitChunks({
-            chunks: 'all',
+            // Split initial chunks only for multi-entry builds to extract shared modules.
+            chunks: Object.keys(environment.entry).length > 1 ? 'all' : 'async',
             minSize: 0,
             ...getSplitChunksByPreset(config, preset),
             ...rest,

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -1688,7 +1688,7 @@ exports[`should apply default plugins correctly when target is node 1`] = `
   "optimization": {
     "minimize": false,
     "splitChunks": {
-      "chunks": "all",
+      "chunks": "async",
       "minSize": 0,
     },
   },

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1065,7 +1065,7 @@ exports[`environment config > should allow configuring tools.rspack and bundlerC
     "optimization": {
       "minimize": false,
       "splitChunks": {
-        "chunks": "all",
+        "chunks": "async",
         "minSize": 0,
       },
     },

--- a/packages/core/tests/splitChunks.test.ts
+++ b/packages/core/tests/splitChunks.test.ts
@@ -87,6 +87,26 @@ describe('plugin-split-chunks', () => {
     });
   });
 
+  it('should allow overriding chunks for the per-package preset in Node.js builds', async () => {
+    const rsbuild = await createRsbuild({
+      config: {
+        output: {
+          target: 'node',
+        },
+        splitChunks: {
+          preset: 'per-package',
+          chunks: 'async',
+        },
+      },
+    });
+
+    const config = await rsbuild.initConfigs();
+    expect(config[0].optimization?.splitChunks).toMatchObject({
+      chunks: 'async',
+      minSize: 0,
+    });
+  });
+
   it('should allow overriding minSize for Node.js builds', async () => {
     const rsbuild = await createRsbuild({
       config: {

--- a/packages/core/tests/splitChunks.test.ts
+++ b/packages/core/tests/splitChunks.test.ts
@@ -5,7 +5,7 @@ import {
 } from '../src/plugins/splitChunks';
 
 describe('plugin-split-chunks', () => {
-  it('should set minSize to 0 by default for Node.js builds', async () => {
+  it('should split async chunks for Node.js builds with one entry', async () => {
     const rsbuild = await createRsbuild({
       config: {
         output: {
@@ -16,7 +16,73 @@ describe('plugin-split-chunks', () => {
 
     const config = await rsbuild.initConfigs();
     expect(config[0].optimization?.splitChunks).toMatchObject({
+      chunks: 'async',
+      minSize: 0,
+    });
+  });
+
+  it('should split all chunks for Node.js builds with multiple entries', async () => {
+    const rsbuild = await createRsbuild({
+      config: {
+        source: {
+          entry: {
+            first: './src/first.js',
+            second: './src/second.js',
+          },
+        },
+        output: {
+          target: 'node',
+        },
+      },
+    });
+
+    const config = await rsbuild.initConfigs();
+    expect(config[0].optimization?.splitChunks).toMatchObject({
       chunks: 'all',
+      minSize: 0,
+    });
+  });
+
+  it('should allow using all chunks for a Node.js build with one entry', async () => {
+    const rsbuild = await createRsbuild({
+      config: {
+        output: {
+          target: 'node',
+        },
+        splitChunks: {
+          chunks: 'all',
+        },
+      },
+    });
+
+    const config = await rsbuild.initConfigs();
+    expect(config[0].optimization?.splitChunks).toMatchObject({
+      chunks: 'all',
+      minSize: 0,
+    });
+  });
+
+  it('should allow using async chunks for a Node.js build with multiple entries', async () => {
+    const rsbuild = await createRsbuild({
+      config: {
+        source: {
+          entry: {
+            first: './src/first.js',
+            second: './src/second.js',
+          },
+        },
+        output: {
+          target: 'node',
+        },
+        splitChunks: {
+          chunks: 'async',
+        },
+      },
+    });
+
+    const config = await rsbuild.initConfigs();
+    expect(config[0].optimization?.splitChunks).toMatchObject({
+      chunks: 'async',
       minSize: 0,
     });
   });
@@ -35,7 +101,7 @@ describe('plugin-split-chunks', () => {
 
     const config = await rsbuild.initConfigs();
     expect(config[0].optimization?.splitChunks).toMatchObject({
-      chunks: 'all',
+      chunks: 'async',
       minSize: 5000,
     });
   });

--- a/website/docs/en/config/split-chunks.mdx
+++ b/website/docs/en/config/split-chunks.mdx
@@ -44,7 +44,7 @@ For Node.js builds with one entry, Rsbuild sets `chunks` to `'async'`, allowing 
 
 Rsbuild also sets `minSize` to `0` so that small shared modules can be extracted instead of being duplicated across chunks.
 
-### Web Worker
+### Web worker
 
 - **Default:** `false`
 

--- a/website/docs/en/config/split-chunks.mdx
+++ b/website/docs/en/config/split-chunks.mdx
@@ -14,10 +14,6 @@ type SplitChunksConfig =
   | false;
 ```
 
-- **Default:** depends on [output.target](/config/output/target):
-  - When `output.target` is `'web'`, the default is `{ preset: 'default', chunks: 'all' }`
-  - When `output.target` is `'node'`, the default is `{ preset: 'none', chunks: 'all', minSize: 0 }`
-  - When `output.target` is `'web-worker'`, the default is `false`
 - **Version:** `>= 2.0.0`
 
 `splitChunks` is used to configure Rsbuild's chunk splitting strategy.
@@ -26,16 +22,33 @@ It is built on top of Rspack's [optimization.splitChunks](https://rspack.rs/plug
 
 ## Default behavior
 
-When `output.target` is `'web'` or `'node'`, Rsbuild enables chunk splitting by default and sets `chunks` to `'all'`. This allows eligible modules in both initial and async chunks to be extracted into separate chunks, helping reduce duplicated code across output chunks.
+The default value of `splitChunks` depends on [output.target](/config/output/target).
 
-- For web builds, unspecified options such as `minSize` and `minChunks` use the defaults from Rspack's [`optimization.splitChunks`](https://rspack.rs/plugins/webpack/split-chunks-plugin).
-- For Node.js builds, Rsbuild also sets `minSize` to `0` so that small shared modules can be extracted instead of being duplicated across chunks.
+### Web
 
-Because Web Worker outputs do not support dynamic imports, Rsbuild disables chunk splitting by default when `output.target` is `'web-worker'`.
+- **Default:** `{ preset: 'default', chunks: 'all' }`
+
+For web builds, Rsbuild sets `chunks` to `'all'`. Unspecified options such as `minSize` and `minChunks` use the defaults from Rspack's [`optimization.splitChunks`](https://rspack.rs/plugins/webpack/split-chunks-plugin).
 
 :::tip
 When a project acts as a Module Federation provider and configures [`moduleFederation.options.exposes`](/config/module-federation/options), Rsbuild sets `chunks` to `'async'` to prevent chunk splitting from affecting the remote entry.
 :::
+
+### Node.js
+
+- **Default:**
+  - With one entry: `{ preset: 'none', chunks: 'async', minSize: 0 }`
+  - With multiple entries: `{ preset: 'none', chunks: 'all', minSize: 0 }`
+
+For Node.js builds with one entry, Rsbuild sets `chunks` to `'async'`, allowing shared modules in async chunks to be extracted without splitting the initial entry chunk. With multiple entries, Rsbuild sets `chunks` to `'all'`, allowing shared modules used by different entry chunks to be extracted.
+
+Rsbuild also sets `minSize` to `0` so that small shared modules can be extracted instead of being duplicated across chunks.
+
+### Web Worker
+
+- **Default:** `false`
+
+Because Web Worker outputs do not support dynamic imports, Rsbuild disables chunk splitting by default when `output.target` is `'web-worker'`.
 
 ## splitChunks.preset
 
@@ -135,6 +148,6 @@ export default {
 
 ## Version history
 
-| Version | Changes                                                                                                               |
-| ------- | --------------------------------------------------------------------------------------------------------------------- |
-| v2.2.0  | When `output.target` is `'node'`, the default changed from `false` to `{ preset: 'none', chunks: 'all', minSize: 0 }` |
+| Version | Changes                                                                         |
+| ------- | ------------------------------------------------------------------------------- |
+| v2.2.0  | Enabled chunk splitting by default for Node.js builds and set `minSize` to `0`. |

--- a/website/docs/zh/config/split-chunks.mdx
+++ b/website/docs/zh/config/split-chunks.mdx
@@ -14,10 +14,6 @@ type SplitChunksConfig =
   | false;
 ```
 
-- **默认值：** 根据 [output.target](/config/output/target) 而定：
-  - `output.target` 为 `'web'` 时，为 `{ preset: 'default', chunks: 'all' }`
-  - `output.target` 为 `'node'` 时，为 `{ preset: 'none', chunks: 'all', minSize: 0 }`
-  - `output.target` 为 `'web-worker'` 时，为 `false`
 - **版本：** `>= 2.0.0`
 
 `splitChunks` 用于配置 Rsbuild 的 chunk 拆分策略。
@@ -26,16 +22,33 @@ type SplitChunksConfig =
 
 ## 默认行为 \{#default-behavior}
 
-当 `output.target` 为 `'web'` 或 `'node'` 时，Rsbuild 默认启用 chunk 拆分，并将 `chunks` 设置为 `'all'`。因此，初始 chunk 和异步 chunk 中符合条件的模块都可以被提取到独立的 chunk 中，有助于减少不同输出 chunk 之间的重复代码。
+`splitChunks` 的默认值根据 [output.target](/config/output/target) 而定。
 
-- 对于 Web 构建，其余未指定的选项（如 `minSize` 和 `minChunks`）均沿用 Rspack [`optimization.splitChunks`](https://rspack.rs/zh/plugins/webpack/split-chunks-plugin) 的默认值。
-- 对于 Node.js 构建，Rsbuild 还会将 `minSize` 设置为 `0`，使较小的共享模块也能被提取，避免这些模块重复出现在多个 chunk 中。
+### Web
 
-由于 Web Worker 产物不支持 dynamic import，当 `output.target` 为 `'web-worker'` 时，Rsbuild 默认关闭 chunk 拆分。
+- **默认值：** `{ preset: 'default', chunks: 'all' }`
+
+对于 Web 构建，Rsbuild 会将 `chunks` 设置为 `'all'`。其余未指定的选项（如 `minSize` 和 `minChunks`）均沿用 Rspack [`optimization.splitChunks`](https://rspack.rs/zh/plugins/webpack/split-chunks-plugin) 的默认值。
 
 :::tip
 当项目作为 Module Federation provider 并配置 [`moduleFederation.options.exposes`](/config/module-federation/options) 时，为避免 chunk 拆分影响 remote entry，Rsbuild 会将 `chunks` 设置为 `'async'`。
 :::
+
+### Node.js
+
+- **默认值：**
+  - 只有一个入口时：`{ preset: 'none', chunks: 'async', minSize: 0 }`
+  - 有多个入口时：`{ preset: 'none', chunks: 'all', minSize: 0 }`
+
+对于只有一个入口的 Node.js 构建，Rsbuild 会将 `chunks` 设置为 `'async'`，在不拆分初始入口 chunk 的情况下提取异步 chunk 之间的公共模块。对于有多个入口的 Node.js 构建，Rsbuild 会将 `chunks` 设置为 `'all'`，从而提取不同入口 chunk 使用的公共模块。
+
+Rsbuild 还会将 `minSize` 设置为 `0`，使较小的共享模块也能被提取，避免这些模块重复出现在多个 chunk 中。
+
+### Web Worker
+
+- **默认值：** `false`
+
+由于 Web Worker 产物不支持 dynamic import，当 `output.target` 为 `'web-worker'` 时，Rsbuild 默认关闭 chunk 拆分。
 
 ## splitChunks.preset
 
@@ -136,6 +149,6 @@ export default {
 
 ## 版本历史 \{#version-history}
 
-| 版本   | 变更内容                                                                                                 |
-| ------ | -------------------------------------------------------------------------------------------------------- |
-| v2.2.0 | 当 `output.target` 为 `'node'` 时，默认值从 `false` 改为 `{ preset: 'none', chunks: 'all', minSize: 0 }` |
+| 版本   | 变更内容                                                     |
+| ------ | ------------------------------------------------------------ |
+| v2.2.0 | Node.js 构建默认启用 chunk 拆分，并将 `minSize` 设置为 `0`。 |

--- a/website/docs/zh/config/split-chunks.mdx
+++ b/website/docs/zh/config/split-chunks.mdx
@@ -44,7 +44,7 @@ type SplitChunksConfig =
 
 Rsbuild 还会将 `minSize` 设置为 `0`，使较小的共享模块也能被提取，避免这些模块重复出现在多个 chunk 中。
 
-### Web Worker
+### Web worker
 
 - **默认值：** `false`
 


### PR DESCRIPTION
## Summary

Rspress has a single entry for its Node.js build and configures a fixed `output.filename`. With `chunks: 'all'`, extracting a shared initial chunk can make multiple initial chunks target the same filename.

This PR uses `chunks: 'async'` for single-entry Node.js builds to avoid splitting the initial entry, while keeping `chunks: 'all'` for multi-entry builds where shared modules can be extracted across entries. `minSize: 0` remains unchanged, and the related tests and documentation are updated accordingly.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/8363