### PR TITLE
chore(examples): remove Babel from Solid example

### DIFF
--- a/examples/solid/package.json
+++ b/examples/solid/package.json
@@ -13,7 +13,6 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rsbuild/plugin-babel": "workspace:*",
     "@rsbuild/plugin-solid": "workspace:*"
   }
 }

--- a/examples/solid/rsbuild.config.ts
+++ b/examples/solid/rsbuild.config.ts
@@ -1,12 +1,6 @@
 import { defineConfig } from '@rsbuild/core';
-import { pluginBabel } from '@rsbuild/plugin-babel';
 import { pluginSolid } from '@rsbuild/plugin-solid';
 
 export default defineConfig({
-  plugins: [
-    pluginBabel({
-      include: /\.(?:jsx|tsx)$/,
-    }),
-    pluginSolid({}),
-  ],
+  plugins: [pluginSolid()],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -834,9 +834,6 @@ importers:
       '@rsbuild/core':
         specifier: workspace:*
         version: link:../../packages/core
-      '@rsbuild/plugin-babel':
-        specifier: workspace:*
-        version: link:../../packages/plugin-babel
       '@rsbuild/plugin-solid':
         specifier: workspace:*
         version: link:../../packages/plugin-solid


### PR DESCRIPTION
## Summary

The Solid example can now use `@rsbuild/plugin-solid`'s native JSX compiler without `@rsbuild/plugin-babel`. This removes the redundant Babel dependency and configuration from the example.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8327