### PR TITLE
chore(create-rsbuild): remove Babel from Solid 2 templates

### DIFF
--- a/packages/create-rsbuild/template-solid2-js/package.json
+++ b/packages/create-rsbuild/template-solid2-js/package.json
@@ -14,7 +14,6 @@
   },
   "devDependencies": {
     "@rsbuild/core": "^2.2.0-rc.0",
-    "@rsbuild/plugin-babel": "^2.1.0",
     "@rsbuild/plugin-solid": "^2.0.0-beta.1"
   }
 }

--- a/packages/create-rsbuild/template-solid2-js/rsbuild.config.js
+++ b/packages/create-rsbuild/template-solid2-js/rsbuild.config.js
@@ -1,14 +1,8 @@
 // @ts-check
 import { defineConfig } from '@rsbuild/core';
-import { pluginBabel } from '@rsbuild/plugin-babel';
 import { pluginSolid } from '@rsbuild/plugin-solid';
 
 // Docs: https://rsbuild.rs/config/
 export default defineConfig({
-  plugins: [
-    pluginBabel({
-      include: /\.(?:jsx|tsx)$/,
-    }),
-    pluginSolid(),
-  ],
+  plugins: [pluginSolid()],
 });

--- a/packages/create-rsbuild/template-solid2-ts/package.json
+++ b/packages/create-rsbuild/template-solid2-ts/package.json
@@ -14,7 +14,6 @@
   },
   "devDependencies": {
     "@rsbuild/core": "^2.2.0-rc.0",
-    "@rsbuild/plugin-babel": "^2.1.0",
     "@rsbuild/plugin-solid": "^2.0.0-beta.1",
     "@types/node": "^24.13.3",
     "typescript": "^6.0.3"

--- a/packages/create-rsbuild/template-solid2-ts/rsbuild.config.ts
+++ b/packages/create-rsbuild/template-solid2-ts/rsbuild.config.ts
@@ -1,13 +1,7 @@
 import { defineConfig } from '@rsbuild/core';
-import { pluginBabel } from '@rsbuild/plugin-babel';
 import { pluginSolid } from '@rsbuild/plugin-solid';
 
 // Docs: https://rsbuild.rs/config/
 export default defineConfig({
-  plugins: [
-    pluginBabel({
-      include: /\.(?:jsx|tsx)$/,
-    }),
-    pluginSolid(),
-  ],
+  plugins: [pluginSolid()],
 });


### PR DESCRIPTION
## Summary

The Solid 2 templates can use the native JSX compiler added in #8327, so they no longer need `@rsbuild/plugin-babel`. This removes the redundant Babel dependency and configuration from both JavaScript and TypeScript templates.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8327