### PR TITLE
fix(plugin-solid): parse TypeScript correctly with Babel

### DIFF
--- a/e2e/cases/plugin-solid/babel-ts-parser/index.test.ts
+++ b/e2e/cases/plugin-solid/babel-ts-parser/index.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@e2e/helper';
+
+test('should parse TypeScript without treating it as JSX', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview();
+
+  const button = page.locator('#button');
+  await expect(button).toHaveText('count: 0');
+
+  await button.click();
+  await expect(button).toHaveText('count: 1');
+});

--- a/e2e/cases/plugin-solid/babel-ts-parser/rsbuild.config.ts
+++ b/e2e/cases/plugin-solid/babel-ts-parser/rsbuild.config.ts
@@ -1,0 +1,5 @@
+import { pluginSolid } from '@rsbuild/plugin-solid';
+
+export default {
+  plugins: [pluginSolid({ compiler: 'babel' })],
+};

--- a/e2e/cases/plugin-solid/babel-ts-parser/src/count.ts
+++ b/e2e/cases/plugin-solid/babel-ts-parser/src/count.ts
@@ -1,0 +1,1 @@
+export const initialCount = <number>0;

--- a/e2e/cases/plugin-solid/babel-ts-parser/src/index.tsx
+++ b/e2e/cases/plugin-solid/babel-ts-parser/src/index.tsx
@@ -1,0 +1,15 @@
+import { render } from '@solidjs/web';
+import { createSignal } from 'solid-js';
+import { initialCount } from './count';
+
+const App = () => {
+  const [count, setCount] = createSignal<number>(initialCount);
+
+  return (
+    <button id="button" type="button" onClick={() => setCount(count() + 1)}>
+      count: {count()}
+    </button>
+  );
+};
+
+render(App, document.getElementById('root')!);

--- a/e2e/cases/plugin-solid/babel-ts-parser/tsconfig.json
+++ b/e2e/cases/plugin-solid/babel-ts-parser/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@scripts/config/tsconfig",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js"
+  },
+  "include": ["src"]
+}

--- a/packages/plugin-solid/src/solidLoader.ts
+++ b/packages/plugin-solid/src/solidLoader.ts
@@ -14,6 +14,7 @@ import type { SolidCompiler, SolidPresetOptions } from './types.js';
 const require = createRequire(import.meta.url);
 const BABEL_PRESET_SOLID_PATH = require.resolve('babel-preset-solid');
 const JS_REGEX = /\.[cm]?js$/;
+const JSX_REGEX = /\.(?:js|jsx|mjs|cjs|tsx)$/;
 const TS_REGEX = /\.(?:ts|tsx|mts|cts)$/;
 
 const getTransformFilename = (filename: string): string =>
@@ -63,7 +64,11 @@ const solidLoader: Rspack.LoaderDefinition<SolidLoaderOptions> =
       if (compiler === 'babel') {
         const parserPlugins: NonNullable<
           NonNullable<TransformOptions['parserOpts']>['plugins']
-        > = ['jsx', 'decorators'];
+        > = ['decorators'];
+
+        if (JSX_REGEX.test(filename)) {
+          parserPlugins.push('jsx');
+        }
 
         if (TS_REGEX.test(filename)) {
           parserPlugins.push('typescript');

--- a/packages/plugin-solid/src/types.ts
+++ b/packages/plugin-solid/src/types.ts
@@ -2,7 +2,7 @@
  * Options passed to the Solid JSX compiler.
  *
  * The option types are aligned with `@dom-expressions/compiler` and adjusted
- * for the Babel backend.
+ * for `babel-preset-solid`.
  *
  * https://github.com/solidjs/solid/blob/next/packages/babel-preset-solid/index.js
  * https://github.com/ryansolid/dom-expressions/blob/main/packages/babel-plugin-jsx/README.md


### PR DESCRIPTION
## Summary

The Babel compiler backend currently enables JSX parsing for plain TypeScript files, causing angle-bracket assertions in `.ts`, `.mts`, and `.cts` files to be parsed as JSX. This PR enables JSX parsing only for JSX-capable extensions while preserving both JSX and TypeScript parsing for `.tsx` files.