### PR TITLE
fix(plugin-solid)!: remove deprecated solidPresetOptions

### DIFF
--- a/packages/plugin-solid/src/index.ts
+++ b/packages/plugin-solid/src/index.ts
@@ -55,18 +55,12 @@ export type PluginSolidOptions = {
    * `solid.dev` overrides compiler transforms without changing runtime resolution.
    */
   solid?: SolidPresetOptions;
-  /**
-   * Options passed to the selected JSX compiler.
-   * If both `solid` and `solidPresetOptions` are set, `solid` takes precedence.
-   * @deprecated Use `solid` instead.
-   */
-  solidPresetOptions?: SolidPresetOptions;
 };
 
 export const PLUGIN_SOLID_NAME = 'rsbuild:solid';
 
 export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
-  const { compiler = 'native', dev, solid, solidPresetOptions, ssr } = options;
+  const { compiler = 'native', dev, solid, ssr } = options;
   const isDevModeEnabled = (mode: RsbuildMode) => dev ?? mode === 'development';
 
   return {
@@ -113,7 +107,6 @@ export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
           };
           const solidOptions = {
             ...defaultPresetOptions,
-            ...solidPresetOptions,
             ...solid,
           };
 

--- a/packages/plugin-solid/tests/index.test.ts
+++ b/packages/plugin-solid/tests/index.test.ts
@@ -332,30 +332,4 @@ describe('plugin-solid', () => {
       }),
     );
   });
-
-  it('should allow deprecated solidPresetOptions alias', async () => {
-    const rsbuild = await createRsbuild({
-      config: {
-        ...rsbuildConfig,
-        plugins: [
-          pluginSolid({
-            solidPresetOptions: {
-              generate: 'ssr',
-              hydratable: true,
-            },
-          }),
-        ],
-      },
-    });
-    const config = await rsbuild.initConfigs();
-
-    expect(getSolidLoaderOptions(config[0])).toEqual(
-      expect.objectContaining({
-        solid: expect.objectContaining({
-          generate: 'ssr',
-          hydratable: true,
-        }),
-      }),
-    );
-  });
 });

--- a/website/docs/en/plugins/list/plugin-solid.mdx
+++ b/website/docs/en/plugins/list/plugin-solid.mdx
@@ -175,5 +175,3 @@ pluginSolid({
   },
 });
 ```
-
-> `solidPresetOptions` is a deprecated alias for `solid`. Use `solid` instead. If both options are set, `solid` takes precedence.

--- a/website/docs/zh/plugins/list/plugin-solid.mdx
+++ b/website/docs/zh/plugins/list/plugin-solid.mdx
@@ -171,5 +171,3 @@ pluginSolid({
   },
 });
 ```
-
-> `solidPresetOptions` 是 `solid` 的废弃别名，请使用 `solid` 代替。如果两个选项同时设置，则 `solid` 优先生效。


### PR DESCRIPTION
## Summary

This PR removes the deprecated `solidPresetOptions` alias from `PluginSolidOptions`, along with its compatibility merge path, test, and documentation. Use the `solid` option to configure the Solid compiler instead.