### PR TITLE
feat(plugin-solid)!: publish as pure ESM package

### DIFF
--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -16,8 +16,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.js"
     }
   },
   "types": "./dist/index.d.ts",

--- a/packages/plugin-solid/rstack.config.ts
+++ b/packages/plugin-solid/rstack.config.ts
@@ -1,18 +1,11 @@
 import { define } from 'rstack';
 
 define.lib(async () => {
-  const { esmConfig, nodeMinifyConfig } = await import('@scripts/config/lib');
+  const { esmConfig } = await import('@scripts/config/lib');
 
   return {
     lib: [
       esmConfig,
-      {
-        format: 'cjs',
-        syntax: 'es2023',
-        output: {
-          minify: nodeMinifyConfig,
-        },
-      },
       {
         source: {
           entry: {


### PR DESCRIPTION
## Summary

This PR publishes `@rsbuild/plugin-solid` as a pure ESM package, aligning it with the other Rsbuild v2 framework plugins. It removes the CommonJS export and build while preserving the ESM plugin entry and `.mjs` loader outputs.