### PR TITLE
feat(plugin-solid)!: drop Rsbuild v1 support

### DIFF
--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -42,7 +42,7 @@
     "typescript": "catalog:"
   },
   "peerDependencies": {
-    "@rsbuild/core": "^1.0.0 || ^2.0.0",
+    "@rsbuild/core": "^2.0.0",
     "@solidjs/web": "^2.0.0-rc.0",
     "solid-js": "^2.0.0-rc.0"
   },


### PR DESCRIPTION
## Summary

`@rsbuild/plugin-solid` v2 should only be used with Rsbuild v2, but its peer dependency still allowed Rsbuild v1. This PR narrows the `@rsbuild/core` peer range to `^2.0.0`, preventing unsupported v1 combinations.