### PR TITLE
fix(plugin-solid): respect legacy decorator config

### DIFF
--- a/e2e/cases/plugin-solid/babel-legacy-decorator/index.test.ts
+++ b/e2e/cases/plugin-solid/babel-legacy-decorator/index.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from '@e2e/helper';
+
+test('should support legacy TypeScript decorators with Babel compiler', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview();
+
+  await expect(page.locator('#decorator')).toHaveText(
+    'legacy decorator works: 0',
+  );
+});

--- a/e2e/cases/plugin-solid/babel-legacy-decorator/rsbuild.config.ts
+++ b/e2e/cases/plugin-solid/babel-legacy-decorator/rsbuild.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginSolid } from '@rsbuild/plugin-solid';
+
+export default defineConfig({
+  source: {
+    decorators: {
+      version: 'legacy',
+    },
+  },
+  plugins: [pluginSolid({ compiler: 'babel' })],
+});

--- a/e2e/cases/plugin-solid/babel-legacy-decorator/src/index.tsx
+++ b/e2e/cases/plugin-solid/babel-legacy-decorator/src/index.tsx
@@ -1,0 +1,24 @@
+import { render } from '@solidjs/web';
+
+let decoratedParameterIndex = -1;
+
+const trackParameter =
+  (): ParameterDecorator => (_target, _propertyKey, parameterIndex) => {
+    decoratedParameterIndex = parameterIndex;
+  };
+
+class ViewModel {
+  constructor(
+    @trackParameter()
+    readonly message: string,
+  ) {}
+}
+
+const viewModel = new ViewModel('legacy decorator works');
+const App = () => (
+  <div id="decorator">
+    {viewModel.message}: {decoratedParameterIndex}
+  </div>
+);
+
+render(App, document.getElementById('root')!);

--- a/e2e/cases/plugin-solid/babel-legacy-decorator/tsconfig.json
+++ b/e2e/cases/plugin-solid/babel-legacy-decorator/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@scripts/config/tsconfig",
   "compilerOptions": {
+    "experimentalDecorators": true,
     "jsx": "preserve",
     "jsxImportSource": "@solidjs/web"
   },

--- a/e2e/cases/plugin-solid/babel-ts-parser/tsconfig.json
+++ b/e2e/cases/plugin-solid/babel-ts-parser/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@scripts/config/tsconfig",
   "compilerOptions": {
     "jsx": "preserve",
-    "jsxImportSource": "solid-js"
+    "jsxImportSource": "@solidjs/web"
   },
   "include": ["src"]
 }

--- a/e2e/cases/plugin-solid/ts/tsconfig.json
+++ b/e2e/cases/plugin-solid/ts/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@scripts/config/tsconfig",
   "compilerOptions": {
     "jsx": "preserve",
-    "jsxImportSource": "solid-js"
+    "jsxImportSource": "@solidjs/web"
   },
   "include": ["src"]
 }

--- a/packages/plugin-solid/src/index.ts
+++ b/packages/plugin-solid/src/index.ts
@@ -126,6 +126,7 @@ export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
             .loader(path.join(import.meta.dirname, 'solidLoader.mjs'))
             .options({
               compiler,
+              decoratorVersion: environmentConfig.source.decorators.version,
               solid: solidOptions,
             });
 

--- a/packages/plugin-solid/src/solidLoader.ts
+++ b/packages/plugin-solid/src/solidLoader.ts
@@ -8,7 +8,7 @@ import {
   type TransformOptions as NativeTransformOptions,
 } from '@dom-expressions/compiler';
 import remapping from '@jridgewell/remapping';
-import type { Rspack } from '@rsbuild/core';
+import type { Decorators, Rspack } from '@rsbuild/core';
 import type { SolidCompiler, SolidPresetOptions } from './types.js';
 
 const require = createRequire(import.meta.url);
@@ -22,6 +22,7 @@ const getTransformFilename = (filename: string): string =>
 
 export type SolidLoaderOptions = {
   compiler: SolidCompiler;
+  decoratorVersion: NonNullable<Decorators['version']>;
   solid: SolidPresetOptions;
 };
 
@@ -56,7 +57,7 @@ const mergeSourceMaps = (
 const solidLoader: Rspack.LoaderDefinition<SolidLoaderOptions> =
   async function (source, sourceMap): Promise<void> {
     const callback = this.async();
-    const { compiler, solid } = this.getOptions();
+    const { compiler, decoratorVersion, solid } = this.getOptions();
     const filename = this.resourcePath;
     const inputSourceMap = normalizeSourceMap(sourceMap);
 
@@ -64,7 +65,9 @@ const solidLoader: Rspack.LoaderDefinition<SolidLoaderOptions> =
       if (compiler === 'babel') {
         const parserPlugins: NonNullable<
           NonNullable<TransformOptions['parserOpts']>['plugins']
-        > = ['decorators'];
+        > = [
+          decoratorVersion === 'legacy' ? 'decorators-legacy' : 'decorators',
+        ];
 
         if (JSX_REGEX.test(filename)) {
           parserPlugins.push('jsx');

--- a/packages/plugin-solid/tests/index.test.ts
+++ b/packages/plugin-solid/tests/index.test.ts
@@ -47,6 +47,7 @@ describe('plugin-solid', () => {
 
     expect(getSolidLoaderOptions(config[0])).toEqual({
       compiler: 'native',
+      decoratorVersion: '2023-11',
       solid: {
         builtIns: [
           'For',
@@ -81,6 +82,27 @@ describe('plugin-solid', () => {
 
     expect(JSON.stringify(matchRules(config[0], 'a.tsx'))).toContain(
       '"compiler":"babel"',
+    );
+  });
+
+  it('should pass decorator version to Babel compiler', async () => {
+    const rsbuild = await createRsbuild({
+      config: {
+        ...rsbuildConfig,
+        source: {
+          decorators: {
+            version: 'legacy',
+          },
+        },
+        plugins: [pluginSolid({ compiler: 'babel' })],
+      },
+    });
+    const config = await rsbuild.initConfigs();
+
+    expect(getSolidLoaderOptions(config[0])).toEqual(
+      expect.objectContaining({
+        decoratorVersion: 'legacy',
+      }),
     );
   });
 


### PR DESCRIPTION
## Summary

`pluginSolid({ compiler: 'babel' })` currently parses all decorators as modern syntax, causing TypeScript parameter decorators to fail even when `source.decorators.version` is `legacy`. This PR forwards each environment's decorator version to the Solid loader and selects the legacy parser when configured. It also aligns the Solid 2 TypeScript e2e configurations with the `@solidjs/web` JSX runtime.