### PR TITLE
test(plugin-solid): cover dev hydration walk output

### DIFF
--- a/e2e/cases/plugin-solid/dev-hydration-walk/index.test.ts
+++ b/e2e/cases/plugin-solid/dev-hydration-walk/index.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@e2e/helper';
+import { pluginSolid } from '@rsbuild/plugin-solid';
+import { getFileContent } from '@rstackjs/test-utils';
+
+for (const compiler of ['native', 'babel'] as const) {
+  test(`should emit hydration walk helpers with ${compiler} when dev is true`, async ({
+    build,
+  }) => {
+    const rsbuild = await build({
+      config: {
+        output: {
+          minify: false,
+        },
+        plugins: [
+          pluginSolid({
+            compiler,
+            dev: true,
+            refresh: { disabled: true },
+            ssr: true,
+          }),
+        ],
+      },
+    });
+    const content = getFileContent(rsbuild.getDistFiles(), 'index.js');
+
+    expect(content).toContain('getFirstChild');
+    expect(content).toContain('getNextSibling');
+  });
+
+  test(`should omit hydration walk helpers with ${compiler} when dev is false`, async ({
+    devOnly,
+  }) => {
+    const rsbuild = await devOnly({
+      config: {
+        output: {
+          minify: false,
+        },
+        plugins: [
+          pluginSolid({
+            compiler,
+            dev: false,
+            refresh: { disabled: true },
+            ssr: true,
+          }),
+        ],
+      },
+    });
+    const content = getFileContent(rsbuild.getDistFiles(), 'index.js');
+
+    expect(content).not.toContain('getFirstChild');
+    expect(content).not.toContain('getNextSibling');
+  });
+}

--- a/e2e/cases/plugin-solid/dev-hydration-walk/index.test.ts
+++ b/e2e/cases/plugin-solid/dev-hydration-walk/index.test.ts
@@ -1,6 +1,24 @@
 import { expect, test } from '@e2e/helper';
+import type { RsbuildConfig } from '@rsbuild/core';
 import { pluginSolid } from '@rsbuild/plugin-solid';
 import { getFileContent } from '@rstackjs/test-utils';
+
+const commonConfig = {
+  output: {
+    minify: false,
+  },
+  splitChunks: {
+    preset: 'none',
+    cacheGroups: {
+      'solid-runtime': {
+        test: /node_modules[\\/]@solidjs[\\/]web[\\/]/,
+        name: 'solid-runtime',
+        chunks: 'all',
+        enforce: true,
+      },
+    },
+  },
+} satisfies RsbuildConfig;
 
 for (const compiler of ['native', 'babel'] as const) {
   test(`should emit hydration walk helpers with ${compiler} when dev is true`, async ({
@@ -8,20 +26,7 @@ for (const compiler of ['native', 'babel'] as const) {
   }) => {
     const rsbuild = await build({
       config: {
-        output: {
-          minify: false,
-        },
-        splitChunks: {
-          preset: 'none',
-          cacheGroups: {
-            'solid-runtime': {
-              test: /node_modules[\\/]@solidjs[\\/]web[\\/]/,
-              name: 'solid-runtime',
-              chunks: 'all',
-              enforce: true,
-            },
-          },
-        },
+        ...commonConfig,
         plugins: [
           pluginSolid({
             compiler,
@@ -43,20 +48,7 @@ for (const compiler of ['native', 'babel'] as const) {
   }) => {
     const rsbuild = await devOnly({
       config: {
-        output: {
-          minify: false,
-        },
-        splitChunks: {
-          preset: 'none',
-          cacheGroups: {
-            'solid-runtime': {
-              test: /node_modules[\\/]@solidjs[\\/]web[\\/]/,
-              name: 'solid-runtime',
-              chunks: 'all',
-              enforce: true,
-            },
-          },
-        },
+        ...commonConfig,
         plugins: [
           pluginSolid({
             compiler,

--- a/e2e/cases/plugin-solid/dev-hydration-walk/index.test.ts
+++ b/e2e/cases/plugin-solid/dev-hydration-walk/index.test.ts
@@ -11,6 +11,14 @@ for (const compiler of ['native', 'babel'] as const) {
         output: {
           minify: false,
         },
+        performance: {
+          chunkSplit: {
+            strategy: 'single-vendor',
+            forceSplitting: {
+              'solid-runtime': /node_modules[\\/]@solidjs[\\/]web[\\/]/,
+            },
+          },
+        },
         plugins: [
           pluginSolid({
             compiler,
@@ -35,6 +43,14 @@ for (const compiler of ['native', 'babel'] as const) {
         output: {
           minify: false,
         },
+        performance: {
+          chunkSplit: {
+            strategy: 'single-vendor',
+            forceSplitting: {
+              'solid-runtime': /node_modules[\\/]@solidjs[\\/]web[\\/]/,
+            },
+          },
+        },
         plugins: [
           pluginSolid({
             compiler,
@@ -47,6 +63,8 @@ for (const compiler of ['native', 'babel'] as const) {
     });
     const content = getFileContent(rsbuild.getDistFiles(), 'index.js');
 
+    expect(content).toContain('.firstChild');
+    expect(content).toContain('.nextSibling');
     expect(content).not.toContain('getFirstChild');
     expect(content).not.toContain('getNextSibling');
   });

--- a/e2e/cases/plugin-solid/dev-hydration-walk/index.test.ts
+++ b/e2e/cases/plugin-solid/dev-hydration-walk/index.test.ts
@@ -11,11 +11,14 @@ for (const compiler of ['native', 'babel'] as const) {
         output: {
           minify: false,
         },
-        performance: {
-          chunkSplit: {
-            strategy: 'single-vendor',
-            forceSplitting: {
-              'solid-runtime': /node_modules[\\/]@solidjs[\\/]web[\\/]/,
+        splitChunks: {
+          preset: 'none',
+          cacheGroups: {
+            'solid-runtime': {
+              test: /node_modules[\\/]@solidjs[\\/]web[\\/]/,
+              name: 'solid-runtime',
+              chunks: 'all',
+              enforce: true,
             },
           },
         },
@@ -43,11 +46,14 @@ for (const compiler of ['native', 'babel'] as const) {
         output: {
           minify: false,
         },
-        performance: {
-          chunkSplit: {
-            strategy: 'single-vendor',
-            forceSplitting: {
-              'solid-runtime': /node_modules[\\/]@solidjs[\\/]web[\\/]/,
+        splitChunks: {
+          preset: 'none',
+          cacheGroups: {
+            'solid-runtime': {
+              test: /node_modules[\\/]@solidjs[\\/]web[\\/]/,
+              name: 'solid-runtime',
+              chunks: 'all',
+              enforce: true,
             },
           },
         },

--- a/e2e/cases/plugin-solid/dev-hydration-walk/src/index.jsx
+++ b/e2e/cases/plugin-solid/dev-hydration-walk/src/index.jsx
@@ -1,0 +1,14 @@
+import { render } from '@solidjs/web';
+import { createSignal } from 'solid-js';
+
+const [value] = createSignal('value');
+
+render(
+  () => (
+    <main>
+      <p class={value()}>first</p>
+      <span>{value()}</span>
+    </main>
+  ),
+  document.getElementById('root'),
+);


### PR DESCRIPTION
## Summary

Solid's `dev` option controls development-only hydration walk helpers, but this behavior was previously covered only through configuration assertions. This PR adds focused e2e coverage for both native and Babel compilers, verifying that `dev: true` emits the helpers and `dev: false` omits them.