### PR TITLE
docs: move LLMs UI to page outline

### DIFF
--- a/website/rstack.config.ts
+++ b/website/rstack.config.ts
@@ -185,6 +185,9 @@ define.doc({
     exclude: ['**/zh/shared/**', '**/en/shared/**'],
   },
   themeConfig: {
+    llmsUI: {
+      placement: 'outline',
+    },
     socialLinks: [
       {
         icon: 'github',


### PR DESCRIPTION
## Summary

This PR moves the LLMs UI action into the documentation page outline so it stays accessible alongside page navigation. It sets `themeConfig.llmsUI.placement` to `outline`.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/414