### PR TITLE
fix(plugin-solid): support JSX in JavaScript data URIs

### DIFF
--- a/e2e/cases/plugin-solid/data-uri-jsx/index.test.ts
+++ b/e2e/cases/plugin-solid/data-uri-jsx/index.test.ts
@@ -1,0 +1,47 @@
+import { expect, gotoPage, test } from '@e2e/helper';
+import { pluginSolid } from '@rsbuild/plugin-solid';
+import { getFileContent } from '@rstackjs/test-utils';
+
+for (const compiler of ['native', 'babel'] as const) {
+  test(`should compile Solid JSX in a data URI with ${compiler}`, async ({
+    build,
+    page,
+  }) => {
+    const rsbuild = await build({
+      runServer: true,
+      config: {
+        plugins: [pluginSolid({ compiler })],
+      },
+    });
+
+    await gotoPage(page, rsbuild);
+    await expect(page.locator('#data-uri')).toHaveText('data uri');
+  });
+
+  test(`should preserve the data URI source map with ${compiler}`, async ({
+    build,
+  }) => {
+    const rsbuild = await build({
+      config: {
+        output: {
+          sourceMap: {
+            js: 'source-map',
+          },
+        },
+        plugins: [pluginSolid({ compiler })],
+      },
+    });
+    const sourceMap = JSON.parse(
+      getFileContent(
+        rsbuild.getDistFiles({ sourceMaps: true }),
+        'index.js.map',
+      ),
+    ) as { sources: string[] };
+
+    expect(
+      sourceMap.sources.some((source) =>
+        source.includes('data:text/javascript'),
+      ),
+    ).toBe(true);
+  });
+}

--- a/e2e/cases/plugin-solid/data-uri-jsx/src/index.jsx
+++ b/e2e/cases/plugin-solid/data-uri-jsx/src/index.jsx
@@ -1,0 +1,4 @@
+import { render } from '@solidjs/web';
+import Component from 'data:text/javascript,export default () => <p id="data-uri">data uri</p>';
+
+render(Component, document.getElementById('root'));

--- a/packages/plugin-solid/src/index.ts
+++ b/packages/plugin-solid/src/index.ts
@@ -112,23 +112,34 @@ export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
 
           const jsRule = chain.module.rules.get(CHAIN_ID.RULE.JS);
           const jsMainRule = jsRule.oneOfs.get(CHAIN_ID.ONE_OF.JS_MAIN);
-          const solidUse = jsMainRule.use('solid');
+          const solidRules = [
+            { rule: jsMainRule },
+            {
+              rule: chain.module.rules.get(CHAIN_ID.RULE.JS_DATA_URI),
+              transformFilename: 'data-uri.jsx',
+            },
+          ];
 
-          // Rspack executes loaders in reverse declaration order. Position the
-          // Solid loader so transforms run as: user Babel -> Solid JSX -> SWC.
-          if (jsMainRule.uses.has(CHAIN_ID.USE.BABEL)) {
-            solidUse.before(CHAIN_ID.USE.BABEL);
-          } else {
-            solidUse.after(CHAIN_ID.USE.SWC);
+          for (const { rule, transformFilename } of solidRules) {
+            const solidUse = rule.use('solid');
+
+            // Rspack executes loaders in reverse declaration order. Position the
+            // Solid loader so transforms run as: user Babel -> Solid JSX -> SWC.
+            if (rule.uses.has(CHAIN_ID.USE.BABEL)) {
+              solidUse.before(CHAIN_ID.USE.BABEL);
+            } else {
+              solidUse.after(CHAIN_ID.USE.SWC);
+            }
+
+            solidUse
+              .loader(path.join(import.meta.dirname, 'solidLoader.mjs'))
+              .options({
+                compiler,
+                decoratorVersion: environmentConfig.source.decorators.version,
+                solid: solidOptions,
+                ...(transformFilename ? { transformFilename } : {}),
+              });
           }
-
-          solidUse
-            .loader(path.join(import.meta.dirname, 'solidLoader.mjs'))
-            .options({
-              compiler,
-              decoratorVersion: environmentConfig.source.decorators.version,
-              solid: solidOptions,
-            });
 
           if (usingHMR) {
             const refreshRule = chain.module

--- a/packages/plugin-solid/src/solidLoader.ts
+++ b/packages/plugin-solid/src/solidLoader.ts
@@ -24,6 +24,7 @@ export type SolidLoaderOptions = {
   compiler: SolidCompiler;
   decoratorVersion: NonNullable<Decorators['version']>;
   solid: SolidPresetOptions;
+  transformFilename?: string;
 };
 
 const normalizeSourceMap = (
@@ -57,8 +58,14 @@ const mergeSourceMaps = (
 const solidLoader: Rspack.LoaderDefinition<SolidLoaderOptions> =
   async function (source, sourceMap): Promise<void> {
     const callback = this.async();
-    const { compiler, decoratorVersion, solid } = this.getOptions();
-    const filename = this.resourcePath;
+    const { compiler, decoratorVersion, solid, transformFilename } =
+      this.getOptions();
+    const sourceFilename = this.resourcePath;
+    const filename =
+      transformFilename ??
+      (compiler === 'native'
+        ? getTransformFilename(sourceFilename)
+        : sourceFilename);
     const inputSourceMap = normalizeSourceMap(sourceMap);
 
     try {
@@ -79,7 +86,7 @@ const solidLoader: Rspack.LoaderDefinition<SolidLoaderOptions> =
 
         const result = await babelTransformAsync(String(source), {
           filename,
-          sourceFileName: filename,
+          sourceFileName: sourceFilename,
           sourceMaps: true,
           inputSourceMap,
           ast: false,
@@ -97,14 +104,14 @@ const solidLoader: Rspack.LoaderDefinition<SolidLoaderOptions> =
 
       const result = await nativeTransformAsync(String(source), {
         ...solid,
-        filename: getTransformFilename(filename),
+        filename,
         sourceMap: true,
       } as NativeTransformOptions);
 
       callback(
         null,
         result.code,
-        mergeSourceMaps(inputSourceMap, result.map, filename),
+        mergeSourceMaps(inputSourceMap, result.map, sourceFilename),
       );
     } catch (error) {
       callback(error instanceof Error ? error : new Error(String(error)));


### PR DESCRIPTION
## Summary

Solid JSX in JavaScript data URIs currently bypasses the Solid compiler and is transformed as React output. This PR applies the Solid loader to the JavaScript data URI rule for both compiler backends while preserving loader order and original source map paths.