### PR TITLE
fix(core): wait for child compilers after fatal errors

### DIFF
--- a/e2e/cases/server/fatal-watch-error/index.test.ts
+++ b/e2e/cases/server/fatal-watch-error/index.test.ts
@@ -10,18 +10,70 @@ const createDeferred = () => {
   return { promise, resolve };
 };
 
+const createRebuildController = ({
+  fatal = false,
+  onWatchClose,
+}: {
+  fatal?: boolean;
+  onWatchClose?: () => void;
+} = {}) => {
+  const started = createDeferred();
+  const release = createDeferred();
+  const failed = createDeferred();
+  const name = fatal ? 'FatalRebuild' : 'BlockingRebuild';
+  let armed = false;
+  let shouldRun = false;
+
+  return {
+    arm: () => {
+      armed = true;
+    },
+    failed,
+    plugin: {
+      apply(compiler: Rspack.Compiler) {
+        compiler.hooks.watchRun.tap(name, () => {
+          shouldRun = armed;
+        });
+
+        if (fatal) {
+          compiler.hooks.failed.tap(name, failed.resolve);
+        }
+
+        if (onWatchClose) {
+          compiler.hooks.watchClose.tap(name, onWatchClose);
+        }
+
+        compiler.hooks.thisCompilation.tap(name, (compilation) => {
+          compilation.hooks.processAssets.tapPromise(name, async () => {
+            if (!shouldRun) {
+              return;
+            }
+
+            started.resolve();
+            await release.promise;
+
+            if (fatal) {
+              throw new Error('intentional fatal watch error');
+            }
+          });
+        });
+      },
+    },
+    release,
+    started,
+  };
+};
+
 test('should respond to requests after a fatal rebuild error', async ({
   copySrcDir,
   devOnly,
   editFile,
 }) => {
-  const rebuildStarted = createDeferred();
+  const fatal = createRebuildController({ fatal: true });
   const requestQueued = createDeferred();
-  const triggerFatalError = createDeferred();
-  let compileCount = 0;
-  let shouldThrow = false;
-
   const tempSrc = await copySrcDir();
+  const entryFile = join(tempSrc, 'index.js');
+
   const rsbuild = await devOnly({
     config: {
       server: {
@@ -43,52 +95,26 @@ test('should respond to requests after a fatal rebuild error', async ({
       },
       source: {
         entry: {
-          index: join(tempSrc, 'index.js'),
+          index: entryFile,
         },
       },
       tools: {
         rspack(_config, { appendPlugins }) {
-          appendPlugins({
-            apply(compiler: Rspack.Compiler) {
-              compiler.hooks.watchRun.tap('ThrowOnFirstRebuild', () => {
-                compileCount++;
-                shouldThrow = compileCount === 2;
-              });
-
-              compiler.hooks.thisCompilation.tap(
-                'ThrowOnFirstRebuild',
-                (compilation) => {
-                  compilation.hooks.processAssets.tapPromise(
-                    'ThrowOnFirstRebuild',
-                    async () => {
-                      if (!shouldThrow) {
-                        return;
-                      }
-
-                      rebuildStarted.resolve();
-                      await triggerFatalError.promise;
-                      throw new Error('intentional fatal watch error');
-                    },
-                  );
-                },
-              );
-            },
-          });
+          appendPlugins(fatal.plugin);
         },
       },
     },
   });
   const url = `http://localhost:${rsbuild.port}/`;
 
-  const initialResponse = await fetch(url);
-  expect(initialResponse.status).toBe(200);
+  expect((await fetch(url)).status).toBe(200);
 
-  rsbuild.clearLogs();
-  await editFile(join(tempSrc, 'index.js'), (code) =>
+  fatal.arm();
+  await editFile(entryFile, (code) =>
     code.replace('Hello Rsbuild!', 'Hello Rsbuild 2!'),
   );
 
-  await rebuildStarted.promise;
+  await fatal.started.promise;
   const pendingResponse = fetch(url, {
     headers: {
       'x-test-pending-request': 'true',
@@ -96,13 +122,112 @@ test('should respond to requests after a fatal rebuild error', async ({
     signal: AbortSignal.timeout(2_000),
   });
   await requestQueued.promise;
-  triggerFatalError.resolve();
-  await rsbuild.expectLog('intentional fatal watch error');
+  fatal.release.resolve();
+  await fatal.failed.promise;
 
   expect((await pendingResponse).status).toBe(200);
+  expect(
+    (
+      await fetch(url, {
+        signal: AbortSignal.timeout(2_000),
+      })
+    ).status,
+  ).toBe(200);
+});
 
-  const subsequentResponse = await fetch(url, {
-    signal: AbortSignal.timeout(2_000),
+test('should wait for active child compilers after a fatal error', async ({
+  copySrcDir,
+  devOnly,
+  editFile,
+}) => {
+  let blockingClosed = false;
+  const fatal = createRebuildController({ fatal: true });
+  const blocking = createRebuildController({
+    onWatchClose: () => {
+      blockingClosed = true;
+    },
   });
-  expect(subsequentResponse.status).toBe(200);
+  const requestArrived = createDeferred();
+  const tempSrc = await copySrcDir();
+  const entryFile = join(tempSrc, 'index.js');
+
+  const rsbuild = await devOnly({
+    config: {
+      dev: {
+        assetPrefix: 'auto',
+      },
+      server: {
+        setup: ({ action, server }) => {
+          if (action !== 'dev') {
+            return;
+          }
+
+          server.middlewares.use((req, _res, next) => {
+            if (req.url === '/multi-compiler-ready') {
+              requestArrived.resolve();
+            }
+            next();
+          });
+
+          return () => {
+            server.middlewares.use('/multi-compiler-ready', (_req, res) => {
+              res.statusCode = blockingClosed ? 200 : 500;
+              res.end();
+            });
+          };
+        },
+      },
+      source: {
+        entry: {
+          index: entryFile,
+        },
+      },
+      environments: {
+        fatal: {
+          output: {
+            distPath: 'dist/fatal',
+          },
+          tools: {
+            rspack(_config, { appendPlugins }) {
+              appendPlugins(fatal.plugin);
+            },
+          },
+        },
+        blocking: {
+          output: {
+            distPath: 'dist/blocking',
+          },
+          tools: {
+            rspack(_config, { appendPlugins }) {
+              appendPlugins(blocking.plugin);
+            },
+          },
+        },
+      },
+    },
+  });
+
+  fatal.arm();
+  blocking.arm();
+  await editFile(entryFile, (code) =>
+    code.replace('Hello Rsbuild!', 'Hello Rsbuild 2!'),
+  );
+  await Promise.all([fatal.started.promise, blocking.started.promise]);
+
+  fatal.release.resolve();
+  await fatal.failed.promise;
+
+  const response = fetch(
+    `http://localhost:${rsbuild.port}/multi-compiler-ready`,
+    {
+      method: 'POST',
+      signal: AbortSignal.timeout(2_000),
+    },
+  );
+  await requestArrived.promise;
+
+  blocking.release.resolve();
+
+  expect((await response).status).toBe(200);
+  await rsbuild.expectLog('intentional fatal watch error');
 });

--- a/packages/core/src/createCompiler.ts
+++ b/packages/core/src/createCompiler.ts
@@ -119,6 +119,26 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
 
   let isVersionLogged = false;
   let isCompiling = false;
+  let hasFatalError = false;
+
+  const compilers = isMultiCompiler
+    ? (compiler as Rspack.MultiCompiler).compilers
+    : [compiler as Rspack.Compiler];
+
+  const finishFatalBuild = () => {
+    if (
+      !hasFatalError ||
+      compilers.some((item) =>
+        item.watching ? item.watching.running : item.running,
+      )
+    ) {
+      return;
+    }
+
+    context.buildState.status = 'failed';
+    context.buildState.hasErrors = true;
+    isCompiling = false;
+  };
 
   const logRspackVersion = () => {
     if (!isVersionLogged) {
@@ -176,21 +196,20 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
   });
 
   compiler.hooks.invalid.tap(HOOK_NAME, () => {
+    hasFatalError = false;
     context.buildState.stats = null;
     context.buildState.status = 'idle';
     context.buildState.hasErrors = false;
   });
 
-  const compilers = isMultiCompiler
-    ? (compiler as Rspack.MultiCompiler).compilers
-    : [compiler as Rspack.Compiler];
-
   for (const item of compilers) {
     item.hooks.failed.tap(HOOK_NAME, () => {
-      context.buildState.status = 'failed';
+      hasFatalError = true;
       context.buildState.hasErrors = true;
-      isCompiling = false;
+      finishFatalBuild();
     });
+    item.hooks.afterDone.tap(HOOK_NAME, finishFatalBuild);
+    item.hooks.watchClose.tap(HOOK_NAME, finishFatalBuild);
   }
 
   if (context.action === 'build') {
@@ -236,6 +255,7 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
   compiler.hooks.done.tap(
     HOOK_NAME,
     (statsInstance: Rspack.Stats | Rspack.MultiStats) => {
+      hasFatalError = false;
       const stats = getRsbuildStats(
         statsInstance,
         compiler,

--- a/packages/core/src/createCompiler.ts
+++ b/packages/core/src/createCompiler.ts
@@ -119,6 +119,7 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
 
   let isVersionLogged = false;
   let isCompiling = false;
+  // Fatal errors abort compilation and trigger `failed` instead of producing stats via `done`.
   let hasFatalError = false;
 
   const compilers = isMultiCompiler

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -73,7 +73,15 @@ export type RsbuildContext = {
   callerName: string;
 };
 
-export type BuildStatus = 'idle' | 'building' | 'done' | 'failed';
+export type BuildStatus =
+  /** No build is running yet, or the previous result has been invalidated. */
+  | 'idle'
+  /** The compiler is currently building or rebuilding. */
+  | 'building'
+  /** The compiler completed and produced stats, which may contain errors. */
+  | 'done'
+  /** The compiler aborted due to a fatal error without producing stats. */
+  | 'failed';
 
 export type BuildState = {
   /**


### PR DESCRIPTION
## Summary

When one compiler in a MultiCompiler fails fatally, Rsbuild can mark the overall build as failed while sibling compilers are still running, allowing dev middleware requests to proceed too early. This PR defers the fatal state until all child compilers have finished or closed.

## Related Links

https://github.com/web-infra-dev/rspack/issues/15370
https://github.com/web-infra-dev/rsbuild/pull/8361