### PR TITLE
fix(deps): use tilde range for @rspack/core

### DIFF
--- a/.agents/skills/upgrade-rspack/SKILL.md
+++ b/.agents/skills/upgrade-rspack/SKILL.md
@@ -15,8 +15,7 @@ If the version is missing, ask for it before making changes.
 
 1. Check the worktree with `git status --short`. If there are uncommitted edits, stop and ask the user how to proceed.
 
-2. Update the `@rspack/core` entry in the default catalog in
-   `pnpm-workspace.yaml` to `~<version>`, preserving package dependencies as `catalog:`, then run `pnpm update @rspack/core --recursive`.
+2. Update the `@rspack/core` entry in the default catalog in `pnpm-workspace.yaml` to `~<version>`, preserving package dependencies as `catalog:`, then run `pnpm update @rspack/core --recursive`.
 
 3. Run `pnpm i` at the repository root.
 

--- a/.agents/skills/upgrade-rspack/SKILL.md
+++ b/.agents/skills/upgrade-rspack/SKILL.md
@@ -15,7 +15,8 @@ If the version is missing, ask for it before making changes.
 
 1. Check the worktree with `git status --short`. If there are uncommitted edits, stop and ask the user how to proceed.
 
-2. Run `pnpm update @rspack/core@<version> --recursive` to update the dependency across all packages in the workspace.
+2. Update the `@rspack/core` entry in the default catalog in
+   `pnpm-workspace.yaml` to `~<version>`, preserving package dependencies as `catalog:`, then run `pnpm update @rspack/core --recursive`.
 
 3. Run `pnpm i` at the repository root.
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,7 +56,7 @@ catalogs:
       specifier: ^1.6.0
       version: 1.6.0
     '@rspack/core':
-      specifier: 2.2.1
+      specifier: ~2.2.1
       version: 2.2.1
     '@rspack/plugin-preact-refresh':
       specifier: ^2.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,7 +31,7 @@ catalog:
   '@rsbuild/plugin-check-syntax': '^2.0.1'
   '@rsbuild/plugin-rem': '^1.0.6'
   '@rsbuild/plugin-type-check': '^1.6.0'
-  '@rspack/core': '2.2.1'
+  '@rspack/core': '~2.2.1'
   '@rspack/plugin-preact-refresh': '^2.0.1'
   '@rspack/plugin-react-refresh': '^2.0.2'
   '@rspress/core': '^2.0.19'


### PR DESCRIPTION
## Summary

Use a tilde range for `@rspack/core` so compatible patch releases can be adopted through the workspace catalog. Update the Rspack upgrade skill to preserve `catalog:` dependencies when refreshing the lockfile.

## Related Links

https://github.com/web-infra-dev/rspack/releases/tag/v2.2.1