### PR TITLE
perf(plugin-solid): skip transforms for plain JS and TS

### DIFF
--- a/e2e/cases/environments/solid-react-plugins/src/solid/index.js
+++ b/e2e/cases/environments/solid-react-plugins/src/solid/index.js
@@ -3,5 +3,5 @@ import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
-  render(() => <App />, container);
+  render(App, container);
 }

--- a/packages/plugin-solid/src/helpers.ts
+++ b/packages/plugin-solid/src/helpers.ts
@@ -1,0 +1,4 @@
+export const DEFAULT_SOLID_SCRIPT_REGEX: RegExp = /\.(?:jsx|tsx)$/i;
+
+export const isDefaultSolidScript = (filename: string): boolean =>
+  DEFAULT_SOLID_SCRIPT_REGEX.test(filename);

--- a/packages/plugin-solid/src/index.ts
+++ b/packages/plugin-solid/src/index.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import type { RsbuildMode, RsbuildPlugin } from '@rsbuild/core';
+import { DEFAULT_SOLID_SCRIPT_REGEX } from './helpers.js';
 import type { SolidCompiler, SolidPresetOptions } from './types.js';
 
 export type { SolidCompiler, SolidPresetOptions } from './types.js';
@@ -16,8 +17,6 @@ const SOLID_BUILT_INS = [
   'Dynamic',
   'Errored',
 ];
-const SCRIPT_REGEX = /\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/;
-
 export type PluginSolidOptions = {
   /**
    * JSX compiler backend to use.
@@ -146,7 +145,7 @@ export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
               .rule('solid-refresh')
               .after(CHAIN_ID.RULE.JS)
               .enforce('pre')
-              .test(SCRIPT_REGEX)
+              .test(DEFAULT_SOLID_SCRIPT_REGEX)
               .dependency({ not: 'url' })
               .resourceQuery({ not: /[?&]raw(?:&|=|$)/ })
               .with({ type: { not: 'text' } });

--- a/packages/plugin-solid/src/refreshLoader.ts
+++ b/packages/plugin-solid/src/refreshLoader.ts
@@ -1,11 +1,8 @@
 import { transformRefreshAsync } from '@dom-expressions/compiler';
 import type { Rspack } from '@rsbuild/core';
+import { isDefaultSolidScript } from './helpers.js';
 
 const NODE_MODULES_REGEX = /[\\/]node_modules[\\/]/;
-const JS_REGEX = /\.[cm]?js$/;
-
-const getTransformFilename = (filename: string): string =>
-  JS_REGEX.test(filename) ? `${filename}.jsx` : filename;
 
 export type SolidRefreshLoaderOptions = {
   granular?: boolean;
@@ -16,14 +13,17 @@ const solidRefreshLoader: Rspack.LoaderDefinition<SolidRefreshLoaderOptions> =
     const callback = this.async();
     const { granular } = this.getOptions();
 
-    if (NODE_MODULES_REGEX.test(this.resourcePath)) {
+    if (
+      NODE_MODULES_REGEX.test(this.resourcePath) ||
+      !isDefaultSolidScript(this.resourcePath)
+    ) {
       callback(null, source, sourceMap);
       return;
     }
 
     try {
       const result = await transformRefreshAsync(String(source), {
-        filename: getTransformFilename(this.resourcePath),
+        filename: this.resourcePath,
         bundler: 'rspack-esm',
         fixRender: true,
         ...(typeof granular === 'boolean' ? { granular } : {}),

--- a/packages/plugin-solid/src/solidLoader.ts
+++ b/packages/plugin-solid/src/solidLoader.ts
@@ -9,16 +9,12 @@ import {
 } from '@dom-expressions/compiler';
 import remapping from '@jridgewell/remapping';
 import type { Decorators, Rspack } from '@rsbuild/core';
+import { isDefaultSolidScript } from './helpers.js';
 import type { SolidCompiler, SolidPresetOptions } from './types.js';
 
 const require = createRequire(import.meta.url);
 const BABEL_PRESET_SOLID_PATH = require.resolve('babel-preset-solid');
-const JS_REGEX = /\.[cm]?js$/;
-const JSX_REGEX = /\.(?:js|jsx|mjs|cjs|tsx)$/;
-const TS_REGEX = /\.(?:ts|tsx|mts|cts)$/;
-
-const getTransformFilename = (filename: string): string =>
-  JS_REGEX.test(filename) ? `${filename}.jsx` : filename;
+const TSX_REGEX = /\.tsx$/i;
 
 export type SolidLoaderOptions = {
   compiler: SolidCompiler;
@@ -58,14 +54,16 @@ const mergeSourceMaps = (
 const solidLoader: Rspack.LoaderDefinition<SolidLoaderOptions> =
   async function (source, sourceMap): Promise<void> {
     const callback = this.async();
-    const { compiler, decoratorVersion, solid, transformFilename } =
-      this.getOptions();
+    const options = this.getOptions();
     const sourceFilename = this.resourcePath;
-    const filename =
-      transformFilename ??
-      (compiler === 'native'
-        ? getTransformFilename(sourceFilename)
-        : sourceFilename);
+    const filename = options.transformFilename ?? sourceFilename;
+
+    if (!isDefaultSolidScript(filename)) {
+      callback(null, source, sourceMap);
+      return;
+    }
+
+    const { compiler, decoratorVersion, solid } = options;
     const inputSourceMap = normalizeSourceMap(sourceMap);
 
     try {
@@ -76,11 +74,9 @@ const solidLoader: Rspack.LoaderDefinition<SolidLoaderOptions> =
           decoratorVersion === 'legacy' ? 'decorators-legacy' : 'decorators',
         ];
 
-        if (JSX_REGEX.test(filename)) {
-          parserPlugins.push('jsx');
-        }
+        parserPlugins.push('jsx');
 
-        if (TS_REGEX.test(filename)) {
+        if (TSX_REGEX.test(filename)) {
           parserPlugins.push('typescript');
         }
 

--- a/packages/plugin-solid/tests/index.test.ts
+++ b/packages/plugin-solid/tests/index.test.ts
@@ -258,6 +258,25 @@ describe('plugin-solid', () => {
     expect(JSON.stringify(refreshRule)).toContain('"granular":false');
   });
 
+  it('should only apply solid refresh to JSX and TSX by default', async () => {
+    const rsbuild = await createRsbuild({
+      config: {
+        ...rsbuildConfig,
+        plugins: [pluginSolid()],
+      },
+    });
+    const config = await rsbuild.initConfigs();
+    const hasRefreshLoader = (filename: string) =>
+      JSON.stringify(matchRules(config[0], filename)).includes(
+        'refreshLoader.mjs',
+      );
+
+    expect(hasRefreshLoader('a.js')).toBe(false);
+    expect(hasRefreshLoader('a.ts')).toBe(false);
+    expect(hasRefreshLoader('a.jsx')).toBe(true);
+    expect(hasRefreshLoader('a.tsx')).toBe(true);
+  });
+
   it('should use hydratable dom output for ssr option on web target', async () => {
     const rsbuild = await createRsbuild({
       config: {


### PR DESCRIPTION
## Summary

- Align `plugin-solid` with the official Solid Vite plugin by skipping Solid JSX and refresh transforms for plain JavaScript and TypeScript files by default, avoiding unnecessary compiler work.
- A follow-up PR will add an `extensions` option for including additional or custom file extensions in Solid compilation.

## Related Links

- https://github.com/solidjs/solid-vite-plugin/blob/next/src/index.ts#L966-L1002