### PR TITLE
perf(core): use compact hashed IDs in production

### DIFF
--- a/packages/core/src/helpers/version.ts
+++ b/packages/core/src/helpers/version.ts
@@ -1,4 +1,5 @@
-export const rspackMinVersion = '2.0.0';
+// Rspack 2.2.1 is required for `compact-hashed` module and chunk IDs.
+export const rspackMinVersion = '2.2.1';
 
 const compareSemver = (version1: string, version2: string) => {
   const parts1 = version1.split('.').map(Number);

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -8,7 +8,7 @@ export const pluginBasic = (): RsbuildPlugin => ({
 
   setup(api) {
     api.modifyBundlerChain(
-      (chain, { isDev, target, rspack, environment, CHAIN_ID }) => {
+      (chain, { isDev, isProd, target, rspack, environment, CHAIN_ID }) => {
         const { config } = environment;
 
         chain.name(environment.name);
@@ -41,6 +41,12 @@ export const pluginBasic = (): RsbuildPlugin => ({
             typeReexportsPresence: 'tolerant',
           },
         });
+
+        if (isProd) {
+          chain.optimization
+            .chunkIds('compact-hashed')
+            .moduleIds('compact-hashed');
+        }
 
         const usingHMR = isDev && config.dev.hmr && target === 'web';
 

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -1089,6 +1089,7 @@ exports[`should apply default plugins correctly in production 1`] = `
   },
   "name": "web",
   "optimization": {
+    "chunkIds": "compact-hashed",
     "minimize": true,
     "minimizer": [
       SwcJsMinimizerRspackPlugin {
@@ -1123,6 +1124,7 @@ exports[`should apply default plugins correctly in production 1`] = `
         "name": "LightningCssMinimizerRspackPlugin",
       },
     ],
+    "moduleIds": "compact-hashed",
     "splitChunks": {
       "chunks": "all",
     },

--- a/packages/core/tests/configureRspack.test.ts
+++ b/packages/core/tests/configureRspack.test.ts
@@ -56,6 +56,26 @@ describe('configure Rspack', () => {
     expect(config[0].devtool).toEqual('eval');
   });
 
+  it('should allow tools.rspack to override default module and chunk IDs', async () => {
+    const rsbuild = await createRsbuild({
+      config: {
+        mode: 'production',
+        tools: {
+          rspack: {
+            optimization: {
+              chunkIds: 'named',
+              moduleIds: 'named',
+            },
+          },
+        },
+      },
+    });
+
+    const config = await rsbuild.initConfigs();
+    expect(config[0].optimization?.chunkIds).toEqual('named');
+    expect(config[0].optimization?.moduleIds).toEqual('named');
+  });
+
   it('should allow tools.rspack to be an array', async () => {
     const rsbuild = await createRsbuild({
       config: {


### PR DESCRIPTION
## Summary

Production builds can reduce bundle overhead by using Rspack's compact hashed identifiers for modules and chunks.

This PR enables `compact-hashed` module and chunk IDs by default in production while preserving overrides through `tools.rspack`.

## Benchmark

Results for the `react-10k` case in `build-tools-performance`:

| Metric | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Minified size | 5723.329 kB | 5683.005 kB | 40.324 kB (0.705%) |
| Minified + gzip | 1357.803 kB | 1342.670 kB | 15.133 kB (1.115%) |

## Related Links

- Module IDs: https://github.com/web-infra-dev/rspack/pull/14926
- Chunk IDs: https://github.com/web-infra-dev/rspack/pull/14959
- Canonical `compact-hashed` API name: https://github.com/web-infra-dev/rspack/pull/15356