### PR TITLE
chore: enable pnpm global virtual store

### DIFF
--- a/e2e/cases/browser-logs/stack-trace-full-react-error/index.test.ts
+++ b/e2e/cases/browser-logs/stack-trace-full-react-error/index.test.ts
@@ -1,13 +1,15 @@
 import { test } from '@e2e/helper';
 
-// Omitted some parts of the stack trace as they are not static
 const EXPECTED_LOG = `error   [browser] Uncaught ReferenceError: undefinedValue is not defined
-    at App (src/App.jsx:4:0)
-    at Object.react_stack_bottom_frame (../../../../node_modules/.pnpm/react-dom`;
+    at App (src/App.jsx:4:0)`;
+
+const EXPECTED_REACT_STACK_FRAME =
+  / {4}at .+ \((?:[^)\n]*\/)?node_modules\/react-dom\/[^)\n]+:\d+:\d+\)/;
 
 test('should display formatted full stack trace in React component', async ({
   dev,
 }) => {
   const rsbuild = await dev();
   await rsbuild.expectLog(EXPECTED_LOG, { posix: true });
+  await rsbuild.expectLog(EXPECTED_REACT_STACK_FRAME, { posix: true });
 });

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -148,6 +148,8 @@ allowBuilds:
 
 dedupePeers: true
 
+enableGlobalVirtualStore: true
+
 autoInstallPeers: false
 
 peerDependencyRules:

--- a/scripts/config/rstest.setup.ts
+++ b/scripts/config/rstest.setup.ts
@@ -5,7 +5,7 @@ import { createSnapshotSerializer } from 'path-serializer';
 const repoRoot = path.join(__dirname, '../..');
 
 const GLOBAL_VIRTUAL_STORE_PATH =
-  /(?:file:\/{2})?(?:[a-zA-Z]:)?\/(?:[^/"'\r\n]+\/)*store\/v\d+\/links\/.+?\/node_modules(?=\/)/g;
+  /(?:file:\/{2})?(?:[a-zA-Z]:)?\/(?:[^/"'\r\n]+\/)*v\d+\/links\/.+?\/node_modules(?=\/)/g;
 
 process.chdir(repoRoot);
 

--- a/scripts/config/rstest.setup.ts
+++ b/scripts/config/rstest.setup.ts
@@ -20,6 +20,8 @@ expect.addSnapshotSerializer(
     workspace: path.join(__dirname, '..'),
     replace: [
       {
+        // TODO: Remove after path-serializer supports custom store directories.
+        // https://github.com/rstackjs/path-serializer/pull/27
         match: GLOBAL_VIRTUAL_STORE_PATH,
         mark: 'pnpm-inner',
       },

--- a/scripts/config/rstest.setup.ts
+++ b/scripts/config/rstest.setup.ts
@@ -4,6 +4,9 @@ import { createSnapshotSerializer } from 'path-serializer';
 
 const repoRoot = path.join(__dirname, '../..');
 
+const GLOBAL_VIRTUAL_STORE_PATH =
+  /(?:file:\/{2})?(?:[a-zA-Z]:)?\/(?:[^/"'\r\n]+\/)*store\/v\d+\/links\/.+?\/node_modules(?=\/)/g;
+
 process.chdir(repoRoot);
 
 beforeAll((suite) => {
@@ -15,5 +18,11 @@ expect.addSnapshotSerializer(
   createSnapshotSerializer({
     root: repoRoot,
     workspace: path.join(__dirname, '..'),
+    replace: [
+      {
+        match: GLOBAL_VIRTUAL_STORE_PATH,
+        mark: 'pnpm-inner',
+      },
+    ],
   }),
 );


### PR DESCRIPTION
## Summary

Enable pnpm's global virtual store for the workspace so dependency graphs can be reused across projects.

Make the React full-stack e2e assertion validate the logical `react-dom` frame instead of a project-local `.pnpm` path.

Normalize global virtual store paths in the shared Rstest snapshot serializer so CI-specific pnpm store locations remain stable.

## Related Links

https://github.com/rstackjs/path-serializer/pull/27