### PR TITLE
chore: use heading-case as a formatter plugin

### DIFF
--- a/.agents/skills/add-doc-anchor-ids/SKILL.md
+++ b/.agents/skills/add-doc-anchor-ids/SKILL.md
@@ -3,7 +3,7 @@ name: add-doc-anchor-ids
 description: Align Rspress heading anchor IDs between English and Chinese docs. Use for MDX `\{#...}` anchors, shortened hashes, redundant anchors, or dead links.
 ---
 
-# Add Doc Anchor IDs
+# Add doc anchor IDs
 
 Use this skill for Rspress docs mirrored under `website/docs/en` and `website/docs/zh`.
 
@@ -80,7 +80,7 @@ Use this skill for Rspress docs mirrored under `website/docs/en` and `website/do
 
 8. If there is an existing repository command for docs link checking or docs build, run it. Otherwise, inspect changed hashes with `rg` and verify each target heading exists in the target file.
 
-## Rspress Anchor Notes
+## Rspress anchor notes
 
 - Rspress/GitHub-style anchors lowercase headings and remove punctuation such as `.` from API names; verify these IDs instead of guessing.
 - Some characters are preserved by the actual Rspress slugger, such as underscores in `BASE_URL`; avoid guessing when a link already works.

--- a/.agents/skills/docs-en-improvement/SKILL.md
+++ b/.agents/skills/docs-en-improvement/SKILL.md
@@ -3,7 +3,7 @@ name: docs-en-improvement
 description: Improve English documentation under `website/docs/en` by rewriting unnatural translated sentences into clear, professional English while preserving meaning. Use when editing or polishing English docs.
 ---
 
-# Docs En Improvement
+# Docs en improvement
 
 ## Steps
 

--- a/.agents/skills/release-core/SKILL.md
+++ b/.agents/skills/release-core/SKILL.md
@@ -3,7 +3,7 @@ name: release-core
 description: Use when asked to release `@rsbuild/core` for a specific version.
 ---
 
-# Release Core
+# Release core
 
 ## Input
 

--- a/.agents/skills/release-plugin-package/SKILL.md
+++ b/.agents/skills/release-plugin-package/SKILL.md
@@ -3,7 +3,7 @@ name: release-plugin-package
 description: Use when asked to create a release PR for an official Rsbuild plugin package under `packages/plugin-*`, such as `@rsbuild/plugin-react v2.1.0` or `@rsbuild/plugin-sass v2.0.0`.
 ---
 
-# Release Plugin Package
+# Release plugin package
 
 ## Input
 
@@ -146,7 +146,7 @@ To collect changelog items:
 
 11. If running in Codex, create the PR with the GitHub connector/plugin. Otherwise, use the GitHub workflow available in the current environment.
 
-## PR Body
+## PR body
 
 Use the repository PR template. Keep the body concise.
 

--- a/.agents/skills/rsbuild-performance-profiling/SKILL.md
+++ b/.agents/skills/rsbuild-performance-profiling/SKILL.md
@@ -3,7 +3,7 @@ name: rsbuild-performance-profiling
 description: Use when profiling, analyzing, reporting, or optimizing Rsbuild performance, including build, dev server, rebuild, static asset serving, memory usage, and CPU profile analysis.
 ---
 
-# Rsbuild Performance Profiling
+# Rsbuild performance profiling
 
 ## Workflow
 
@@ -31,7 +31,7 @@ description: Use when profiling, analyzing, reporting, or optimizing Rsbuild per
 
 7. Re-run the same benchmark after changes. Report before/after numbers, absolute delta, percentage delta, and any variance or confidence limits you can observe.
 
-## Analysis Rules
+## Analysis rules
 
 - Treat the user's supplied profiles, reports, and benchmark numbers as the source of truth for that task.
 - Do not claim a performance win without comparable before/after measurements.

--- a/.agents/skills/sync-zh-en-docs/SKILL.md
+++ b/.agents/skills/sync-zh-en-docs/SKILL.md
@@ -3,7 +3,7 @@ name: sync-zh-en-docs
 description: Sync uncommitted docs between `website/docs/zh` and `website/docs/en`. Use when authors update docs in one language and need to align the mirrored `.md`/`.mdx` file in the other language.
 ---
 
-# Sync Zh/En Documentation
+# Sync Zh/En documentation
 
 ## Steps
 

--- a/.agents/skills/write-e2e-cases/SKILL.md
+++ b/.agents/skills/write-e2e-cases/SKILL.md
@@ -3,7 +3,7 @@ name: write-e2e-cases
 description: Use when adding or updating Rsbuild end-to-end tests in `e2e/cases`, including new feature coverage, bug reproduction, and regression prevention.
 ---
 
-# Write E2E Cases
+# Write E2E cases
 
 ## Steps
 
@@ -19,7 +19,7 @@ description: Use when adding or updating Rsbuild end-to-end tests in `e2e/cases`
 
 6. Run `pnpm build` once, then run `pnpm e2e` to validate.
 
-## Case Structure
+## Case structure
 
 - Include a `src` directory in every case (required).
 - Prefer putting static Rsbuild configurations in `rsbuild.config.ts` to enable easier debugging via `npx rsbuild`.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 ## Summary
 
-## Related Links
+## Related links
 
 <!--- Provide links of related issues or pages -->

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
   "scripts": {
     "build": "pnpm --workspace-concurrency=10 --filter \"./packages/*\" --filter \"./scripts/*\" run build",
     "check": "rs check --type-check",
-    "check-spell": "pnpx cspell && heading-case",
+    "check-spell": "pnpx cspell",
     "doc": "cd website && node --run dev",
     "e2e": "cd ./e2e && pnpm e2e",
-    "format": "rs fmt && heading-case --write",
+    "format": "rs fmt",
     "lint": "rs lint",
     "prebundle": "pnpm --parallel --filter \"./packages/*\" run prebundle",
     "prepare": "rs hooks && node --run prebundle",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,8 +209,8 @@ catalogs:
       specifier: ^11.4.0
       version: 11.4.0
     heading-case:
-      specifier: ^1.1.8
-      version: 1.1.8
+      specifier: ^2.0.0
+      version: 2.0.0
     hono:
       specifier: ^4.13.5
       version: 4.13.5
@@ -398,7 +398,7 @@ importers:
         version: 0.0.4
       heading-case:
         specifier: 'catalog:'
-        version: 1.1.8
+        version: 2.0.0(prettier@3.9.6)
       rstack:
         specifier: 'catalog:'
         version: 0.6.5(@module-federation/runtime-tools@2.9.0)(@rspress/core@2.0.21)(core-js@3.50.0)(jiti@2.7.0)(typescript@6.0.3)
@@ -3893,9 +3893,11 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
-  heading-case@1.1.8:
-    resolution: {integrity: sha512-zGhfkYlKqTbkXyu6RluO4DFyD3fEGHOMl/16UZcXX315drkUa/sg8vlvQXm3trqpnoj8LhPsYCrg5R6oP9mtyQ==}
+  heading-case@2.0.0:
+    resolution: {integrity: sha512-yznMB5NlBOlCqGL68oRa9gvA8vINQB56D1rTQwCRNoh2aLjtEAK4UKYD5mZ4rXJ0GCuyRmzGCgP1/3To1Mj/vA==}
     hasBin: true
+    peerDependencies:
+      prettier: ^3.0.0
 
   hono@4.13.5:
     resolution: {integrity: sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==}
@@ -6495,7 +6497,6 @@ snapshots:
       core-js: 3.50.0
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
-    optional: true
 
   '@rsbuild/plugin-check-syntax@2.0.1(@rsbuild/core@packages+core)':
     dependencies:
@@ -6506,12 +6507,12 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': link:packages/core
 
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.0)(@rspack/core@2.2.1)':
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)':
     dependencies:
       '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.2.1)(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.2.0(@module-federation/runtime-tools@2.9.0)(core-js@3.50.0)
+      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)(core-js@3.50.0)
     transitivePeerDependencies:
       - '@rspack/core'
 
@@ -6741,8 +6742,8 @@ snapshots:
     dependencies:
       '@mdx-js/mdx': 3.1.1(supports-color@8.1.1)
       '@mdx-js/react': 3.1.1(@types/react@19.2.18)(react@19.2.8)
-      '@rsbuild/core': 2.2.0(@module-federation/runtime-tools@2.9.0)(core-js@3.50.0)
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.2.0)(@rspack/core@2.2.1)
+      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)(core-js@3.50.0)
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)
       '@rspress/shared': 2.0.21(@module-federation/runtime-tools@2.9.0)(core-js@3.50.0)(supports-color@8.1.1)
       '@shikijs/rehype': 4.3.0
       '@types/mdast': 4.0.4
@@ -6813,7 +6814,7 @@ snapshots:
 
   '@rspress/shared@2.0.21(@module-federation/runtime-tools@2.9.0)(core-js@3.50.0)(supports-color@8.1.1)':
     dependencies:
-      '@rsbuild/core': 2.2.0(@module-federation/runtime-tools@2.9.0)(core-js@3.50.0)
+      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)(core-js@3.50.0)
       '@shikijs/rehype': 4.3.0
       '@types/react': 19.2.18
       mdast-util-mdx-jsx: 3.2.0(supports-color@8.1.1)
@@ -8017,7 +8018,9 @@ snapshots:
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
 
-  heading-case@1.1.8: {}
+  heading-case@2.0.0(prettier@3.9.6):
+    dependencies:
+      prettier: 3.9.6
 
   hono@4.13.5: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -83,7 +83,7 @@ catalog:
   'fast-glob': '^3.3.3'
   'fresh-import': '^0.2.1'
   'fs-extra': '^11.4.0'
-  'heading-case': '^1.1.8'
+  'heading-case': '^2.0.0'
   'hono': '^4.13.5'
   'html-loader': '^5.1.0'
   'html-rspack-plugin': '6.1.9'
@@ -183,8 +183,6 @@ minimumReleaseAgeExclude:
   - 'rsbuild-plugin-*'
   - '@swc/*'
   - 'heading-case'
-  # Renovate security update: hono@4.12.34
-  - hono@4.12.34
 
 patchedDependencies:
   css-loader@7.1.5: patches/css-loader@7.1.5.patch

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -10,7 +10,14 @@ define.fmt({
     'e2e/cases/syntax-es/using-declaration/src/index.ts',
     // Preserve uppercase DOCTYPE in create-rsbuild templates.
     'packages/create-rsbuild/**/*.html',
+    // Installed Skills
+    '.agents/skills/rstack-cli-docs',
+    '.agents/skills/rspress-description-generator',
+    '.agents/skills/release-blog-writer',
+    '.agents/skills/pr-creator',
+    '.agents/skills/create-draft-release-notes',
   ],
+  plugins: ['heading-case'],
 });
 
 define.staged({


### PR DESCRIPTION
## Summary

This PR upgrades `heading-case` to v2 and integrates it as an `rs fmt` plugin, keeping heading normalization within the repository's standard formatting workflow.

It removes the standalone `heading-case` invocations and updates existing skill and pull request template headings to the new output.

## Related links

- https://github.com/rstackjs/heading-case/releases/tag/v2.0.0