### PR TITLE
chore: ignore installed skills dynamically

### DIFF
--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -12,9 +12,7 @@ define.fmt({
     // Preserve uppercase DOCTYPE in create-rsbuild templates.
     'packages/create-rsbuild/**/*.html',
     // Ignore installed Skills because their formatting may differ from this repository.
-    ...Object.keys(skillsLock.skills).map(
-      (name) => `.agents/skills/${name}/**`,
-    ),
+    ...Object.keys(skillsLock.skills).map((name) => `.agents/skills/${name}`),
   ],
   plugins: ['heading-case'],
 });

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -1,23 +1,27 @@
 import { define } from 'rstack';
 
-define.fmt({
-  singleQuote: true,
-  sortPackageJson: true,
-  ignorePatterns: [
-    // Avoid parser errors in intentionally invalid or unsupported fixtures.
-    'e2e/cases/plugin-less/inline-js/src/*.less',
-    'e2e/cases/browser-logs/skip-build-error/src/**',
-    'e2e/cases/syntax-es/using-declaration/src/index.ts',
-    // Preserve uppercase DOCTYPE in create-rsbuild templates.
-    'packages/create-rsbuild/**/*.html',
-    // Installed Skills
-    '.agents/skills/rstack-cli-docs',
-    '.agents/skills/rspress-description-generator',
-    '.agents/skills/release-blog-writer',
-    '.agents/skills/pr-creator',
-    '.agents/skills/create-draft-release-notes',
-  ],
-  plugins: ['heading-case'],
+define.fmt(async () => {
+  const { default: skillsLock } = await import('./skills-lock.json', {
+    with: { type: 'json' },
+  });
+
+  return {
+    singleQuote: true,
+    sortPackageJson: true,
+    ignorePatterns: [
+      // Avoid parser errors in intentionally invalid or unsupported fixtures.
+      'e2e/cases/plugin-less/inline-js/src/*.less',
+      'e2e/cases/browser-logs/skip-build-error/src/**',
+      'e2e/cases/syntax-es/using-declaration/src/index.ts',
+      // Preserve uppercase DOCTYPE in create-rsbuild templates.
+      'packages/create-rsbuild/**/*.html',
+      // Ignore installed Skills because their formatting may differ from this repository.
+      ...Object.keys(skillsLock.skills).map(
+        (name) => `.agents/skills/${name}/**`,
+      ),
+    ],
+    plugins: ['heading-case'],
+  };
 });
 
 define.staged({

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -1,27 +1,22 @@
 import { define } from 'rstack';
+import skillsLock from './skills-lock.json' with { type: 'json' };
 
-define.fmt(async () => {
-  const { default: skillsLock } = await import('./skills-lock.json', {
-    with: { type: 'json' },
-  });
-
-  return {
-    singleQuote: true,
-    sortPackageJson: true,
-    ignorePatterns: [
-      // Avoid parser errors in intentionally invalid or unsupported fixtures.
-      'e2e/cases/plugin-less/inline-js/src/*.less',
-      'e2e/cases/browser-logs/skip-build-error/src/**',
-      'e2e/cases/syntax-es/using-declaration/src/index.ts',
-      // Preserve uppercase DOCTYPE in create-rsbuild templates.
-      'packages/create-rsbuild/**/*.html',
-      // Ignore installed Skills because their formatting may differ from this repository.
-      ...Object.keys(skillsLock.skills).map(
-        (name) => `.agents/skills/${name}/**`,
-      ),
-    ],
-    plugins: ['heading-case'],
-  };
+define.fmt({
+  singleQuote: true,
+  sortPackageJson: true,
+  ignorePatterns: [
+    // Avoid parser errors in intentionally invalid or unsupported fixtures.
+    'e2e/cases/plugin-less/inline-js/src/*.less',
+    'e2e/cases/browser-logs/skip-build-error/src/**',
+    'e2e/cases/syntax-es/using-declaration/src/index.ts',
+    // Preserve uppercase DOCTYPE in create-rsbuild templates.
+    'packages/create-rsbuild/**/*.html',
+    // Ignore installed Skills because their formatting may differ from this repository.
+    ...Object.keys(skillsLock.skills).map(
+      (name) => `.agents/skills/${name}/**`,
+    ),
+  ],
+  plugins: ['heading-case'],
 });
 
 define.staged({


### PR DESCRIPTION
## Summary

Installed Skills can use formatting conventions that differ from this repository, so applying `rs fmt` may rewrite externally managed files.

This PR statically imports `skills-lock.json` and derives the corresponding Skill ignore patterns inline, while continuing to format repository-owned Skills.

## Related links

- https://github.com/web-infra-dev/rsbuild/pull/8398