### PR TITLE
chore(deps): upgrade path-serializer to 0.7.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,8 +254,8 @@ catalogs:
       specifier: ^11.0.2
       version: 11.0.2
     path-serializer:
-      specifier: 0.6.0
-      version: 0.6.0
+      specifier: 0.7.0
+      version: 0.7.0
     playwright:
       specifier: 1.61.1
       version: 1.61.1
@@ -1339,7 +1339,7 @@ importers:
         version: 24.13.3
       path-serializer:
         specifier: 'catalog:'
-        version: 0.6.0
+        version: 0.7.0
       rstack:
         specifier: 'catalog:'
         version: 0.6.5(@module-federation/runtime-tools@2.9.0)(@rspress/core@2.0.21)(core-js@3.50.0)(jiti@2.7.0)(typescript@6.0.3)
@@ -4579,8 +4579,8 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
-  path-serializer@0.6.0:
-    resolution: {integrity: sha512-LlnjpuCARGnJ4X3IirMg0qozvqyTQHmM5ZqUDYmz+yanhjHSP5BqpmgHkOjiFHad9+bYNW9f5ECXv1tUyw2B9A==}
+  path-serializer@0.7.0:
+    resolution: {integrity: sha512-QlO3NuhGp1ZjOojCEfe2x6dZ+OOw70ugmjwvETPlWrsllhZouPNRQAKXNs9zTA1CnKVWTtBA5n6V6xtbA9Me5A==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -8963,7 +8963,7 @@ snapshots:
 
   path-key@3.1.1: {}
 
-  path-serializer@0.6.0: {}
+  path-serializer@0.7.0: {}
 
   path-type@4.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -166,7 +166,6 @@ hoistPattern: []
 # Reduce the risk of installing compromised packages
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
-  - 'path-serializer@0.7.0'
   - '@rspack/*'
   - 'rspack-chain'
   - '@rsbuild/*'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -166,6 +166,7 @@ hoistPattern: []
 # Reduce the risk of installing compromised packages
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
+  - 'path-serializer@0.7.0'
   - '@rspack/*'
   - 'rspack-chain'
   - '@rsbuild/*'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -98,7 +98,7 @@ catalog:
   'mrmime': '^2.0.1'
   'on-finished': '2.4.1'
   'open': '^11.0.2'
-  'path-serializer': '0.6.0'
+  'path-serializer': '0.7.0'
   'playwright': '1.61.1'
   'postcss': '^8.5.26'
   'postcss-load-config': '6.0.1'
@@ -166,6 +166,7 @@ hoistPattern: []
 # Reduce the risk of installing compromised packages
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
+  - 'path-serializer@0.7.0'
   - '@rspack/*'
   - 'rspack-chain'
   - '@rsbuild/*'

--- a/scripts/config/rstest.setup.ts
+++ b/scripts/config/rstest.setup.ts
@@ -4,9 +4,6 @@ import { createSnapshotSerializer } from 'path-serializer';
 
 const repoRoot = path.join(__dirname, '../..');
 
-const GLOBAL_VIRTUAL_STORE_PATH =
-  /(?:file:\/{2})?(?:[a-zA-Z]:)?\/(?:[^/"'\r\n]+\/)*v\d+\/links\/.+?\/node_modules(?=\/)/g;
-
 process.chdir(repoRoot);
 
 beforeAll((suite) => {
@@ -18,13 +15,5 @@ expect.addSnapshotSerializer(
   createSnapshotSerializer({
     root: repoRoot,
     workspace: path.join(__dirname, '..'),
-    replace: [
-      {
-        // TODO: Remove after path-serializer supports custom store directories.
-        // https://github.com/rstackjs/path-serializer/pull/27
-        match: GLOBAL_VIRTUAL_STORE_PATH,
-        mark: 'pnpm-inner',
-      },
-    ],
   }),
 );


### PR DESCRIPTION
## Summary

path-serializer 0.7.0 supports custom pnpm global store paths, so the snapshot workaround from #8395 is no longer needed.

Upgrade to 0.7.0 and remove the custom path replacement. Exempt only `path-serializer@0.7.0` from the minimum release age so installation and CI can use the newly published version.

## Related links

https://github.com/web-infra-dev/rsbuild/pull/8395
https://github.com/rstackjs/path-serializer/releases/tag/v0.7.0