### PR TITLE
docs: fix use of deprecated module in rspack.mdx

### DIFF
--- a/website/docs/en/guide/configuration/rspack.mdx
+++ b/website/docs/en/guide/configuration/rspack.mdx
@@ -29,7 +29,7 @@ export default {
   tools: {
     rspack: {
       plugins: [
-        new rspack.CircularDependencyRspackPlugin({
+        new rspack.CircularCheckRspackPlugin({
           // options
         }),
       ],


### PR DESCRIPTION
## Summary

From the Rspack docs: "CircularDependencyRspackPlugin is deprecated. Use CircularCheckRspackPlugin, which has better performance and a more reasonable API design."

## Related links

* https://rspack.rs/plugins/circular-dependency-rspack-plugin (deprecated)
* https://rspack.rs/plugins/circular-check-rspack-plugin
