### PR TITLE
docs: fix deprecated plugin in zh rspack guide

### DIFF
--- a/website/docs/zh/guide/configuration/rspack.mdx
+++ b/website/docs/zh/guide/configuration/rspack.mdx
@@ -29,7 +29,7 @@ export default {
   tools: {
     rspack: {
       plugins: [
-        new rspack.CircularDependencyRspackPlugin({
+        new rspack.CircularCheckRspackPlugin({
           // options
         }),
       ],


### PR DESCRIPTION
## Summary

This PR updates the Chinese Rspack configuration guide to use `CircularCheckRspackPlugin`, matching #8403 and avoiding the deprecated `CircularDependencyRspackPlugin`.

## Related links

- https://github.com/web-infra-dev/rsbuild/pull/8403