### PR TITLE
fix(core): revert compact hashed IDs in production

### DIFF
--- a/packages/core/src/helpers/version.ts
+++ b/packages/core/src/helpers/version.ts
@@ -1,5 +1,4 @@
-// Rspack 2.2.1 is required for `compact-hashed` module and chunk IDs.
-export const rspackMinVersion = '2.2.1';
+export const rspackMinVersion = '2.0.0';
 
 const compareSemver = (version1: string, version2: string) => {
   const parts1 = version1.split('.').map(Number);

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -8,7 +8,7 @@ export const pluginBasic = (): RsbuildPlugin => ({
 
   setup(api) {
     api.modifyBundlerChain(
-      (chain, { isDev, isProd, target, rspack, environment, CHAIN_ID }) => {
+      (chain, { isDev, target, rspack, environment, CHAIN_ID }) => {
         const { config } = environment;
 
         chain.name(environment.name);
@@ -41,12 +41,6 @@ export const pluginBasic = (): RsbuildPlugin => ({
             typeReexportsPresence: 'tolerant',
           },
         });
-
-        if (isProd) {
-          chain.optimization
-            .chunkIds('compact-hashed')
-            .moduleIds('compact-hashed');
-        }
 
         const usingHMR = isDev && config.dev.hmr && target === 'web';
 

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -1089,7 +1089,6 @@ exports[`should apply default plugins correctly in production 1`] = `
   },
   "name": "web",
   "optimization": {
-    "chunkIds": "compact-hashed",
     "minimize": true,
     "minimizer": [
       SwcJsMinimizerRspackPlugin {
@@ -1124,7 +1123,6 @@ exports[`should apply default plugins correctly in production 1`] = `
         "name": "LightningCssMinimizerRspackPlugin",
       },
     ],
-    "moduleIds": "compact-hashed",
     "splitChunks": {
       "chunks": "all",
     },

--- a/packages/core/tests/configureRspack.test.ts
+++ b/packages/core/tests/configureRspack.test.ts
@@ -56,26 +56,6 @@ describe('configure Rspack', () => {
     expect(config[0].devtool).toEqual('eval');
   });
 
-  it('should allow tools.rspack to override default module and chunk IDs', async () => {
-    const rsbuild = await createRsbuild({
-      config: {
-        mode: 'production',
-        tools: {
-          rspack: {
-            optimization: {
-              chunkIds: 'named',
-              moduleIds: 'named',
-            },
-          },
-        },
-      },
-    });
-
-    const config = await rsbuild.initConfigs();
-    expect(config[0].optimization?.chunkIds).toEqual('named');
-    expect(config[0].optimization?.moduleIds).toEqual('named');
-  });
-
   it('should allow tools.rspack to be an array', async () => {
     const rsbuild = await createRsbuild({
       config: {


### PR DESCRIPTION
## Summary

Rstest ecosystem CI started panicking after Rsbuild switched production module and chunk IDs to `compact-hashed`: `Unable to assign a unique compact-hashed id ... after using all 13 hash characters`.

Modern modules can create more than 13 anonymous chunks with no modules, causing identical compact hashes and exhausting the 13-character collision chain. This PR reverts #8394 and restores the previous production ID defaults and Rspack minimum version until the collision can be handled safely.

## Related links

- https://github.com/web-infra-dev/rsbuild/pull/8394