### PR TITLE
docs: update Rspack documentation links

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -25,7 +25,7 @@ Rsbuild 具备以下特性：
 
 - **易于配置**：Rsbuild 的目标之一，是为 Rspack 用户提供开箱即用的构建能力，使开发者能够在零配置的情况下开发 web 项目。同时，Rsbuild 提供一套语义化的构建配置，以降低 Rspack 配置的学习成本。
 
-- **性能优先**：Rsbuild 集成了社区中基于 Rust 的高性能工具，包括 [Rspack](https://rspack.rs)，[SWC](https://swc.rs/) 和 [Lightning CSS](https://lightningcss.dev/)，以提供一流的构建速度和开发体验。
+- **性能优先**：Rsbuild 集成了社区中基于 Rust 的高性能工具，包括 [Rspack](https://rspack.rs/zh/)，[SWC](https://swc.rs/) 和 [Lightning CSS](https://lightningcss.dev/)，以提供一流的构建速度和开发体验。
 
 - **插件生态**：Rsbuild 内置一个轻量级的插件系统，提供一系列高质量的官方插件。此外，Rsbuild 兼容大部分的 webpack 插件和所有的 Rspack 插件，这意味着你可以在 Rsbuild 中使用社区或公司内沉淀的现有插件，而无须重写相关代码。
 

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -195,7 +195,7 @@ export interface ToolsConfig {
    */
   lightningcssLoader?: boolean | ConfigChain<Rspack.LightningcssLoaderOptions>;
   /**
-   * Modify the options of [CssExtractRspackPlugin](https://rspack.rs/plugins/rspack/css-extract-rspack-plugin).
+   * Modify the options of [CssExtractRspackPlugin](https://rspack.rs/plugins/css-extract-rspack-plugin).
    */
   cssExtract?: CSSExtractOptions;
   /**

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -365,7 +365,7 @@ export type TransformDescriptor = {
   /**
    * If raw is `true`, the transform handler will receive the Buffer type code
    * instead of the string type.
-   * @see https://rspack.rs/api/loader-api/examples#raw-loader
+   * @see https://rspack.rs/api/loader-api/writing-loaders#raw-loader
    */
   raw?: boolean;
   /**

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -42,7 +42,7 @@ export type PluginReactOptions = {
    * Enable or configure React Compiler via `builtin:swc-loader`,
    * the same as Rspack's `jsc.transform.reactCompiler` option.
    *
-   * @see https://rspack.rs/guide/tech/react#using-builtinswc-loader
+   * @see https://rspack.rs/guide/integrations/react#using-builtinswc-loader
    */
   reactCompiler?: Rspack.SwcLoaderTransformConfig['reactCompiler'];
   /**
@@ -64,7 +64,7 @@ export type PluginReactOptions = {
    *   exclude: [/[\\/]node_modules[\\/]/],
    *   resourceQuery: { not: /^\?raw$/ },
    * }
-   * @see https://rspack.rs/guide/tech/react#rspackplugin-react-refresh
+   * @see https://rspack.rs/guide/integrations/react#fast-refresh
    */
   reactRefreshOptions?: ReactRefreshOptions;
   /**

--- a/website/docs/en/blog/v0-7.mdx
+++ b/website/docs/en/blog/v0-7.mdx
@@ -75,7 +75,7 @@ Rsbuild has also enabled the latest sass-loader's [modern-compiler](https://gith
 
 ## Better CSS supports
 
-Rsbuild now uses [CssExtractRspackPlugin](https://rspack.rs/plugins/rspack/css-extract-rspack-plugin) to extract CSS into separate files, rather than using the [experimental.css](https://v0.rspack.rs/config/experiments#experimentscss) config to do so.
+Rsbuild now uses [CssExtractRspackPlugin](https://rspack.rs/plugins/css-extract-rspack-plugin) to extract CSS into separate files, rather than using the [experimental.css](https://v0.rspack.rs/config/experiments#experimentscss) config to do so.
 
 This allows Rsbuild to support more CSS features, including:
 

--- a/website/docs/en/config/dev/lazy-compilation.mdx
+++ b/website/docs/en/config/dev/lazy-compilation.mdx
@@ -47,7 +47,7 @@ const defaultOptions = {
 };
 ```
 
-Enable lazy compilation (compilation on demand), implemented based on Rspack's [lazy compilation](https://rspack.rs/guide/features/lazy-compilation) feature.
+Enable lazy compilation (compilation on demand), implemented based on Rspack's [lazy compilation](https://rspack.rs/guide/advanced/lazy-compilation) feature.
 
 ## Introduction
 
@@ -140,7 +140,7 @@ When the `imports` option is enabled, all async modules will only be compiled wh
 
 ### Server URL
 
-Use [lazyCompilation.serverUrl](https://rspack.rs/config/lazy-compilation#lazycompilationserverurl) to tell the client the server URL that needs to be requested.
+Use [lazyCompilation.serverUrl](https://rspack.rs/config/lazy-compilation#serverurl) to tell the client the server URL that needs to be requested.
 
 If `lazyCompilation.serverUrl` is not explicitly configured, Rsbuild derives the default `serverUrl` from [dev.client](/config/dev/client) when both of the following conditions are met:
 

--- a/website/docs/en/config/mode.mdx
+++ b/website/docs/en/config/mode.mdx
@@ -50,7 +50,7 @@ When using the Rsbuild JavaScript API:
 
 If `mode` is `development`:
 
-- Enable HMR and register the [HotModuleReplacementPlugin](https://rspack.rs/plugins/webpack/hot-module-replacement-plugin).
+- Enable HMR and register the [HotModuleReplacementPlugin](https://rspack.rs/plugins/hot-module-replacement-plugin).
 - Generate JavaScript source maps, but do not generate CSS source maps. See [output.sourceMap](/config/output/source-map) for details.
 - The `process.env.NODE_ENV` in the source code will be replaced with `'development'`.
 - The `import.meta.env.MODE` in the source code will be replaced with `'development'`.
@@ -62,8 +62,8 @@ If `mode` is `development`:
 
 If `mode` is `production`:
 
-- Enable JavaScript code minification and register the [SwcJsMinimizerRspackPlugin](https://rspack.rs/plugins/rspack/swc-js-minimizer-rspack-plugin).
-- Enable CSS code minification and register the [LightningCssMinimizerRspackPlugin](https://rspack.rs/plugins/rspack/lightning-css-minimizer-rspack-plugin).
+- Enable JavaScript code minification and register the [SwcJsMinimizerRspackPlugin](https://rspack.rs/plugins/swc-js-minimizer-rspack-plugin).
+- Enable CSS code minification and register the [LightningCssMinimizerRspackPlugin](https://rspack.rs/plugins/lightning-css-minimizer-rspack-plugin).
 - JavaScript and CSS filenames include hash suffixes. See [output.filenameHash](/config/output/filename-hash).
 - CSS Modules class names are shorter. See [cssModules.localIdentName](/config/output/css-modules#cssmoduleslocalidentname).
 - JavaScript and CSS source maps are disabled. See [output.sourceMap](/config/output/source-map).

--- a/website/docs/en/config/module-federation/options.mdx
+++ b/website/docs/en/config/module-federation/options.mdx
@@ -6,7 +6,7 @@ import { PackageManagerTabs } from '@theme';
 
 # moduleFederation.options
 
-- **Type:** [Rspack.ModuleFederationPluginOptions](https://rspack.rs/plugins/webpack/module-federation-plugin#options)
+- **Type:** [Rspack.ModuleFederationPluginOptions](https://rspack.rs/plugins/module-federation-plugin#options)
 - **Default:** `undefined`
 
 Used to configure the Rspack's Module Federation plugin (Module Federation v1.5).
@@ -21,7 +21,7 @@ When using Module Federation, it is recommended that you use the `moduleFederati
 
 When you set the `moduleFederation.options` option, Rsbuild will take the following actions:
 
-- Automatically register the [ModuleFederationPlugin](https://rspack.rs/plugins/webpack/module-federation-plugin) plugin, and pass the value of `options` to the plugin.
+- Automatically register the [ModuleFederationPlugin](https://rspack.rs/plugins/module-federation-plugin) plugin, and pass the value of `options` to the plugin.
 - Set the default value of the provider's [dev.assetPrefix](/config/dev/asset-prefix) configuration to `true`. This will ensure that the static asset URL is correct for remote modules.
 - Set the default value of Rspack's [output.uniqueName](https://rspack.rs/config/output#outputuniquename) configuration to `moduleFederation.options.name`, this allows HMR to work as expected.
 
@@ -44,7 +44,7 @@ This option depends on the runtime package [@module-federation/runtime-tools](ht
 
 <PackageManagerTabs command="add @module-federation/runtime-tools" />
 
-> Refer to the [ModuleFederationPlugin](https://rspack.rs/plugins/webpack/module-federation-plugin) document for all available options.
+> Refer to the [ModuleFederationPlugin](https://rspack.rs/plugins/module-federation-plugin) document for all available options.
 
 ## Example
 

--- a/website/docs/en/config/output/copy.mdx
+++ b/website/docs/en/config/output/copy.mdx
@@ -7,9 +7,9 @@ description: 'Copies the specified file or directory to the dist directory, impl
 - **Type:** `Rspack.CopyRspackPluginOptions | Rspack.CopyRspackPluginOptions['patterns']`
 - **Default:** `undefined`
 
-Copies the specified file or directory to the dist directory, implemented based on [rspack.CopyRspackPlugin](https://rspack.rs/plugins/rspack/copy-rspack-plugin).
+Copies the specified file or directory to the dist directory, implemented based on [rspack.CopyRspackPlugin](https://rspack.rs/plugins/copy-rspack-plugin).
 
-> Please refer to the configuration options here: [rspack.CopyRspackPlugin](https://rspack.rs/plugins/rspack/copy-rspack-plugin).
+> Please refer to the configuration options here: [rspack.CopyRspackPlugin](https://rspack.rs/plugins/copy-rspack-plugin).
 
 ## Example
 

--- a/website/docs/en/config/output/minify.mdx
+++ b/website/docs/en/config/output/minify.mdx
@@ -107,7 +107,7 @@ export default {
 - **Type:** `SwcJsMinimizerRspackPluginOptions | SwcJsMinimizerRspackPluginOptions[]`
 - **Default:** `{}`
 
-`output.minify.jsOptions` configures SWC's minification options. See [SwcJsMinimizerRspackPlugin](https://rspack.rs/plugins/rspack/swc-js-minimizer-rspack-plugin) for detailed configuration options.
+`output.minify.jsOptions` configures SWC's minification options. See [SwcJsMinimizerRspackPlugin](https://rspack.rs/plugins/swc-js-minimizer-rspack-plugin) for detailed configuration options.
 
 For example, disable the mangle feature:
 
@@ -194,7 +194,7 @@ export default {
 - **Type:** `LightningCssMinimizerRspackPluginOptions | LightningCssMinimizerRspackPluginOptions[]`
 - **Default:** inherit from [tools.lightningcssLoader](/config/tools/lightningcss-loader)
 
-`output.minify.cssOptions` configures Lightning CSS's minification options. See [LightningCssMinimizerRspackPlugin Documentation](https://rspack.rs/plugins/rspack/lightning-css-minimizer-rspack-plugin) for detailed configuration options.
+`output.minify.cssOptions` configures Lightning CSS's minification options. See [LightningCssMinimizerRspackPlugin Documentation](https://rspack.rs/plugins/lightning-css-minimizer-rspack-plugin) for detailed configuration options.
 
 For example, disable error recovery:
 

--- a/website/docs/en/config/performance/build-cache.mdx
+++ b/website/docs/en/config/performance/build-cache.mdx
@@ -93,7 +93,7 @@ export default defineConfig({
 
 `buildDependencies` is an array of additional code dependencies for the build. Rspack will use a hash of each of these items and all dependencies to invalidate the filesystem cache.
 
-Equivalent to Rspack's [cache.buildDependencies](https://rspack.rs/config/cache#cachebuilddependencies) option.
+Equivalent to Rspack's [cache.buildDependencies](https://rspack.rs/config/cache#builddependencies) option.
 
 #### Default value
 

--- a/website/docs/en/config/security/sri.mdx
+++ b/website/docs/en/config/security/sri.mdx
@@ -19,7 +19,7 @@ type SriOptions = {
 
 Adds an `integrity` attribute to `<script>` and `<link>` tags injected into HTML so the browser can verify the resource's integrity and prevent tampering.
 
-> `security.sri` is implemented based on Rspack's [SubresourceIntegrityPlugin](https://rspack.rs/plugins/rspack/subresource-integrity-plugin)
+> `security.sri` is implemented based on Rspack's [SubresourceIntegrityPlugin](https://rspack.rs/plugins/subresource-integrity-plugin)
 
 ## What is SRI
 

--- a/website/docs/en/config/source/define.mdx
+++ b/website/docs/en/config/source/define.mdx
@@ -16,7 +16,7 @@ Each configuration key represents an identifier or multiple identifiers joined w
 - Object values define all keys the same way.
 - Keys prefixed with `typeof` are only defined for typeof calls.
 
-> For more usage, see [Using define](/guide/advanced/env-vars#using-define) and [Rspack - DefinePlugin](https://rspack.rs/plugins/webpack/define-plugin).
+> For more usage, see [Using define](/guide/advanced/env-vars#using-define) and [Rspack - DefinePlugin](https://rspack.rs/plugins/define-plugin).
 
 ## Example
 

--- a/website/docs/en/config/source/exclude.mdx
+++ b/website/docs/en/config/source/exclude.mdx
@@ -48,7 +48,7 @@ export default {
 
 `source.exclude` specifies JavaScript/TypeScript files that do not need to be compiled. These files will not be transformed by SWC, but referenced files will still be bundled into the outputs.
 
-If you want certain files to be excluded and not bundled into the outputs, you can use Rspack's [IgnorePlugin](https://rspack.rs/plugins/webpack/ignore-plugin).
+If you want certain files to be excluded and not bundled into the outputs, you can use Rspack's [IgnorePlugin](https://rspack.rs/plugins/ignore-plugin).
 
 ```ts title="rsbuild.config.ts"
 export default {

--- a/website/docs/en/config/split-chunks.mdx
+++ b/website/docs/en/config/split-chunks.mdx
@@ -18,7 +18,7 @@ type SplitChunksConfig =
 
 `splitChunks` is used to configure Rsbuild's chunk splitting strategy.
 
-It is built on top of Rspack's [optimization.splitChunks](https://rspack.rs/plugins/webpack/split-chunks-plugin) and extends it with an additional `preset` option, which provides several Rsbuild-specific presets for common use cases.
+It is built on top of Rspack's [optimization.splitChunks](https://rspack.rs/plugins/split-chunks-plugin) and extends it with an additional `preset` option, which provides several Rsbuild-specific presets for common use cases.
 
 ## Default behavior
 
@@ -28,7 +28,7 @@ The default value of `splitChunks` depends on [output.target](/config/output/tar
 
 - **Default:** `{ preset: 'default', chunks: 'all' }`
 
-For web builds, Rsbuild sets `chunks` to `'all'`. Unspecified options such as `minSize` and `minChunks` use the defaults from Rspack's [`optimization.splitChunks`](https://rspack.rs/plugins/webpack/split-chunks-plugin).
+For web builds, Rsbuild sets `chunks` to `'all'`. Unspecified options such as `minSize` and `minChunks` use the defaults from Rspack's [`optimization.splitChunks`](https://rspack.rs/plugins/split-chunks-plugin).
 
 :::tip
 When a project acts as a Module Federation provider and configures [`moduleFederation.options.exposes`](/config/module-federation/options), Rsbuild sets `chunks` to `'async'` to prevent chunk splitting from affecting the remote entry.
@@ -111,7 +111,7 @@ export default {
 
 ## Other options
 
-Apart from the `preset` option, all other options behave the same as in Rspack. For detailed usage, see the [Rspack documentation](https://rspack.rs/plugins/webpack/split-chunks-plugin).
+Apart from the `preset` option, all other options behave the same as in Rspack. For detailed usage, see the [Rspack documentation](https://rspack.rs/plugins/split-chunks-plugin).
 
 ```ts title="rsbuild.config.ts"
 export default {

--- a/website/docs/en/config/tools/bundler-chain.mdx
+++ b/website/docs/en/config/tools/bundler-chain.mdx
@@ -283,7 +283,7 @@ See [Custom plugin](/guide/configuration/rspack#custom-plugin) for more details.
 
 `MINIMIZER.[ID]` can match a certain minimizer.
 
-| ID              | Description                                                                                                               |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `MINIMIZER.JS`  | correspond to [SwcJsMinimizerRspackPlugin](https://rspack.rs/plugins/rspack/swc-js-minimizer-rspack-plugin)               |
-| `MINIMIZER.CSS` | correspond to [LightningCssMinimizerRspackPlugin](https://rspack.rs/plugins/rspack/lightning-css-minimizer-rspack-plugin) |
+| ID              | Description                                                                                                        |
+| --------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `MINIMIZER.JS`  | correspond to [SwcJsMinimizerRspackPlugin](https://rspack.rs/plugins/swc-js-minimizer-rspack-plugin)               |
+| `MINIMIZER.CSS` | correspond to [LightningCssMinimizerRspackPlugin](https://rspack.rs/plugins/lightning-css-minimizer-rspack-plugin) |

--- a/website/docs/en/config/tools/css-extract.mdx
+++ b/website/docs/en/config/tools/css-extract.mdx
@@ -34,7 +34,7 @@ const defaultOptions = {
 
 Rsbuild uses the CssExtractRspackPlugin plugin by default to extract CSS into separate files.
 
-The options for [CssExtractRspackPlugin](https://rspack.rs/plugins/rspack/css-extract-rspack-plugin) can be changed through `tools.cssExtract`.
+The options for [CssExtractRspackPlugin](https://rspack.rs/plugins/css-extract-rspack-plugin) can be changed through `tools.cssExtract`.
 
 ## pluginOptions
 
@@ -70,4 +70,4 @@ export default {
 };
 ```
 
-> Please refer to the [CssExtractRspackPlugin](https://rspack.rs/plugins/rspack/css-extract-rspack-plugin) plugin documentation to learn about all available options.
+> Please refer to the [CssExtractRspackPlugin](https://rspack.rs/plugins/css-extract-rspack-plugin) plugin documentation to learn about all available options.

--- a/website/docs/en/config/tools/rspack.mdx
+++ b/website/docs/en/config/tools/rspack.mdx
@@ -7,7 +7,7 @@ description: 'The built-in Rspack config in Rsbuild may change with iterations, 
 - **Type:** `Rspack.Configuration | Function | undefined`
 - **Default:** `undefined`
 
-`tools.rspack` configures [Rspack](https://rspack.rs/config/index).
+`tools.rspack` configures [Rspack](https://rspack.rs/config/).
 
 :::tip
 The built-in Rspack config in Rsbuild may change with iterations, and these changes will not be reflected in semver. Therefore, your custom config may become invalid when you upgrade Rsbuild.

--- a/website/docs/en/guide/configuration/swc.mdx
+++ b/website/docs/en/guide/configuration/swc.mdx
@@ -9,7 +9,7 @@ description: 'SWC (Speedy Web Compiler) is a transformer and minimizer for JavaS
 Rsbuild enables the following SWC features by default:
 
 - Transform JavaScript and TypeScript code using Rspack's [builtin:swc-loader](https://rspack.rs/guide/features/builtin-swc-loader), which is the Rust version of [swc-loader](https://github.com/swc-project/pkgs/tree/main/packages/swc-loader).
-- Minify JavaScript code using Rspack's [SwcJsMinimizerRspackPlugin](https://rspack.rs/plugins/rspack/swc-js-minimizer-rspack-plugin).
+- Minify JavaScript code using Rspack's [SwcJsMinimizerRspackPlugin](https://rspack.rs/plugins/swc-js-minimizer-rspack-plugin).
 
 ## Loader options
 

--- a/website/docs/en/guide/styling/css-usage.mdx
+++ b/website/docs/en/guide/styling/css-usage.mdx
@@ -50,7 +50,7 @@ export default {
 
 ## CSS minification
 
-When building for production, Rsbuild enables Rspack's built-in [LightningCssMinimizerRspackPlugin](https://rspack.rs/plugins/rspack/lightning-css-minimizer-rspack-plugin) plugin to minify CSS assets for better transmission efficiency.
+When building for production, Rsbuild enables Rspack's built-in [LightningCssMinimizerRspackPlugin](https://rspack.rs/plugins/lightning-css-minimizer-rspack-plugin) plugin to minify CSS assets for better transmission efficiency.
 
 - You can disable CSS minification using the [output.minify](/config/output/minify) option or customize the options for `LightningCssMinimizerRspackPlugin`.
 - You can use [@rsbuild/plugin-css-minimizer](https://github.com/rstackjs/rsbuild-plugin-css-minimizer) to customize the CSS minimizer, switching to [cssnano](https://github.com/cssnano/cssnano) or another CSS minimizer.

--- a/website/docs/en/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/en/guide/upgrade/v1-to-v2.mdx
@@ -268,7 +268,7 @@ export default {
 
 `performance.chunkSplit` is deprecated in Rsbuild 2.0, but not removed yet, so it still works.
 
-We recommend migrating to the new [splitChunks](/config/split-chunks) option. It aligns with Rspack's [optimization.splitChunks](https://rspack.rs/plugins/webpack/split-chunks-plugin) and provides presets that mirror `performance.chunkSplit.strategy`.
+We recommend migrating to the new [splitChunks](/config/split-chunks) option. It aligns with Rspack's [optimization.splitChunks](https://rspack.rs/plugins/split-chunks-plugin) and provides presets that mirror `performance.chunkSplit.strategy`.
 
 #### strategy
 

--- a/website/docs/en/plugins/dev/index.mdx
+++ b/website/docs/en/plugins/dev/index.mdx
@@ -188,7 +188,7 @@ Rsbuild internally uses lifecycle hooks to schedule tasks, and plugins can also 
 
 The full list of Rsbuild's lifetime hooks can be found in the [API References](/plugins/dev/hooks).
 
-Rsbuild does not take over the hooks of the underlying Rspack, whose documents can be found here: [Rspack Plugin API](https://rspack.rs/api/plugin-api).
+Rsbuild does not take over the hooks of the underlying Rspack, whose documents can be found here: [Rspack Plugin API](https://rspack.rs/api/plugin-api/).
 
 ## Migrate Vite plugin
 

--- a/website/docs/en/plugins/list/plugin-react.mdx
+++ b/website/docs/en/plugins/list/plugin-react.mdx
@@ -145,7 +145,7 @@ Most of the time, you should use the plugin's [fastRefresh](#fastrefresh) option
 
 ### reactCompiler
 
-Enable or configure [React Compiler](https://react.dev/learn/react-compiler), which Rsbuild passes to Rspack's [`builtin:swc-loader`](https://rspack.rs/guide/tech/react#using-builtinswc-loader) as the `jsc.transform.reactCompiler` option.
+Enable or configure [React Compiler](https://react.dev/learn/react-compiler), which Rsbuild passes to Rspack's [`builtin:swc-loader`](https://rspack.rs/guide/integrations/react#using-builtinswc-loader) as the `jsc.transform.reactCompiler` option.
 
 :::tip
 This option is only supported in `@rsbuild/core` v2.1.0 and later.

--- a/website/docs/zh/api/javascript-api/environment-api.mdx
+++ b/website/docs/zh/api/javascript-api/environment-api.mdx
@@ -372,7 +372,7 @@ environments.web.hot.send('custom', {
 });
 ```
 
-Rsbuild 在 Rspack 的 [import.meta.webpackHot](https://rspack.rs/api/runtime-api/hmr) 对象上扩展了 `on()` 方法，它允许你在浏览器端监听自定义事件，并处理数据：
+Rsbuild 在 Rspack 的 [import.meta.webpackHot](https://rspack.rs/zh/api/runtime-api/hmr) 对象上扩展了 `on()` 方法，它允许你在浏览器端监听自定义事件，并处理数据：
 
 ```ts title="client.js"
 if (import.meta.webpackHot) {

--- a/website/docs/zh/blog/v0-7.mdx
+++ b/website/docs/zh/blog/v0-7.mdx
@@ -75,7 +75,7 @@ export default config;
 
 ## 更好的 CSS 支持 \{#better-css-supports}
 
-Rsbuild 现在使用 [CssExtractRspackPlugin](https://rspack.rs/zh/plugins/rspack/css-extract-rspack-plugin) 来提取 CSS 到单独的文件中，而不是使用 [experiments.css](https://v0.rspack.rs/zh/config/experiments#experimentscss) 配置来实现。
+Rsbuild 现在使用 [CssExtractRspackPlugin](https://rspack.rs/zh/plugins/css-extract-rspack-plugin) 来提取 CSS 到单独的文件中，而不是使用 [experiments.css](https://v0.rspack.rs/zh/config/experiments#experimentscss) 配置来实现。
 
 这允许 Rsbuild 支持更多 CSS 特性，包括：
 

--- a/website/docs/zh/config/dev/lazy-compilation.mdx
+++ b/website/docs/zh/config/dev/lazy-compilation.mdx
@@ -47,7 +47,7 @@ const defaultOptions = {
 };
 ```
 
-用于开启 lazy compilation（即按需编译），基于 Rspack 的 [lazy compilation](https://rspack.rs/zh/guide/features/lazy-compilation) 特性实现。
+用于开启 lazy compilation（即按需编译），基于 Rspack 的 [lazy compilation](https://rspack.rs/zh/guide/advanced/lazy-compilation) 特性实现。
 
 ## 介绍
 
@@ -140,7 +140,7 @@ export default {
 
 ### Server URL
 
-通过 [lazyCompilation.serverUrl](https://rspack.rs/zh/config/lazy-compilation#lazycompilationserverurl) 可以指定 client 需要请求的 server URL。
+通过 [lazyCompilation.serverUrl](https://rspack.rs/zh/config/lazy-compilation#serverurl) 可以指定 client 需要请求的 server URL。
 
 如果未显式配置 `lazyCompilation.serverUrl`，Rsbuild 会在同时满足以下条件时，根据 [dev.client](/config/dev/client) 推导默认的 `serverUrl`：
 

--- a/website/docs/zh/config/mode.mdx
+++ b/website/docs/zh/config/mode.mdx
@@ -50,7 +50,7 @@ export default {
 
 当 `mode` 的值为 `development` 时：
 
-- 开启 HMR，注册 [HotModuleReplacementPlugin](https://rspack.rs/zh/plugins/webpack/hot-module-replacement-plugin)。
+- 开启 HMR，注册 [HotModuleReplacementPlugin](https://rspack.rs/zh/plugins/hot-module-replacement-plugin)。
 - 生成 JavaScript 的 source map，不生成 CSS 的 source map，详见 [output.sourceMap](/config/output/source-map)。
 - 源代码中的 `process.env.NODE_ENV` 会被替换为 `'development'`。
 - 源代码中的 `import.meta.env.MODE` 会被替换为 `'development'`。
@@ -62,8 +62,8 @@ export default {
 
 当 `mode` 的值为 `production` 时：
 
-- 开启 JavaScript 代码压缩，注册 [SwcJsMinimizerRspackPlugin](https://rspack.rs/zh/plugins/rspack/swc-js-minimizer-rspack-plugin)。
-- 开启 CSS 代码压缩，注册 [LightningCssMinimizerRspackPlugin](https://rspack.rs/zh/plugins/rspack/lightning-css-minimizer-rspack-plugin)。
+- 开启 JavaScript 代码压缩，注册 [SwcJsMinimizerRspackPlugin](https://rspack.rs/zh/plugins/swc-js-minimizer-rspack-plugin)。
+- 开启 CSS 代码压缩，注册 [LightningCssMinimizerRspackPlugin](https://rspack.rs/zh/plugins/lightning-css-minimizer-rspack-plugin)。
 - 生成的 JavaScript 和 CSS 文件名会带有 hash 后缀，详见 [output.filenameHash](/config/output/filename-hash)。
 - 生成的 CSS Modules 类名更简短，详见 [cssModules.localIdentName](/config/output/css-modules#cssmoduleslocalidentname)。
 - 不生成 JavaScript 和 CSS 的 source map，详见 [output.sourceMap](/config/output/source-map)。

--- a/website/docs/zh/config/module-federation/options.mdx
+++ b/website/docs/zh/config/module-federation/options.mdx
@@ -6,7 +6,7 @@ import { PackageManagerTabs } from '@theme';
 
 # moduleFederation.options
 
-- **类型：** [Rspack.ModuleFederationPluginOptions](https://rspack.rs/zh/plugins/webpack/module-federation-plugin#选项)
+- **类型：** [Rspack.ModuleFederationPluginOptions](https://rspack.rs/zh/plugins/module-federation-plugin#选项)
 - **默认值：** `undefined`
 
 用于配置 Rspack 模块联邦插件（对应模块联邦 v1.5）。
@@ -21,7 +21,7 @@ import { PackageManagerTabs } from '@theme';
 
 当你设置 `moduleFederation.options` 选项后，Rsbuild 会执行以下操作：
 
-- 自动注册 [ModuleFederationPlugin](https://rspack.rs/zh/plugins/webpack/module-federation-plugin) 插件，并将 `options` 的值透传给插件。
+- 自动注册 [ModuleFederationPlugin](https://rspack.rs/zh/plugins/module-federation-plugin) 插件，并将 `options` 的值透传给插件。
 - 将 provider 的 [dev.assetPrefix](/config/dev/asset-prefix) 配置的默认值设置为 `true`，这可以确保 remote modules 的静态资源 URL 是正确的。
 - 将 Rspack [output.uniqueName](https://rspack.rs/zh/config/output#outputuniquename) 配置的默认值设置为 `moduleFederation.options.name`，使 HMR 可以正常工作。
 
@@ -44,7 +44,7 @@ export default defineConfig({
 
 <PackageManagerTabs command="add @module-federation/runtime-tools" />
 
-> 参考 [ModuleFederationPlugin](https://rspack.rs/zh/plugins/webpack/module-federation-plugin) 文档来了解所有可用的选项。
+> 参考 [ModuleFederationPlugin](https://rspack.rs/zh/plugins/module-federation-plugin) 文档来了解所有可用的选项。
 
 ## 示例
 

--- a/website/docs/zh/config/output/copy.mdx
+++ b/website/docs/zh/config/output/copy.mdx
@@ -7,9 +7,9 @@ description: '将指定的文件或目录拷贝到构建输出目录中，基于
 - **类型：** `Rspack.CopyRspackPluginOptions | Rspack.CopyRspackPluginOptions['patterns']`
 - **默认值：** `undefined`
 
-将指定的文件或目录拷贝到构建输出目录中，基于 [rspack.CopyRspackPlugin](https://rspack.rs/zh/plugins/rspack/copy-rspack-plugin) 实现。
+将指定的文件或目录拷贝到构建输出目录中，基于 [rspack.CopyRspackPlugin](https://rspack.rs/zh/plugins/copy-rspack-plugin) 实现。
 
-> 配置项请参考：[rspack.CopyRspackPlugin](https://rspack.rs/zh/plugins/rspack/copy-rspack-plugin)。
+> 配置项请参考：[rspack.CopyRspackPlugin](https://rspack.rs/zh/plugins/copy-rspack-plugin)。
 
 ## 示例
 

--- a/website/docs/zh/config/output/minify.mdx
+++ b/website/docs/zh/config/output/minify.mdx
@@ -107,7 +107,7 @@ export default {
 - **类型：** `SwcJsMinimizerRspackPluginOptions | SwcJsMinimizerRspackPluginOptions[]`
 - **默认值：** `{}`
 
-`output.minify.jsOptions` 用于配置 SWC 的压缩选项，具体配置项请参考 [SwcJsMinimizerRspackPlugin 文档](https://rspack.rs/zh/plugins/rspack/swc-js-minimizer-rspack-plugin)。
+`output.minify.jsOptions` 用于配置 SWC 的压缩选项，具体配置项请参考 [SwcJsMinimizerRspackPlugin 文档](https://rspack.rs/zh/plugins/swc-js-minimizer-rspack-plugin)。
 
 例如，关闭变量和函数名的重命名：
 
@@ -194,7 +194,7 @@ export default {
 - **类型：** `LightningCssMinimizerRspackPluginOptions | LightningCssMinimizerRspackPluginOptions[]`
 - **默认值：** 继承 [tools.lightningcssLoader](/config/tools/lightningcss-loader) 的值
 
-`output.minify.cssOptions` 用于配置 Lightning CSS 的压缩选项，具体配置项请参考 [LightningCssMinimizerRspackPlugin 文档](https://rspack.rs/zh/plugins/rspack/lightning-css-minimizer-rspack-plugin)。
+`output.minify.cssOptions` 用于配置 Lightning CSS 的压缩选项，具体配置项请参考 [LightningCssMinimizerRspackPlugin 文档](https://rspack.rs/zh/plugins/lightning-css-minimizer-rspack-plugin)。
 
 例如，关闭 `errorRecovery` 选项：
 

--- a/website/docs/zh/config/performance/build-cache.mdx
+++ b/website/docs/zh/config/performance/build-cache.mdx
@@ -93,7 +93,7 @@ export default {
 
 `buildDependencies` 是一个包含构建依赖的文件数组，Rspack 将使用其中每个文件的哈希值来判断持久化缓存是否失效。
 
-等价于 Rspack 的 [cache.buildDependencies](https://rspack.rs/zh/config/cache#cachebuilddependencies) 选项。
+等价于 Rspack 的 [cache.buildDependencies](https://rspack.rs/zh/config/cache#builddependencies) 选项。
 
 #### 默认值
 

--- a/website/docs/zh/config/security/sri.mdx
+++ b/website/docs/zh/config/security/sri.mdx
@@ -19,7 +19,7 @@ type SriOptions = {
 
 为 HTML 所引入的 `<script>` 和 `<link>` 标签添加完整性属性 —— `integrity`，使浏览器能够验证引入资源的完整性，以此防止下载的资源被篡改。
 
-> `security.sri` 是基于 Rspack 的 [SubresourceIntegrityPlugin](https://rspack.rs/zh/plugins/rspack/subresource-integrity-plugin) 实现的。
+> `security.sri` 是基于 Rspack 的 [SubresourceIntegrityPlugin](https://rspack.rs/zh/plugins/subresource-integrity-plugin) 实现的。
 
 ## 什么是 SRI
 

--- a/website/docs/zh/config/source/define.mdx
+++ b/website/docs/zh/config/source/define.mdx
@@ -16,7 +16,7 @@ description: '构建时将代码中的变量替换成其它值或者表达式，
 - 嵌套对象的父子键名之间会用 `.` 连接作为需要替换的变量名。
 - 以 typeof 开头的键名会用来替换 typeof 调用。
 
-> 更多用法请参考 [使用 define](/guide/advanced/env-vars#using-define) 和 [Rspack - DefinePlugin](https://rspack.rs/zh/plugins/webpack/define-plugin)。
+> 更多用法请参考 [使用 define](/guide/advanced/env-vars#using-define) 和 [Rspack - DefinePlugin](https://rspack.rs/zh/plugins/define-plugin)。
 
 ## 示例
 

--- a/website/docs/zh/config/source/exclude.mdx
+++ b/website/docs/zh/config/source/exclude.mdx
@@ -48,7 +48,7 @@ export default {
 
 `source.exclude` 用于指定不需要编译的 JavaScript/TypeScript 文件。这意味着这些文件不会经过 SWC 转译，但被引用的文件仍然会被打包到产物中。
 
-如果你希望某些文件在打包过程中被排除，不被打包到产物中，可以使用 Rspack 的 [IgnorePlugin](https://rspack.rs/zh/plugins/webpack/ignore-plugin)。
+如果你希望某些文件在打包过程中被排除，不被打包到产物中，可以使用 Rspack 的 [IgnorePlugin](https://rspack.rs/zh/plugins/ignore-plugin)。
 
 ```ts title="rsbuild.config.ts"
 export default {

--- a/website/docs/zh/config/split-chunks.mdx
+++ b/website/docs/zh/config/split-chunks.mdx
@@ -18,7 +18,7 @@ type SplitChunksConfig =
 
 `splitChunks` 用于配置 Rsbuild 的 chunk 拆分策略。
 
-该选项基于 Rspack 的 [optimization.splitChunks](https://rspack.rs/zh/plugins/webpack/split-chunks-plugin) 实现，并在其基础上扩展了 `preset` 选项，用于启用 Rsbuild 提供的一组常用拆分预设。
+该选项基于 Rspack 的 [optimization.splitChunks](https://rspack.rs/zh/plugins/split-chunks-plugin) 实现，并在其基础上扩展了 `preset` 选项，用于启用 Rsbuild 提供的一组常用拆分预设。
 
 ## 默认行为 \{#default-behavior}
 
@@ -28,7 +28,7 @@ type SplitChunksConfig =
 
 - **默认值：** `{ preset: 'default', chunks: 'all' }`
 
-对于 Web 构建，Rsbuild 会将 `chunks` 设置为 `'all'`。其余未指定的选项（如 `minSize` 和 `minChunks`）均沿用 Rspack [`optimization.splitChunks`](https://rspack.rs/zh/plugins/webpack/split-chunks-plugin) 的默认值。
+对于 Web 构建，Rsbuild 会将 `chunks` 设置为 `'all'`。其余未指定的选项（如 `minSize` 和 `minChunks`）均沿用 Rspack [`optimization.splitChunks`](https://rspack.rs/zh/plugins/split-chunks-plugin) 的默认值。
 
 :::tip
 当项目作为 Module Federation provider 并配置 [`moduleFederation.options.exposes`](/config/module-federation/options) 时，为避免 chunk 拆分影响 remote entry，Rsbuild 会将 `chunks` 设置为 `'async'`。
@@ -112,7 +112,7 @@ export default {
 
 ## 其他选项
 
-除 `preset` 之外，其余配置项的行为与 Rspack 的 `optimization.splitChunks` 保持一致，详细用法请参考 [Rspack 文档](https://rspack.rs/zh/plugins/webpack/split-chunks-plugin)。
+除 `preset` 之外，其余配置项的行为与 Rspack 的 `optimization.splitChunks` 保持一致，详细用法请参考 [Rspack 文档](https://rspack.rs/zh/plugins/split-chunks-plugin)。
 
 ```ts title="rsbuild.config.ts"
 export default {

--- a/website/docs/zh/config/tools/bundler-chain.mdx
+++ b/website/docs/zh/config/tools/bundler-chain.mdx
@@ -283,7 +283,7 @@ Rsbuild 中预先定义了一些常用的 Chain ID，你可以通过这些 ID �
 
 通过 `MINIMIZER.[ID]` 可以匹配到对应的压缩工具。
 
-| ID              | 描述                                                                                                                |
-| --------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `MINIMIZER.JS`  | 对应 [SwcJsMinimizerRspackPlugin](https://rspack.rs/zh/plugins/rspack/swc-js-minimizer-rspack-plugin)               |
-| `MINIMIZER.CSS` | 对应 [LightningCssMinimizerRspackPlugin](https://rspack.rs/zh/plugins/rspack/lightning-css-minimizer-rspack-plugin) |
+| ID              | 描述                                                                                                         |
+| --------------- | ------------------------------------------------------------------------------------------------------------ |
+| `MINIMIZER.JS`  | 对应 [SwcJsMinimizerRspackPlugin](https://rspack.rs/zh/plugins/swc-js-minimizer-rspack-plugin)               |
+| `MINIMIZER.CSS` | 对应 [LightningCssMinimizerRspackPlugin](https://rspack.rs/zh/plugins/lightning-css-minimizer-rspack-plugin) |

--- a/website/docs/zh/config/tools/css-extract.mdx
+++ b/website/docs/zh/config/tools/css-extract.mdx
@@ -34,7 +34,7 @@ const defaultOptions = {
 
 Rsbuild 默认使用 CssExtractRspackPlugin 插件将 CSS 提取为独立的文件。
 
-通过 `tools.cssExtract` 可以更改 [CssExtractRspackPlugin](https://rspack.rs/zh/plugins/rspack/css-extract-rspack-plugin) 的选项。
+通过 `tools.cssExtract` 可以更改 [CssExtractRspackPlugin](https://rspack.rs/zh/plugins/css-extract-rspack-plugin) 的选项。
 
 ## pluginOptions
 
@@ -70,4 +70,4 @@ export default {
 };
 ```
 
-> 请参考 [CssExtractRspackPlugin](https://rspack.rs/zh/plugins/rspack/css-extract-rspack-plugin) 插件文档来了解所有可用的选项。
+> 请参考 [CssExtractRspackPlugin](https://rspack.rs/zh/plugins/css-extract-rspack-plugin) 插件文档来了解所有可用的选项。

--- a/website/docs/zh/config/tools/rspack.mdx
+++ b/website/docs/zh/config/tools/rspack.mdx
@@ -7,7 +7,7 @@ description: 'tools.rspack 选项用于修改 Rspack 的配置项。'
 - **类型：** `Rspack.Configuration | Function | undefined`
 - **默认值：** `undefined`
 
-`tools.rspack` 选项用于修改 [Rspack](https://rspack.rs/zh/config/index) 的配置项。
+`tools.rspack` 选项用于修改 [Rspack](https://rspack.rs/zh/config/) 的配置项。
 
 :::tip
 Rsbuild 内置的 Rspack 配置会随着迭代而发生变化，这些变化不会反映在 semver 中，因此在升级 Rsbuild 时，你的自定义配置可能会失效。

--- a/website/docs/zh/guide/configuration/swc.mdx
+++ b/website/docs/zh/guide/configuration/swc.mdx
@@ -9,7 +9,7 @@ description: 'SWC（Speedy Web Compiler）是基于 Rust 语言编写的高性�
 Rsbuild 默认启用 SWC 的以下功能：
 
 - 通过 Rspack 的 [builtin:swc-loader](https://rspack.rs/zh/guide/features/builtin-swc-loader) 来转换 JavaScript 和 TypeScript 代码，它是 [swc-loader](https://github.com/swc-project/pkgs/tree/main/packages/swc-loader) 的 Rust 版本。
-- 通过 Rspack 的 [SwcJsMinimizerRspackPlugin](https://rspack.rs/zh/plugins/rspack/swc-js-minimizer-rspack-plugin) 来压缩 JavaScript 代码。
+- 通过 Rspack 的 [SwcJsMinimizerRspackPlugin](https://rspack.rs/zh/plugins/swc-js-minimizer-rspack-plugin) 来压缩 JavaScript 代码。
 
 ## Loader 选项
 

--- a/website/docs/zh/guide/debug/debug-mode.mdx
+++ b/website/docs/zh/guide/debug/debug-mode.mdx
@@ -80,4 +80,4 @@ export default {
 };
 ```
 
-关于 Rspack 配置项的完整介绍，请查看 [Rspack 官方文档](https://rspack.rs/zh/config)。
+关于 Rspack 配置项的完整介绍，请查看 [Rspack 官方文档](https://rspack.rs/zh/config/)。

--- a/website/docs/zh/guide/start/index.mdx
+++ b/website/docs/zh/guide/start/index.mdx
@@ -48,7 +48,7 @@ Rsbuild 具备以下特性：
 
 - **易于配置**：Rsbuild 的目标之一，是为 Rspack 用户提供开箱即用的构建能力，使开发者能够在零配置的情况下开发 web 项目。同时，Rsbuild 提供一套语义化的构建配置，以降低 Rspack 配置的学习成本。
 
-- **性能优先**：Rsbuild 集成了社区中基于 Rust 的高性能工具，包括 [Rspack](https://rspack.rs)、[SWC](https://swc.rs/) 和 [Lightning CSS](https://lightningcss.dev/)，以提供一流的构建速度和开发体验。
+- **性能优先**：Rsbuild 集成了社区中基于 Rust 的高性能工具，包括 [Rspack](https://rspack.rs/zh/)、[SWC](https://swc.rs/) 和 [Lightning CSS](https://lightningcss.dev/)，以提供一流的构建速度和开发体验。
 
 - **插件生态**：Rsbuild 内置一个轻量级的插件系统，提供一系列高质量的官方插件。此外，Rsbuild 兼容大部分的 webpack 插件和所有的 Rspack 插件，这意味着你可以在 Rsbuild 中使用社区或公司内现有的插件，而无须重写相关代码。
 

--- a/website/docs/zh/guide/styling/css-usage.mdx
+++ b/website/docs/zh/guide/styling/css-usage.mdx
@@ -50,7 +50,7 @@ export default {
 
 ## CSS 压缩
 
-在生产模式构建时，Rsbuild 会开启 Rspack 内置的 [LightningCssMinimizerRspackPlugin](https://rspack.rs/zh/plugins/rspack/lightning-css-minimizer-rspack-plugin) 插件，将 CSS 资源压缩，以达到更好的传输效率。
+在生产模式构建时，Rsbuild 会开启 Rspack 内置的 [LightningCssMinimizerRspackPlugin](https://rspack.rs/zh/plugins/lightning-css-minimizer-rspack-plugin) 插件，将 CSS 资源压缩，以达到更好的传输效率。
 
 - 你可以通过 [output.minify](/config/output/minify) 选项来禁用 CSS 压缩，或是自定义 `LightningCssMinimizerRspackPlugin` 的选项。
 - 你可以通过 [@rsbuild/plugin-css-minimizer](https://github.com/rstackjs/rsbuild-plugin-css-minimizer) 来自定义 CSS 压缩工具，切换到 [cssnano](https://github.com/cssnano/cssnano) 或是其他 CSS 压缩器。

--- a/website/docs/zh/guide/upgrade/v1-to-v2.mdx
+++ b/website/docs/zh/guide/upgrade/v1-to-v2.mdx
@@ -268,7 +268,7 @@ export default {
 
 `performance.chunkSplit` 已在 Rsbuild 2.0 中废弃，但暂未移除，仍可继续使用。
 
-我们推荐使用新的 [splitChunks](/config/split-chunks) 选项代替它，新选项对齐了 Rspack 的 [optimization.splitChunks](https://rspack.rs/zh/plugins/webpack/split-chunks-plugin) 配置，并提供了与 `performance.chunkSplit.strategy` 相似的预设选项。
+我们推荐使用新的 [splitChunks](/config/split-chunks) 选项代替它，新选项对齐了 Rspack 的 [optimization.splitChunks](https://rspack.rs/zh/plugins/split-chunks-plugin) 配置，并提供了与 `performance.chunkSplit.strategy` 相似的预设选项。
 
 #### strategy
 
@@ -505,7 +505,7 @@ Rsbuild 2.0 不再支持使用 webpack 作为打包工具。在 Rsbuild v1 版�
 
 ## 内置规则变化
 
-Rsbuild 内置的 JS 和 CSS 转换规则现在使用了 [oneOf](https://rspack.rs/config/module-rules#rulesoneof) 来区分不同的分支，如果你使用 [tools.bundlerChain](/config/tools/bundler-chain#toolsbundlerchain) 或 [api.modifyBundlerChain](/plugins/dev/hooks#modifybundlerchain) 修改了 JS 或 CSS 规则，可能需要进行相应调整。
+Rsbuild 内置的 JS 和 CSS 转换规则现在使用了 [oneOf](https://rspack.rs/zh/config/module-rules#rulesoneof) 来区分不同的分支，如果你使用 [tools.bundlerChain](/config/tools/bundler-chain#toolsbundlerchain) 或 [api.modifyBundlerChain](/plugins/dev/hooks#modifybundlerchain) 修改了 JS 或 CSS 规则，可能需要进行相应调整。
 
 ### JS 规则
 

--- a/website/docs/zh/plugins/dev/core.mdx
+++ b/website/docs/zh/plugins/dev/core.mdx
@@ -407,7 +407,7 @@ api.transform({ test: /\.node$/, raw: true }, ({ code }) => {
 });
 ```
 
-- `layer`：标识匹配的模块的 [layer](https://rspack.rs/zh/guide/features/layer#layer)，可以将一组模块聚合到一个 layer 中，等同于 Rspack 的 [rules[].layer](https://rspack.rs/zh/config/module-rules#ruleslayer)。
+- `layer`：标识匹配的模块的 [layer](https://rspack.rs/zh/guide/advanced/layer)，可以将一组模块聚合到一个 layer 中，等同于 Rspack 的 [rules[].layer](https://rspack.rs/zh/config/module-rules#ruleslayer)。
 
 ```js
 api.transform({ test: /\.md$/, layer: 'foo' }, ({ code }) => {
@@ -415,7 +415,7 @@ api.transform({ test: /\.md$/, layer: 'foo' }, ({ code }) => {
 });
 ```
 
-- `issuerLayer`：与"引入当前模块"的模块的 [layer](https://rspack.rs/zh/guide/features/layer#layer) 进行匹配，等同于 Rspack 的 [rules[].issuerLayer](https://rspack.rs/zh/config/module-rules#rulesissuerlayer)。
+- `issuerLayer`：与"引入当前模块"的模块的 [layer](https://rspack.rs/zh/guide/advanced/layer) 进行匹配，等同于 Rspack 的 [rules[].issuerLayer](https://rspack.rs/zh/config/module-rules#rulesissuerlayer)。
 
 ```js
 api.transform({ test: /\.md$/, issuerLayer: 'foo' }, ({ code }) => {

--- a/website/docs/zh/plugins/dev/index.mdx
+++ b/website/docs/zh/plugins/dev/index.mdx
@@ -188,7 +188,7 @@ Rsbuild 在内部按照约定的生命周期进行任务调度，插件可以通
 
 Rsbuild 生命周期钩子的完整列表参考 [API 文档](/plugins/dev/hooks)。
 
-Rsbuild 不会接管底层 Rspack 的生命周期，相关生命周期钩子的使用方式见对应文档：[Rspack Plugin API](https://rspack.rs/zh/api/plugin-api)。
+Rsbuild 不会接管底层 Rspack 的生命周期，相关生命周期钩子的使用方式见对应文档：[Rspack Plugin API](https://rspack.rs/zh/api/plugin-api/)。
 
 ## 迁移 Vite 插件
 

--- a/website/docs/zh/plugins/list/plugin-react.mdx
+++ b/website/docs/zh/plugins/list/plugin-react.mdx
@@ -145,7 +145,7 @@ pluginReact({
 
 ### reactCompiler
 
-启用或配置 [React Compiler](https://react.dev/learn/react-compiler)，Rsbuild 会将该选项传递给 Rspack 的 [`builtin:swc-loader`](https://rspack.rs/zh/guide/tech/react#%E4%BD%BF%E7%94%A8-builtinswc-loader)，对应 `jsc.transform.reactCompiler` 配置。
+启用或配置 [React Compiler](https://react.dev/learn/react-compiler)，Rsbuild 会将该选项传递给 Rspack 的 [`builtin:swc-loader`](https://rspack.rs/zh/guide/integrations/react#%E4%BD%BF%E7%94%A8-builtinswc-loader)，对应 `jsc.transform.reactCompiler` 配置。
 
 :::tip
 该选项仅在 `@rsbuild/core` v2.1.0 及以上版本中支持。


### PR DESCRIPTION
## Summary

Rspack recently reorganized several documentation routes. Update all affected `rspack.rs` links across the English and Chinese docs and source API comments to their current canonical paths, anchors, and locales.

## Related links

- https://rspack.rs/
