### PR TITLE
chore: remove redundant sort-package-json script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "lint": "rs lint",
     "prebundle": "pnpm --parallel --filter \"./packages/*\" run prebundle",
     "prepare": "rs hooks && node --run prebundle",
-    "sort-package-json": "pnpx sort-package-json \"./package.json\" \"packages/*/package.json\"",
     "test": "pnpm --parallel --filter \"./packages/*\" test"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Remove the redundant `sort-package-json` script because `rs fmt` already sorts package manifests through `sortPackageJson`.

## Related links

N/A