### PR TITLE
chore: update Rstack config

### DIFF
--- a/packages/core/rstack.config.ts
+++ b/packages/core/rstack.config.ts
@@ -1,4 +1,6 @@
 import path from 'node:path';
+import { nodeMinifyConfig } from '@scripts/config/lib';
+import { baseConfig } from '@scripts/config/test';
 import { define as rstack } from 'rstack';
 import type { Rsbuild, Rspack } from 'rstack/lib';
 import pkgJson from './package.json' with { type: 'json' };
@@ -101,134 +103,126 @@ const replacePlugin: Rsbuild.RsbuildPlugin = {
   },
 };
 
-rstack.lib(async () => {
-  const { nodeMinifyConfig } = await import('@scripts/config/lib');
-
-  return {
-    source: {
-      define,
-    },
-    output: {
-      externals,
-    },
-    tools: {
-      rspack: {
-        experiments: {
-          nativeWatcher: true,
-        },
+rstack.lib({
+  source: {
+    define,
+  },
+  output: {
+    externals,
+  },
+  tools: {
+    rspack: {
+      experiments: {
+        nativeWatcher: true,
       },
     },
-    lib: [
-      // Build client modules and copy dependencies to compiled folder
-      {
-        id: 'prepare',
-        syntax: 'es2017',
-        source: {
-          entry: {
-            hmr: 'src/client/hmr.ts',
-            overlay: 'src/client/overlay.ts',
-          },
-          define: {
-            // use define to avoid compile time evaluation of import.meta.rspackHash
-            BUILD_HASH: 'import.meta.rspackHash',
-          },
+  },
+  lib: [
+    // Build client modules and copy dependencies to compiled folder
+    {
+      id: 'prepare',
+      syntax: 'es2017',
+      source: {
+        entry: {
+          hmr: 'src/client/hmr.ts',
+          overlay: 'src/client/overlay.ts',
         },
-        output: {
-          target: 'web',
-          externals: ['./hmr.js'],
-          distPath: {
-            root: './dist/client',
-          },
-          copy: {
-            patterns: [
-              {
-                from: './node_modules/jiti',
-                to: path.join(import.meta.dirname, 'compiled/jiti'),
-                globOptions: {
-                  dot: false,
-                },
-              },
-            ],
-          },
+        define: {
+          // use define to avoid compile time evaluation of import.meta.rspackHash
+          BUILD_HASH: 'import.meta.rspackHash',
         },
-        performance: {
-          printFileSize: {
-            exclude: (asset) => /compiled/.test(asset.name),
-          },
-        },
-        plugins: [replacePlugin],
       },
-      {
-        id: 'node',
-        syntax: 'es2023',
-        source: {
-          entry: {
-            index: './src/index.ts',
-            cssUrlLoader: './src/loader/cssUrlLoader.ts',
-            ignoreCssLoader: './src/loader/ignoreCssLoader.ts',
-            transformLoader: './src/loader/transformLoader.ts',
-            transformRawLoader: './src/loader/transformRawLoader.ts',
-            workerLoader: './src/loader/workerLoader.ts',
-          },
+      output: {
+        target: 'web',
+        externals: ['./hmr.js'],
+        distPath: {
+          root: './dist/client',
         },
-        dts: {
-          isolated: true,
-          alias: {
-            // alias to pre-bundled types as they are public API
-            cors: './compiled/cors',
-            rslog: './compiled/rslog',
-            postcss: './compiled/postcss/lib/postcss',
-            chokidar: './compiled/chokidar',
-            'connect-next': './compiled/connect-next',
-            '@rstackjs/load-config': './compiled/@rstackjs/load-config',
-            'rspack-chain': './compiled/rspack-chain/types',
-            'html-rspack-plugin': './compiled/html-rspack-plugin',
-            'http-proxy-middleware': './compiled/http-proxy-middleware',
-            'rspack-manifest-plugin': './compiled/rspack-manifest-plugin',
-          },
-        },
-        output: {
-          minify: {
-            jsOptions: [
-              {
-                // Fully minify large chunks composed primarily of third-party code.
-                include: fullyMinifiedChunks,
+        copy: {
+          patterns: [
+            {
+              from: './node_modules/jiti',
+              to: path.join(import.meta.dirname, 'compiled/jiti'),
+              globOptions: {
+                dot: false,
               },
-              {
-                ...nodeMinifyConfig.jsOptions,
-                exclude: fullyMinifiedChunks,
-              },
-            ],
-          },
-          filename: {
-            js: ({ chunk }) => {
-              // Use `.mjs` for Rspack loaders
-              if (chunk?.name?.endsWith('Loader')) {
-                return '[name].mjs';
-              }
-              return `[name].js`;
             },
-          },
+          ],
         },
-        shims: {
-          esm: {
-            // For `postcss-load-config`
-            __filename: true,
-          },
+      },
+      performance: {
+        printFileSize: {
+          exclude: (asset) => /compiled/.test(asset.name),
         },
-        tools: {
-          rspack: {
-            // Wait the pre compiler to copy jiti to compiled folder
-            dependencies: ['prepare'],
+      },
+      plugins: [replacePlugin],
+    },
+    {
+      id: 'node',
+      syntax: 'es2023',
+      source: {
+        entry: {
+          index: './src/index.ts',
+          cssUrlLoader: './src/loader/cssUrlLoader.ts',
+          ignoreCssLoader: './src/loader/ignoreCssLoader.ts',
+          transformLoader: './src/loader/transformLoader.ts',
+          transformRawLoader: './src/loader/transformRawLoader.ts',
+          workerLoader: './src/loader/workerLoader.ts',
+        },
+      },
+      dts: {
+        isolated: true,
+        alias: {
+          // alias to pre-bundled types as they are public API
+          cors: './compiled/cors',
+          rslog: './compiled/rslog',
+          postcss: './compiled/postcss/lib/postcss',
+          chokidar: './compiled/chokidar',
+          'connect-next': './compiled/connect-next',
+          '@rstackjs/load-config': './compiled/@rstackjs/load-config',
+          'rspack-chain': './compiled/rspack-chain/types',
+          'html-rspack-plugin': './compiled/html-rspack-plugin',
+          'http-proxy-middleware': './compiled/http-proxy-middleware',
+          'rspack-manifest-plugin': './compiled/rspack-manifest-plugin',
+        },
+      },
+      output: {
+        minify: {
+          jsOptions: [
+            {
+              // Fully minify large chunks composed primarily of third-party code.
+              include: fullyMinifiedChunks,
+            },
+            {
+              ...nodeMinifyConfig.jsOptions,
+              exclude: fullyMinifiedChunks,
+            },
+          ],
+        },
+        filename: {
+          js: ({ chunk }) => {
+            // Use `.mjs` for Rspack loaders
+            if (chunk?.name?.endsWith('Loader')) {
+              return '[name].mjs';
+            }
+            return `[name].js`;
           },
         },
       },
-    ],
-  };
+      shims: {
+        esm: {
+          // For `postcss-load-config`
+          __filename: true,
+        },
+      },
+      tools: {
+        rspack: {
+          // Wait the pre compiler to copy jiti to compiled folder
+          dependencies: ['prepare'],
+        },
+      },
+    },
+  ],
 });
 
-rstack.test(async () => {
-  const { baseConfig } = await import('@scripts/config/test');
-
-  return baseConfig;
-});
+rstack.test(baseConfig);

--- a/packages/plugin-babel/rstack.config.ts
+++ b/packages/plugin-babel/rstack.config.ts
@@ -1,13 +1,7 @@
+import { esmConfig } from '@scripts/config/lib';
+import { baseConfig } from '@scripts/config/test';
 import { define } from 'rstack';
 
-define.lib(async () => {
-  const { esmConfig } = await import('@scripts/config/lib');
+define.lib(esmConfig);
 
-  return esmConfig;
-});
-
-define.test(async () => {
-  const { baseConfig } = await import('@scripts/config/test');
-
-  return baseConfig;
-});
+define.test(baseConfig);

--- a/packages/plugin-less/rstack.config.ts
+++ b/packages/plugin-less/rstack.config.ts
@@ -1,19 +1,13 @@
+import { esmConfig } from '@scripts/config/lib';
+import { baseConfig } from '@scripts/config/test';
 import { define } from 'rstack';
 
-define.lib(async () => {
-  const { esmConfig } = await import('@scripts/config/lib');
-
-  return {
-    ...esmConfig,
-    output: {
-      ...esmConfig.output,
-      externals: /[\\/]compiled[\\/]/,
-    },
-  };
+define.lib({
+  ...esmConfig,
+  output: {
+    ...esmConfig.output,
+    externals: /[\\/]compiled[\\/]/,
+  },
 });
 
-define.test(async () => {
-  const { baseConfig } = await import('@scripts/config/test');
-
-  return baseConfig;
-});
+define.test(baseConfig);

--- a/packages/plugin-preact/rstack.config.ts
+++ b/packages/plugin-preact/rstack.config.ts
@@ -1,13 +1,7 @@
+import { esmConfig } from '@scripts/config/lib';
+import { baseConfig } from '@scripts/config/test';
 import { define } from 'rstack';
 
-define.lib(async () => {
-  const { esmConfig } = await import('@scripts/config/lib');
+define.lib(esmConfig);
 
-  return esmConfig;
-});
-
-define.test(async () => {
-  const { baseConfig } = await import('@scripts/config/test');
-
-  return baseConfig;
-});
+define.test(baseConfig);

--- a/packages/plugin-react/rstack.config.ts
+++ b/packages/plugin-react/rstack.config.ts
@@ -1,13 +1,7 @@
+import { esmConfig } from '@scripts/config/lib';
+import { baseConfig } from '@scripts/config/test';
 import { define } from 'rstack';
 
-define.lib(async () => {
-  const { esmConfig } = await import('@scripts/config/lib');
+define.lib(esmConfig);
 
-  return esmConfig;
-});
-
-define.test(async () => {
-  const { baseConfig } = await import('@scripts/config/test');
-
-  return baseConfig;
-});
+define.test(baseConfig);

--- a/packages/plugin-sass/rstack.config.ts
+++ b/packages/plugin-sass/rstack.config.ts
@@ -1,19 +1,13 @@
+import { esmConfig } from '@scripts/config/lib';
+import { baseConfig } from '@scripts/config/test';
 import { define } from 'rstack';
 
-define.lib(async () => {
-  const { esmConfig } = await import('@scripts/config/lib');
-
-  return {
-    ...esmConfig,
-    output: {
-      ...esmConfig.output,
-      externals: /[\\/]compiled[\\/]/,
-    },
-  };
+define.lib({
+  ...esmConfig,
+  output: {
+    ...esmConfig.output,
+    externals: /[\\/]compiled[\\/]/,
+  },
 });
 
-define.test(async () => {
-  const { baseConfig } = await import('@scripts/config/test');
-
-  return baseConfig;
-});
+define.test(baseConfig);

--- a/packages/plugin-solid/rstack.config.ts
+++ b/packages/plugin-solid/rstack.config.ts
@@ -1,30 +1,24 @@
+import { esmConfig } from '@scripts/config/lib';
+import { baseConfig } from '@scripts/config/test';
 import { define } from 'rstack';
 
-define.lib(async () => {
-  const { esmConfig } = await import('@scripts/config/lib');
-
-  return {
-    lib: [
-      esmConfig,
-      {
-        source: {
-          entry: {
-            refreshLoader: './src/refreshLoader.ts',
-            solidLoader: './src/solidLoader.ts',
-          },
-        },
-        output: {
-          filename: {
-            js: '[name].mjs',
-          },
+define.lib({
+  lib: [
+    esmConfig,
+    {
+      source: {
+        entry: {
+          refreshLoader: './src/refreshLoader.ts',
+          solidLoader: './src/solidLoader.ts',
         },
       },
-    ],
-  };
+      output: {
+        filename: {
+          js: '[name].mjs',
+        },
+      },
+    },
+  ],
 });
 
-define.test(async () => {
-  const { baseConfig } = await import('@scripts/config/test');
-
-  return baseConfig;
-});
+define.test(baseConfig);

--- a/packages/plugin-svelte/rstack.config.ts
+++ b/packages/plugin-svelte/rstack.config.ts
@@ -1,13 +1,7 @@
+import { esmConfig } from '@scripts/config/lib';
+import { baseConfig } from '@scripts/config/test';
 import { define } from 'rstack';
 
-define.lib(async () => {
-  const { esmConfig } = await import('@scripts/config/lib');
+define.lib(esmConfig);
 
-  return esmConfig;
-});
-
-define.test(async () => {
-  const { baseConfig } = await import('@scripts/config/test');
-
-  return baseConfig;
-});
+define.test(baseConfig);

--- a/packages/plugin-svgr/rstack.config.ts
+++ b/packages/plugin-svgr/rstack.config.ts
@@ -1,30 +1,24 @@
+import { esmConfig } from '@scripts/config/lib';
+import { baseConfig } from '@scripts/config/test';
 import { define } from 'rstack';
 
-define.lib(async () => {
-  const { esmConfig } = await import('@scripts/config/lib');
-
-  return {
-    lib: [
-      esmConfig,
-      {
-        source: {
-          entry: {
-            assetLoader: './src/assetLoader.ts',
-            loader: './src/loader.ts',
-          },
-        },
-        output: {
-          filename: {
-            js: '[name].mjs',
-          },
+define.lib({
+  lib: [
+    esmConfig,
+    {
+      source: {
+        entry: {
+          assetLoader: './src/assetLoader.ts',
+          loader: './src/loader.ts',
         },
       },
-    ],
-  };
+      output: {
+        filename: {
+          js: '[name].mjs',
+        },
+      },
+    },
+  ],
 });
 
-define.test(async () => {
-  const { baseConfig } = await import('@scripts/config/test');
-
-  return baseConfig;
-});
+define.test(baseConfig);

--- a/packages/plugin-tailwindcss/rstack.config.ts
+++ b/packages/plugin-tailwindcss/rstack.config.ts
@@ -1,13 +1,7 @@
+import { esmConfig } from '@scripts/config/lib';
+import { baseConfig } from '@scripts/config/test';
 import { define } from 'rstack';
 
-define.lib(async () => {
-  const { esmConfig } = await import('@scripts/config/lib');
+define.lib(esmConfig);
 
-  return esmConfig;
-});
-
-define.test(async () => {
-  const { baseConfig } = await import('@scripts/config/test');
-
-  return baseConfig;
-});
+define.test(baseConfig);

--- a/packages/plugin-vue/rstack.config.ts
+++ b/packages/plugin-vue/rstack.config.ts
@@ -1,13 +1,7 @@
+import { esmConfig } from '@scripts/config/lib';
+import { baseConfig } from '@scripts/config/test';
 import { define } from 'rstack';
 
-define.lib(async () => {
-  const { esmConfig } = await import('@scripts/config/lib');
+define.lib(esmConfig);
 
-  return esmConfig;
-});
-
-define.test(async () => {
-  const { baseConfig } = await import('@scripts/config/test');
-
-  return baseConfig;
-});
+define.test(baseConfig);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -317,8 +317,8 @@ catalogs:
       specifier: ^1.0.4
       version: 1.0.4
     rstack:
-      specifier: ^0.7.1
-      version: 0.7.1
+      specifier: ^0.7.2
+      version: 0.7.2
     sass:
       specifier: ^1.103.1
       version: 1.103.1
@@ -401,7 +401,7 @@ importers:
         version: 2.0.0(prettier@3.9.6)
       rstack:
         specifier: 'catalog:'
-        version: 0.7.1(@module-federation/runtime-tools@2.9.0)(@rspress/core@2.0.21)(core-js@3.50.0)(jiti@2.7.0)(typescript@6.0.3)
+        version: 0.7.2(@module-federation/runtime-tools@2.9.0)(@rspress/core@2.0.21)(core-js@3.50.0)(jiti@2.7.0)(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1342,7 +1342,7 @@ importers:
         version: 0.7.0
       rstack:
         specifier: 'catalog:'
-        version: 0.7.1(@module-federation/runtime-tools@2.9.0)(@rspress/core@2.0.21)(core-js@3.50.0)(jiti@2.7.0)(typescript@6.0.3)
+        version: 0.7.2(@module-federation/runtime-tools@2.9.0)(@rspress/core@2.0.21)(core-js@3.50.0)(jiti@2.7.0)(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1405,16 +1405,16 @@ importers:
         version: 19.2.8(react@19.2.8)
       rsbuild-plugin-google-analytics:
         specifier: 'catalog:'
-        version: 1.0.6(@rsbuild/core@2.2.1)
+        version: 1.0.6(@rsbuild/core@2.2.2)
       rsbuild-plugin-open-graph:
         specifier: 'catalog:'
-        version: 1.1.3(@rsbuild/core@2.2.1)
+        version: 1.1.3(@rsbuild/core@2.2.2)
       rspress-plugin-font-open-sans:
         specifier: 'catalog:'
         version: 1.0.4(@rspress/core@2.0.21)
       rstack:
         specifier: 'catalog:'
-        version: 0.7.1(@module-federation/runtime-tools@2.9.0)(@rspress/core@2.0.21)(core-js@3.50.0)(jiti@2.7.0)(typescript@6.0.3)
+        version: 0.7.2(@module-federation/runtime-tools@2.9.0)(@rspress/core@2.0.21)(core-js@3.50.0)(jiti@2.7.0)(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -2334,6 +2334,16 @@ packages:
       core-js:
         optional: true
 
+  '@rsbuild/core@2.2.2':
+    resolution: {integrity: sha512-T82jUaeMUFhcBqpmKvRiNAcWMp6abxkvMEwiZi4x+gf7NAbyiF5jrbLnQLm1y4909eANsTSHenp99HlRPIByLw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      core-js: '>= 3.0.0'
+    peerDependenciesMeta:
+      core-js:
+        optional: true
+
   '@rsbuild/plugin-check-syntax@2.0.1':
     resolution: {integrity: sha512-z+NMAUXEbM4fhoQlKJNgTjsf+O1tknBihsXj4JnSFlwpfoY5uDjKC6D+StATATvUilSKXFrk4WDhcIyoxkj1gg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2441,11 +2451,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-arm64@2.2.1':
-    resolution: {integrity: sha512-Y/Naw/7V76QiUYdYRuBzBZtzRjt/3fjDUuF8GK0+/BO7BP1RrpY4tk1ln+iiqegRUD8u9uGn08fi8No1rwfyUg==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rspack/binding-darwin-arm64@2.2.2':
     resolution: {integrity: sha512-/le/AvV4HSinXTPs2Lqpujxt189Z5T10Ggt96QzckLRPvIchzqoavVDDjltzC7XcaZ87XCH/X06jNKgzkcBBNA==}
     cpu: [arm64]
@@ -2456,11 +2461,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@2.2.1':
-    resolution: {integrity: sha512-rTIG/xZIW7RbEEuMR9hnNn5dv3fDBpX0N4FAQUwfhUYy3tN2+3vibTTq/Nj1Sd9Vn4yWydbWIEwBX6m/aGejig==}
-    cpu: [x64]
-    os: [darwin]
-
   '@rspack/binding-darwin-x64@2.2.2':
     resolution: {integrity: sha512-uFIcUPUXiPxM6ljenLafp5TemT8eLZm1riRn8fJYmpqNCK+aCcTaud18XHZpI5SjzzcY+xUHfVShgvNzKXuf2g==}
     cpu: [x64]
@@ -2468,12 +2468,6 @@ packages:
 
   '@rspack/binding-linux-arm64-gnu@2.2.0':
     resolution: {integrity: sha512-0t8QOiOMcBV7RvPSsTJ5DQ4QCK6FIyUZy77qbxnS6asGTOXPZZn7V5cL26IxEv/wuHdQ6tQOXheau1fi+gGyBQ==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rspack/binding-linux-arm64-gnu@2.2.1':
-    resolution: {integrity: sha512-53rAMU6Hqiat21IMU1hTt4Si2F33h+ZbXOt+Y18W39AFjcwmleIBId2u7beqJeGXLJuBgIAm31jcbJj/PN7mWQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -2490,12 +2484,6 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-arm64-musl@2.2.1':
-    resolution: {integrity: sha512-o7zFiWkt4MqSfSdTbxUdF27fcrWKpRizcuVB8H3yd2G6xW9V2OfYbhVGQnOlbKi+GK74RkCmoJtANB+QboIqKQ==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@rspack/binding-linux-arm64-musl@2.2.2':
     resolution: {integrity: sha512-0u9O7tTVT2z+F6o/eEY6f6+My8Jn9U56QiBwkfy90ZaoAfZyQSSTxqaK/zA7W43oFxQefeCpiPas27VUzrSakw==}
     cpu: [arm64]
@@ -2504,12 +2492,6 @@ packages:
 
   '@rspack/binding-linux-ppc64-gnu@2.2.0':
     resolution: {integrity: sha512-nCHqZLv/E8nm2ccGkb00F5DQtXxzGy3W3X73ArA+N0+zXJUnzRcSRSwr7AE8pVgP/FYfX4yMFgUXy0g0YxYGRA==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rspack/binding-linux-ppc64-gnu@2.2.1':
-    resolution: {integrity: sha512-pvx1oeg1z7cr8OcNt7PAt1SJTHzdsN/pvu7HkGnfks2fWE7GDs9DLL2KvN7tUkzQvJm6bGgUwqSCOrqV4uSwAg==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
@@ -2526,12 +2508,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-riscv64-gnu@2.2.1':
-    resolution: {integrity: sha512-WQ6P94Wz2tgwOsgifTWP2/bV63iZH5+rkxngQwF22FC8KmIXXy/Yug7lyMH1ld8Hzg4p1qXjBBr4i1cCyJTR+w==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
   '@rspack/binding-linux-riscv64-gnu@2.2.2':
     resolution: {integrity: sha512-ReClZyp32/rJkUDV/oGDU0X6BCFyEkTR6r4stFwm/qOOaG6mUMRzZe4gur8Yh979p4Hiz9EdkmfEHY02GBXcaQ==}
     cpu: [riscv64]
@@ -2540,12 +2516,6 @@ packages:
 
   '@rspack/binding-linux-riscv64-musl@2.2.0':
     resolution: {integrity: sha512-kHB960oClkoPRPZ6sdkhRvqbdRIlbpIMYd/Tbxfmn3DWQahiCk1pkUFJbOtFq3EgESxZISV4THl442W2Y57HvQ==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
-
-  '@rspack/binding-linux-riscv64-musl@2.2.1':
-    resolution: {integrity: sha512-GEFUFHQkjKU7OYyHXnrIo8wWcUHM7jeKov5z6Lxd3i+3hKo11yBOgb7b+uD94Rx2tPuWF4jyFdWmcNu46Njb/A==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
@@ -2562,12 +2532,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-s390x-gnu@2.2.1':
-    resolution: {integrity: sha512-Cqw2UjSmFGZaw1EjQXClKDud86ThynGEEIazy2PZfPzZG4WjICK1WjdeFCJd7xWsSbUQ3jGyzb7/EHiDVa+sKA==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   '@rspack/binding-linux-s390x-gnu@2.2.2':
     resolution: {integrity: sha512-ql2Jub8QYWSugBppmj2u0SjcIj6fOQuAaLCYQOqU7zbvz/uuWTfoqmdWKExwrxeCU9Tzt7emVM0ETuVEpoca+A==}
     cpu: [s390x]
@@ -2576,12 +2540,6 @@ packages:
 
   '@rspack/binding-linux-x64-gnu@2.2.0':
     resolution: {integrity: sha512-M49UaWspE0YJ3268DsquD8idEQTfjBDMvO/I8qccV/Z5T+Q98FJ+kIs5liUaTWb48OIbDEK+8ZKx5QzLbfVN6g==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rspack/binding-linux-x64-gnu@2.2.1':
-    resolution: {integrity: sha512-QX+gRxg2CS9ri2fUG5eNurdsrOCWoJ56SsD2O7kcVGiRm+S2+muNb/QhkdkAdt/u/m++7Ve5TMIpHTnaKYCpCw==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -2598,12 +2556,6 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-x64-musl@2.2.1':
-    resolution: {integrity: sha512-mBZQl1NdGbEB3y5M9d0tkuF7RL1GLz3Hb3gqFa3QRZBymP9PCV83Jiji8s2PJimNUJIVcdZRIw8+VGYs/35c2A==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   '@rspack/binding-linux-x64-musl@2.2.2':
     resolution: {integrity: sha512-y9/9CmE8lrECaF17GAhacibTL+SvlEPEotQnUuBFC/WFtXh8hU2E7a7bAkpYGSLH6kM0nrJZHO3hTvM1wdWOJw==}
     cpu: [x64]
@@ -2614,21 +2566,12 @@ packages:
     resolution: {integrity: sha512-rerLPTN/HD4EvLNWs3O2N+Eb37eGvLRIP3dXXc3n+UzTebOepAsahNn44vXeRBsE4m/pHkpDJjwgWTytgQ2gBw==}
     cpu: [wasm32]
 
-  '@rspack/binding-wasm32-wasi@2.2.1':
-    resolution: {integrity: sha512-/d2ImKDS+lT+FJ07MxKBeUkTat84tr2Nm2+nIRt8HmZK7/N8odkQml9vb4MHr8E7oYOp4B+jm6W5frdRzKrkJQ==}
-    cpu: [wasm32]
-
   '@rspack/binding-wasm32-wasi@2.2.2':
     resolution: {integrity: sha512-VbDIjjeFwZvMSKAOGY5IbU6lLzt6AHHHncTdMMkZ94Xk7O2BOHe9BXDV32Ln29TIW2C8m1fdxfPZWDiecVghUQ==}
     cpu: [wasm32]
 
   '@rspack/binding-win32-arm64-msvc@2.2.0':
     resolution: {integrity: sha512-JUAmnbOQYGTRyX28vls/MOMonZWcmcCi5YtEq6YMc8Xqh3Qx0HUwaLM/I1xr/N9BX3b8CV0dQDOpNuBc2ei+CA==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rspack/binding-win32-arm64-msvc@2.2.1':
-    resolution: {integrity: sha512-TfmaKPF3KC7uoZb6A+8ZUbLS8g8P5EdeXFGLCaJ+UgdkJ20TsapcfJXZXWNnKzFEkV8dUO/t5oNxNLYy2URusw==}
     cpu: [arm64]
     os: [win32]
 
@@ -2642,11 +2585,6 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@2.2.1':
-    resolution: {integrity: sha512-rdBXayngvpQFMSUIC4b71FDZrSBJszSHNEkln/Nis3a17DMAE7IkgJcqe7SqLWbk2OPF/N920AOWmBEDQQCaMg==}
-    cpu: [ia32]
-    os: [win32]
-
   '@rspack/binding-win32-ia32-msvc@2.2.2':
     resolution: {integrity: sha512-TFPvr9RZw9oHIhooDhXHzWjKcHpGPTxkznSeM2poIWU0CdEuua2rVUfsrriTF1Dmx+9kMly61DQmyOHCbb+b2g==}
     cpu: [ia32]
@@ -2654,11 +2592,6 @@ packages:
 
   '@rspack/binding-win32-x64-msvc@2.2.0':
     resolution: {integrity: sha512-v6/3bFr9+i7hRpgulL9b5qCvZL0VgR4vQGQNqOWezUzZmPUj9LYpvB0L9xZIVwDQ2ug/xBiA58bfg5IbESgoyw==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rspack/binding-win32-x64-msvc@2.2.1':
-    resolution: {integrity: sha512-l3K4s7nrQJc+3LacPFjZGjX8Jk1sf8Q4TK6IXAsdSucOjTqYSpD8PMl2NUXCBDXOl8T2V4v323z1LfxwW8BPmA==}
     cpu: [x64]
     os: [win32]
 
@@ -2670,26 +2603,11 @@ packages:
   '@rspack/binding@2.2.0':
     resolution: {integrity: sha512-nxZzJqqB0EmEKp6qjzFNkBb/SgGt0k0DSENrLvAJgvVvrm3waVsubD0cfxtPlZY/rd5SzadzxWGEHRyFcds5nA==}
 
-  '@rspack/binding@2.2.1':
-    resolution: {integrity: sha512-56TqztuEMd+aHGv1jDXnkJQGSLTb4NoO146flFxJqPG8931UdXPO2pNR9M0Q2Pz+GvmO0fLHGPLYBHoRVrRlHw==}
-
   '@rspack/binding@2.2.2':
     resolution: {integrity: sha512-gWjKDQfVQJSBh/I+y9WTlyERsiShSJ7eI6Yl0SJs/6gjx8t4ixuwWCsaEFFjwSL4nSn6ML5hNQ7UFY3gj72BWA==}
 
   '@rspack/core@2.2.0':
     resolution: {integrity: sha512-3W7oX0BAHbK4VlknH3lfyfRvupzxdZtyEa+DfKmdjzmIAcqYtHnFd0nLqp5dzitDPyDI1TIKkDhpB0AZJn0pVg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    peerDependencies:
-      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
-      '@swc/helpers': ^0.5.23
-    peerDependenciesMeta:
-      '@module-federation/runtime-tools':
-        optional: true
-      '@swc/helpers':
-        optional: true
-
-  '@rspack/core@2.2.1':
-    resolution: {integrity: sha512-EHFX2oWCY1HkHJkG/Ev8HXCcl4gQzgETyairdIlBkKaypuW8i7kowBxUFzpHHg/ObF70vB3focToel9Wwg4MRA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -2768,88 +2686,88 @@ packages:
   '@rspress/shared@2.0.21':
     resolution: {integrity: sha512-siCWkv1a4n6y7JdVRII+fwCRZGZtG5KGFfKi2w/Tt33UnIgh4XGqozZ5F/K0iZ/QUwg0wi93SoVdOQm2Q+wf8w==}
 
-  '@rstackjs/cli-darwin-arm64@0.7.1':
-    resolution: {integrity: sha512-sRTBY2qZXatWYRPre26FLIKEa0RQjBeQKZrcVxA2At7VE39D4i3Wyv/ukhKZaVI94TJniSdYwHXAcJjsktbvww==}
+  '@rstackjs/cli-darwin-arm64@0.7.2':
+    resolution: {integrity: sha512-po/JUgHx7DZ+Kmrbyy3L0/xr3rlZfVEk0Oy4D2xsjmAa3bHhP63B5XCOCyArLAZeMOqYPze9VaOcgWmGN5qWwQ==}
     engines: {node: ^22.18.0 || >=24.3.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rstackjs/cli-darwin-x64@0.7.1':
-    resolution: {integrity: sha512-L9S60Rjbf/rsLkROpOBwsPpr4ufAFiakATf4d7+WWc+hCTqy3oWDjYT6yJKNNE7xtDsbYk6iYLojdJVHSEN9uQ==}
+  '@rstackjs/cli-darwin-x64@0.7.2':
+    resolution: {integrity: sha512-RFgUgUUXC3ZLF2iKJplsK2Ty49VkVw+rR8y5Hgf+3BAUn9ffRCUAqscWQGPCrJZENVbTEUWDyEVCMNnUpM6+Ww==}
     engines: {node: ^22.18.0 || >=24.3.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rstackjs/cli-linux-arm64-gnu@0.7.1':
-    resolution: {integrity: sha512-RPS8z9ydbfajyh+xBRZzu0XIlCm519EY2O7mAZhYdFX24+2EAAlVPp3xqVNiBg/wdDmOHWflgQjujxWdZRartw==}
+  '@rstackjs/cli-linux-arm64-gnu@0.7.2':
+    resolution: {integrity: sha512-pNUbP/Bd962FznXLiJHnCcxpP/l1L9wmLsdIh43T8MQkY4m0Rv/s5tpA1rRcoqYHymhnVqWFcBAWxAPTSnOFFQ==}
     engines: {node: ^22.18.0 || >=24.3.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rstackjs/cli-linux-arm64-musl@0.7.1':
-    resolution: {integrity: sha512-/yCaFh4BiN5lr0io+7dDMUnAj3T7uKhR6Vv2DcPWwf9vodLS/swmcVYsxTVKE6wPsm6ityUQIxRRTlOb8aQeZQ==}
+  '@rstackjs/cli-linux-arm64-musl@0.7.2':
+    resolution: {integrity: sha512-cOC1WNNAZEeUxA0Lvbkk0ZBGMQIhKcjlZZinwGkg6zHJ7jxW42/SvwjNdnXv1xEpQd59OGJ1aSR1/Gt7PpItzw==}
     engines: {node: ^22.18.0 || >=24.3.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rstackjs/cli-linux-ppc64-gnu@0.7.1':
-    resolution: {integrity: sha512-lyBvTntv8tpr9uebh/rj+uquU2+M9eZlQQrDYrSSI63lkWwrGG/QmFziB8h60kr4DirMouH+gQVqhJ43wgBcEg==}
+  '@rstackjs/cli-linux-ppc64-gnu@0.7.2':
+    resolution: {integrity: sha512-jOk/KA3gpNapZO8y0Pc99XG7kjtgz6ndOGqKczgYD7VWBZcnMvD2KKI1GmeLxLf+9v0NiLtefj1CCtFEbqwXKg==}
     engines: {node: ^22.18.0 || >=24.3.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rstackjs/cli-linux-riscv64-gnu@0.7.1':
-    resolution: {integrity: sha512-uzrI+m5FiQOhhKoPWhFWR3aXQkbB6Nt8MpJKB1ZXU3G40icNQ2fxNTNOJoQyQZBOqWxMs1QYY9MH4LQjkPVtXw==}
+  '@rstackjs/cli-linux-riscv64-gnu@0.7.2':
+    resolution: {integrity: sha512-8fukS3qf1nrvYDQ4886gWphHsg9gyktSkUUudSEFkamKKKOCmdZn+tDUvEebxYiqQCUEC/mqkUc/jg7EQKvP7Q==}
     engines: {node: ^22.18.0 || >=24.3.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@rstackjs/cli-linux-riscv64-musl@0.7.1':
-    resolution: {integrity: sha512-PMpM8U8qgTJAaUssWsyUVXH7PAlJw/rfW6CyUkLESuzqvuXQrwptw9wBFFgs9q19f8tmIHii7C6Ep8K0VklbOw==}
+  '@rstackjs/cli-linux-riscv64-musl@0.7.2':
+    resolution: {integrity: sha512-AciMUbdFgC/bDP05iuC13x4uPDISkyx2S9KiWDnjhs7bCjHv19bhPeOGLnpUWjAL86LxbHNuk+rM8wdt1da4gg==}
     engines: {node: ^22.18.0 || >=24.3.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@rstackjs/cli-linux-s390x-gnu@0.7.1':
-    resolution: {integrity: sha512-AzyL+xCk9OPYtWiZBhHMxCzByt8qBSrF6firgnKlfD+5UtE9XyScDJh12zR7OiO84TyVQicz2mWewl8dAmZqNA==}
+  '@rstackjs/cli-linux-s390x-gnu@0.7.2':
+    resolution: {integrity: sha512-pj5V7Thbdc0FfK7Ngl3wLish7S0Yyy/ZmlH0Qd9UEMrNwMyMoyR+ZAJaWRjv7LFJQegPZNKBEgXfDc6Yeg7KjA==}
     engines: {node: ^22.18.0 || >=24.3.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rstackjs/cli-linux-x64-gnu@0.7.1':
-    resolution: {integrity: sha512-xc/9nSql1uwpwO2vHJCB+X0etIevgYm1Wz0cxRBW7X9BbbU6V9Lu/BuF9Jsx8Z/6Qd63xim6mZig8QNR1tFGwg==}
+  '@rstackjs/cli-linux-x64-gnu@0.7.2':
+    resolution: {integrity: sha512-25Xzm2SXyDA1WkXrcHQym1ZI71ZK4n9AD32+0UT8IhVF+FGDBw0WG2UeOIr5XcaCCxgjGw1qec4aZ4GEd0/6vg==}
     engines: {node: ^22.18.0 || >=24.3.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rstackjs/cli-linux-x64-musl@0.7.1':
-    resolution: {integrity: sha512-Rp1GHTfgJfB8Pcmymf4AgKQ1Yg9NXHCPd6tPBDmr9LAsSwA5k2uY5Ca56rSA6YI0ZZrIdBGSGV+o79a2BLND9Q==}
+  '@rstackjs/cli-linux-x64-musl@0.7.2':
+    resolution: {integrity: sha512-77E3zZ5nrIP86nh40mMOvAu547a8qPDfTcKUQU/4fVjcE7g7zX17gQGGOHubzoqWRxv5abTABkG/ovhxqZ8bwQ==}
     engines: {node: ^22.18.0 || >=24.3.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rstackjs/cli-win32-arm64-msvc@0.7.1':
-    resolution: {integrity: sha512-Xk2MwC1Ql+Fb8ThvSupRk9C+rZqtgTHSxRsxyjnoS0UZbYuzwUp8TtTiNBb+NZz8YVv2Ouabk6CoSxwqjf9A/A==}
+  '@rstackjs/cli-win32-arm64-msvc@0.7.2':
+    resolution: {integrity: sha512-fg8vRphmnXZQIC0lo757rwbFJS1s7Ft9RT9BzaJrqEcMWinxHx9HtKCddJ1scEpgu5Al8Vws74KYu2XNcUFUbA==}
     engines: {node: ^22.18.0 || >=24.3.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rstackjs/cli-win32-ia32-msvc@0.7.1':
-    resolution: {integrity: sha512-Ka0lPt6H5ZIoqaXPEFwuXPmgTwGNVKAeIFL//oyp/snME7fxtTA3DuPqe51biFc452pJpYM3YtZXb2Am7kDTjw==}
+  '@rstackjs/cli-win32-ia32-msvc@0.7.2':
+    resolution: {integrity: sha512-veUcxZ+ZqGzkkRYfkKj0GHlIKxR3NKm/Va4taifZLFXcqDFrSAmoueXTfhIzsLrNII+g85gizyaMdjytWhw8Lw==}
     engines: {node: ^22.18.0 || >=24.3.0}
     cpu: [ia32]
     os: [win32]
 
-  '@rstackjs/cli-win32-x64-msvc@0.7.1':
-    resolution: {integrity: sha512-ot5aDRTSuOSef2/xb9bummjHqJCXicfFpazrX3bxY3MLhLMePKLOzCvIZF0ZXFsAMIWmz1dy4QnN3b7NBMngdg==}
+  '@rstackjs/cli-win32-x64-msvc@0.7.2':
+    resolution: {integrity: sha512-E/+K2W+GtezTLaOZ87erMyWOEbivKZiN/m/Iqeg8UJrfp9Zkqm7yIhQnYwG+KxN0gp3qjB/zxlcYdN5fnnhOWQ==}
     engines: {node: ^22.18.0 || >=24.3.0}
     cpu: [x64]
     os: [win32]
@@ -2879,6 +2797,19 @@ packages:
 
   '@rstest/core@0.11.10':
     resolution: {integrity: sha512-x/PNGPdyKQWbiVhpoOQco8xXevh4P/QamuyJ0/YdTrdEiUcUglT6tGSnxaudwyrQr8e/5gwWuOt6zykZKWmSUg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      happy-dom: ^20.8.3
+      jsdom: '>=15.0.0'
+    peerDependenciesMeta:
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  '@rstest/core@0.11.11':
+    resolution: {integrity: sha512-7Ii2/2/ex1Oa0Kg5Qk5RKx2+e0I83BHLwH0/gn1B7IDwXCh5msFCF7yTyVGFuMltlm3E8Cf4QD7jadOEaBfXfw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -3300,69 +3231,69 @@ packages:
   '@vue/shared@3.5.42':
     resolution: {integrity: sha512-2rPxex1jQf4jvl9MOHl6YaXCPcrNqz/FstMOEh3QWY+/OME9nQTvl9WYeCwhW7AFjaR0SnngZGlp/wkR6rkI6g==}
 
-  '@yuku-parser/binding-android-arm64@0.9.1':
-    resolution: {integrity: sha512-AohsA9tsg7xQkYnPNlP/upeXbVGXyVwSFNmDNictfNqiMaqks82H7wsz7zF/5yFYTren/mLGWVrzJ9vFw7ovrg==}
+  '@yuku-parser/binding-android-arm64@0.9.3':
+    resolution: {integrity: sha512-z3tDGTaUXD5Q4IuebFOY/QHxhR/SqujMhkMv9C5bh25upyFEXdafp0MsXQIIheWhVZzn5VMOniyxFni/7s9LgQ==}
     cpu: [arm64]
     os: [android]
 
-  '@yuku-parser/binding-darwin-arm64@0.9.1':
-    resolution: {integrity: sha512-EMJbDXAR6CwOmq54SLKVr6fh3a9JaBQu8UNJKpUihClR2GpW2f4rF8qAgvOci07Q5AUJp00/FWZp8uZkNXj9eg==}
+  '@yuku-parser/binding-darwin-arm64@0.9.3':
+    resolution: {integrity: sha512-hzKvKSKS7z3ufnu1VkQYEoxmS6A5uNnkwukKnc2atxpWdq648nLVOqut4h1jUXjbM2WcoTfuZLF6AHAGFf8cmg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@yuku-parser/binding-darwin-x64@0.9.1':
-    resolution: {integrity: sha512-HFMB34UzToIqELUU71D5arkJDSOUiPuVGCt3a/p0n6YMUEHmlNGZntVkG0Gf70Qss7EECU75hx7fKWEtAmFLSQ==}
+  '@yuku-parser/binding-darwin-x64@0.9.3':
+    resolution: {integrity: sha512-OM2PiVlPATvzlj/KGHNlu+t8FC3YzM5joVNjhsz/EaigQ8x2UUQ1Q0agQLiv5GZ2L8TSzrLUwBCZ7YOvP8q+tw==}
     cpu: [x64]
     os: [darwin]
 
-  '@yuku-parser/binding-freebsd-x64@0.9.1':
-    resolution: {integrity: sha512-xw0O3G93kosvM+Byclp9W6ssHz6ngfduJDPuNki7rAG4OQ0nz1rZp/Zj4mAk8I8fR31vzwLuCH1qT1j1kv+09Q==}
+  '@yuku-parser/binding-freebsd-x64@0.9.3':
+    resolution: {integrity: sha512-WMn9M4LHNVysGNwsAJ9gpRPqQIW2lcPrDNGcyk0agx3IYqCJq1MQugh6Be8Otc5U08eGdE39o8Kx9YWJmXz7GA==}
     cpu: [x64]
     os: [freebsd]
 
-  '@yuku-parser/binding-linux-arm-gnu@0.9.1':
-    resolution: {integrity: sha512-ZZ3a/sKzEpsQGa9cFL3XjYc0ylVohiXK3cW/hHdg0cMU9es8Vtck94pQ/K8xwlX1kncjUn40XutFuAXx8Ow8vA==}
+  '@yuku-parser/binding-linux-arm-gnu@0.9.3':
+    resolution: {integrity: sha512-vqKjwiyW1FWvbykYMEQIcAJwA17WxK3rxxqDuyCvQwcNVaLEUxI4BXiUdlF3kHucc7MnoFQhoRPkySgOzlLM+Q==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-parser/binding-linux-arm-musl@0.9.1':
-    resolution: {integrity: sha512-dtKTQ5CybtIAzll0EoN/jyUPvhgbcDCcoLSWcm9YsguTiW8LkHySe78Mnir3DS//QqwrO59O8C2NADtv21wnxg==}
+  '@yuku-parser/binding-linux-arm-musl@0.9.3':
+    resolution: {integrity: sha512-qohilhYOT+zkt2gYzym4F1T6BzRdvPqS9/sFB03pmnVV8LrvjOXVsGwEBAa3CEvzJKhAZjdTmVz7zsVdjyHWLg==}
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
-  '@yuku-parser/binding-linux-arm64-gnu@0.9.1':
-    resolution: {integrity: sha512-csRtiN90U9Gfy/OnYvC/XR32eSd3E/+1GUIM2UmsEnTwnZ2mAd4VxW2CgbuCQCMNSEaeQzeueh5cu2dKEId1Pg==}
+  '@yuku-parser/binding-linux-arm64-gnu@0.9.3':
+    resolution: {integrity: sha512-tvTIyUvTGkeee68i4JIo9o27As+Ug6LXOZvElGgFbTs6+KBdb5LGhvugaIQljdfIsm2XnIbOLG6OnQSXHMLB9w==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-parser/binding-linux-arm64-musl@0.9.1':
-    resolution: {integrity: sha512-HGmIyK1B8ve7EOPM/VCAq03LPWpWFsKW29lxQWQxlXryqGMs16m73EurMu+d+RgWmEQQLAj5gSoj1KVD+P4epw==}
+  '@yuku-parser/binding-linux-arm64-musl@0.9.3':
+    resolution: {integrity: sha512-OWZBHW1wuChBpFlrF+On1yiBcFPMRrj2g0VKsM/PCBGffu1OM0ORkS+vLS3Snu6wYwndM5Dd9Ctvux6eUlrQjA==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@yuku-parser/binding-linux-x64-gnu@0.9.1':
-    resolution: {integrity: sha512-pp/acGgrUokF4KSh+EECfz4Nqwx3J23g24IM+Rh91pkCUj0/QfW7C6KwB2/ZhyuN6qWEZ8s1j+DAddcAXWtBBQ==}
+  '@yuku-parser/binding-linux-x64-gnu@0.9.3':
+    resolution: {integrity: sha512-/tbk1h0dlADOCngbiQO9V3SHwBIJkoGBq8BDEraSw2CC3nGxPEPTCCYUDp5738Ij2FxVwy1FWVuhFkHvpMrPbQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-parser/binding-linux-x64-musl@0.9.1':
-    resolution: {integrity: sha512-XdBOP/a5Jx5C36w7XBrGsZKRy45oSrD6ZMyCR6xBHEnL3TihKadH9o+UExPGOh0dLnQ8vZ/6sWwU+CTsGzay0g==}
+  '@yuku-parser/binding-linux-x64-musl@0.9.3':
+    resolution: {integrity: sha512-u3+0sCso/mcjDvtc3866D2giV7l34PDyDVBkMesAWa3DWbIWPlybehi2SSnmScgArV22ctqSSgUzdBBVJ6zYAg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@yuku-parser/binding-win32-arm64@0.9.1':
-    resolution: {integrity: sha512-sVA1I57uWAQsDD2ND6loFZXnMynxtCEcsR9L4O31lVd5/xCoGSOo5v+rbqJU2cDPSyAZTFBAFQLzipcYfwUO4w==}
+  '@yuku-parser/binding-win32-arm64@0.9.3':
+    resolution: {integrity: sha512-xnGEvdhyjRkXozHtpXVpEEkyGZWAxJ3RoILv7XRV5SvTEztaTCk5GQyfcOzI9An/EJtcL4ERCI8QmS0TpDPJiA==}
     cpu: [arm64]
     os: [win32]
 
-  '@yuku-parser/binding-win32-x64@0.9.1':
-    resolution: {integrity: sha512-hNzy7ZE4iFW4gkhYiHBB05BJPS6NE+oOw9oddyvBiBi9s+xP1keli3ZHxII8l7Qedh/3pNc8X43wo6UPoNarrw==}
+  '@yuku-parser/binding-win32-x64@0.9.3':
+    resolution: {integrity: sha512-N5eShGcuwnrXEprePFmEjtng6acZmtnC4zgazK9xxkavcx1q1uX8Nz8lU5RS973EMlNr902cIc6Cd2D4tqZDBg==}
     cpu: [x64]
     os: [win32]
 
@@ -5050,8 +4981,8 @@ packages:
     peerDependencies:
       '@rspress/core': ^2.0.0
 
-  rstack@0.7.1:
-    resolution: {integrity: sha512-/bInr/2dBshFVLXADduvjunK0HHaVUdhxQmq3nnrgJMhudsnFBLE1braGcSYi9NiohauL6ZkN+ChSC3R1Bs7Dg==}
+  rstack@0.7.2:
+    resolution: {integrity: sha512-A0nL89XfrcA1tqhX7WmA+6p7ogMr4oWSYaPH1h+Kybl/e4+mEQAO/GCVA2BPsoUsSx8KltC3wUkmuhkKtoQojQ==}
     engines: {node: ^22.18.0 || >=24.3.0}
     hasBin: true
     peerDependencies:
@@ -5612,8 +5543,8 @@ packages:
   yuku-ast@0.9.3:
     resolution: {integrity: sha512-Kt0PXlPCXdKF1fWFTl7N3DaxsVk6DHF8VAXHJMkwPtJnWYgbx20pYgGSweuC/86mIM7k1NUITQ4JffgOLUWTCw==}
 
-  yuku-parser@0.9.1:
-    resolution: {integrity: sha512-N4YmuFq7fPTaxhti0mC73nsmxYe30DKHlAxZdTYr4A88NAT3BckilMkuuusHofrfFSeswAdxfixcYy8MMhkvcQ==}
+  yuku-parser@0.9.3:
+    resolution: {integrity: sha512-96wPoHnwaXfkZv7UIOUkDb+s7ZH8lv8Qtg+MxdvHUV1LFa5jV9iKOaams1942YQt+krFQrWiD6lSg2ermv5kHA==}
 
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
@@ -6583,7 +6514,16 @@ snapshots:
 
   '@rsbuild/core@2.2.1(@module-federation/runtime-tools@2.9.0)(core-js@3.50.0)':
     dependencies:
-      '@rspack/core': 2.2.1(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.2(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
+      '@swc/helpers': 0.5.23
+    optionalDependencies:
+      core-js: 3.50.0
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+
+  '@rsbuild/core@2.2.2(@module-federation/runtime-tools@2.9.0)(core-js@3.50.0)':
+    dependencies:
+      '@rspack/core': 2.2.2(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
       '@swc/helpers': 0.5.23
     optionalDependencies:
       core-js: 3.50.0
@@ -6678,16 +6618,10 @@ snapshots:
   '@rspack/binding-darwin-arm64@2.2.0':
     optional: true
 
-  '@rspack/binding-darwin-arm64@2.2.1':
-    optional: true
-
   '@rspack/binding-darwin-arm64@2.2.2':
     optional: true
 
   '@rspack/binding-darwin-x64@2.2.0':
-    optional: true
-
-  '@rspack/binding-darwin-x64@2.2.1':
     optional: true
 
   '@rspack/binding-darwin-x64@2.2.2':
@@ -6696,16 +6630,10 @@ snapshots:
   '@rspack/binding-linux-arm64-gnu@2.2.0':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@2.2.1':
-    optional: true
-
   '@rspack/binding-linux-arm64-gnu@2.2.2':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@2.2.0':
-    optional: true
-
-  '@rspack/binding-linux-arm64-musl@2.2.1':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@2.2.2':
@@ -6714,16 +6642,10 @@ snapshots:
   '@rspack/binding-linux-ppc64-gnu@2.2.0':
     optional: true
 
-  '@rspack/binding-linux-ppc64-gnu@2.2.1':
-    optional: true
-
   '@rspack/binding-linux-ppc64-gnu@2.2.2':
     optional: true
 
   '@rspack/binding-linux-riscv64-gnu@2.2.0':
-    optional: true
-
-  '@rspack/binding-linux-riscv64-gnu@2.2.1':
     optional: true
 
   '@rspack/binding-linux-riscv64-gnu@2.2.2':
@@ -6732,16 +6654,10 @@ snapshots:
   '@rspack/binding-linux-riscv64-musl@2.2.0':
     optional: true
 
-  '@rspack/binding-linux-riscv64-musl@2.2.1':
-    optional: true
-
   '@rspack/binding-linux-riscv64-musl@2.2.2':
     optional: true
 
   '@rspack/binding-linux-s390x-gnu@2.2.0':
-    optional: true
-
-  '@rspack/binding-linux-s390x-gnu@2.2.1':
     optional: true
 
   '@rspack/binding-linux-s390x-gnu@2.2.2':
@@ -6750,29 +6666,16 @@ snapshots:
   '@rspack/binding-linux-x64-gnu@2.2.0':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@2.2.1':
-    optional: true
-
   '@rspack/binding-linux-x64-gnu@2.2.2':
     optional: true
 
   '@rspack/binding-linux-x64-musl@2.2.0':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@2.2.1':
-    optional: true
-
   '@rspack/binding-linux-x64-musl@2.2.2':
     optional: true
 
   '@rspack/binding-wasm32-wasi@2.2.0':
-    dependencies:
-      '@emnapi/core': 1.11.3
-      '@emnapi/runtime': 1.11.3
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
-    optional: true
-
-  '@rspack/binding-wasm32-wasi@2.2.1':
     dependencies:
       '@emnapi/core': 1.11.3
       '@emnapi/runtime': 1.11.3
@@ -6789,25 +6692,16 @@ snapshots:
   '@rspack/binding-win32-arm64-msvc@2.2.0':
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@2.2.1':
-    optional: true
-
   '@rspack/binding-win32-arm64-msvc@2.2.2':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@2.2.0':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@2.2.1':
-    optional: true
-
   '@rspack/binding-win32-ia32-msvc@2.2.2':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@2.2.0':
-    optional: true
-
-  '@rspack/binding-win32-x64-msvc@2.2.1':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@2.2.2':
@@ -6830,23 +6724,6 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 2.2.0
       '@rspack/binding-win32-x64-msvc': 2.2.0
 
-  '@rspack/binding@2.2.1':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 2.2.1
-      '@rspack/binding-darwin-x64': 2.2.1
-      '@rspack/binding-linux-arm64-gnu': 2.2.1
-      '@rspack/binding-linux-arm64-musl': 2.2.1
-      '@rspack/binding-linux-ppc64-gnu': 2.2.1
-      '@rspack/binding-linux-riscv64-gnu': 2.2.1
-      '@rspack/binding-linux-riscv64-musl': 2.2.1
-      '@rspack/binding-linux-s390x-gnu': 2.2.1
-      '@rspack/binding-linux-x64-gnu': 2.2.1
-      '@rspack/binding-linux-x64-musl': 2.2.1
-      '@rspack/binding-wasm32-wasi': 2.2.1
-      '@rspack/binding-win32-arm64-msvc': 2.2.1
-      '@rspack/binding-win32-ia32-msvc': 2.2.1
-      '@rspack/binding-win32-x64-msvc': 2.2.1
-
   '@rspack/binding@2.2.2':
     optionalDependencies:
       '@rspack/binding-darwin-arm64': 2.2.2
@@ -6867,13 +6744,6 @@ snapshots:
   '@rspack/core@2.2.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)':
     dependencies:
       '@rspack/binding': 2.2.0
-    optionalDependencies:
-      '@module-federation/runtime-tools': 2.9.0
-      '@swc/helpers': 0.5.23
-
-  '@rspack/core@2.2.1(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)':
-    dependencies:
-      '@rspack/binding': 2.2.1
     optionalDependencies:
       '@module-federation/runtime-tools': 2.9.0
       '@swc/helpers': 0.5.23
@@ -6986,43 +6856,43 @@ snapshots:
       - core-js
       - supports-color
 
-  '@rstackjs/cli-darwin-arm64@0.7.1':
+  '@rstackjs/cli-darwin-arm64@0.7.2':
     optional: true
 
-  '@rstackjs/cli-darwin-x64@0.7.1':
+  '@rstackjs/cli-darwin-x64@0.7.2':
     optional: true
 
-  '@rstackjs/cli-linux-arm64-gnu@0.7.1':
+  '@rstackjs/cli-linux-arm64-gnu@0.7.2':
     optional: true
 
-  '@rstackjs/cli-linux-arm64-musl@0.7.1':
+  '@rstackjs/cli-linux-arm64-musl@0.7.2':
     optional: true
 
-  '@rstackjs/cli-linux-ppc64-gnu@0.7.1':
+  '@rstackjs/cli-linux-ppc64-gnu@0.7.2':
     optional: true
 
-  '@rstackjs/cli-linux-riscv64-gnu@0.7.1':
+  '@rstackjs/cli-linux-riscv64-gnu@0.7.2':
     optional: true
 
-  '@rstackjs/cli-linux-riscv64-musl@0.7.1':
+  '@rstackjs/cli-linux-riscv64-musl@0.7.2':
     optional: true
 
-  '@rstackjs/cli-linux-s390x-gnu@0.7.1':
+  '@rstackjs/cli-linux-s390x-gnu@0.7.2':
     optional: true
 
-  '@rstackjs/cli-linux-x64-gnu@0.7.1':
+  '@rstackjs/cli-linux-x64-gnu@0.7.2':
     optional: true
 
-  '@rstackjs/cli-linux-x64-musl@0.7.1':
+  '@rstackjs/cli-linux-x64-musl@0.7.2':
     optional: true
 
-  '@rstackjs/cli-win32-arm64-msvc@0.7.1':
+  '@rstackjs/cli-win32-arm64-msvc@0.7.2':
     optional: true
 
-  '@rstackjs/cli-win32-ia32-msvc@0.7.1':
+  '@rstackjs/cli-win32-ia32-msvc@0.7.2':
     optional: true
 
-  '@rstackjs/cli-win32-x64-msvc@0.7.1':
+  '@rstackjs/cli-win32-x64-msvc@0.7.2':
     optional: true
 
   '@rstackjs/create-toolkit@2.2.4': {}
@@ -7040,6 +6910,14 @@ snapshots:
   '@rstest/core@0.11.10(@module-federation/runtime-tools@2.9.0)(core-js@3.50.0)':
     dependencies:
       '@rsbuild/core': 2.2.0(@module-federation/runtime-tools@2.9.0)(core-js@3.50.0)
+      '@types/chai': 5.2.3
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - core-js
+
+  '@rstest/core@0.11.11(@module-federation/runtime-tools@2.9.0)(core-js@3.50.0)':
+    dependencies:
+      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)(core-js@3.50.0)
       '@types/chai': 5.2.3
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
@@ -7505,40 +7383,40 @@ snapshots:
 
   '@vue/shared@3.5.42': {}
 
-  '@yuku-parser/binding-android-arm64@0.9.1':
+  '@yuku-parser/binding-android-arm64@0.9.3':
     optional: true
 
-  '@yuku-parser/binding-darwin-arm64@0.9.1':
+  '@yuku-parser/binding-darwin-arm64@0.9.3':
     optional: true
 
-  '@yuku-parser/binding-darwin-x64@0.9.1':
+  '@yuku-parser/binding-darwin-x64@0.9.3':
     optional: true
 
-  '@yuku-parser/binding-freebsd-x64@0.9.1':
+  '@yuku-parser/binding-freebsd-x64@0.9.3':
     optional: true
 
-  '@yuku-parser/binding-linux-arm-gnu@0.9.1':
+  '@yuku-parser/binding-linux-arm-gnu@0.9.3':
     optional: true
 
-  '@yuku-parser/binding-linux-arm-musl@0.9.1':
+  '@yuku-parser/binding-linux-arm-musl@0.9.3':
     optional: true
 
-  '@yuku-parser/binding-linux-arm64-gnu@0.9.1':
+  '@yuku-parser/binding-linux-arm64-gnu@0.9.3':
     optional: true
 
-  '@yuku-parser/binding-linux-arm64-musl@0.9.1':
+  '@yuku-parser/binding-linux-arm64-musl@0.9.3':
     optional: true
 
-  '@yuku-parser/binding-linux-x64-gnu@0.9.1':
+  '@yuku-parser/binding-linux-x64-gnu@0.9.3':
     optional: true
 
-  '@yuku-parser/binding-linux-x64-musl@0.9.1':
+  '@yuku-parser/binding-linux-x64-musl@0.9.3':
     optional: true
 
-  '@yuku-parser/binding-win32-arm64@0.9.1':
+  '@yuku-parser/binding-win32-arm64@0.9.3':
     optional: true
 
-  '@yuku-parser/binding-win32-x64@0.9.1':
+  '@yuku-parser/binding-win32-x64@0.9.3':
     optional: true
 
   '@yuku-toolchain/types@0.9.3': {}
@@ -9480,13 +9358,13 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.2.1):
+  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.2.2):
     optionalDependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)(core-js@3.50.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)(core-js@3.50.0)
 
-  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.2.1):
+  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.2.2):
     optionalDependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)(core-js@3.50.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)(core-js@3.50.0)
 
   rslog@2.3.0: {}
 
@@ -9515,30 +9393,30 @@ snapshots:
     dependencies:
       '@rspress/core': 2.0.21(@module-federation/runtime-tools@2.9.0)(@rspack/core@2.2.2)(core-js@3.50.0)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@8.1.1)
 
-  rstack@0.7.1(@module-federation/runtime-tools@2.9.0)(@rspress/core@2.0.21)(core-js@3.50.0)(jiti@2.7.0)(typescript@6.0.3):
+  rstack@0.7.2(@module-federation/runtime-tools@2.9.0)(@rspress/core@2.0.21)(core-js@3.50.0)(jiti@2.7.0)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)(core-js@3.50.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)(core-js@3.50.0)
       '@rslib/core': 1.0.0-rc.2(@module-federation/runtime-tools@2.9.0)(core-js@3.50.0)(typescript@6.0.3)
       '@rslint/core': 0.9.0(jiti@2.7.0)
-      '@rstest/core': 0.11.10(@module-federation/runtime-tools@2.9.0)(core-js@3.50.0)
+      '@rstest/core': 0.11.11(@module-federation/runtime-tools@2.9.0)(core-js@3.50.0)
       prettier: 3.9.6
       tinypool: 2.1.2
-      yuku-parser: 0.9.1
+      yuku-parser: 0.9.3
     optionalDependencies:
       '@rspress/core': 2.0.21(@module-federation/runtime-tools@2.9.0)(@rspack/core@2.2.2)(core-js@3.50.0)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@8.1.1)
-      '@rstackjs/cli-darwin-arm64': 0.7.1
-      '@rstackjs/cli-darwin-x64': 0.7.1
-      '@rstackjs/cli-linux-arm64-gnu': 0.7.1
-      '@rstackjs/cli-linux-arm64-musl': 0.7.1
-      '@rstackjs/cli-linux-ppc64-gnu': 0.7.1
-      '@rstackjs/cli-linux-riscv64-gnu': 0.7.1
-      '@rstackjs/cli-linux-riscv64-musl': 0.7.1
-      '@rstackjs/cli-linux-s390x-gnu': 0.7.1
-      '@rstackjs/cli-linux-x64-gnu': 0.7.1
-      '@rstackjs/cli-linux-x64-musl': 0.7.1
-      '@rstackjs/cli-win32-arm64-msvc': 0.7.1
-      '@rstackjs/cli-win32-ia32-msvc': 0.7.1
-      '@rstackjs/cli-win32-x64-msvc': 0.7.1
+      '@rstackjs/cli-darwin-arm64': 0.7.2
+      '@rstackjs/cli-darwin-x64': 0.7.2
+      '@rstackjs/cli-linux-arm64-gnu': 0.7.2
+      '@rstackjs/cli-linux-arm64-musl': 0.7.2
+      '@rstackjs/cli-linux-ppc64-gnu': 0.7.2
+      '@rstackjs/cli-linux-riscv64-gnu': 0.7.2
+      '@rstackjs/cli-linux-riscv64-musl': 0.7.2
+      '@rstackjs/cli-linux-s390x-gnu': 0.7.2
+      '@rstackjs/cli-linux-x64-gnu': 0.7.2
+      '@rstackjs/cli-linux-x64-musl': 0.7.2
+      '@rstackjs/cli-win32-arm64-msvc': 0.7.2
+      '@rstackjs/cli-win32-ia32-msvc': 0.7.2
+      '@rstackjs/cli-win32-x64-msvc': 0.7.2
     transitivePeerDependencies:
       - '@microsoft/api-extractor'
       - '@module-federation/runtime-tools'
@@ -10027,23 +9905,23 @@ snapshots:
     dependencies:
       '@yuku-toolchain/types': 0.9.3
 
-  yuku-parser@0.9.1:
+  yuku-parser@0.9.3:
     dependencies:
       '@yuku-toolchain/types': 0.9.3
       yuku-ast: 0.9.3
     optionalDependencies:
-      '@yuku-parser/binding-android-arm64': 0.9.1
-      '@yuku-parser/binding-darwin-arm64': 0.9.1
-      '@yuku-parser/binding-darwin-x64': 0.9.1
-      '@yuku-parser/binding-freebsd-x64': 0.9.1
-      '@yuku-parser/binding-linux-arm-gnu': 0.9.1
-      '@yuku-parser/binding-linux-arm-musl': 0.9.1
-      '@yuku-parser/binding-linux-arm64-gnu': 0.9.1
-      '@yuku-parser/binding-linux-arm64-musl': 0.9.1
-      '@yuku-parser/binding-linux-x64-gnu': 0.9.1
-      '@yuku-parser/binding-linux-x64-musl': 0.9.1
-      '@yuku-parser/binding-win32-arm64': 0.9.1
-      '@yuku-parser/binding-win32-x64': 0.9.1
+      '@yuku-parser/binding-android-arm64': 0.9.3
+      '@yuku-parser/binding-darwin-arm64': 0.9.3
+      '@yuku-parser/binding-darwin-x64': 0.9.3
+      '@yuku-parser/binding-freebsd-x64': 0.9.3
+      '@yuku-parser/binding-linux-arm-gnu': 0.9.3
+      '@yuku-parser/binding-linux-arm-musl': 0.9.3
+      '@yuku-parser/binding-linux-arm64-gnu': 0.9.3
+      '@yuku-parser/binding-linux-arm64-musl': 0.9.3
+      '@yuku-parser/binding-linux-x64-gnu': 0.9.3
+      '@yuku-parser/binding-linux-x64-musl': 0.9.3
+      '@yuku-parser/binding-win32-arm64': 0.9.3
+      '@yuku-parser/binding-win32-x64': 0.9.3
 
   zimmerframe@1.1.4: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -119,7 +119,7 @@ catalog:
   'rspack-merge': '1.0.1'
   'rspack-vue-loader': '^17.6.2'
   'rspress-plugin-font-open-sans': '^1.0.4'
-  'rstack': '^0.7.1'
+  'rstack': '^0.7.2'
   'sass': '^1.103.1'
   'sass-embedded': '^1.103.1'
   'sass-loader': '^16.0.8'

--- a/scripts/config/test.ts
+++ b/scripts/config/test.ts
@@ -1,9 +1,10 @@
 import path from 'node:path';
 import type { RstestConfig } from 'rstack/test';
 
-process.env.NO_COLOR = '1';
-
 export const baseConfig: RstestConfig = {
+  env: {
+    FORCE_COLOR: '0',
+  },
   globals: true,
   output: {
     externals: ['@rsbuild/core'],


### PR DESCRIPTION
## Summary

This PR simplifies project-level Rstack configs by using static imports for focused library and test configuration, following the updated Rstack guidance. It also upgrades Rstack to 0.7.2.

## Related links

- https://github.com/rstackjs/rstack-cli/pull/449
- https://www.npmjs.com/package/rstack/v/0.7.2