### PR TITLE
fix(plugin-svgr): avoid redundant type assertion

### DIFF
--- a/packages/plugin-svgr/src/loader.ts
+++ b/packages/plugin-svgr/src/loader.ts
@@ -43,9 +43,8 @@ const svgrLoader: Rspack.LoaderDefinition<Config> = function (contents): void {
   if (!previousExport) {
     transformSvg(contents, options, state, callback);
   } else {
-    const loaderFileSystem = this.fs as NonNullable<
-      Rspack.Compiler['inputFileSystem']
-    >;
+    const loaderFileSystem: NonNullable<Rspack.Compiler['inputFileSystem']> =
+      this.fs;
     loaderFileSystem.readFile(this.resourcePath, (err, result) => {
       if (err) {
         callback(err);


### PR DESCRIPTION
## Summary

Fix the plugin-svgr loader filesystem typing across released and latest Rspack types. Use a local type annotation instead of an assertion so older types remain supported without triggering `no-unnecessary-type-assertion` with the latest `LoaderContext.fs` type.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8412
- https://github.com/web-infra-dev/rspack/pull/15437
- https://github.com/rstackjs/rstack-ecosystem-ci/actions/runs/33630889713
