### PR TITLE
fix(core): exclude Node outputs from asset serving

### DIFF
--- a/e2e/cases/server/environment-assets/index.test.ts
+++ b/e2e/cases/server/environment-assets/index.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@e2e/helper';
+
+test('should only serve assets from web environments', async ({
+  devOnly,
+  request,
+}) => {
+  const rsbuild = await devOnly();
+  const baseUrl = `http://localhost:${rsbuild.port}`;
+
+  const webAsset = await request.get(
+    `${baseUrl}/browser-assets/static/js/shared.js`,
+  );
+  expect(webAsset.status()).toBe(200);
+  expect(await webAsset.text()).toContain('web-environment');
+
+  const sharedAsset = await request.get(`${baseUrl}/static/js/shared.js`);
+  expect(sharedAsset.status()).toBe(200);
+  expect(await sharedAsset.text()).toContain('web-environment');
+
+  const nodeAsset = await request.get(`${baseUrl}/static/js/server.js`);
+  expect(nodeAsset.status()).toBe(404);
+
+  const prefixedNodeAsset = await request.get(
+    `${baseUrl}/server-assets/static/js/server.js`,
+  );
+  expect(prefixedNodeAsset.status()).toBe(404);
+
+  const bundle = await rsbuild.server!.environments.node.loadBundle<{
+    marker: string;
+  }>('server');
+  expect(bundle.marker).toBe('node-environment');
+});

--- a/e2e/cases/server/environment-assets/rsbuild.config.ts
+++ b/e2e/cases/server/environment-assets/rsbuild.config.ts
@@ -1,10 +1,6 @@
 import { defineConfig } from '@rsbuild/core';
 
 export default defineConfig({
-  dev: {
-    hmr: false,
-    liveReload: false,
-  },
   server: {
     htmlFallback: false,
   },
@@ -16,7 +12,6 @@ export default defineConfig({
       output: {
         target: 'node',
         distPath: 'dist/server',
-        filenameHash: false,
       },
       source: {
         entry: {
@@ -31,7 +26,6 @@ export default defineConfig({
       },
       output: {
         distPath: 'dist/client',
-        filenameHash: false,
       },
       source: {
         entry: {

--- a/e2e/cases/server/environment-assets/rsbuild.config.ts
+++ b/e2e/cases/server/environment-assets/rsbuild.config.ts
@@ -1,0 +1,43 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  dev: {
+    hmr: false,
+    liveReload: false,
+  },
+  server: {
+    htmlFallback: false,
+  },
+  environments: {
+    node: {
+      dev: {
+        assetPrefix: '/server-assets/',
+      },
+      output: {
+        target: 'node',
+        distPath: 'dist/server',
+        filenameHash: false,
+      },
+      source: {
+        entry: {
+          server: './src/server.js',
+          shared: './src/server.js',
+        },
+      },
+    },
+    web: {
+      dev: {
+        assetPrefix: '/browser-assets/',
+      },
+      output: {
+        distPath: 'dist/client',
+        filenameHash: false,
+      },
+      source: {
+        entry: {
+          shared: './src/client.js',
+        },
+      },
+    },
+  },
+});

--- a/e2e/cases/server/environment-assets/src/client.js
+++ b/e2e/cases/server/environment-assets/src/client.js
@@ -1,0 +1,1 @@
+globalThis.__ENVIRONMENT_ASSET__ = 'web-environment';

--- a/e2e/cases/server/environment-assets/src/server.js
+++ b/e2e/cases/server/environment-assets/src/server.js
@@ -1,0 +1,1 @@
+export const marker = 'node-environment';

--- a/e2e/cases/server/node-environment-assets/index.test.ts
+++ b/e2e/cases/server/node-environment-assets/index.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@e2e/helper';
+
+test('should not serve assets when only a node environment exists', async ({
+  devOnly,
+  request,
+}) => {
+  const rsbuild = await devOnly();
+  const baseUrl = `http://localhost:${rsbuild.port}`;
+
+  const nodeAsset = await request.get(`${baseUrl}/static/js/server.js`);
+  expect(nodeAsset.status()).toBe(404);
+
+  const prefixedNodeAsset = await request.get(
+    `${baseUrl}/server-assets/static/js/server.js`,
+  );
+  expect(prefixedNodeAsset.status()).toBe(404);
+
+  const bundle = await rsbuild.server!.environments.node.loadBundle<{
+    marker: string;
+  }>('server');
+  expect(bundle.marker).toBe('node-environment');
+});

--- a/e2e/cases/server/node-environment-assets/rsbuild.config.ts
+++ b/e2e/cases/server/node-environment-assets/rsbuild.config.ts
@@ -1,10 +1,6 @@
 import { defineConfig } from '@rsbuild/core';
 
 export default defineConfig({
-  dev: {
-    hmr: false,
-    liveReload: false,
-  },
   server: {
     htmlFallback: false,
   },
@@ -15,7 +11,6 @@ export default defineConfig({
       },
       output: {
         target: 'node',
-        filenameHash: false,
       },
       source: {
         entry: {

--- a/e2e/cases/server/node-environment-assets/rsbuild.config.ts
+++ b/e2e/cases/server/node-environment-assets/rsbuild.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  dev: {
+    hmr: false,
+    liveReload: false,
+  },
+  server: {
+    htmlFallback: false,
+  },
+  environments: {
+    node: {
+      dev: {
+        assetPrefix: '/server-assets/',
+      },
+      output: {
+        target: 'node',
+        filenameHash: false,
+      },
+      source: {
+        entry: {
+          server: './src/server.js',
+        },
+      },
+    },
+  },
+});

--- a/e2e/cases/server/node-environment-assets/src/server.js
+++ b/e2e/cases/server/node-environment-assets/src/server.js
@@ -1,0 +1,1 @@
+export const marker = 'node-environment';

--- a/packages/core/src/server/assets-middleware/middleware.ts
+++ b/packages/core/src/server/assets-middleware/middleware.ts
@@ -7,6 +7,7 @@ import type {
 import { lookup } from 'mrmime';
 import onFinished from 'on-finished';
 import type { Range, Result as RangeResult, Ranges } from 'range-parser';
+import { isWebTarget } from '../../helpers';
 import type { InternalContext, RequestHandler, Rspack } from '../../types';
 import { HttpCode } from '../helper';
 import { getFileFromUrl } from './getFileFromUrl';
@@ -311,12 +312,32 @@ function sendError(res: ServerResponse, code: number): void {
   res.end(document);
 }
 
+/**
+ * Filters environments to those whose outputs may be exposed by the HTTP assets
+ * middleware. Node-targeted outputs are intended for server-side execution,
+ * such as through `loadBundle`, and must not participate in URL resolution.
+ */
+export const filterWebEnvironments = (
+  environmentList: InternalContext['environmentList'],
+): InternalContext['environmentList'] =>
+  environmentList.filter((environment) =>
+    isWebTarget(environment.config.output.target),
+  );
+
 export function createAssetsMiddleware(
   context: InternalContext,
   ready: (callback: () => void) => void,
   outputFileSystem: Rspack.OutputFileSystem,
 ): RequestHandler {
   const { logger } = context;
+  const webEnvironments = filterWebEnvironments(context.environmentList);
+  const assetContext: InternalContext = {
+    ...context,
+    environmentList: webEnvironments,
+    publicPathnames: webEnvironments.map(
+      (environment) => context.publicPathnames[environment.index],
+    ),
+  };
 
   return async function assetsMiddleware(req, res, next) {
     async function goNext() {
@@ -339,7 +360,11 @@ export function createAssetsMiddleware(
         return;
       }
 
-      const resolved = await getFileFromUrl(req.url, outputFileSystem, context);
+      const resolved = await getFileFromUrl(
+        req.url,
+        outputFileSystem,
+        assetContext,
+      );
 
       if (!resolved) {
         await goNext();

--- a/packages/core/src/server/previewServer.ts
+++ b/packages/core/src/server/previewServer.ts
@@ -1,13 +1,15 @@
 import { once } from 'node:events';
 import fs from 'node:fs';
-import { isWebTarget } from '../helpers';
 import { isVerbose } from '../logger';
 import type {
   InternalContext,
   NormalizedConfig,
   PreviewOptions,
 } from '../types';
-import { createAssetsMiddleware } from './assets-middleware/middleware';
+import {
+  createAssetsMiddleware,
+  filterWebEnvironments,
+} from './assets-middleware/middleware';
 import { isCliShortcutsEnabled, setupCliShortcuts } from './cliShortcuts';
 import {
   registerCleanup,
@@ -41,20 +43,6 @@ import { createProxyMiddleware } from './proxy';
 import { applyServerSetup } from './serverSetup';
 
 export type RsbuildPreviewServer = RsbuildServerBase;
-
-const getPreviewAssetContext = (context: InternalContext): InternalContext => {
-  const environmentList = context.environmentList.filter((environment) =>
-    isWebTarget(environment.config.output.target),
-  );
-
-  return {
-    ...context,
-    environmentList,
-    publicPathnames: environmentList.map(
-      (environment) => context.publicPathnames[environment.index],
-    ),
-  };
-};
 
 export async function startPreviewServer(
   context: InternalContext,
@@ -150,17 +138,15 @@ export async function startPreviewServer(
     environments: context.environments,
   });
 
-  const assetContext = getPreviewAssetContext(context);
+  const webEnvironments = filterWebEnvironments(context.environmentList);
   const assetsMiddleware = createAssetsMiddleware(
-    assetContext,
+    context,
     (callback) => callback(),
     fs,
   );
   const htmlMiddlewareOptions = {
     assetsMiddleware,
-    distPaths: assetContext.environmentList.map(
-      (environment) => environment.distPath,
-    ),
+    distPaths: webEnvironments.map((environment) => environment.distPath),
     outputFileSystem: fs,
   };
 


### PR DESCRIPTION
## Summary

This PR limits HTTP asset lookup to web-target environments and enforces the filtering inside the shared asset middleware factory.

## Background

In a multi-environment development build, the asset middleware searched outputs from both web and Node environments, allowing Node/SSR bundles to be requested as static HTTP assets.

Keeping Node outputs out of HTTP asset resolution reduces the risk of unintentionally exposing server implementation details, source maps, or other server-only artifacts through a browser-accessible development server. 

It also prevents Node outputs from taking precedence when Web and Node environments emit files with the same name. Node bundles remain available for server-side execution through APIs such as `loadBundle`, without disabling Node compilation or internal bundle loading.