### PR TITLE
fix(core): prevent asset prefix path traversal

### DIFF
--- a/e2e/cases/server/environment-assets/index.test.ts
+++ b/e2e/cases/server/environment-assets/index.test.ts
@@ -1,6 +1,8 @@
 import { request as httpRequest } from 'node:http';
 import { expect, test } from '@e2e/helper';
 
+const encodedUpPath = '%2e%2e%2f';
+
 const requestRawPath = (
   port: number,
   path: string,
@@ -60,7 +62,7 @@ test('should reject path traversal after stripping the asset prefix', async ({
   await runBothServe(async ({ result }) => {
     const response = await requestRawPath(
       result.port,
-      '/browser-assets/%2e%2e%2fserver/server.js?probe=1',
+      `/browser-assets/${encodedUpPath}server/server.js?probe=1`,
     );
 
     expect(response.statusCode).toBe(403);

--- a/e2e/cases/server/environment-assets/index.test.ts
+++ b/e2e/cases/server/environment-assets/index.test.ts
@@ -1,29 +1,7 @@
-import { request as httpRequest } from 'node:http';
 import { expect, test } from '@e2e/helper';
 
+// Decodes to `../`.
 const encodedUpPath = '%2e%2e%2f';
-
-const requestRawPath = (
-  port: number,
-  path: string,
-): Promise<{ body: string; statusCode: number | undefined }> =>
-  new Promise((resolve, reject) => {
-    const request = httpRequest(
-      { hostname: 'localhost', port, path },
-      (res) => {
-        let body = '';
-        res.setEncoding('utf8');
-        res.on('data', (chunk) => {
-          body += chunk;
-        });
-        res.on('end', () => {
-          resolve({ body, statusCode: res.statusCode });
-        });
-      },
-    );
-    request.on('error', reject);
-    request.end();
-  });
 
 test('should only serve assets from web environments', async ({
   devOnly,
@@ -57,15 +35,15 @@ test('should only serve assets from web environments', async ({
 });
 
 test('should reject path traversal after stripping the asset prefix', async ({
+  request,
   runBothServe,
 }) => {
   await runBothServe(async ({ result }) => {
-    const response = await requestRawPath(
-      result.port,
-      `/browser-assets/${encodedUpPath}server/server.js?probe=1`,
+    const response = await request.get(
+      `http://localhost:${result.port}/browser-assets/${encodedUpPath}server/server.js?probe=1`,
     );
 
-    expect(response.statusCode).toBe(403);
-    expect(response.body).toContain('Forbidden');
+    expect(response.status()).toBe(403);
+    expect(await response.text()).toContain('Forbidden');
   });
 });

--- a/e2e/cases/server/environment-assets/index.test.ts
+++ b/e2e/cases/server/environment-assets/index.test.ts
@@ -1,4 +1,27 @@
+import { request as httpRequest } from 'node:http';
 import { expect, test } from '@e2e/helper';
+
+const requestRawPath = (
+  port: number,
+  path: string,
+): Promise<{ body: string; statusCode: number | undefined }> =>
+  new Promise((resolve, reject) => {
+    const request = httpRequest(
+      { hostname: 'localhost', port, path },
+      (res) => {
+        let body = '';
+        res.setEncoding('utf8');
+        res.on('data', (chunk) => {
+          body += chunk;
+        });
+        res.on('end', () => {
+          resolve({ body, statusCode: res.statusCode });
+        });
+      },
+    );
+    request.on('error', reject);
+    request.end();
+  });
 
 test('should only serve assets from web environments', async ({
   devOnly,
@@ -17,11 +40,11 @@ test('should only serve assets from web environments', async ({
   expect(sharedAsset.status()).toBe(200);
   expect(await sharedAsset.text()).toContain('web-environment');
 
-  const nodeAsset = await request.get(`${baseUrl}/static/js/server.js`);
+  const nodeAsset = await request.get(`${baseUrl}/server.js`);
   expect(nodeAsset.status()).toBe(404);
 
   const prefixedNodeAsset = await request.get(
-    `${baseUrl}/server-assets/static/js/server.js`,
+    `${baseUrl}/server-assets/server.js`,
   );
   expect(prefixedNodeAsset.status()).toBe(404);
 
@@ -29,4 +52,18 @@ test('should only serve assets from web environments', async ({
     marker: string;
   }>('server');
   expect(bundle.marker).toBe('node-environment');
+});
+
+test('should reject path traversal after stripping the asset prefix', async ({
+  runBothServe,
+}) => {
+  await runBothServe(async ({ result }) => {
+    const response = await requestRawPath(
+      result.port,
+      '/browser-assets/%2e%2e%2fserver/server.js?probe=1',
+    );
+
+    expect(response.statusCode).toBe(403);
+    expect(response.body).toContain('Forbidden');
+  });
 });

--- a/e2e/cases/server/environment-assets/rsbuild.config.ts
+++ b/e2e/cases/server/environment-assets/rsbuild.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
         assetPrefix: '/server-assets/',
       },
       output: {
+        assetPrefix: '/server-assets/',
         target: 'node',
         distPath: 'dist/server',
       },
@@ -25,6 +26,7 @@ export default defineConfig({
         assetPrefix: '/browser-assets/',
       },
       output: {
+        assetPrefix: '/browser-assets/',
         distPath: 'dist/client',
       },
       source: {

--- a/e2e/cases/server/node-environment-assets/index.test.ts
+++ b/e2e/cases/server/node-environment-assets/index.test.ts
@@ -7,11 +7,11 @@ test('should not serve assets when only a node environment exists', async ({
   const rsbuild = await devOnly();
   const baseUrl = `http://localhost:${rsbuild.port}`;
 
-  const nodeAsset = await request.get(`${baseUrl}/static/js/server.js`);
+  const nodeAsset = await request.get(`${baseUrl}/server.js`);
   expect(nodeAsset.status()).toBe(404);
 
   const prefixedNodeAsset = await request.get(
-    `${baseUrl}/server-assets/static/js/server.js`,
+    `${baseUrl}/server-assets/server.js`,
   );
   expect(prefixedNodeAsset.status()).toBe(404);
 

--- a/packages/core/src/server/assets-middleware/getFileFromUrl.ts
+++ b/packages/core/src/server/assets-middleware/getFileFromUrl.ts
@@ -74,10 +74,7 @@ export async function getFileFromUrl(
         // Whole-path normalization can hide traversal after the public prefix
         // is removed, so validate the final candidate against its output path.
         const relativePath = path.relative(distPath, candidatePath);
-        if (
-          path.isAbsolute(relativePath) ||
-          UP_PATH_REGEXP.test(relativePath)
-        ) {
+        if (UP_PATH_REGEXP.test(relativePath)) {
           return { errorCode: HttpCode.Forbidden };
         }
       }

--- a/packages/core/src/server/assets-middleware/getFileFromUrl.ts
+++ b/packages/core/src/server/assets-middleware/getFileFromUrl.ts
@@ -68,12 +68,12 @@ export async function getFileFromUrl(
       // Strip the `pathname` property from the `publicPath` option from the start
       // of requested url. (`/prefix/foo.js` => `foo.js`)
       // And add outputPath (`foo.js` => `/home/user/my-project/dist/foo.js`)
-      const filename = path.join(distPath, pathname.slice(prefix.length));
+      const candidatePath = path.join(distPath, pathname.slice(prefix.length));
 
       if (hasUpPath) {
         // Whole-path normalization can hide traversal after the public prefix
         // is removed, so validate the final candidate against its output path.
-        const relativePath = path.relative(distPath, filename);
+        const relativePath = path.relative(distPath, candidatePath);
         if (
           path.isAbsolute(relativePath) ||
           UP_PATH_REGEXP.test(relativePath)
@@ -82,7 +82,7 @@ export async function getFileFromUrl(
         }
       }
 
-      possibleFilenames.add(filename);
+      possibleFilenames.add(candidatePath);
     }
   }
 

--- a/packages/core/src/server/assets-middleware/getFileFromUrl.ts
+++ b/packages/core/src/server/assets-middleware/getFileFromUrl.ts
@@ -48,8 +48,12 @@ export async function getFileFromUrl(
     return { errorCode: HttpCode.BadRequest };
   }
 
+  // Avoid normalizing ordinary asset requests. Only paths containing a parent
+  // directory segment can escape an output directory through `path.join`.
+  const hasUpPath = UP_PATH_REGEXP.test(pathname);
+
   // Prevent path traversal attacks by checking for ".." patterns
-  if (UP_PATH_REGEXP.test(path.normalize(`./${pathname}`))) {
+  if (hasUpPath && UP_PATH_REGEXP.test(path.normalize(`./${pathname}`))) {
     return { errorCode: HttpCode.Forbidden };
   }
 
@@ -64,7 +68,21 @@ export async function getFileFromUrl(
       // Strip the `pathname` property from the `publicPath` option from the start
       // of requested url. (`/prefix/foo.js` => `foo.js`)
       // And add outputPath (`foo.js` => `/home/user/my-project/dist/foo.js`)
-      possibleFilenames.add(path.join(distPath, pathname.slice(prefix.length)));
+      const filename = path.join(distPath, pathname.slice(prefix.length));
+
+      if (hasUpPath) {
+        // Whole-path normalization can hide traversal after the public prefix
+        // is removed, so validate the final candidate against its output path.
+        const relativePath = path.relative(distPath, filename);
+        if (
+          path.isAbsolute(relativePath) ||
+          UP_PATH_REGEXP.test(relativePath)
+        ) {
+          return { errorCode: HttpCode.Forbidden };
+        }
+      }
+
+      possibleFilenames.add(filename);
     }
   }
 


### PR DESCRIPTION
## Summary

This PR validates asset candidates after stripping the matched asset prefix, preventing parent-directory segments from escaping an environment output directory. To keep ordinary asset requests on the fast path, the final containment check only runs when the decoded pathname contains a parent-directory segment.

## Background

Previously, traversal validation normalized the complete pathname before the matching asset prefix was removed. The prefix could absorb a parent-directory segment during normalization while the remaining suffix still escaped the Web output root, allowing sibling build outputs to be served in dev or preview.

## Related links

https://github.com/web-infra-dev/rsbuild/pull/8415