### PR TITLE
docs: use separate web and node output directories

### DIFF
--- a/website/docs/en/config/environments.mdx
+++ b/website/docs/en/config/environments.mdx
@@ -55,6 +55,9 @@ export default {
       },
       output: {
         target: 'web',
+        distPath: {
+          root: 'dist/client',
+        },
       },
       resolve: {
         alias: {
@@ -96,6 +99,9 @@ const webConfig = {
   },
   output: {
     target: 'web',
+    distPath: {
+      root: 'dist/client',
+    },
   },
   resolve: {
     alias: {

--- a/website/docs/en/config/output/target.mdx
+++ b/website/docs/en/config/output/target.mdx
@@ -51,6 +51,9 @@ export default {
     web: {
       output: {
         target: 'web',
+        distPath: {
+          root: 'dist/client',
+        },
       },
     },
     node: {

--- a/website/docs/en/guide/advanced/environments.mdx
+++ b/website/docs/en/guide/advanced/environments.mdx
@@ -40,6 +40,9 @@ export default {
       output: {
         // Use 'web' target for the browser outputs
         target: 'web',
+        distPath: {
+          root: 'dist/client',
+        },
       },
       resolve: {
         alias: {
@@ -158,6 +161,9 @@ export default {
     web: {
       output: {
         target: 'web',
+        distPath: {
+          root: 'dist/client',
+        },
       },
       plugins: [pluginReact()],
     },
@@ -177,11 +183,11 @@ If you are a plugin developer, you can view [Developing environment plugins](/pl
 
 ## Configuring output directories
 
-When building for multiple environments, it's recommended to configure different output directories for each environment to prevent dist files with the same name from overwriting each other.
+When building for multiple environments, we recommend configuring separate, non-overlapping output directories for each environment. This prevents output files with the same name from overwriting each other and keeps server output outside the web asset directory.
 
 You can use [output.distPath.root](/config/output/dist-path) to set independent output root directories for each environment.
 
-For example, output the web bundles to the default `dist` directory, and the node bundles to `dist/server`:
+For example, output the web bundles to `dist/client` and the node bundles to `dist/server`:
 
 ```ts title="rsbuild.config.ts"
 export default {
@@ -190,6 +196,11 @@ export default {
       source: {
         entry: {
           index: './src/index.client.js',
+        },
+      },
+      output: {
+        distPath: {
+          root: 'dist/client',
         },
       },
     },

--- a/website/docs/en/guide/advanced/ssr.mdx
+++ b/website/docs/en/guide/advanced/ssr.mdx
@@ -61,6 +61,9 @@ export default {
       output: {
         // Use 'web' target for the browser outputs
         target: 'web',
+        distPath: {
+          root: 'dist/client',
+        },
       },
       html: {
         // Custom HTML template
@@ -198,7 +201,10 @@ export default {
 
 ```ts title="server.ts"
 async function renderHtmlPage(): Promise<string> {
-  const manifest = await fs.promises.readFile('./dist/manifest.json', 'utf-8');
+  const manifest = await fs.promises.readFile(
+    './dist/client/manifest.json',
+    'utf-8',
+  );
   const { entries } = JSON.parse(manifest);
 
   const { js, css } = entries['index'].initial;

--- a/website/docs/en/guide/basic/output-files.mdx
+++ b/website/docs/en/guide/basic/output-files.mdx
@@ -122,9 +122,9 @@ dist
 
 Node.js outputs typically contain only JS files, without HTML or CSS. JS filenames do not include hash values.
 
-You can modify the output path for Node.js files using the [environments](/config/environments) configuration.
+You can configure separate output paths for web and Node.js files using the [environments](/config/environments) configuration.
 
-For example, to write Node.js files to the `server` directory:
+For example, output web files to `dist/client` and Node.js files to `dist/server`:
 
 ```ts
 export default {
@@ -132,6 +132,9 @@ export default {
     web: {
       output: {
         target: 'web',
+        distPath: {
+          root: 'dist/client',
+        },
       },
     },
     node: {

--- a/website/docs/zh/config/environments.mdx
+++ b/website/docs/zh/config/environments.mdx
@@ -55,6 +55,9 @@ export default {
       },
       output: {
         target: 'web',
+        distPath: {
+          root: 'dist/client',
+        },
       },
       resolve: {
         alias: {
@@ -96,6 +99,9 @@ const webConfig = {
   },
   output: {
     target: 'web',
+    distPath: {
+      root: 'dist/client',
+    },
   },
   resolve: {
     alias: {

--- a/website/docs/zh/config/output/target.mdx
+++ b/website/docs/zh/config/output/target.mdx
@@ -51,6 +51,9 @@ export default {
     web: {
       output: {
         target: 'web',
+        distPath: {
+          root: 'dist/client',
+        },
       },
     },
     node: {

--- a/website/docs/zh/guide/advanced/environments.mdx
+++ b/website/docs/zh/guide/advanced/environments.mdx
@@ -40,6 +40,9 @@ export default {
       output: {
         // 浏览器产物的 target 类型为 'web'
         target: 'web',
+        distPath: {
+          root: 'dist/client',
+        },
       },
       resolve: {
         alias: {
@@ -158,6 +161,9 @@ export default {
     web: {
       output: {
         target: 'web',
+        distPath: {
+          root: 'dist/client',
+        },
       },
       plugins: [pluginReact()],
     },
@@ -177,11 +183,11 @@ export default {
 
 ## 配置输出目录
 
-在多环境构建时，建议为不同的环境配置不同的输出目录，以避免不同环境的同名构建产物互相覆盖。
+在多环境构建时，建议为不同的环境配置相互独立且不存在包含关系的输出目录。这样既可以避免不同环境的同名构建产物互相覆盖，也可以避免服务端产物位于 Web 资源目录中。
 
 你可以通过 [output.distPath.root](/config/output/dist-path) 来为每个环境设置独立的输出根目录。
 
-比如，将 web 产物输出到默认的 `dist`，将 node 产物输出到 `dist/server`：
+比如，将 web 产物输出到 `dist/client`，将 node 产物输出到 `dist/server`：
 
 ```ts title="rsbuild.config.ts"
 export default {
@@ -190,6 +196,11 @@ export default {
       source: {
         entry: {
           index: './src/index.client.js',
+        },
+      },
+      output: {
+        distPath: {
+          root: 'dist/client',
         },
       },
     },

--- a/website/docs/zh/guide/advanced/ssr.mdx
+++ b/website/docs/zh/guide/advanced/ssr.mdx
@@ -61,6 +61,9 @@ export default {
       output: {
         // 浏览器产物的 target 类型为 'web'
         target: 'web',
+        distPath: {
+          root: 'dist/client',
+        },
       },
       html: {
         // 自定义 HTML 模版
@@ -198,7 +201,10 @@ export default {
 
 ```ts title="server.ts"
 async function renderHtmlPage(): Promise<string> {
-  const manifest = await fs.promises.readFile('./dist/manifest.json', 'utf-8');
+  const manifest = await fs.promises.readFile(
+    './dist/client/manifest.json',
+    'utf-8',
+  );
 
   const { entries } = JSON.parse(manifest);
   const { js, css } = entries['index'].initial;

--- a/website/docs/zh/guide/basic/output-files.mdx
+++ b/website/docs/zh/guide/basic/output-files.mdx
@@ -124,9 +124,9 @@ dist
 
 Node.js 产物通常只包含 JS 文件，不包含 HTML、CSS 等文件。此外，Node 产物的 JS 文件名称也不会自动生成哈希值。
 
-你可以通过 [environments](/config/environments) 配置项来修改 Node 产物的输出路径。
+你可以通过 [environments](/config/environments) 配置项分别设置 Web 和 Node.js 产物的输出路径。
 
-比如，将 Node.js 产物输出到 `dist/server` 目录：
+比如，将 Web 产物输出到 `dist/client`，将 Node.js 产物输出到 `dist/server`：
 
 ```ts
 export default {
@@ -134,6 +134,9 @@ export default {
     web: {
       output: {
         target: 'web',
+        distPath: {
+          root: 'dist/client',
+        },
       },
     },
     node: {


### PR DESCRIPTION
## Summary

The current multi-environment examples place Node.js output under the default web output directory, which may cause server bundles to be included in web asset serving. This PR recommends non-overlapping sibling directories, `dist/client` and `dist/server`, across the English and Chinese docs and updates the SSR manifest path accordingly.

## Related links

https://github.com/web-infra-dev/rsbuild/pull/8415