### PR TITLE
test: cover asset prefix path boundaries

### DIFF
--- a/e2e/cases/server/environment-assets/index.test.ts
+++ b/e2e/cases/server/environment-assets/index.test.ts
@@ -40,10 +40,24 @@ test('should reject path traversal after stripping the asset prefix', async ({
 }) => {
   await runBothServe(async ({ result }) => {
     const response = await request.get(
-      `http://localhost:${result.port}/browser-assets/${encodedUpPath}server/server.js?probe=1`,
+      `http://localhost:${result.port}/browser-assets/${encodedUpPath}server/server.js`,
     );
 
     expect(response.status()).toBe(403);
     expect(await response.text()).toContain('Forbidden');
+  });
+});
+
+test('should not match sibling paths sharing the asset prefix', async ({
+  request,
+  runBothServe,
+}) => {
+  await runBothServe(async ({ result }) => {
+    const response = await request.get(
+      `http://localhost:${result.port}/browser-assets../server/server.js`,
+    );
+
+    expect(response.status()).toBe(404);
+    expect(await response.text()).not.toContain('node-environment');
   });
 });

--- a/e2e/cases/server/environment-assets/rsbuild.config.ts
+++ b/e2e/cases/server/environment-assets/rsbuild.config.ts
@@ -23,10 +23,10 @@ export default defineConfig({
     },
     web: {
       dev: {
-        assetPrefix: '/browser-assets/',
+        assetPrefix: '/browser-assets',
       },
       output: {
-        assetPrefix: '/browser-assets/',
+        assetPrefix: '/browser-assets',
         distPath: 'dist/client',
       },
       source: {


### PR DESCRIPTION
## Summary

This PR adds e2e coverage for an asset prefix configured without a trailing slash, ensuring sibling paths such as `/browser-assets..` are not treated as assets in either dev or preview mode. The existing environment-assets scenario continues to verify valid asset serving with the normalized prefix.

## Related links

- https://github.com/web-infra-dev/rsbuild/pull/8416
- https://github.com/webpack/webpack-dev-middleware/security/advisories/GHSA-g84c-rxfj-3j2c