### PR TITLE
fix(core): print dev server URLs after onAfterStartDevServer

### DIFF
--- a/e2e/cases/server/print-urls/index.test.ts
+++ b/e2e/cases/server/print-urls/index.test.ts
@@ -1,4 +1,5 @@
 import os, { type NetworkInterfaceInfo } from 'node:os';
+import type { RsbuildPlugin } from '@rsbuild/core';
 import { expect, NETWORK_LOG_REGEX, test } from '@e2e/helper';
 import { rs } from 'rstack/test';
 
@@ -370,4 +371,43 @@ test('should print server urls for web and node environments with custom distPat
   await rsbuild.expectLog(`➜  Local:    http://localhost:${rsbuild.port}/`, {
     strict: true,
   });
+});
+
+const addRoutePlugin = (
+  hook: 'onAfterStartDevServer' | 'onAfterStartPreviewServer',
+): RsbuildPlugin => ({
+  name: 'test:add-route',
+  setup(api) {
+    api[hook](({ routes }) => {
+      routes.push({ entryName: 'added', pathname: '/added' });
+    });
+  },
+});
+
+test('should print routes added by a plugin in onAfterStartDevServer', async ({
+  devOnly,
+}) => {
+  const rsbuild = await devOnly({
+    config: {
+      plugins: [addRoutePlugin('onAfterStartDevServer')],
+    },
+  });
+
+  await rsbuild.expectLog(
+    new RegExp(`-\\s+added\\s+http://localhost:${rsbuild.port}/added`),
+  );
+});
+
+test('should print routes added by a plugin in onAfterStartPreviewServer', async ({
+  buildPreview,
+}) => {
+  const rsbuild = await buildPreview({
+    config: {
+      plugins: [addRoutePlugin('onAfterStartPreviewServer')],
+    },
+  });
+
+  await rsbuild.expectLog(
+    new RegExp(`-\\s+added\\s+http://localhost:${rsbuild.port}/added`),
+  );
 });

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -280,7 +280,7 @@ export async function createDevServer<
     registerCleanup(closeServer);
   }
 
-  const beforeCreateCompiler = async () => {
+  const logStartedServer = async () => {
     printUrls();
 
     if (cliShortcutsEnabled) {
@@ -442,6 +442,10 @@ export async function createDevServer<
         routes,
         environments: context.environments,
       });
+
+      // Print after the hook, so a plugin that adds its own routes there sees
+      // them printed. The preview server already prints in this order.
+      await logStartedServer();
     },
     connectWebSocket: ({ server }: { server: HTTPServer }) => {
       if (state.devMiddlewares) {
@@ -467,13 +471,6 @@ export async function createDevServer<
   ).filter((item) => typeof item === 'function');
 
   const postCallbacks = [...hookPostCallbacks, ...setupPostCallbacks];
-
-  if (runCompile) {
-    // print server url should between listen and beforeCompile
-    context.hooks.onBeforeCreateCompiler.tap(beforeCreateCompiler);
-  } else {
-    await beforeCreateCompiler();
-  }
 
   state.buildManager = runCompile ? await startCompile() : undefined;
 


### PR DESCRIPTION
## Summary

The dev server and the preview server call `server.printUrls` on opposite sides of the `onAfterStart*Server` hook, so a plugin that adds routes in that hook sees them printed on preview but never on dev.

Both servers build `routes` once with `getRoutes(context)` and hand that same array to the hook and to `printServerURLs`, so whichever runs first decides what the other sees:

- dev: `printUrls()` is called from `beforeCreateCompiler`, i.e. before the compiler exists and well before `afterListen()` fires `onAfterStartDevServer`
- preview: `onAfterStartPreviewServer.callBatch(...)` is awaited and `printUrls()` is called immediately after

The dev side also contradicts the comment that sat above it — `// print server url should between listen and beforeCompile` — the URLs were printed *before* the port was bound, not between listen and compile.

## Repro

https://github.com/upupming/rsbuild-routes-timing-repro — a plugin pushes one route in each hook and logs the `routes` that `printUrls` receives.

`rsbuild dev` — `printUrls` runs first, the pushed route is never printed:

```
[repro] printUrls                routes=["/"]
  ➜  Repro     http://localhost:3123/
[repro] onAfterStartDevServer     routes=["/"]
```

`rsbuild build && rsbuild preview` — the hook runs first, the pushed route is printed:

```
[repro] onAfterStartPreviewServer routes=["/"]
[repro] printUrls                routes=["/","/pushed-by-plugin"]
  ➜  Repro
  -  index               http://localhost:3123/
  -  pushed-by-plugin    http://localhost:3123/pushed-by-plugin
```

Reproduced on 2.1.10, 2.1.13 and 2.2.3.

## Why it matters

A server that does not serve HTML gets no routes from `getRoutes()`, so a plugin has to contribute them in these hooks for anything to be printed. Because the visibility differs between the two servers, such a plugin has to branch on `routes.length > 0` and resolve the entry path itself in one case but not the other — and it can only tell the two cases apart by inspecting the array it was handed.

## Change

Move the dev server's `printUrls()` (with the CLI-shortcuts hint that follows it) into `afterListen`, after `onAfterStartDevServer`, matching the preview server. `afterListen` is documented as the call a custom server makes once it has started, so middleware-mode servers keep printing too.

Side effect worth calling out: the URLs are now printed after `listen` rather than during compiler creation, so `build started...` appears above the URL block instead of below it. That also means the printed URLs are reachable when they appear, which the removed comment seems to have been aiming for.

## Tests

Two e2e cases in `cases/server/print-urls`, one per server, asserting that a route added in the hook is printed. On `main` the dev one fails and the preview one passes — which is the asymmetry. Both pass with this change.

Marked draft: the print-timing change is user-visible, so please say if you would rather keep printing early and close the gap another way (e.g. a hook that lets plugins contribute routes before printing, in both servers).
