### PR TITLE
docs: document how to disable async chunks

### DIFF
--- a/website/docs/en/config/split-chunks.mdx
+++ b/website/docs/en/config/split-chunks.mdx
@@ -146,6 +146,23 @@ export default {
 };
 ```
 
+With `splitChunks: false`, modules loaded with dynamic `import()` are still emitted as separate async chunks. To bundle these modules into existing chunks as well, also set Rspack's [output.asyncChunks](https://rspack.rs/config/output#outputasyncchunks) to `false`:
+
+```ts title="rsbuild.config.ts"
+export default {
+  splitChunks: false,
+  tools: {
+    rspack: {
+      output: {
+        asyncChunks: false,
+      },
+    },
+  },
+};
+```
+
+For single-entry applications, this bundles application code and dynamically imported modules into the same JavaScript chunk. Multi-entry applications still produce a separate chunk for each entry.
+
 ## Version history
 
 | Version | Changes                                                                         |

--- a/website/docs/zh/config/split-chunks.mdx
+++ b/website/docs/zh/config/split-chunks.mdx
@@ -137,7 +137,7 @@ export default {
 Rsbuild 会先将预设规则转换为配置对象，再与你配置的 `splitChunks` 选项进行合并，用户配置的优先级更高。
 :::
 
-## 关闭 chunk 拆分
+## 关闭 chunk 拆分 \{#disable-chunk-splitting}
 
 如果你希望关闭 chunk 拆分，可以将 `splitChunks` 设置为 `false`：
 
@@ -146,6 +146,23 @@ export default {
   splitChunks: false,
 };
 ```
+
+设置 `splitChunks: false` 后，动态 `import()` 引入的模块仍会生成独立的异步 chunk。若要将这些模块也打包到已有的 chunk 中，可以同时将 Rspack 的 [output.asyncChunks](https://rspack.rs/zh/config/output#outputasyncchunks) 设置为 `false`：
+
+```ts title="rsbuild.config.ts"
+export default {
+  splitChunks: false,
+  tools: {
+    rspack: {
+      output: {
+        asyncChunks: false,
+      },
+    },
+  },
+};
+```
+
+对于单入口应用，这会将应用代码和动态导入的模块打包到同一个 JavaScript chunk 中。多入口应用仍会为每个入口生成独立的 chunk。
 
 ## 版本历史 \{#version-history}
 


### PR DESCRIPTION
## Summary

`splitChunks: false` still emits async chunks for dynamic imports, but the v2 docs did not explain how to bundle them into existing chunks. This PR adds an `output.asyncChunks: false` example to the English and Chinese `splitChunks` docs and clarifies the behavior for single-entry and multi-entry applications.

## Related links

- [Rsbuild v1 documentation](https://v1.rsbuild.rs/zh/guide/optimization/code-splitting#%E6%B3%A8%E6%84%8F%E4%BA%8B%E9%A1%B9-2)