### PR TITLE
fix(types): mark server callback routes as readonly

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -170,6 +170,7 @@ export type {
   ProxyOptions,
   PublicDir,
   PublicDirOptions,
+  ReadonlyRoutes,
   RequestHandler,
   ResolveConfig,
   ResolvedCreateRsbuildOptions,

--- a/packages/core/src/server/open.ts
+++ b/packages/core/src/server/open.ts
@@ -2,7 +2,7 @@ import { URL } from 'node:url';
 import { STATIC_PATH } from '../constants';
 import { castArray, color } from '../helpers';
 import type { Logger } from '../logger';
-import type { NormalizedConfig, Routes } from '../types';
+import type { NormalizedConfig, ReadonlyRoutes } from '../types';
 import { getHostInUrl } from './helper';
 
 /**
@@ -186,7 +186,7 @@ export async function open({
   logger,
 }: {
   port: number;
-  routes: Routes;
+  routes: ReadonlyRoutes;
   config: NormalizedConfig;
   protocol: string;
   clearCache?: boolean;

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -27,7 +27,7 @@ import type {
   EnvironmentContext,
   ModifyBundlerChainUtils,
   ModifyChainUtils,
-  Routes,
+  ReadonlyRoutes,
   WatchFileEvent,
 } from './hooks';
 import type { RsbuildPlugins } from './plugin';
@@ -385,7 +385,7 @@ export type HistoryApiFallbackOptions = {
 export type PrintUrlsParams = {
   urls: string[];
   port: number;
-  routes: Routes;
+  routes: ReadonlyRoutes;
   protocol: string;
 };
 

--- a/packages/core/src/types/hooks.ts
+++ b/packages/core/src/types/hooks.ts
@@ -118,9 +118,11 @@ export type Routes = {
   pathname: string;
 }[];
 
+export type ReadonlyRoutes = ReadonlyArray<Readonly<Routes[number]>>;
+
 export type OnAfterStartDevServerFn = (params: {
   port: number;
-  routes: Routes;
+  routes: ReadonlyRoutes;
   /**
    * Context information for all environments.
    */
@@ -129,7 +131,7 @@ export type OnAfterStartDevServerFn = (params: {
 
 export type OnAfterStartPreviewServerFn = (params: {
   port: number;
-  routes: Routes;
+  routes: ReadonlyRoutes;
   /**
    * Context information for all environments.
    */

--- a/website/docs/en/config/server/print-urls.mdx
+++ b/website/docs/en/config/server/print-urls.mdx
@@ -7,9 +7,9 @@ description: 'Controls whether and how server URLs are printed when the server s
 - **Type:**
 
 ```ts
-type Routes = Array<{
-  entryName: string;
-  pathname: string;
+type ReadonlyRoutes = ReadonlyArray<{
+  readonly entryName: string;
+  readonly pathname: string;
 }>;
 
 type PrintUrlsOptions = {
@@ -22,7 +22,7 @@ type PrintUrls =
   | ((params: {
       urls: string[];
       port: number;
-      routes: Routes;
+      routes: ReadonlyRoutes;
       protocol: string;
     }) => (string | { url: string; label?: string })[] | void);
 ```

--- a/website/docs/en/shared/onAfterStartDevServer.mdx
+++ b/website/docs/en/shared/onAfterStartDevServer.mdx
@@ -3,15 +3,15 @@ Called after starting the dev server, you can get the port number with the `port
 - **Type:**
 
 ```ts
-type Routes = Array<{
-  entryName: string;
-  pathname: string;
+type ReadonlyRoutes = ReadonlyArray<{
+  readonly entryName: string;
+  readonly pathname: string;
 }>;
 
 function OnAfterStartDevServer(
   callback: (params: {
     port: number;
-    routes: Routes;
+    routes: ReadonlyRoutes;
     environments: Record<string, EnvironmentContext>;
   }) => Promise<void> | void,
 ): void;

--- a/website/docs/en/shared/onAfterStartPreviewServer.mdx
+++ b/website/docs/en/shared/onAfterStartPreviewServer.mdx
@@ -3,15 +3,15 @@ Called after starting the preview server, you can get the port number with the `
 - **Type:**
 
 ```ts
-type Routes = Array<{
-  entryName: string;
-  pathname: string;
+type ReadonlyRoutes = ReadonlyArray<{
+  readonly entryName: string;
+  readonly pathname: string;
 }>;
 
 function OnAfterStartPreviewServer(
   callback: (params: {
     port: number;
-    routes: Routes;
+    routes: ReadonlyRoutes;
     environments: Record<string, EnvironmentContext>;
   }) => Promise<void> | void,
 ): void;

--- a/website/docs/zh/config/server/print-urls.mdx
+++ b/website/docs/zh/config/server/print-urls.mdx
@@ -7,9 +7,9 @@ description: '控制是否以及如何打印 server 的 URL 地址。'
 - **类型：**
 
 ```ts
-type Routes = Array<{
-  entryName: string;
-  pathname: string;
+type ReadonlyRoutes = ReadonlyArray<{
+  readonly entryName: string;
+  readonly pathname: string;
 }>;
 
 type PrintUrlsOptions = {
@@ -22,7 +22,7 @@ type PrintUrls =
   | ((params: {
       urls: string[];
       port: number;
-      routes: Routes;
+      routes: ReadonlyRoutes;
       protocol: string;
     }) => (string | { url: string; label?: string })[] | void);
 ```

--- a/website/docs/zh/shared/onAfterStartDevServer.mdx
+++ b/website/docs/zh/shared/onAfterStartDevServer.mdx
@@ -3,15 +3,15 @@
 - **类型：**
 
 ```ts
-type Routes = Array<{
-  entryName: string;
-  pathname: string;
+type ReadonlyRoutes = ReadonlyArray<{
+  readonly entryName: string;
+  readonly pathname: string;
 }>;
 
 function OnAfterStartDevServer(
   callback: (params: {
     port: number;
-    routes: Routes;
+    routes: ReadonlyRoutes;
     environments: Record<string, EnvironmentContext>;
   }) => Promise<void> | void,
 ): void;

--- a/website/docs/zh/shared/onAfterStartPreviewServer.mdx
+++ b/website/docs/zh/shared/onAfterStartPreviewServer.mdx
@@ -3,15 +3,15 @@
 - **类型：**
 
 ```ts
-type Routes = Array<{
-  entryName: string;
-  pathname: string;
+type ReadonlyRoutes = ReadonlyArray<{
+  readonly entryName: string;
+  readonly pathname: string;
 }>;
 
 function OnAfterStartPreviewServer(
   callback: (params: {
     port: number;
-    routes: Routes;
+    routes: ReadonlyRoutes;
     environments: Record<string, EnvironmentContext>;
   }) => Promise<void> | void,
 ): void;


### PR DESCRIPTION
## Summary

Server callbacks expose shared route data, so mutating `routes` can make URL output depend on startup order.

This PR exports `ReadonlyRoutes` for `onAfterStartDevServer`, `onAfterStartPreviewServer`, and `server.printUrls`, while preserving the mutable `Routes` type. TypeScript consumers that modify callback routes must copy the data first; runtime behavior is unchanged.
