### PR TITLE
feat: log after the initial watch build

### DIFF
--- a/e2e/cases/cli/build-watch-log/index.test.ts
+++ b/e2e/cases/cli/build-watch-log/index.test.ts
@@ -1,0 +1,57 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { expect, test } from '@e2e/helper';
+import { waitForFileContent } from '@rstackjs/test-utils';
+
+const watchingLog = 'watching for changes...';
+
+for (const environment of [['web'], ['web', 'node']]) {
+  test(`should log only after the first watch build for ${environment.join(', ')}`, async ({
+    execCli,
+    copySrcDir,
+    editFile,
+    logHelper,
+  }) => {
+    await copySrcDir();
+    execCli(`build --watch --environment ${environment.join(',')}`);
+    await logHelper.expectLog(watchingLog);
+
+    const bundles = environment.map((name) =>
+      path.join(
+        import.meta.dirname,
+        'dist',
+        name,
+        name === 'node' ? 'index.js' : 'static/js/index.js',
+      ),
+    );
+    for (const bundle of bundles) {
+      expect(fs.readFileSync(bundle, 'utf8')).toContain('initial');
+    }
+    expect(
+      logHelper.logs.join('').match(/watching for changes\.\.\./g),
+    ).toHaveLength(1);
+
+    logHelper.clearLogs();
+    await editFile('test-temp-src/index.js', (code) =>
+      code.replace('initial', 'updated'),
+    );
+    await logHelper.expectLog('building test-temp-src/index.js', {
+      posix: true,
+    });
+    await logHelper.expectBuildEnd();
+
+    for (const bundle of bundles) {
+      await waitForFileContent(bundle, 'updated');
+    }
+
+    logHelper.expectNoLog(watchingLog);
+  });
+}
+
+test('should not log watching for a regular build', async ({
+  execCliSync,
+  copySrcDir,
+}) => {
+  await copySrcDir();
+  expect(execCliSync('build')).not.toContain(watchingLog);
+});

--- a/e2e/cases/cli/build-watch-log/rsbuild.config.ts
+++ b/e2e/cases/cli/build-watch-log/rsbuild.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  source: {
+    entry: {
+      index: './test-temp-src/index.js',
+    },
+  },
+  output: {
+    filenameHash: false,
+  },
+  environments: {
+    web: {
+      output: {
+        distPath: { root: 'dist/web' },
+      },
+    },
+    node: {
+      output: {
+        target: 'node',
+        distPath: { root: 'dist/node' },
+      },
+    },
+  },
+});

--- a/e2e/cases/cli/build-watch-log/src/index.js
+++ b/e2e/cases/cli/build-watch-log/src/index.js
@@ -1,0 +1,1 @@
+console.log('initial');

--- a/packages/core/src/hooks.ts
+++ b/packages/core/src/hooks.ts
@@ -394,6 +394,7 @@ export const registerBuildHook = ({
   };
 
   const onDone = async (stats: Rspack.Stats | Rspack.MultiStats) => {
+    const shouldLogWatching = isWatch && isFirstCompile;
     const promise = context.hooks.onAfterBuild.callBatch({
       isFirstCompile,
       stats,
@@ -402,6 +403,10 @@ export const registerBuildHook = ({
     });
     isFirstCompile = false;
     await promise;
+
+    if (shouldLogWatching) {
+      context.logger.info('watching for changes...');
+    }
   };
 
   const onEnvironmentDone = async (index: number, stats: Rspack.Stats) => {


### PR DESCRIPTION
## Summary

Watch builds need a clear signal that the initial build has completed, especially with multiple environments. This PR logs `watching for changes...` after the first watch build and its `onAfterBuild` hooks finish, so external tools can detect completion. Subsequent rebuilds do not repeat the message.

## Related links

Closes #8408