### PR TITLE
chore(e2e): upgrade test-utils to v1.0.0

### DIFF
--- a/e2e/cases/cli/build-watch-log/index.test.ts
+++ b/e2e/cases/cli/build-watch-log/index.test.ts
@@ -27,9 +27,7 @@ for (const environment of [['web'], ['web', 'node']]) {
     for (const bundle of bundles) {
       expect(fs.readFileSync(bundle, 'utf8')).toContain('initial');
     }
-    expect(
-      logHelper.logs.join('').match(/watching for changes\.\.\./g),
-    ).toHaveLength(1);
+    logHelper.expectLogTimes(watchingLog, 1);
 
     logHelper.clearLogs();
     await editFile('test-temp-src/index.js', (code) =>

--- a/e2e/cases/cli/shortcut-restart-watcher/index.test.ts
+++ b/e2e/cases/cli/shortcut-restart-watcher/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { expect, test } from '@e2e/helper';
+import { test } from '@e2e/helper';
 import { getRandomPort } from '@rstackjs/test-utils';
 
 const watchedFile = path.join(import.meta.dirname, 'test-temp-watch.txt');
@@ -24,7 +24,7 @@ test('should close the old watcher after a shortcut restart', async ({
       PORT: String(port),
     },
   });
-  const { clearLogs, expectBuildEnd, expectLog, logs } = logHelper;
+  const { clearLogs, expectBuildEnd, expectLog, expectLogTimes } = logHelper;
 
   await expectBuildEnd();
   clearLogs();
@@ -37,5 +37,5 @@ test('should close the old watcher after a shortcut restart', async ({
   await expectLog(restartLog);
   await expectBuildEnd();
 
-  expect(logs.filter((log) => log.includes(restartLog))).toHaveLength(1);
+  expectLogTimes(restartLog, 1);
 });

--- a/e2e/cases/cli/strict-port/index.test.ts
+++ b/e2e/cases/cli/strict-port/index.test.ts
@@ -1,32 +1,13 @@
-import net from 'node:net';
 import { stripVTControlCharacters as stripAnsi } from 'node:util';
 import { expect, test } from '@e2e/helper';
-import { getRandomPort } from '@rstackjs/test-utils';
+import { occupyPort } from '@rstackjs/test-utils';
 
 const HOST = '0.0.0.0';
-
-const occupyPort = async () => {
-  const port = await getRandomPort();
-  const blocker = net.createServer();
-
-  await new Promise<void>((resolve, reject) => {
-    blocker.once('error', reject);
-    blocker.listen({ port, host: HOST }, resolve);
-  });
-
-  return {
-    port,
-    close: () =>
-      new Promise<void>((resolve) => {
-        blocker.close(() => resolve());
-      }),
-  };
-};
 
 test('should exit when port is occupied and --strict-port is used', async ({
   execCliSync,
 }) => {
-  const blocker = await occupyPort();
+  const blocker = await occupyPort(HOST);
 
   let message = '';
   try {

--- a/e2e/cases/cli/watch-files-multiple-restart/index.test.ts
+++ b/e2e/cases/cli/watch-files-multiple-restart/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { expect, test } from '@e2e/helper';
+import { test } from '@e2e/helper';
 
 const defaultFile = path.join(import.meta.dirname, 'test-temp-default.txt');
 const customFile = path.join(import.meta.dirname, 'test-temp-custom.txt');
@@ -14,7 +14,7 @@ test('should restart once with multiple restart watchers', async ({
   fs.writeFileSync(customFile, '1');
   execCli('build --watch');
 
-  const { clearLogs, expectBuildEnd, expectLog } = logHelper;
+  const { clearLogs, expectBuildEnd, expectLog, expectLogTimes } = logHelper;
   await expectBuildEnd();
 
   clearLogs();
@@ -27,7 +27,5 @@ test('should restart once with multiple restart watchers', async ({
   await expectLog(defaultRestartLog);
   await expectBuildEnd();
 
-  expect(
-    logHelper.logs.filter((log) => log.includes(defaultRestartLog)),
-  ).toHaveLength(1);
+  expectLogTimes(defaultRestartLog, 1);
 });

--- a/e2e/cases/css/emit-css/index.test.ts
+++ b/e2e/cases/css/emit-css/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@e2e/helper';
-import { getFileContent } from '@rstackjs/test-utils';
+import { findFiles, getFileContent } from '@rstackjs/test-utils';
 
 test('should not emit CSS files when build node target', async ({ build }) => {
   const rsbuild = await build({
@@ -15,7 +15,7 @@ test('should not emit CSS files when build node target', async ({ build }) => {
   const jsContent = getFileContent(files, 'index.js');
   expect(jsContent.includes('"title-class":')).toBeTruthy();
 
-  const cssFiles = Object.keys(files).filter((file) => file.endsWith('.css'));
+  const cssFiles = findFiles(files, '.css');
   expect(cssFiles).toHaveLength(0);
 });
 
@@ -36,7 +36,7 @@ test('should allow to emit CSS with output.emitCss when build node target', asyn
   const jsContent = getFileContent(files, 'index.js');
   expect(jsContent.includes('"title-class":')).toBeTruthy();
 
-  const cssFiles = Object.keys(files).filter((file) => file.endsWith('.css'));
+  const cssFiles = findFiles(files, '.css');
   expect(cssFiles).toHaveLength(1);
 });
 
@@ -56,7 +56,7 @@ test('should not emit CSS files when build web-worker target', async ({
   const jsContent = getFileContent(files, 'index.js');
   expect(jsContent.includes('"title-class":')).toBeTruthy();
 
-  const cssFiles = Object.keys(files).filter((file) => file.endsWith('.css'));
+  const cssFiles = findFiles(files, '.css');
   expect(cssFiles).toHaveLength(0);
 });
 
@@ -77,7 +77,7 @@ test('should allow to emit CSS with output.emitCss when build web-worker target'
   const jsContent = getFileContent(files, 'index.js');
   expect(jsContent.includes('"title-class":')).toBeTruthy();
 
-  const cssFiles = Object.keys(files).filter((file) => file.endsWith('.css'));
+  const cssFiles = findFiles(files, '.css');
   expect(cssFiles).toHaveLength(1);
 });
 
@@ -98,6 +98,6 @@ test('should allow to disable CSS emit with output.emitCss when build web target
   const jsContent = getFileContent(files, 'index.js');
   expect(jsContent.includes('"title-class":')).toBeTruthy();
 
-  const cssFiles = Object.keys(files).filter((file) => file.endsWith('.css'));
+  const cssFiles = findFiles(files, '.css');
   expect(cssFiles).toHaveLength(0);
 });

--- a/e2e/cases/output/filename-hash-stability-mpa/index.test.ts
+++ b/e2e/cases/output/filename-hash-stability-mpa/index.test.ts
@@ -1,10 +1,9 @@
 import { basename, join } from 'node:path';
 import { expect, test } from '@e2e/helper';
+import { findFiles } from '@rstackjs/test-utils';
 
 const getJsFilenames = (files: Record<string, string>) =>
-  Object.keys(files)
-    .filter((filename) => filename.endsWith('.js'))
-    .map((filename) => basename(filename));
+  findFiles(files, '.js').map((filename) => basename(filename));
 
 const findChunk = (filenames: string[], name: string) =>
   filenames.find((filename) =>

--- a/e2e/cases/output/filename-hash-stability-spa/index.test.ts
+++ b/e2e/cases/output/filename-hash-stability-spa/index.test.ts
@@ -1,10 +1,9 @@
 import { basename, join } from 'node:path';
 import { expect, test } from '@e2e/helper';
+import { findFiles } from '@rstackjs/test-utils';
 
 const getJsFilenames = (files: Record<string, string>) =>
-  Object.keys(files)
-    .filter((filename) => filename.endsWith('.js'))
-    .map((filename) => basename(filename));
+  findFiles(files, '.js').map((filename) => basename(filename));
 
 const findChunk = (filenames: string[], name: string) =>
   filenames.find((filename) =>

--- a/e2e/cases/output/inline-chunk/index.test.ts
+++ b/e2e/cases/output/inline-chunk/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@e2e/helper';
-import { getFileContent } from '@rstackjs/test-utils';
+import { findFiles, getFileContent } from '@rstackjs/test-utils';
 import type { RspackChain } from '@rsbuild/core';
 
 // use source-map for easy to test. By default, Rsbuild use hidden-source-map
@@ -42,16 +42,14 @@ test('should inline all scripts and emit all source maps', async ({
 
   // no entry chunks or runtime chunks in output
   expect(
-    Object.keys(files).filter(
+    findFiles(
+      files,
       (fileName) => fileName.endsWith('.js') && !fileName.includes('/async/'),
     ).length,
   ).toEqual(0);
 
   // all source maps in output
-  expect(
-    Object.keys(files).filter((fileName) => fileName.endsWith('.js.map'))
-      .length,
-  ).toEqual(3);
+  expect(findFiles(files, '.js.map')).toHaveLength(3);
 });
 
 test('should inline scripts when matching a RegExp', async ({ build }) => {
@@ -66,17 +64,10 @@ test('should inline scripts when matching a RegExp', async ({ build }) => {
   const files = rsbuild.getDistFiles({ sourceMaps: true });
 
   // no index.js in output
-  expect(
-    Object.keys(files).filter(
-      (fileName) => fileName.endsWith('.js') && fileName.includes('/index.'),
-    ).length,
-  ).toEqual(0);
+  expect(findFiles(files, '/index.js')).toHaveLength(0);
 
   // all source maps in output
-  expect(
-    Object.keys(files).filter((fileName) => fileName.endsWith('.js.map'))
-      .length,
-  ).toBeGreaterThanOrEqual(2);
+  expect(findFiles(files, '.js.map').length).toBeGreaterThanOrEqual(2);
 });
 
 test('should inline scripts based on filename and size', async ({ build }) => {
@@ -93,17 +84,10 @@ test('should inline scripts based on filename and size', async ({ build }) => {
   const files = rsbuild.getDistFiles({ sourceMaps: true });
 
   // no index.js in output
-  expect(
-    Object.keys(files).filter(
-      (fileName) => fileName.endsWith('.js') && fileName.includes('/index.'),
-    ).length,
-  ).toEqual(0);
+  expect(findFiles(files, '/index.js')).toHaveLength(0);
 
   // all source maps in output
-  expect(
-    Object.keys(files).filter((fileName) => fileName.endsWith('.js.map'))
-      .length,
-  ).toBeGreaterThanOrEqual(2);
+  expect(findFiles(files, '.js.map').length).toBeGreaterThanOrEqual(2);
 });
 
 test('should inline styles when matching a RegExp', async ({ build }) => {
@@ -118,11 +102,7 @@ test('should inline styles when matching a RegExp', async ({ build }) => {
   const files = rsbuild.getDistFiles({ sourceMaps: true });
 
   // no index.css in output
-  expect(
-    Object.keys(files).filter(
-      (fileName) => fileName.endsWith('.css') && fileName.includes('/index.'),
-    ).length,
-  ).toEqual(0);
+  expect(findFiles(files, '/index.css')).toHaveLength(0);
 });
 
 test('should inline styles based on filename and size', async ({ build }) => {
@@ -139,11 +119,7 @@ test('should inline styles based on filename and size', async ({ build }) => {
   const files = rsbuild.getDistFiles({ sourceMaps: true });
 
   // no index.css in output
-  expect(
-    Object.keys(files).filter(
-      (fileName) => fileName.endsWith('.css') && fileName.includes('/index.'),
-    ).length,
-  ).toEqual(0);
+  expect(findFiles(files, '/index.css')).toHaveLength(0);
 });
 
 test('should not inline styles by default in dev', async ({ page, dev }) => {
@@ -226,17 +202,10 @@ test('should not inline scripts when disabled', async ({ build }) => {
   const files = rsbuild.getDistFiles({ sourceMaps: true });
 
   // all index.js in output
-  expect(
-    Object.keys(files).filter(
-      (fileName) => fileName.endsWith('.js') && fileName.includes('/index.'),
-    ).length,
-  ).toEqual(1);
+  expect(findFiles(files, '/index.js')).toHaveLength(1);
 
   // all source maps in output
-  expect(
-    Object.keys(files).filter((fileName) => fileName.endsWith('.js.map'))
-      .length,
-  ).toBeGreaterThanOrEqual(2);
+  expect(findFiles(files, '.js.map').length).toBeGreaterThanOrEqual(2);
 });
 
 test('should not inline styles when disabled', async ({ build }) => {
@@ -254,11 +223,7 @@ test('should not inline styles when disabled', async ({ build }) => {
   const files = rsbuild.getDistFiles({ sourceMaps: true });
 
   // all index.css in output
-  expect(
-    Object.keys(files).filter(
-      (fileName) => fileName.endsWith('.css') && fileName.includes('/index.'),
-    ).length,
-  ).toEqual(1);
+  expect(findFiles(files, '/index.css')).toHaveLength(1);
 });
 
 test('should inline assets in build when enable is auto', async ({ build }) => {
@@ -280,24 +245,13 @@ test('should inline assets in build when enable is auto', async ({ build }) => {
   const files = rsbuild.getDistFiles({ sourceMaps: true });
 
   // no index.js in output
-  expect(
-    Object.keys(files).filter(
-      (fileName) => fileName.endsWith('.js') && fileName.includes('/index.'),
-    ).length,
-  ).toEqual(0);
+  expect(findFiles(files, '/index.js')).toHaveLength(0);
 
   // all source maps in output
-  expect(
-    Object.keys(files).filter((fileName) => fileName.endsWith('.js.map'))
-      .length,
-  ).toBeGreaterThanOrEqual(2);
+  expect(findFiles(files, '.js.map').length).toBeGreaterThanOrEqual(2);
 
   // no index.css in output
-  expect(
-    Object.keys(files).filter(
-      (fileName) => fileName.endsWith('.css') && fileName.includes('/index.'),
-    ).length,
-  ).toEqual(0);
+  expect(findFiles(files, '/index.css')).toHaveLength(0);
 });
 
 test('should not inline assets in dev when enable is auto', async ({
@@ -418,7 +372,8 @@ test('should inline assets independently for multiple environments', async ({
   expect(web1Html).toContain('window.test');
 
   const countJs = (root: string) =>
-    Object.keys(files).filter(
+    findFiles(
+      files,
       (file) =>
         file.includes(root) &&
         file.endsWith('.js') &&
@@ -426,9 +381,8 @@ test('should inline assets independently for multiple environments', async ({
     ).length;
 
   const countCss = (root: string) =>
-    Object.keys(files).filter(
-      (file) => file.includes(root) && file.endsWith('.css'),
-    ).length;
+    findFiles(files, (file) => file.includes(root) && file.endsWith('.css'))
+      .length;
 
   expect(countJs('/dist/web/')).toEqual(0);
   expect(countJs('/dist/web1/')).toEqual(0);

--- a/e2e/cases/plugin-less/exclude-with-helper/index.test.ts
+++ b/e2e/cases/plugin-less/exclude-with-helper/index.test.ts
@@ -1,12 +1,13 @@
 import { expect, test } from '@e2e/helper';
+import { findFiles } from '@rstackjs/test-utils';
 
 test('should exclude specified Less files using addExcludes', async ({
   build,
 }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
-  const cssFiles = Object.keys(files).filter((file) => file.endsWith('.css'));
-  const lessFiles = Object.keys(files).filter((file) => file.endsWith('.less'));
+  const cssFiles = findFiles(files, '.css');
+  const lessFiles = findFiles(files, '.less');
 
   expect(lessFiles.length).toBe(1);
   expect(cssFiles.length).toBe(1);

--- a/e2e/cases/plugin-less/exclude/index.test.ts
+++ b/e2e/cases/plugin-less/exclude/index.test.ts
@@ -1,12 +1,13 @@
 import { expect, test } from '@e2e/helper';
+import { findFiles } from '@rstackjs/test-utils';
 
 test('should exclude specified Less files using the exclude option', async ({
   build,
 }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
-  const cssFiles = Object.keys(files).filter((file) => file.endsWith('.css'));
-  const lessFiles = Object.keys(files).filter((file) => file.endsWith('.less'));
+  const cssFiles = findFiles(files, '.css');
+  const lessFiles = findFiles(files, '.less');
 
   expect(lessFiles.length).toBe(1);
   expect(cssFiles.length).toBe(1);

--- a/e2e/cases/plugin-sass/exclude-with-helper/index.test.ts
+++ b/e2e/cases/plugin-sass/exclude-with-helper/index.test.ts
@@ -1,12 +1,13 @@
 import { expect, test } from '@e2e/helper';
+import { findFiles } from '@rstackjs/test-utils';
 
 test('should exclude specified Sass files using addExcludes', async ({
   build,
 }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
-  const cssFiles = Object.keys(files).filter((file) => file.endsWith('.css'));
-  const scssFiles = Object.keys(files).filter((file) => file.endsWith('.scss'));
+  const cssFiles = findFiles(files, '.css');
+  const scssFiles = findFiles(files, '.scss');
 
   expect(scssFiles.length).toBe(1);
   expect(cssFiles.length).toBe(1);

--- a/e2e/cases/plugin-sass/exclude/index.test.ts
+++ b/e2e/cases/plugin-sass/exclude/index.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@e2e/helper';
+import { findFiles } from '@rstackjs/test-utils';
 
 test('should exclude specified Sass files using the exclude option', async ({
   build,
@@ -17,8 +18,8 @@ test('should exclude specified Sass files using the exclude option', async ({
   });
 
   const files = rsbuild.getDistFiles();
-  const cssFiles = Object.keys(files).filter((file) => file.endsWith('.css'));
-  const scssFiles = Object.keys(files).filter((file) => file.endsWith('.scss'));
+  const cssFiles = findFiles(files, '.css');
+  const scssFiles = findFiles(files, '.scss');
 
   expect(scssFiles.length).toBe(1);
   expect(cssFiles.length).toBe(1);

--- a/e2e/cases/plugin-svgr/hash-digest/index.test.ts
+++ b/e2e/cases/plugin-svgr/hash-digest/index.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@e2e/helper';
+import { findFiles } from '@rstackjs/test-utils';
 
 // https://github.com/web-infra-dev/rsbuild/issues/4610
 test('should generate the same hash digest for the same SVG', async ({
@@ -8,7 +9,5 @@ test('should generate the same hash digest for the same SVG', async ({
 
   const files = rsbuild.getDistFiles();
 
-  expect(
-    Object.keys(files).filter((key) => key.endsWith('.svg')).length,
-  ).toEqual(1);
+  expect(findFiles(files, '.svg').length).toEqual(1);
 });

--- a/e2e/cases/plugin-tailwindcss/inject-styles/index.test.ts
+++ b/e2e/cases/plugin-tailwindcss/inject-styles/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@e2e/helper';
-import { getFileContent } from '@rstackjs/test-utils';
+import { findFiles, getFileContent } from '@rstackjs/test-utils';
 
 test('should inject transformed Tailwind CSS when injectStyles is enabled', async ({
   page,
@@ -8,7 +8,7 @@ test('should inject transformed Tailwind CSS when injectStyles is enabled', asyn
   const rsbuild = await buildPreview();
 
   const files = rsbuild.getDistFiles();
-  const cssFiles = Object.keys(files).filter((file) => file.endsWith('.css'));
+  const cssFiles = findFiles(files, '.css');
   expect(cssFiles).toHaveLength(0);
 
   const indexJs = getFileContent(files, 'index.js');

--- a/e2e/cases/server/load-bundle-cjs/index.test.ts
+++ b/e2e/cases/server/load-bundle-cjs/index.test.ts
@@ -14,7 +14,5 @@ test('should load CJS bundle with runtime globals', async ({
   expect(await response1.text()).toBe('index.js:function');
   expect(await response2.text()).toBe('index.js:function');
 
-  expect(
-    rsbuild.logs.filter((log) => log.includes('load bundle cjs')).length,
-  ).toBe(1);
+  rsbuild.expectLogTimes('load bundle cjs', 1);
 });

--- a/e2e/cases/server/ssr/index.test.ts
+++ b/e2e/cases/server/ssr/index.test.ts
@@ -12,7 +12,7 @@ test('support SSR', async ({ page, devOnly }) => {
   await page.goto(url.href);
 
   // bundle result should cacheable and only load once.
-  expect(rsbuild.logs.filter((log) => log.includes('load SSR')).length).toBe(1);
+  rsbuild.expectLogTimes('load SSR', 1);
 });
 
 test('support SSR with autoExternal', async ({ page, devOnly }) => {
@@ -41,7 +41,7 @@ test('support SSR with autoExternal', async ({ page, devOnly }) => {
   await page.goto(url.href);
 
   // bundle result should cacheable and only load once.
-  expect(rsbuild.logs.filter((log) => log.includes('load SSR')).length).toBe(1);
+  rsbuild.expectLogTimes('load SSR', 1);
 });
 
 test('support SSR with esm target', async ({ page, devOnly }) => {

--- a/e2e/cases/server/strict-port/index.test.ts
+++ b/e2e/cases/server/strict-port/index.test.ts
@@ -1,32 +1,13 @@
-import net from 'node:net';
 import { stripVTControlCharacters as stripAnsi } from 'node:util';
 import { expect, test } from '@e2e/helper';
-import { getRandomPort } from '@rstackjs/test-utils';
+import { occupyPort } from '@rstackjs/test-utils';
 
 const HOST = '0.0.0.0';
-
-const occupyPort = async () => {
-  const port = await getRandomPort();
-  const blocker = net.createServer();
-
-  await new Promise<void>((resolve, reject) => {
-    blocker.once('error', reject);
-    blocker.listen({ port, host: HOST }, resolve);
-  });
-
-  return {
-    port,
-    close: () =>
-      new Promise<void>((resolve) => {
-        blocker.close(() => resolve());
-      }),
-  };
-};
 
 test('should throw when strictPort is enabled and port is taken', async ({
   devOnly,
 }) => {
-  const blocker = await occupyPort();
+  const blocker = await occupyPort(HOST);
 
   let message = '';
   try {
@@ -43,8 +24,9 @@ test('should throw when strictPort is enabled and port is taken', async ({
     if (error instanceof Error) {
       message = error.message;
     }
+  } finally {
+    await blocker.close();
   }
 
   expect(stripAnsi(message)).toContain(`Port ${blocker.port} is occupied`);
-  await blocker.close();
 });

--- a/e2e/cases/source-map/basic/index.test.ts
+++ b/e2e/cases/source-map/basic/index.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import path, { join } from 'node:path';
 import { type Build, expect, mapSourceMapPositions, test } from '@e2e/helper';
-import { findFile, getFileContent } from '@rstackjs/test-utils';
+import { findFile, findFiles, getFileContent } from '@rstackjs/test-utils';
 import type { Rspack } from '@rsbuild/core';
 
 const cwd = import.meta.dirname;
@@ -87,12 +87,8 @@ test('should not generate source map by default in build', async ({
 
   const files = rsbuild.getDistFiles({ sourceMaps: true });
 
-  const jsMapPaths = Object.keys(files).filter((files) =>
-    files.endsWith('.js.map'),
-  );
-  const cssMapFiles = Object.keys(files).filter((files) =>
-    files.endsWith('.css.map'),
-  );
+  const jsMapPaths = findFiles(files, '.js.map');
+  const cssMapFiles = findFiles(files, '.css.map');
   expect(jsMapPaths.length).toEqual(0);
   expect(cssMapFiles.length).toEqual(0);
 });
@@ -110,12 +106,8 @@ test('should generate source map if `output.sourceMap` is true', async ({
 
   const files = rsbuild.getDistFiles({ sourceMaps: true });
 
-  const jsMapPaths = Object.keys(files).filter((files) =>
-    files.endsWith('.js.map'),
-  );
-  const cssMapFiles = Object.keys(files).filter((files) =>
-    files.endsWith('.css.map'),
-  );
+  const jsMapPaths = findFiles(files, '.js.map');
+  const cssMapFiles = findFiles(files, '.css.map');
   expect(jsMapPaths.length).toBeGreaterThan(0);
   expect(cssMapFiles.length).toBeGreaterThan(0);
 });
@@ -133,12 +125,8 @@ test('should not generate source map if `output.sourceMap` is false', async ({
 
   const files = rsbuild.getDistFiles({ sourceMaps: true });
 
-  const jsMapPaths = Object.keys(files).filter((files) =>
-    files.endsWith('.js.map'),
-  );
-  const cssMapFiles = Object.keys(files).filter((files) =>
-    files.endsWith('.css.map'),
-  );
+  const jsMapPaths = findFiles(files, '.js.map');
+  const cssMapFiles = findFiles(files, '.css.map');
   expect(jsMapPaths.length).toEqual(0);
   expect(cssMapFiles.length).toEqual(0);
 });
@@ -174,12 +162,8 @@ test('should generate source maps only for CSS files', async ({ build }) => {
 
   const files = rsbuild.getDistFiles({ sourceMaps: true });
 
-  const jsMapPaths = Object.keys(files).filter((files) =>
-    files.endsWith('.js.map'),
-  );
-  const cssMapFiles = Object.keys(files).filter((files) =>
-    files.endsWith('.css.map'),
-  );
+  const jsMapPaths = findFiles(files, '.js.map');
+  const cssMapFiles = findFiles(files, '.css.map');
   expect(jsMapPaths.length).toEqual(0);
   expect(cssMapFiles.length).toBeGreaterThan(0);
 

--- a/e2e/cases/split-chunks/disable-polyfill-cache-group/index.test.ts
+++ b/e2e/cases/split-chunks/disable-polyfill-cache-group/index.test.ts
@@ -1,10 +1,11 @@
 import { expect, test } from '@e2e/helper';
+import { findFiles } from '@rstackjs/test-utils';
 
 test('should allow to disable the default `lib-polyfill` cache group', async ({
   build,
 }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
-  const jsFiles = Object.keys(files).filter((name) => name.endsWith('.js'));
+  const jsFiles = findFiles(files, '.js');
   expect(jsFiles.find((file) => file.includes('lib-polyfill'))).toBeFalsy();
 });

--- a/e2e/cases/split-chunks/disabled/index.test.ts
+++ b/e2e/cases/split-chunks/disabled/index.test.ts
@@ -1,10 +1,11 @@
 import { expect, test } from '@e2e/helper';
+import { findFiles } from '@rstackjs/test-utils';
 
 test('should not split chunks if `splitChunks` is disabled', async ({
   build,
 }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
-  const jsFiles = Object.keys(files).filter((name) => name.endsWith('.js'));
+  const jsFiles = findFiles(files, '.js');
   expect(jsFiles.length).toEqual(1);
 });

--- a/e2e/cases/split-chunks/legacy-all-in-one/index.test.ts
+++ b/e2e/cases/split-chunks/legacy-all-in-one/index.test.ts
@@ -1,10 +1,11 @@
 import { expect, test } from '@e2e/helper';
+import { findFiles } from '@rstackjs/test-utils';
 
 test('should output a single JavaScript bundle', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
   // expect only one bundle (end with .js)
-  const filePaths = Object.keys(files).filter((file) => file.endsWith('.js'));
+  const filePaths = findFiles(files, '.js');
 
   expect(filePaths.length).toBe(1);
 });

--- a/e2e/cases/split-chunks/legacy-by-module/index.test.ts
+++ b/e2e/cases/split-chunks/legacy-by-module/index.test.ts
@@ -1,6 +1,6 @@
 import { basename } from 'node:path';
 import { expect, test } from '@e2e/helper';
-import { findFile } from '@rstackjs/test-utils';
+import { findFile, findFiles } from '@rstackjs/test-utils';
 
 test('should generate module chunks when chunkSplit is "split-by-module"', async ({
   build,
@@ -17,9 +17,7 @@ test('should generate module chunks when chunkSplit is "split-by-module"', async
   );
   expect(reactFile).toBeTruthy();
 
-  const jsFiles = Object.keys(files)
-    .filter((name) => name.endsWith('.js'))
-    .map((name) => basename(name));
+  const jsFiles = findFiles(files, '.js').map((name) => basename(name));
 
   expect(jsFiles.length).toEqual(4);
   expect(jsFiles).toContain('index.js');

--- a/e2e/cases/split-chunks/legacy-single-vendor-with-force/index.test.ts
+++ b/e2e/cases/split-chunks/legacy-single-vendor-with-force/index.test.ts
@@ -1,6 +1,7 @@
 import { basename } from 'node:path';
 
 import { expect, test } from '@e2e/helper';
+import { findFiles } from '@rstackjs/test-utils';
 
 test('should support `forceSplitting` when chunkSplit is "single-vendor"', async ({
   build,
@@ -9,9 +10,7 @@ test('should support `forceSplitting` when chunkSplit is "single-vendor"', async
 
   const files = rsbuild.getDistFiles();
 
-  const jsFiles = Object.keys(files)
-    .filter((name) => name.endsWith('.js'))
-    .map((name) => basename(name));
+  const jsFiles = findFiles(files, '.js').map((name) => basename(name));
 
   expect(jsFiles.length).toEqual(3);
   expect(jsFiles).toContain('index.js');

--- a/e2e/cases/split-chunks/legacy-single-vendor/index.test.ts
+++ b/e2e/cases/split-chunks/legacy-single-vendor/index.test.ts
@@ -1,6 +1,6 @@
 import { basename } from 'node:path';
 import { expect, test } from '@e2e/helper';
-import { findFile } from '@rstackjs/test-utils';
+import { findFile, findFiles } from '@rstackjs/test-utils';
 
 test('should generate vendor chunk when chunkSplit is "single-vendor"', async ({
   build,
@@ -15,9 +15,7 @@ test('should generate vendor chunk when chunkSplit is "single-vendor"', async ({
   );
   expect(vendorFile).toBeTruthy();
 
-  const jsFiles = Object.keys(files)
-    .filter((name) => name.endsWith('.js'))
-    .map((name) => basename(name));
+  const jsFiles = findFiles(files, '.js').map((name) => basename(name));
 
   expect(jsFiles.length).toEqual(2);
   expect(jsFiles).toContain('index.js');

--- a/e2e/cases/split-chunks/preset-default/index.test.ts
+++ b/e2e/cases/split-chunks/preset-default/index.test.ts
@@ -1,12 +1,11 @@
 import { basename } from 'node:path';
 import { expect, test } from '@e2e/helper';
+import { findFiles } from '@rstackjs/test-utils';
 
 test('should apply default preset as expected', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
-  const jsFiles = Object.keys(files)
-    .filter((name) => name.endsWith('.js'))
-    .map((name) => basename(name));
+  const jsFiles = findFiles(files, '.js').map((name) => basename(name));
   expect(jsFiles.sort()).toEqual([
     'index.js',
     'lib-polyfill.js',

--- a/e2e/cases/split-chunks/preset-none/index.test.ts
+++ b/e2e/cases/split-chunks/preset-none/index.test.ts
@@ -1,14 +1,13 @@
 import { basename } from 'node:path';
 import { expect, test } from '@e2e/helper';
+import { findFiles } from '@rstackjs/test-utils';
 
 test('should not apply built-in preset rules when preset is "none"', async ({
   build,
 }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
-  const jsFiles = Object.keys(files)
-    .filter((name) => name.endsWith('.js'))
-    .map((name) => basename(name));
+  const jsFiles = findFiles(files, '.js').map((name) => basename(name));
 
   expect(jsFiles).toContain('index.js');
   expect(jsFiles.some((file) => file.includes('lib-react'))).toBeFalsy();

--- a/e2e/cases/split-chunks/preset-per-package/index.test.ts
+++ b/e2e/cases/split-chunks/preset-per-package/index.test.ts
@@ -1,6 +1,6 @@
 import { basename } from 'node:path';
 import { expect, test } from '@e2e/helper';
-import { findFile } from '@rstackjs/test-utils';
+import { findFile, findFiles } from '@rstackjs/test-utils';
 
 test('should generate chunks for each package when preset is "per-package"', async ({
   build,
@@ -17,9 +17,7 @@ test('should generate chunks for each package when preset is "per-package"', asy
   );
   expect(reactFile).toBeTruthy();
 
-  const jsFiles = Object.keys(files)
-    .filter((name) => name.endsWith('.js'))
-    .map((name) => basename(name));
+  const jsFiles = findFiles(files, '.js').map((name) => basename(name));
 
   expect(jsFiles.length).toEqual(4);
   expect(jsFiles).toContain('index.js');

--- a/e2e/cases/split-chunks/preset-single-vendor-node/index.test.ts
+++ b/e2e/cases/split-chunks/preset-single-vendor-node/index.test.ts
@@ -1,6 +1,6 @@
 import { basename } from 'node:path';
 import { expect, test } from '@e2e/helper';
-import { findFile } from '@rstackjs/test-utils';
+import { findFile, findFiles } from '@rstackjs/test-utils';
 
 test('should generate a vendor chunk when preset is "single-vendor" and target is "node"', async ({
   build,
@@ -14,9 +14,7 @@ test('should generate a vendor chunk when preset is "single-vendor" and target i
   );
   expect(vendorFile).toBeTruthy();
 
-  const jsFiles = Object.keys(files)
-    .filter((name) => name.endsWith('.js'))
-    .map((name) => basename(name));
+  const jsFiles = findFiles(files, '.js').map((name) => basename(name));
 
   expect(jsFiles.length).toEqual(2);
   expect(jsFiles).toContain('index.js');

--- a/e2e/cases/split-chunks/preset-single-vendor/index.test.ts
+++ b/e2e/cases/split-chunks/preset-single-vendor/index.test.ts
@@ -1,6 +1,6 @@
 import { basename } from 'node:path';
 import { expect, test } from '@e2e/helper';
-import { findFile } from '@rstackjs/test-utils';
+import { findFile, findFiles } from '@rstackjs/test-utils';
 
 test('should generate a vendor chunk when preset is "single-vendor"', async ({
   build,
@@ -14,9 +14,7 @@ test('should generate a vendor chunk when preset is "single-vendor"', async ({
   );
   expect(vendorFile).toBeTruthy();
 
-  const jsFiles = Object.keys(files)
-    .filter((name) => name.endsWith('.js'))
-    .map((name) => basename(name));
+  const jsFiles = findFiles(files, '.js').map((name) => basename(name));
 
   expect(jsFiles.length).toEqual(2);
   expect(jsFiles).toContain('index.js');

--- a/e2e/cases/web-esm/initial-chunks/index.test.ts
+++ b/e2e/cases/web-esm/initial-chunks/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@e2e/helper';
-import { findFile, getFileContent } from '@rstackjs/test-utils';
+import { findFile, findFiles, getFileContent } from '@rstackjs/test-utils';
 
 test('should load split and runtime chunks in web ESM bundles', async ({
   page,
@@ -13,7 +13,8 @@ test('should load split and runtime chunks in web ESM bundles', async ({
 
     if (mode === 'build') {
       const files = result.getDistFiles();
-      const initialJsFiles = Object.keys(files).filter(
+      const initialJsFiles = findFiles(
+        files,
         (filename) =>
           filename.endsWith('.js') &&
           filename.includes('/static/js/') &&

--- a/e2e/cases/web-esm/inline-scripts/index.test.ts
+++ b/e2e/cases/web-esm/inline-scripts/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@e2e/helper';
-import { getFileContent } from '@rstackjs/test-utils';
+import { findFiles, getFileContent } from '@rstackjs/test-utils';
 
 test('should inline scripts in web ESM bundles', async ({
   page,
@@ -21,9 +21,7 @@ test('should inline scripts in web ESM bundles', async ({
 
     expect(html.match(/<script type="module">/g)).toHaveLength(1);
     expect(html).not.toContain('<script type="module" src="');
-    expect(
-      Object.keys(files).filter((filename) => filename.endsWith('.js')),
-    ).toEqual([]);
+    expect(findFiles(files, '.js')).toEqual([]);
   });
 
   expect(pageErrors).toEqual([]);

--- a/e2e/cases/workers/worker-query-filename/index.test.ts
+++ b/e2e/cases/workers/worker-query-filename/index.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@e2e/helper';
+import { findFiles } from '@rstackjs/test-utils';
 
 test('should respect custom JS output filename for worker query imports', async ({
   build,
@@ -6,9 +7,7 @@ test('should respect custom JS output filename for worker query imports', async 
   const result = await build();
 
   const files = result.getDistFiles();
-  const jsFiles = Object.keys(files)
-    .filter((filename) => filename.endsWith('.js'))
-    .sort();
+  const jsFiles = findFiles(files, '.js').sort();
 
   expect(jsFiles).toHaveLength(2);
   expect(jsFiles[0]).toMatch(/\/assets\/async\/.+\.bundle\.js$/);

--- a/e2e/cases/workers/worker-query-inline/index.test.ts
+++ b/e2e/cases/workers/worker-query-inline/index.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@e2e/helper';
+import { findFiles } from '@rstackjs/test-utils';
 
 test('should support inline worker query imports', async ({
   page,
@@ -13,11 +14,11 @@ test('should support inline worker query imports', async ({
 
     if (mode === 'build') {
       const files = result.getDistFiles();
-      const jsFiles = Object.keys(files).filter((filename) =>
-        filename.endsWith('.js'),
-      );
-      const emittedInlineWorkerFiles = Object.keys(files).filter((filename) =>
-        /inline-worker\.[\w-]+\.js$/.test(filename),
+      const jsFiles = findFiles(files, '.js');
+      const emittedInlineWorkerFiles = findFiles(
+        files,
+        /inline-worker\.[\w-]+\.js$/,
+        { ignoreHash: false },
       );
 
       expect(jsFiles).toHaveLength(1);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,8 +89,8 @@ catalogs:
       specifier: ^0.1.2
       version: 0.1.2
     '@rstackjs/test-utils':
-      specifier: ^0.2.0
-      version: 0.2.0
+      specifier: ^1.0.0
+      version: 1.0.0
     '@rstest/core':
       specifier: ^0.11.10
       version: 0.11.10
@@ -495,7 +495,7 @@ importers:
         version: link:../packages/plugin-vue
       '@rstackjs/test-utils':
         specifier: 'catalog:'
-        version: 0.2.0
+        version: 1.0.0
       '@rstest/core':
         specifier: 'catalog:'
         version: 0.11.10(@module-federation/runtime-tools@2.9.0)(core-js@3.50.0)
@@ -664,7 +664,7 @@ importers:
         version: 0.3.31
       '@rstackjs/test-utils':
         specifier: 'catalog:'
-        version: 0.2.0
+        version: 1.0.0
 
   e2e/type-tests/core-types: {}
 
@@ -2633,8 +2633,8 @@ packages:
       jiti:
         optional: true
 
-  '@rstackjs/test-utils@0.2.0':
-    resolution: {integrity: sha512-P+LOo1WE3xYeGkHmEthyq2cIpN69k4LhiB/4UBSceD+nW9hDlhWv8MC0LTLWokZXccWl4ntcfOBjQFllkcBlPA==}
+  '@rstackjs/test-utils@1.0.0':
+    resolution: {integrity: sha512-g7oEZzqwke/pRVGAsvEpML+37PDOo9BwR8nKignbtXlKmW9Cb202pRRUSVEsWG//7pnyIi+q4P7b1H/h1ianGA==}
 
   '@rstest/core@0.11.10':
     resolution: {integrity: sha512-x/PNGPdyKQWbiVhpoOQco8xXevh4P/QamuyJ0/YdTrdEiUcUglT6tGSnxaudwyrQr8e/5gwWuOt6zykZKWmSUg==}
@@ -6575,7 +6575,7 @@ snapshots:
     optionalDependencies:
       jiti: 2.7.0
 
-  '@rstackjs/test-utils@0.2.0': {}
+  '@rstackjs/test-utils@1.0.0': {}
 
   '@rstest/core@0.11.10(@module-federation/runtime-tools@2.9.0)(core-js@3.50.0)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -42,7 +42,7 @@ catalog:
   '@rstackjs/doc-ui': '1.14.11'
   '@rstackjs/create-toolkit': '2.2.4'
   '@rstackjs/load-config': '^0.1.2'
-  '@rstackjs/test-utils': '^0.2.0'
+  '@rstackjs/test-utils': '^1.0.0'
   '@rstest/core': '^0.11.10'
   '@rstest/playwright': '^0.11.10'
   '@shikijs/transformers': '^4.4.3'


### PR DESCRIPTION
## Summary

E2E cases duplicate file filtering, log counting, and port reservation logic. Upgrade `@rstackjs/test-utils` to v1.0.0 and reuse `findFiles`, `expectLogTimes`, and `occupyPort` to simplify these cases.

## Related links

- [test-utils v1.0.0 release notes](https://github.com/rstackjs/test-utils/releases/tag/v1.0.0)
