### PR TITLE
chore: enable restrict-template-expressions lint rule

### DIFF
--- a/e2e/cases/custom-logger/config-option/index.test.ts
+++ b/e2e/cases/custom-logger/config-option/index.test.ts
@@ -73,7 +73,7 @@ test('should use customLogger for build logs', async ({ build }) => {
 
   customLogger.override({
     ready(message) {
-      console.log(`[CUSTOM_READY] ${message}`);
+      console.log('[CUSTOM_READY]', message);
     },
   });
 
@@ -93,7 +93,7 @@ test('should use customLogger for dev server logs', async ({ devOnly }) => {
 
   customLogger.override({
     log(message) {
-      console.log(`[CUSTOM_LOG] ${message}`);
+      console.log('[CUSTOM_LOG]', message);
     },
   });
 
@@ -113,7 +113,7 @@ test('should use customLogger for preview server logs', async ({ build }) => {
 
   customLogger.override({
     log(message) {
-      console.log(`[CUSTOM_LOG] ${message}`);
+      console.log('[CUSTOM_LOG]', message);
     },
   });
 

--- a/e2e/cases/custom-logger/global-override/rsbuild.config.ts
+++ b/e2e/cases/custom-logger/global-override/rsbuild.config.ts
@@ -2,7 +2,7 @@ import { defineConfig, logger, type RsbuildPluginAPI } from '@rsbuild/core';
 
 logger.override({
   info: (message) => {
-    console.log(`[TEST] ${message}`);
+    console.log('[TEST]', message);
   },
 });
 

--- a/e2e/cases/hmr/rspack-target-environment/index.test.ts
+++ b/e2e/cases/hmr/rspack-target-environment/index.test.ts
@@ -2,10 +2,7 @@ import { expect, test } from '@e2e/helper';
 import type { Rspack } from '@rsbuild/core';
 import { findFile } from '@rstackjs/test-utils';
 
-const targetCases: {
-  target: NonNullable<Rspack.Configuration['target']>;
-  injectHMRClient: boolean;
-}[] = [
+const targetCases = [
   {
     target: 'browserslist:last 2 node versions',
     injectHMRClient: false,
@@ -15,7 +12,10 @@ const targetCases: {
   { target: 'electron-preload', injectHMRClient: false },
   { target: 'electron-renderer', injectHMRClient: true },
   { target: 'nwjs', injectHMRClient: false },
-];
+] satisfies {
+  target: NonNullable<Rspack.Configuration['target']>;
+  injectHMRClient: boolean;
+}[];
 
 for (const { target, injectHMRClient } of targetCases) {
   test(`should ${injectHMRClient ? '' : 'not '}inject HMR client when Rspack target is ${target}`, async ({

--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -79,7 +79,7 @@ const mapProcessAssetsStage = (stage: ProcessAssetsStage) => {
       return Compilation.PROCESS_ASSETS_STAGE_REPORT;
     default:
       throw new Error(
-        `${color.dim('[rsbuild]')} Invalid process assets stage: ${stage}`,
+        `${color.dim('[rsbuild]')} Invalid process assets stage: ${String(stage)}`,
       );
   }
 };

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -59,11 +59,12 @@ function applyDebugOverride(targetLogger: Logger) {
       }
       const time = color.gray(getTime());
       const loggerConsole = targetLogger.options.console ?? console;
-      loggerConsole.log(
-        `  ${color.magenta('rsbuild')} ${time}`,
-        message,
-        ...args,
-      );
+      const prefix = `  ${color.magenta('rsbuild')} ${time}`;
+      if (typeof message === 'string') {
+        loggerConsole.log(`${prefix} ${message}`, ...args);
+      } else {
+        loggerConsole.log(prefix, message, ...args);
+      }
     },
   });
 }

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -60,7 +60,8 @@ function applyDebugOverride(targetLogger: Logger) {
       const time = color.gray(getTime());
       const loggerConsole = targetLogger.options.console ?? console;
       loggerConsole.log(
-        `  ${color.magenta('rsbuild')} ${time} ${message}`,
+        `  ${color.magenta('rsbuild')} ${time}`,
+        message,
         ...args,
       );
     },

--- a/packages/core/src/plugins/rspackProfile.ts
+++ b/packages/core/src/plugins/rspackProfile.ts
@@ -50,7 +50,7 @@ async function applyProfile(
   traceOutput?: string,
 ) {
   if (traceLayer !== 'perfetto' && traceLayer !== 'logger') {
-    throw new Error(`unsupported trace layer: ${traceLayer}`);
+    throw new Error(`unsupported trace layer: ${String(traceLayer)}`);
   }
 
   if (

--- a/packages/core/src/plugins/splitChunks.ts
+++ b/packages/core/src/plugins/splitChunks.ts
@@ -253,7 +253,9 @@ function getSplitChunksByPreset(
     case 'none':
       return {};
     default:
-      throw new Error(`[rsbuild] Unknown splitChunks preset: ${preset}`);
+      throw new Error(
+        `[rsbuild] Unknown splitChunks preset: ${String(preset)}`,
+      );
   }
 }
 

--- a/packages/core/src/rspack-plugins/RsbuildHtmlPlugin.ts
+++ b/packages/core/src/rspack-plugins/RsbuildHtmlPlugin.ts
@@ -308,7 +308,7 @@ export class RsbuildHtmlPlugin {
       try {
         fileContent = await readFileAsync(inputFs, inputFilename);
       } catch (error) {
-        logger.debug(`read favicon error: ${error}`);
+        logger.debug('read favicon error:', error);
 
         addCompilationError(
           compilation,

--- a/packages/core/src/server/assets-middleware/middleware.ts
+++ b/packages/core/src/server/assets-middleware/middleware.ts
@@ -108,7 +108,9 @@ function isPreconditionFailure(
       (ifMatch !== '*' &&
         parseTokenList(ifMatch).every(
           (match: string) =>
-            match !== etag && match !== `W/${etag}` && `W/${match}` !== etag,
+            match !== etag &&
+            match !== `W/${String(etag)}` &&
+            `W/${match}` !== etag,
         ))
     );
   }

--- a/packages/core/src/server/browserLogs.ts
+++ b/packages/core/src/server/browserLogs.ts
@@ -84,9 +84,7 @@ const parseFrame = async (
     return { sourceMapPath, originalPosition };
   } catch (error) {
     if (error instanceof Error) {
-      context.logger.debug(
-        `failed to map source map position: ${error.message}`,
-      );
+      context.logger.debug('failed to map source map position:', error);
     }
   }
 };
@@ -149,11 +147,8 @@ const formatOriginalLocation = (
     return;
   }
 
-  let result = resolveSourceRelativeToRoot(source, sourceMapPath, context);
-  if (line !== null) {
-    result += column === null ? `:${line}` : `:${line}:${column}`;
-  }
-  return result;
+  const result = resolveSourceRelativeToRoot(source, sourceMapPath, context);
+  return `${result}:${line}:${column}`;
 };
 
 const formatFrameLocation = (frame: StackFrame) => {

--- a/packages/core/src/server/historyApiFallback.ts
+++ b/packages/core/src/server/historyApiFallback.ts
@@ -137,7 +137,7 @@ function parseReqUrl(req: IncomingMessage) {
   const proto = req.headers['x-forwarded-proto'] || 'http';
   const host = req.headers['x-forwarded-host'] || req.headers.host || LOCALHOST;
   try {
-    return new URL(req.url || '/', `${proto}://${host}`);
+    return new URL(req.url || '/', `${String(proto)}://${String(host)}`);
   } catch {
     return null;
   }

--- a/packages/core/tests/logger.test.ts
+++ b/packages/core/tests/logger.test.ts
@@ -85,12 +85,13 @@ it('should use the custom console for debug override', () => {
     level: 'verbose',
   });
 
-  customLogger.debug('hello');
+  customLogger.debug('built %s in %d ms', 'app', 42);
 
   expect(customConsole.log).toHaveBeenCalledTimes(1);
   expect(customConsole.log).toHaveBeenCalledWith(
-    expect.stringContaining('rsbuild'),
-    'hello',
+    expect.stringContaining('built %s in %d ms'),
+    'app',
+    42,
   );
 
   const error = new Error('debug failure');

--- a/packages/core/tests/logger.test.ts
+++ b/packages/core/tests/logger.test.ts
@@ -89,6 +89,17 @@ it('should use the custom console for debug override', () => {
 
   expect(customConsole.log).toHaveBeenCalledTimes(1);
   expect(customConsole.log).toHaveBeenCalledWith(
-    expect.stringContaining('hello'),
+    expect.stringContaining('rsbuild'),
+    'hello',
+  );
+
+  const error = new Error('debug failure');
+  const details = { filename: 'index.js' };
+  customLogger.debug(error, details);
+
+  expect(customConsole.log).toHaveBeenLastCalledWith(
+    expect.stringContaining('rsbuild'),
+    error,
+    details,
   );
 });

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -49,7 +49,6 @@ define.lint(({ globalIgnores, js, rstestPlugin, ts }) => [
       '@typescript-eslint/no-unsafe-member-access': 'off',
       '@typescript-eslint/no-unsafe-assignment': 'off',
       '@typescript-eslint/no-unsafe-argument': 'off',
-      '@typescript-eslint/restrict-template-expressions': 'off',
       '@typescript-eslint/no-explicit-any': 'off',
     },
   },


### PR DESCRIPTION
## Summary

This PR enables `@typescript-eslint/restrict-template-expressions` and fixes existing violations with explicit string conversions and more precise types. Debug logging passes errors and other objects directly to the console to preserve stack traces and diagnostic fields.