### PR TITLE
chore: enable unicorn/prefer-array-some lint rule

### DIFF
--- a/packages/core/src/helpers/path.ts
+++ b/packages/core/src/helpers/path.ts
@@ -60,7 +60,7 @@ export const dedupeNestedPaths = (paths: string[]): string[] => {
   return paths
     .sort((p1, p2) => (p2.length > p1.length ? -1 : 1))
     .reduce<string[]>((prev, curr) => {
-      const isSub = prev.find((p) => curr.startsWith(p) || curr === p);
+      const isSub = prev.some((p) => curr.startsWith(p) || curr === p);
       if (isSub) {
         return prev;
       }

--- a/packages/core/src/plugins/cleanOutput.ts
+++ b/packages/core/src/plugins/cleanOutput.ts
@@ -117,7 +117,7 @@ export const pluginCleanOutput = (): RsbuildPlugin => ({
       const environments = Object.values(params.environments).reduce<
         EnvironmentContext[]
       >((result, curr) => {
-        if (!result.find((item) => item.distPath === curr.distPath)) {
+        if (!result.some((item) => item.distPath === curr.distPath)) {
           result.push(curr);
         }
         return result;

--- a/packages/plugin-babel/src/helper.ts
+++ b/packages/plugin-babel/src/helper.ts
@@ -94,7 +94,7 @@ const removePlugins = (
   config.plugins = config.plugins.filter((item: BabelPlugin) => {
     const name = getPluginItemName(item);
     if (name) {
-      return !removeList.find((removeItem) => name.includes(removeItem));
+      return !removeList.some((removeItem) => name.includes(removeItem));
     }
     return true;
   });
@@ -113,7 +113,7 @@ const removePresets = (
   config.presets = config.presets.filter((item: BabelPlugin) => {
     const name = getPluginItemName(item);
     if (name) {
-      return !removeList.find((removeItem) => name.includes(removeItem));
+      return !removeList.some((removeItem) => name.includes(removeItem));
     }
     return true;
   });

--- a/packages/plugin-svgr/src/index.ts
+++ b/packages/plugin-svgr/src/index.ts
@@ -103,7 +103,7 @@ const dedupeSvgoPlugins = (config: SvgoConfig): SvgoConfig => {
 
   for (const plugin of config.plugins) {
     if (typeof plugin === 'string') {
-      const exist = mergedPlugins.find(
+      const exist = mergedPlugins.some(
         (item) =>
           item === plugin || (typeof item === 'object' && item.name === plugin),
       );

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -34,6 +34,7 @@ define.lint(({ globalIgnores, js, rstestPlugin, ts }) => [
     ...rstestPlugin.configs.recommended,
   },
   {
+    plugins: ['unicorn'],
     languageOptions: {
       parserOptions: {
         project: [
@@ -46,6 +47,7 @@ define.lint(({ globalIgnores, js, rstestPlugin, ts }) => [
       },
     },
     rules: {
+      'unicorn/prefer-array-some': 'error',
       '@typescript-eslint/no-unsafe-member-access': 'off',
       '@typescript-eslint/no-unsafe-assignment': 'off',
       '@typescript-eslint/no-unsafe-argument': 'off',


### PR DESCRIPTION
## Summary

Enable `unicorn/prefer-array-some` to express array existence checks directly. Replace five truthiness checks on `.find()` results with `.some()` in core and the Babel/SVGR plugins.