### PR TITLE
refactor: improve type safety in core, plugins and tests

### DIFF
--- a/e2e/cases/create-rsbuild/helper.ts
+++ b/e2e/cases/create-rsbuild/helper.ts
@@ -49,7 +49,9 @@ export const createAndValidate = async (
     });
   });
 
-  const pkgJson = await fse.readJSON(path.join(dir, 'package.json'));
+  const pkgJson: Record<string, any> = await fse.readJSON(
+    path.join(dir, 'package.json'),
+  );
   expectPackageJson(pkgJson, path.basename(name), expectedBuildScript);
 
   if (template.endsWith('-ts')) {

--- a/e2e/cases/manifest/async-chunks/index.test.ts
+++ b/e2e/cases/manifest/async-chunks/index.test.ts
@@ -14,7 +14,7 @@ test('should generate manifest for async chunks correctly', async ({
 
   const manifest = JSON.parse(manifestContent);
 
-  expect(Object.keys(manifest.allFiles).length).toBe(4);
+  expect(manifest.allFiles).toHaveLength(4);
 
   expect(manifest.entries.index).toMatchObject({
     html: ['/index.html'],

--- a/e2e/cases/manifest/basic/index.test.ts
+++ b/e2e/cases/manifest/basic/index.test.ts
@@ -21,7 +21,7 @@ test('should generate manifest file in output', async ({ build }) => {
   const manifest = JSON.parse(manifestContent);
 
   // index.js, index.html
-  expect(Object.keys(manifest.allFiles).length).toBe(2);
+  expect(manifest.allFiles).toHaveLength(2);
 
   expect(manifest.entries.index).toMatchObject({
     initial: {

--- a/e2e/cases/manifest/custom-path/index.test.ts
+++ b/e2e/cases/manifest/custom-path/index.test.ts
@@ -12,5 +12,5 @@ test('should generate manifest file at specified path', async ({ build }) => {
   const parsed = JSON.parse(manifestContent);
 
   // index.js, index.html
-  expect(Object.keys(parsed.allFiles).length).toBe(2);
+  expect(parsed.allFiles).toHaveLength(2);
 });

--- a/e2e/cases/manifest/environments/index.test.ts
+++ b/e2e/cases/manifest/environments/index.test.ts
@@ -44,7 +44,7 @@ test('should allow to access manifest data in environment context after build', 
   });
 
   // index.js, index.html
-  expect(Object.keys(webManifest.allFiles).length).toBe(2);
+  expect(webManifest.allFiles).toHaveLength(2);
   expect(webManifest.entries.index).toMatchObject({
     initial: {
       js: ['/static/js/index.js'],
@@ -53,7 +53,7 @@ test('should allow to access manifest data in environment context after build', 
   });
 
   // index.js
-  expect(Object.keys(nodeManifest.allFiles).length).toBe(1);
+  expect(nodeManifest.allFiles).toHaveLength(1);
   expect(nodeManifest.entries.index).toMatchObject({
     initial: {
       js: ['/index.js'],
@@ -104,7 +104,7 @@ test('should allow to access manifest data in environment context after dev buil
   });
 
   // index.js, index.js.map, index.html
-  expect(Object.keys(webManifest.allFiles).length).toBe(3);
+  expect(webManifest.allFiles).toHaveLength(3);
   expect(webManifest.entries.index).toMatchObject({
     initial: {
       js: ['/static/js/index.js'],
@@ -113,7 +113,7 @@ test('should allow to access manifest data in environment context after dev buil
   });
 
   // index.js, index.js.map
-  expect(Object.keys(nodeManifest.allFiles).length).toBe(2);
+  expect(nodeManifest.allFiles).toHaveLength(2);
   expect(nodeManifest.entries.index).toMatchObject({
     initial: {
       js: ['/index.js'],
@@ -165,7 +165,7 @@ test('should allow to access manifest data in environment API', async ({
   await page.goto(`http://localhost:${rsbuild.port}`);
 
   // index.js, index.js.map, index.html
-  expect(Object.keys(webManifest.allFiles).length).toBe(3);
+  expect(webManifest.allFiles).toHaveLength(3);
   expect(webManifest.entries.index).toMatchObject({
     initial: {
       js: ['/static/js/index.js'],
@@ -174,7 +174,7 @@ test('should allow to access manifest data in environment API', async ({
   });
 
   // index.js, index.js.map
-  expect(Object.keys(nodeManifest.allFiles).length).toBe(2);
+  expect(nodeManifest.allFiles).toHaveLength(2);
   expect(nodeManifest.entries.index).toMatchObject({
     initial: {
       js: ['/index.js'],

--- a/e2e/cases/manifest/filter/index.test.ts
+++ b/e2e/cases/manifest/filter/index.test.ts
@@ -20,7 +20,7 @@ test('should allow to filter files in manifest', async ({ build }) => {
   const manifest = JSON.parse(manifestContent);
 
   // index.js
-  expect(Object.keys(manifest.allFiles).length).toBe(1);
+  expect(manifest.allFiles).toHaveLength(1);
 
   expect(manifest.entries.index).toMatchObject({
     initial: {
@@ -47,7 +47,7 @@ test('should allow to include license files in manifest', async ({ build }) => {
   const manifestContent = getFileContent(files, 'manifest.json');
   const manifest = JSON.parse(manifestContent);
 
-  expect(Object.keys(manifest.allFiles).length).toBe(3);
+  expect(manifest.allFiles).toHaveLength(3);
 
   expect(manifest.entries.index).toMatchObject({
     initial: {

--- a/e2e/cases/manifest/single-vendor/index.test.ts
+++ b/e2e/cases/manifest/single-vendor/index.test.ts
@@ -14,7 +14,7 @@ test('should generate manifest with single vendor as expected', async ({
 
   const manifest = JSON.parse(manifestContent);
 
-  expect(Object.keys(manifest.allFiles).length).toBe(3);
+  expect(manifest.allFiles).toHaveLength(3);
 
   expect(manifest.entries.index).toMatchObject({
     html: ['/index.html'],

--- a/e2e/cases/plugin-api/plugin-transform-import-module/myPlugin.ts
+++ b/e2e/cases/plugin-api/plugin-transform-import-module/myPlugin.ts
@@ -5,7 +5,7 @@ export const myPlugin: RsbuildPlugin = {
   name: 'my-plugin',
   setup(api) {
     api.transform({ test: /\.css$/ }, async ({ code, importModule }) => {
-      const { foo } = await importModule(
+      const { foo }: typeof import('./src/foo') = await importModule(
         join(import.meta.dirname, './src/foo.ts'),
       );
       return code.replace('red', foo);

--- a/e2e/cases/print-file-size/diff/index.test.ts
+++ b/e2e/cases/print-file-size/diff/index.test.ts
@@ -69,7 +69,8 @@ test('should not print gzip total diff when change is below threshold', async ({
   expect(snapshotFile).toBeTruthy();
 
   const snapshotPath = join(snapshotDir, snapshotFile!);
-  const snapshots = await fse.readJSON(snapshotPath);
+  const snapshots: Record<string, { totalGzipSize: number }> =
+    await fse.readJSON(snapshotPath);
   const environmentName = Object.keys(snapshots)[0];
 
   expect(snapshots[environmentName].totalGzipSize).toBeGreaterThan(5);

--- a/packages/core/src/helpers/url.ts
+++ b/packages/core/src/helpers/url.ts
@@ -77,7 +77,7 @@ export const getPublicPathFromChain = (
   chain: RspackChain,
   withSlash = true,
 ): string => {
-  const publicPath: Rspack.PublicPath = chain.output.get('publicPath');
+  const publicPath = chain.output.get('publicPath');
 
   if (typeof publicPath === 'string') {
     return formatPublicPath(publicPath, withSlash);

--- a/packages/core/src/hooks.ts
+++ b/packages/core/src/hooks.ts
@@ -126,7 +126,7 @@ export function createEnvironmentAsyncHook<
         continue;
       }
 
-      const result = await callback.handler(...params);
+      const result: T = await callback.handler(...params);
       results.push(result);
     }
 
@@ -181,7 +181,7 @@ export function createAsyncHook<
     const results: T[] = [];
 
     for (const callback of callbacks) {
-      const result = await callback(...params);
+      const result: T = await callback(...params);
       results.push(result);
     }
 

--- a/packages/core/src/plugins/define.ts
+++ b/packages/core/src/plugins/define.ts
@@ -39,7 +39,7 @@ function checkProcessEnvSecurity(define: DefinePluginOptions, logger: Logger) {
   // Check `{ 'process.env': JSON.stringify(process.env) }`
   if (typeof value === 'string') {
     try {
-      check(JSON.parse(value));
+      check(JSON.parse(value) as Record<string, unknown>);
     } catch {
       // ignore
     }

--- a/packages/core/src/plugins/output.ts
+++ b/packages/core/src/plugins/output.ts
@@ -131,9 +131,8 @@ export const pluginOutput = (): RsbuildPlugin => ({
         const isESM = config.output.module;
 
         if (isServer) {
-          chain.output.library({
-            ...(chain.output.get('library') || {}),
-            type: isESM ? 'module' : 'commonjs2',
+          chain.output.merge({
+            library: { type: isESM ? 'module' : 'commonjs2' },
           });
         }
 

--- a/packages/core/src/rspackConfig.ts
+++ b/packages/core/src/rspackConfig.ts
@@ -157,7 +157,7 @@ function validateRspackConfig(config: Rspack.Configuration, logger: Logger) {
         'name' in plugin &&
         'setup' in plugin
       ) {
-        const name = color.bold(color.yellow(plugin.name));
+        const name = color.bold(color.yellow(plugin.name as string));
         throw new Error(
           `${color.dim('[rsbuild:plugin]')} "${color.yellow(name)}" appears to be an Rsbuild plugin. It cannot be used as an Rspack plugin.`,
         );

--- a/packages/core/src/server/gzipMiddleware.ts
+++ b/packages/core/src/server/gzipMiddleware.ts
@@ -171,7 +171,7 @@ export function gzipMiddleware({
     res.end = (...args: any[]) => {
       start();
       if (gzip) {
-        (gzip.end as (...args: any[]) => void)(...args);
+        gzip.end(...(args as Parameters<typeof gzip.end>));
         return res;
       }
 

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -32,7 +32,7 @@ import type { RsbuildPreviewServer } from './previewServer';
 export type UpgradeEvent = (
   req: IncomingMessage,
   socket: Socket,
-  head: any,
+  head: Buffer,
 ) => void;
 
 export type ServerStartResult<T> = {

--- a/packages/plugin-less/src/index.ts
+++ b/packages/plugin-less/src/index.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import type {
   ConfigChainWithContext,
+  CSSLoaderOptions,
   RsbuildPlugin,
   Rspack,
   RspackChain,
@@ -285,16 +286,23 @@ export const pluginLess = (
         rule.resourceQuery(cssBranchRule.get('resourceQuery'));
 
         for (const id of Object.keys(cssBranchRule.uses.entries())) {
-          const loader = cssBranchRule.uses.get(id);
+          const loader = cssBranchRule.use<CSSLoaderOptions>(id);
+          const cssLoaderPath = loader.get('loader');
+
+          if (!cssLoaderPath) {
+            continue;
+          }
+
           const options = loader.get('options') ?? {};
-          const clonedOptions = deepmerge<Record<string, any>>({}, options);
+          const clonedOptions = deepmerge({}, options);
 
           if (id === CHAIN_ID.USE.CSS) {
             // add less-loader
-            clonedOptions.importLoaders += 1;
+            clonedOptions.importLoaders =
+              (clonedOptions.importLoaders ?? 0) + 1;
           }
 
-          rule.use(id).loader(loader.get('loader')).options(clonedOptions);
+          rule.use(id).loader(cssLoaderPath).options(clonedOptions);
         }
 
         const loader = rule

--- a/packages/plugin-sass/src/index.ts
+++ b/packages/plugin-sass/src/index.ts
@@ -1,7 +1,11 @@
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { RsbuildPlugin, RspackChain } from '@rsbuild/core';
+import type {
+  CSSLoaderOptions,
+  RsbuildPlugin,
+  RspackChain,
+} from '@rsbuild/core';
 import deepmerge from 'deepmerge';
 import { reduceConfigsWithContext } from 'reduce-configs';
 import { getResolveUrlJoinFn, patchCompilerGlobalLocation } from './helpers.js';
@@ -222,16 +226,23 @@ export const pluginSass = (
         rule.resourceQuery(cssBranchRule.get('resourceQuery'));
 
         for (const id of Object.keys(cssBranchRule.uses.entries())) {
-          const loader = cssBranchRule.uses.get(id);
+          const loader = cssBranchRule.use<CSSLoaderOptions>(id);
+          const cssLoaderPath = loader.get('loader');
+
+          if (!cssLoaderPath) {
+            continue;
+          }
+
           const options = loader.get('options') ?? {};
-          const clonedOptions = deepmerge<Record<string, any>>({}, options);
+          const clonedOptions = deepmerge({}, options);
 
           if (id === CHAIN_ID.USE.CSS) {
             // add sass-loader and resolve-url-loader
-            clonedOptions.importLoaders += rewriteUrls ? 2 : 1;
+            clonedOptions.importLoaders =
+              (clonedOptions.importLoaders ?? 0) + (rewriteUrls ? 2 : 1);
           }
 
-          rule.use(id).loader(loader.get('loader')).options(clonedOptions);
+          rule.use(id).loader(cssLoaderPath).options(clonedOptions);
         }
 
         // use `resolve-url-loader` to rewrite urls

--- a/packages/plugin-svelte/src/index.ts
+++ b/packages/plugin-svelte/src/index.ts
@@ -117,6 +117,7 @@ export function pluginSvelte(options: PluginSvelteOptions = {}): RsbuildPlugin {
           const jsRule = chain.module.rules.get(CHAIN_ID.RULE.JS);
           const jsMainRule = jsRule.oneOfs.get(CHAIN_ID.ONE_OF.JS_MAIN);
           const swcUse = jsMainRule.uses.get(CHAIN_ID.USE.SWC);
+          const swcLoaderPath = swcUse?.get('loader');
 
           // TODO: Use a oneOf-based rule structure in the next major version.
           const svelteRule = chain.module
@@ -124,10 +125,12 @@ export function pluginSvelte(options: PluginSvelteOptions = {}): RsbuildPlugin {
             .test(/\.svelte$/)
             .with({ type: { not: 'text' } });
 
-          svelteRule
-            .use(CHAIN_ID.USE.SWC)
-            .loader(swcUse.get('loader'))
-            .options(swcUse.get('options'));
+          if (swcLoaderPath) {
+            svelteRule
+              .use(CHAIN_ID.USE.SWC)
+              .loader(swcLoaderPath)
+              .options(swcUse.get('options'));
+          }
 
           svelteRule
             .use(CHAIN_ID.USE.SVELTE)
@@ -146,17 +149,21 @@ export function pluginSvelte(options: PluginSvelteOptions = {}): RsbuildPlugin {
 
           jsRule.exclude.add(regexp);
 
-          chain.module
+          const svelteJsRule = chain.module
             .rule('svelte-js')
             .test(regexp)
             .with({ type: { not: 'text' } })
             .use(CHAIN_ID.USE.SVELTE)
             .loader(loaderPath)
             .options(svelteLoaderOptions)
-            .end()
-            .use(CHAIN_ID.USE.SWC)
-            .loader(swcUse.get('loader'))
-            .options(swcUse.get('options'));
+            .end();
+
+          if (swcLoaderPath) {
+            svelteJsRule
+              .use(CHAIN_ID.USE.SWC)
+              .loader(swcLoaderPath)
+              .options(swcUse.get('options'));
+          }
 
           chain.module
             .rule('svelte-js-text')

--- a/packages/plugin-svgr/src/index.ts
+++ b/packages/plugin-svgr/src/index.ts
@@ -305,9 +305,13 @@ export const pluginSvgr = (options: PluginSvgrOptions = {}): RsbuildPlugin => ({
       const jsMainRule = jsRule.oneOfs.get(CHAIN_ID.ONE_OF.JS_MAIN);
 
       [CHAIN_ID.USE.SWC, CHAIN_ID.USE.BABEL].some((jsUseId) => {
-        const use = jsMainRule.uses.get(jsUseId);
+        if (!jsMainRule.uses.has(jsUseId)) {
+          return false;
+        }
+        const use = jsMainRule.use<Record<string, unknown>>(jsUseId);
+        const loaderPath = use.get('loader');
 
-        if (!use) {
+        if (!loaderPath) {
           return false;
         }
 
@@ -323,7 +327,7 @@ export const pluginSvgr = (options: PluginSvgrOptions = {}): RsbuildPlugin => ({
 
           // disable React refresh runtime for SVGR transformed components
           if (jsUseId === CHAIN_ID.USE.SWC) {
-            loaderOptions = deepmerge(loaderOptions, {
+            loaderOptions = deepmerge(loaderOptions ?? {}, {
               jsc: {
                 transform: {
                   react: {
@@ -339,7 +343,7 @@ export const pluginSvgr = (options: PluginSvgrOptions = {}): RsbuildPlugin => ({
             .oneOf(oneOfId)
             .use(jsUseId)
             .before(CHAIN_ID.USE.SVGR)
-            .loader(use.get('loader'))
+            .loader(loaderPath)
             .options(loaderOptions);
         }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,8 +302,8 @@ catalogs:
       specifier: ^2.3.0
       version: 2.3.0
     rspack-chain:
-      specifier: ^2.2.0
-      version: 2.2.0
+      specifier: ^2.3.1
+      version: 2.3.1
     rspack-manifest-plugin:
       specifier: 5.2.2
       version: 5.2.2
@@ -980,7 +980,7 @@ importers:
         version: 2.3.0
       rspack-chain:
         specifier: 'catalog:'
-        version: 2.2.0(@rspack/core@2.2.2)
+        version: 2.3.1(@rspack/core@2.2.2)
       rspack-manifest-plugin:
         specifier: 'catalog:'
         version: 5.2.2(@rspack/core@2.2.2)
@@ -4763,8 +4763,8 @@ packages:
     resolution: {integrity: sha512-g2wW/ermwzGTLlzGdJBDRc4YKz2/yPBjf57w9g5CvhtpZ91Xq95OaWku0oNHYi+XsuV6v8QrCo2oJJR/pCUR8g==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  rspack-chain@2.2.0:
-    resolution: {integrity: sha512-5h/5duc5uZwygmuX0X41ROovPy358t2L0mvV55e9os6GEw1LnvbhzzHaps2VXu60oEByllVp0+0mKHcFD51fNQ==}
+  rspack-chain@2.3.1:
+    resolution: {integrity: sha512-EvQA6S13FAV2bhdYUpemsPgEeuEpeEcsd6qaTiOfQ33U/pBRSplewUBH5+AV2Dg8CRtffi7/7GKnHeXTgKeleg==}
     peerDependencies:
       '@rspack/core': ^2.0.0
     peerDependenciesMeta:
@@ -9009,7 +9009,7 @@ snapshots:
 
   rslog@2.3.0: {}
 
-  rspack-chain@2.2.0(@rspack/core@2.2.2):
+  rspack-chain@2.3.1(@rspack/core@2.2.2):
     optionalDependencies:
       '@rspack/core': 2.2.2(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -114,7 +114,7 @@ catalog:
   'rsbuild-plugin-google-analytics': '^1.0.6'
   'rsbuild-plugin-open-graph': '^1.1.3'
   'rslog': '^2.3.0'
-  'rspack-chain': '^2.2.0'
+  'rspack-chain': '^2.3.1'
   'rspack-manifest-plugin': '5.2.2'
   'rspack-merge': '1.0.1'
   'rspack-vue-loader': '^17.6.2'

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -48,7 +48,6 @@ define.lint(({ globalIgnores, js, rstestPlugin, ts }) => [
     rules: {
       '@typescript-eslint/no-unsafe-member-access': 'off',
       '@typescript-eslint/no-unsafe-assignment': 'off',
-      '@typescript-eslint/no-unsafe-argument': 'off',
       '@typescript-eslint/no-explicit-any': 'off',
     },
   },


### PR DESCRIPTION
## Summary

Improve type safety in core hooks, server helpers, plugin configuration, and tests by replacing unsafe arguments with explicit types and using array length assertions where appropriate. Upgrade rspack-chain to 2.3.1 to use its more precise configuration types. Skip unconfigured loaders when copying plugin rules and default missing CSS `importLoaders` to zero.

## Related links

- [rspack-chain v2.3.1 release notes](https://github.com/rstackjs/rspack-chain/releases/tag/v2.3.1)