### PR TITLE
chore: enable import recommended lint preset

### DIFF
--- a/examples/react/src/index.tsx
+++ b/examples/react/src/index.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const rootEl = document.getElementById('root');
 if (rootEl) {
-  const root = ReactDOM.createRoot(rootEl);
+  const root = createRoot(rootEl);
   root.render(
-    <React.StrictMode>
+    <StrictMode>
       <App />
-    </React.StrictMode>,
+    </StrictMode>,
   );
 }

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -22,12 +22,13 @@ define.staged({
   '*.{js,jsx,ts,tsx,mjs,cjs}': ['rs lint --type-check', 'rs fmt'],
 });
 
-define.lint(({ globalIgnores, js, rstestPlugin, ts }) => [
+define.lint(({ globalIgnores, importPlugin, js, rstestPlugin, ts }) => [
   globalIgnores([
     'e2e/cases/browser-logs/skip-build-error/src/index.js',
     'e2e/cases/wasm/wasm-source-import/src/index.js',
   ]),
   js.configs.recommended,
+  importPlugin.configs.recommended,
   ts.configs.recommendedTypeChecked,
   {
     files: ['**/*.test.{ts,tsx}'],
@@ -47,6 +48,10 @@ define.lint(({ globalIgnores, js, rstestPlugin, ts }) => [
       },
     },
     rules: {
+      // Rslint does not recognize default exports from text imports yet.
+      // https://github.com/web-infra-dev/rslint/issues/2083
+      'import/default': 'off',
+      'import/no-duplicates': 'off',
       'unicorn/prefer-array-some': 'error',
       '@typescript-eslint/no-unsafe-member-access': 'off',
       '@typescript-eslint/no-unsafe-assignment': 'off',


### PR DESCRIPTION
## Summary

Enable the Import Recommended preset to check namespace imports. Disable `import/default` and `import/no-duplicates` globally because of reports on text imports and resource queries.

## Related links

- https://github.com/web-infra-dev/rslint/issues/2082
- https://github.com/web-infra-dev/rslint/issues/2083