### PR TITLE
refactor: use named React imports

### DIFF
--- a/e2e/cases/assets/assets-url/src/index.js
+++ b/e2e/cases/assets/assets-url/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/assets/filename-hash/src/index.js
+++ b/e2e/cases/assets/filename-hash/src/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
+import { createElement } from 'react';
+import { createRoot } from 'react-dom/client';
 
-console.log(React, ReactDOM);
+console.log(createElement, createRoot);

--- a/e2e/cases/assets/inline-query-auto/src/index.js
+++ b/e2e/cases/assets/inline-query-auto/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/assets/inline-query/src/index.js
+++ b/e2e/cases/assets/inline-query/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/browser-logs/stack-trace-full-react-error/src/index.js
+++ b/e2e/cases/browser-logs/stack-trace-full-react-error/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/css/css-modules-dom/src/index.ts
+++ b/e2e/cases/css/css-modules-dom/src/index.ts
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/css/inject-styles/src/index.ts
+++ b/e2e/cases/css/inject-styles/src/index.ts
@@ -1,11 +1,11 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }
 
 const num = Math.ceil(Math.random() * 100);

--- a/e2e/cases/environments/hmr/src/index.ts
+++ b/e2e/cases/environments/hmr/src/index.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
@@ -13,5 +13,5 @@ document.body.appendChild(testEl);
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/environments/plugins/src/index.ts
+++ b/e2e/cases/environments/plugins/src/index.ts
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/environments/solid-react-plugins/src/react/index.ts
+++ b/e2e/cases/environments/solid-react-plugins/src/react/index.ts
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/glob-import/webpack-context/src/index.js
+++ b/e2e/cases/glob-import/webpack-context/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/hmr/basic/src/index.ts
+++ b/e2e/cases/hmr/basic/src/index.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
@@ -13,5 +13,5 @@ document.body.appendChild(testEl);
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/hmr/client-host/src/index.ts
+++ b/e2e/cases/hmr/client-host/src/index.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
@@ -13,5 +13,5 @@ document.body.appendChild(testEl);
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/hmr/client-port-placeholder/src/index.ts
+++ b/e2e/cases/hmr/client-port-placeholder/src/index.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
@@ -13,5 +13,5 @@ document.body.appendChild(testEl);
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/hmr/error-recovery/src/index.ts
+++ b/e2e/cases/hmr/error-recovery/src/index.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
@@ -13,5 +13,5 @@ document.body.appendChild(testEl);
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/hmr/esm/src/index.ts
+++ b/e2e/cases/hmr/esm/src/index.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
@@ -13,5 +13,5 @@ document.body.appendChild(testEl);
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/hmr/live-reload/src/index.js
+++ b/e2e/cases/hmr/live-reload/src/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
@@ -13,5 +13,5 @@ document.body.appendChild(testEl);
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/hmr/log-level/src/index.tsx
+++ b/e2e/cases/hmr/log-level/src/index.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
 import App from './App';
 
-const root = ReactDOM.createRoot(document.getElementById('root')!);
+const root = createRoot(document.getElementById('root')!);
 root.render(
-  <React.StrictMode>
+  <StrictMode>
     <App />
-  </React.StrictMode>,
+  </StrictMode>,
 );

--- a/e2e/cases/hmr/multiple-connection/src/index.ts
+++ b/e2e/cases/hmr/multiple-connection/src/index.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
@@ -13,5 +13,5 @@ document.body.appendChild(testEl);
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/hmr/rebuild-logs/src/index.ts
+++ b/e2e/cases/hmr/rebuild-logs/src/index.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
@@ -13,5 +13,5 @@ document.body.appendChild(testEl);
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/hmr/reconnect/src/index.ts
+++ b/e2e/cases/hmr/reconnect/src/index.ts
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/hmr/remove-module/src/index.js
+++ b/e2e/cases/hmr/remove-module/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { Button } from './Button';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(Button));
+  root.render(createElement(Button));
 }

--- a/e2e/cases/hmr/unaffected-environment/src/bar.js
+++ b/e2e/cases/hmr/unaffected-environment/src/bar.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { Button } from './Button';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(Button));
+  root.render(createElement(Button));
 }

--- a/e2e/cases/hmr/websocket-url-resolver/src/index.ts
+++ b/e2e/cases/hmr/websocket-url-resolver/src/index.ts
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/lazy-compilation/basic/src/page1/index.js
+++ b/e2e/cases/lazy-compilation/basic/src/page1/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/lazy-compilation/basic/src/page2/index.js
+++ b/e2e/cases/lazy-compilation/basic/src/page2/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/lazy-compilation/port-placeholder/src/page1/index.js
+++ b/e2e/cases/lazy-compilation/port-placeholder/src/page1/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/lazy-compilation/port-placeholder/src/page2/index.js
+++ b/e2e/cases/lazy-compilation/port-placeholder/src/page2/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/manifest/basic/src/index.ts
+++ b/e2e/cases/manifest/basic/src/index.ts
@@ -1,3 +1,3 @@
-import React from 'react';
+import { createElement } from 'react';
 
-console.log('hello!', React);
+console.log('hello!', createElement);

--- a/e2e/cases/manifest/css-order/src/env.d.ts
+++ b/e2e/cases/manifest/css-order/src/env.d.ts
@@ -5,7 +5,7 @@
  * @requires [@rsbuild/plugin-svgr](https://npmjs.com/package/@rsbuild/plugin-svgr)
  */
 declare module '*.svg?react' {
-  import type React from 'react';
-  const ReactComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+  import type { FunctionComponent, SVGProps } from 'react';
+  const ReactComponent: FunctionComponent<SVGProps<SVGSVGElement>>;
   export default ReactComponent;
 }

--- a/e2e/cases/manifest/custom-path/src/index.ts
+++ b/e2e/cases/manifest/custom-path/src/index.ts
@@ -1,3 +1,3 @@
-import React from 'react';
+import { createElement } from 'react';
 
-console.log('hello!', React);
+console.log('hello!', createElement);

--- a/e2e/cases/manifest/filter/src/index.ts
+++ b/e2e/cases/manifest/filter/src/index.ts
@@ -1,3 +1,3 @@
-import React from 'react';
+import { createElement } from 'react';
 
-console.log('hello!', React);
+console.log('hello!', createElement);

--- a/e2e/cases/manifest/integrity/src/index.ts
+++ b/e2e/cases/manifest/integrity/src/index.ts
@@ -1,3 +1,3 @@
-import React from 'react';
+import { createElement } from 'react';
 
-console.log('hello!', React);
+console.log('hello!', createElement);

--- a/e2e/cases/manifest/node/src/index.ts
+++ b/e2e/cases/manifest/node/src/index.ts
@@ -1,3 +1,3 @@
-import React from 'react';
+import { createElement } from 'react';
 
-console.log('hello!', React);
+console.log('hello!', createElement);

--- a/e2e/cases/manifest/remove-prefix/src/index.js
+++ b/e2e/cases/manifest/remove-prefix/src/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 import './index.css';
 
-console.log('hello!', React);
+console.log('hello!', createElement);

--- a/e2e/cases/manifest/single-vendor/src/foo.ts
+++ b/e2e/cases/manifest/single-vendor/src/foo.ts
@@ -1,3 +1,3 @@
-import ReactDOM from 'react-dom';
+import { flushSync } from 'react-dom';
 
-export default ReactDOM;
+export default flushSync;

--- a/e2e/cases/manifest/single-vendor/src/index.ts
+++ b/e2e/cases/manifest/single-vendor/src/index.ts
@@ -1,4 +1,4 @@
-import React from 'react';
-import ReactDOM from './foo';
+import { createElement } from 'react';
+import flushSync from './foo';
 
-console.log(React, ReactDOM);
+console.log(createElement, flushSync);

--- a/e2e/cases/module-federation/v1-basic/host/src/App.jsx
+++ b/e2e/cases/module-federation/v1-basic/host/src/App.jsx
@@ -1,14 +1,14 @@
-import React from 'react';
+import { lazy, Suspense } from 'react';
 
-const RemoteButton = React.lazy(() => import('remote/Button'));
+const RemoteButton = lazy(() => import('remote/Button'));
 
 const App = () => (
   <div>
     <h1>Basic Host-Remote</h1>
     <h2 id="title">Host</h2>
-    <React.Suspense fallback="Loading Button">
+    <Suspense fallback="Loading Button">
       <RemoteButton />
-    </React.Suspense>
+    </Suspense>
   </div>
 );
 

--- a/e2e/cases/module-federation/v2-basic/host/src/App.jsx
+++ b/e2e/cases/module-federation/v2-basic/host/src/App.jsx
@@ -1,14 +1,14 @@
-import React from 'react';
+import { lazy, Suspense } from 'react';
 
-const RemoteButton = React.lazy(() => import('remote/Button'));
+const RemoteButton = lazy(() => import('remote/Button'));
 
 const App = () => (
   <div>
     <h1>Basic Host-Remote</h1>
     <h2 id="title">Host</h2>
-    <React.Suspense fallback="Loading Button">
+    <Suspense fallback="Loading Button">
       <RemoteButton />
-    </React.Suspense>
+    </Suspense>
   </div>
 );
 

--- a/e2e/cases/output/data-uri-limit/src/index.js
+++ b/e2e/cases/output/data-uri-limit/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/output/externals/src/index.js
+++ b/e2e/cases/output/externals/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/output/legal-comments/src/index.jsx
+++ b/e2e/cases/output/legal-comments/src/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 
 /**
@@ -27,5 +27,5 @@ function App() {
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/overlay/basic/src/index.tsx
+++ b/e2e/cases/overlay/basic/src/index.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
 import App from './App';
 
-const root = ReactDOM.createRoot(document.getElementById('root')!);
+const root = createRoot(document.getElementById('root')!);
 root.render(
-  <React.StrictMode>
+  <StrictMode>
     <App />
-  </React.StrictMode>,
+  </StrictMode>,
 );

--- a/e2e/cases/overlay/build-errors-disabled/src/index.jsx
+++ b/e2e/cases/overlay/build-errors-disabled/src/index.jsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
 import App from './App';
 
-const root = ReactDOM.createRoot(document.getElementById('root'));
+const root = createRoot(document.getElementById('root'));
 root.render(
-  <React.StrictMode>
+  <StrictMode>
     <App />
-  </React.StrictMode>,
+  </StrictMode>,
 );

--- a/e2e/cases/overlay/build-errors-filter/src/index.tsx
+++ b/e2e/cases/overlay/build-errors-filter/src/index.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
 import App from './App';
 
-const root = ReactDOM.createRoot(document.getElementById('root')!);
+const root = createRoot(document.getElementById('root')!);
 root.render(
-  <React.StrictMode>
+  <StrictMode>
     <App />
-  </React.StrictMode>,
+  </StrictMode>,
 );

--- a/e2e/cases/overlay/error-recovery/src/index.jsx
+++ b/e2e/cases/overlay/error-recovery/src/index.jsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
 import App from './App';
 
-const root = ReactDOM.createRoot(document.getElementById('root'));
+const root = createRoot(document.getElementById('root'));
 root.render(
-  <React.StrictMode>
+  <StrictMode>
     <App />
-  </React.StrictMode>,
+  </StrictMode>,
 );

--- a/e2e/cases/overlay/runtime-errors/src/index.jsx
+++ b/e2e/cases/overlay/runtime-errors/src/index.jsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
 import App from './App';
 
-const root = ReactDOM.createRoot(document.getElementById('root'));
+const root = createRoot(document.getElementById('root'));
 root.render(
-  <React.StrictMode>
+  <StrictMode>
     <App />
-  </React.StrictMode>,
+  </StrictMode>,
 );

--- a/e2e/cases/performance/dns-prefetch/src/index.js
+++ b/e2e/cases/performance/dns-prefetch/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.jsx';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/performance/preconnect/src/index.js
+++ b/e2e/cases/performance/preconnect/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.jsx';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/performance/resource-hints-prefetch/src/page1/index.ts
+++ b/e2e/cases/performance/resource-hints-prefetch/src/page1/index.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
@@ -9,5 +9,5 @@ import('../test').then((res) => {
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/performance/resource-hints-prefetch/src/page2/index.ts
+++ b/e2e/cases/performance/resource-hints-prefetch/src/page2/index.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
@@ -9,5 +9,5 @@ import('../test').then((res) => {
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/performance/resource-hints-preload/src/page1/index.ts
+++ b/e2e/cases/performance/resource-hints-preload/src/page1/index.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
@@ -9,5 +9,5 @@ import('../test').then((res) => {
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/performance/resource-hints-preload/src/page2/index.ts
+++ b/e2e/cases/performance/resource-hints-preload/src/page2/index.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
@@ -9,5 +9,5 @@ import('../test').then((res) => {
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/plugin-react/basic/src/index.js
+++ b/e2e/cases/plugin-react/basic/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/plugin-react/disable-fast-refresh/src/index.ts
+++ b/e2e/cases/plugin-react/disable-fast-refresh/src/index.ts
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/plugin-react/enable-profiler/src/index.js
+++ b/e2e/cases/plugin-react/enable-profiler/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/plugin-react/jsx-runtime-classic/src/index.js
+++ b/e2e/cases/plugin-react/jsx-runtime-classic/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/plugin-react/jsx-runtime-preserve/src/App.jsx
+++ b/e2e/cases/plugin-react/jsx-runtime-preserve/src/App.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const App = () => <div id="test">Hello Rsbuild!</div>;
 
 export default App;

--- a/e2e/cases/plugin-react/jsx-runtime-preserve/src/index.js
+++ b/e2e/cases/plugin-react/jsx-runtime-preserve/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/plugin-react/react-compiler/src/index.js
+++ b/e2e/cases/plugin-react/react-compiler/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/plugin-svgr/default-export-component/src/index.js
+++ b/e2e/cases/plugin-svgr/default-export-component/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/plugin-svgr/default-export-url/src/index.js
+++ b/e2e/cases/plugin-svgr/default-export-url/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/plugin-svgr/named-export-component/src/index.js
+++ b/e2e/cases/plugin-svgr/named-export-component/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/plugin-svgr/parallel/src/index.js
+++ b/e2e/cases/plugin-svgr/parallel/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/plugin-svgr/query-custom/src/index.js
+++ b/e2e/cases/plugin-svgr/query-custom/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/plugin-svgr/query-react-dynamic-import/src/index.js
+++ b/e2e/cases/plugin-svgr/query-react-dynamic-import/src/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { getApp } from './App';
 
@@ -7,7 +7,7 @@ async function main() {
   if (container) {
     const App = await getApp();
     const root = createRoot(container);
-    root.render(React.createElement(App));
+    root.render(createElement(App));
   }
 }
 

--- a/e2e/cases/plugin-svgr/query-react/src/index.js
+++ b/e2e/cases/plugin-svgr/query-react/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/plugin-svgr/query-url/src/index.js
+++ b/e2e/cases/plugin-svgr/query-url/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/plugin-svgr/svgo-options/src/index.js
+++ b/e2e/cases/plugin-svgr/svgo-options/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/plugin-svgr/utf8-inline-limit/src/index.js
+++ b/e2e/cases/plugin-svgr/utf8-inline-limit/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/print-file-size/basic/src/index.js
+++ b/e2e/cases/print-file-size/basic/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/print-file-size/diff/__snapshots__/index.test.ts.snap
+++ b/e2e/cases/print-file-size/diff/__snapshots__/index.test.ts.snap
@@ -21,16 +21,16 @@ exports[`should print file size diff as expected 2`] = `
 File (web)                           Size                 Gzip
 dist/static/css/index.[[hash]].css   X.X kB (+X.X kB)   X.X kB (+X.X kB)
 dist/index.html                      X.X kB (+X.X kB)   X.X kB (+X.X kB)
-dist/static/js/index.[[hash]].js     X.X kB (+X.X kB)   X.X kB (+X.X kB)
-dist/static/js/vendor.[[hash]].js    X.X kB (+X.X kB)   X.X kB (+X.X kB)
-                            Total:   X.X kB (+X.X kB)   X.X kB (+X.X kB)"
+dist/static/js/index.[[hash]].js     X.X kB (+X.X kB)     X.X kB (+X.X kB)
+dist/static/js/vendor.[[hash]].js    X.X kB (+X.X kB)     X.X kB (+X.X kB)
+                            Total:   X.X kB (+X.X kB)     X.X kB (+X.X kB)"
 `;
 
 exports[`should print file size diff as expected 3`] = `
 "
 File (web)                           Size                 Gzip
-dist/static/js/index.[[hash]].js     X.X kB (-X.X kB)   X.X kB (-X.X kB)
+dist/static/js/index.[[hash]].js     X.X kB (-X.X kB)    X.X kB (-X.X kB)
 dist/static/css/index.[[hash]].css   X.X kB              X.X kB
 dist/index.html                      X.X kB (-X.X kB)   X.X kB (-X.X kB)
-                            Total:   X.X kB (-X.X kB)   X.X kB (-X.X kB)"
+                            Total:   X.X kB (-X.X kB)    X.X kB (-X.X kB)"
 `;

--- a/e2e/cases/print-file-size/diff/index.test.ts
+++ b/e2e/cases/print-file-size/diff/index.test.ts
@@ -27,10 +27,10 @@ test('should print file size diff as expected', async ({
   await editFile(
     join(srcDir, 'index.js'),
     () => `import "./App.css";
-import React from 'react';
-import ReactDOM from 'react-dom';
-console.log(React);
-console.log(ReactDOM);
+import { createElement } from 'react';
+import { flushSync } from 'react-dom';
+console.log(createElement);
+console.log(flushSync);
 `,
   );
 

--- a/e2e/cases/resolve/dedupe/index.test.ts
+++ b/e2e/cases/resolve/dedupe/index.test.ts
@@ -11,7 +11,7 @@ function writeDuplicatedPackage(flag: string) {
   );
   fse.outputFileSync(
     join(fooPath, 'index.js'),
-    'import React from "react";export default React;',
+    'import { createElement } from "react";export default createElement;',
   );
   fse.outputFileSync(
     join(fooPath, 'node_modules', 'react', 'package.json'),

--- a/e2e/cases/resolve/dedupe/src/index.js
+++ b/e2e/cases/resolve/dedupe/src/index.js
@@ -1,5 +1,5 @@
 import foo from 'foo';
-import React from 'react';
-import ReactDOM from 'react-dom';
+import { createElement } from 'react';
+import { flushSync } from 'react-dom';
 
-console.log(React, ReactDOM, foo);
+console.log(createElement, flushSync, foo);

--- a/e2e/cases/server/compress-disable/src/index.js
+++ b/e2e/cases/server/compress-disable/src/index.js
@@ -1,6 +1,6 @@
-import React from 'react';
+import { createElement } from 'react';
 
-console.log(React);
+console.log(createElement);
 
 import(
   /* rspackChunkName: "react-dom" */

--- a/e2e/cases/server/compress-disable/src/react-dom.js
+++ b/e2e/cases/server/compress-disable/src/react-dom.js
@@ -1,3 +1,3 @@
-import ReactDOM from 'react-dom/client';
+import { createRoot } from 'react-dom/client';
 
-console.log(ReactDOM);
+console.log(createRoot);

--- a/e2e/cases/server/compress-filter/src/index.js
+++ b/e2e/cases/server/compress-filter/src/index.js
@@ -1,6 +1,6 @@
-import React from 'react';
+import { createElement } from 'react';
 
-console.log(React);
+console.log(createElement);
 
 import(
   /* rspackChunkName: "react-dom" */

--- a/e2e/cases/server/compress-filter/src/react-dom.js
+++ b/e2e/cases/server/compress-filter/src/react-dom.js
@@ -1,3 +1,3 @@
-import ReactDOM from 'react-dom/client';
+import { createRoot } from 'react-dom/client';
 
-console.log(ReactDOM);
+console.log(createRoot);

--- a/e2e/cases/server/ssr-type-module/src/index.server.tsx
+++ b/e2e/cases/server/ssr-type-module/src/index.server.tsx
@@ -1,14 +1,14 @@
-import React from 'react';
-import ReactDOMServer from 'react-dom/server';
+import { StrictMode } from 'react';
+import { renderToString } from 'react-dom/server';
 import App from './App';
 
 // test dynamic import
 import('./test');
 
 export function render() {
-  return ReactDOMServer.renderToString(
-    <React.StrictMode>
+  return renderToString(
+    <StrictMode>
       <App />
-    </React.StrictMode>,
+    </StrictMode>,
   );
 }

--- a/e2e/cases/server/ssr-type-module/src/index.tsx
+++ b/e2e/cases/server/ssr-type-module/src/index.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
+import { StrictMode } from 'react';
+import { hydrateRoot } from 'react-dom/client';
 import App from './App';
 
-ReactDOM.hydrateRoot(
+hydrateRoot(
   document.getElementById('root')!,
-  <React.StrictMode>
+  <StrictMode>
     <App />
-  </React.StrictMode>,
+  </StrictMode>,
 );

--- a/e2e/cases/server/ssr/src/index.server.tsx
+++ b/e2e/cases/server/ssr/src/index.server.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import ReactDOMServer from 'react-dom/server';
+import { StrictMode } from 'react';
+import { renderToString } from 'react-dom/server';
 import App from './App';
 import { assert } from './assert.server';
 
@@ -12,9 +12,9 @@ import('./test');
 assert();
 
 export function render() {
-  return ReactDOMServer.renderToString(
-    <React.StrictMode>
+  return renderToString(
+    <StrictMode>
       <App />
-    </React.StrictMode>,
+    </StrictMode>,
   );
 }

--- a/e2e/cases/server/ssr/src/index.tsx
+++ b/e2e/cases/server/ssr/src/index.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
+import { StrictMode } from 'react';
+import { hydrateRoot } from 'react-dom/client';
 import App from './App';
 
-ReactDOM.hydrateRoot(
+hydrateRoot(
   document.getElementById('root')!,
-  <React.StrictMode>
+  <StrictMode>
     <App />
-  </React.StrictMode>,
+  </StrictMode>,
 );

--- a/e2e/cases/server/viewing-served-files/src/index.tsx
+++ b/e2e/cases/server/viewing-served-files/src/index.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
 import App from './App';
 
-const root = ReactDOM.createRoot(document.getElementById('root')!);
+const root = createRoot(document.getElementById('root')!);
 root.render(
-  <React.StrictMode>
+  <StrictMode>
     <App />
-  </React.StrictMode>,
+  </StrictMode>,
 );

--- a/e2e/cases/server/viewing-served-files/src2/index.tsx
+++ b/e2e/cases/server/viewing-served-files/src2/index.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
 import App from './App';
 
-const root = ReactDOM.createRoot(document.getElementById('root')!);
+const root = createRoot(document.getElementById('root')!);
 root.render(
-  <React.StrictMode>
+  <StrictMode>
     <App />
-  </React.StrictMode>,
+  </StrictMode>,
 );

--- a/e2e/cases/server/watch-files/src/index.tsx
+++ b/e2e/cases/server/watch-files/src/index.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
 import App from './App';
 
-const root = ReactDOM.createRoot(document.getElementById('root')!);
+const root = createRoot(document.getElementById('root')!);
 root.render(
-  <React.StrictMode>
+  <StrictMode>
     <App />
-  </React.StrictMode>,
+  </StrictMode>,
 );

--- a/e2e/cases/source-map/basic/src/index.js
+++ b/e2e/cases/source-map/basic/src/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
@@ -9,5 +9,5 @@ window.test = 2;
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/split-chunks/disabled/src/index.js
+++ b/e2e/cases/split-chunks/disabled/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/split-chunks/legacy-all-in-one/src/index.js
+++ b/e2e/cases/split-chunks/legacy-all-in-one/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.jsx';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/split-chunks/legacy-by-module/src/index.js
+++ b/e2e/cases/split-chunks/legacy-by-module/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/split-chunks/legacy-chunk-splits/src/index.js
+++ b/e2e/cases/split-chunks/legacy-chunk-splits/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/split-chunks/legacy-single-vendor-with-force/src/index.js
+++ b/e2e/cases/split-chunks/legacy-single-vendor-with-force/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/split-chunks/legacy-single-vendor/src/index.js
+++ b/e2e/cases/split-chunks/legacy-single-vendor/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/split-chunks/preset-default/src/index.js
+++ b/e2e/cases/split-chunks/preset-default/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/split-chunks/preset-none/src/index.js
+++ b/e2e/cases/split-chunks/preset-none/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/split-chunks/preset-per-package/src/index.js
+++ b/e2e/cases/split-chunks/preset-per-package/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/e2e/cases/split-chunks/preset-single-vendor-node/src/index.js
+++ b/e2e/cases/split-chunks/preset-single-vendor-node/src/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 
-console.log(React, createRoot);
+console.log(createElement, createRoot);

--- a/e2e/cases/split-chunks/preset-single-vendor/src/index.js
+++ b/e2e/cases/split-chunks/preset-single-vendor/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(React.createElement(App));
+  root.render(createElement(App));
 }

--- a/examples/module-federation-v2/host/src/App.jsx
+++ b/examples/module-federation-v2/host/src/App.jsx
@@ -1,14 +1,14 @@
-import React from 'react';
+import { lazy, Suspense } from 'react';
 
-const RemoteButton = React.lazy(() => import('remote/Button'));
+const RemoteButton = lazy(() => import('remote/Button'));
 
 const App = () => (
   <div>
     <h1>Basic Host-Remote</h1>
     <h2>Host</h2>
-    <React.Suspense fallback="Loading Button">
+    <Suspense fallback="Loading Button">
       <RemoteButton />
-    </React.Suspense>
+    </Suspense>
   </div>
 );
 

--- a/examples/module-federation-v2/host/src/bootstrap.jsx
+++ b/examples/module-federation-v2/host/src/bootstrap.jsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 const root = createRoot(container);
 root.render(
-  <React.StrictMode>
+  <StrictMode>
     <App />
-  </React.StrictMode>,
+  </StrictMode>,
 );

--- a/examples/module-federation-v2/remote/src/bootstrap.jsx
+++ b/examples/module-federation-v2/remote/src/bootstrap.jsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 const root = createRoot(container);
 root.render(
-  <React.StrictMode>
+  <StrictMode>
     <App />
-  </React.StrictMode>,
+  </StrictMode>,
 );

--- a/examples/module-federation/host/src/App.jsx
+++ b/examples/module-federation/host/src/App.jsx
@@ -1,14 +1,14 @@
-import React from 'react';
+import { lazy, Suspense } from 'react';
 
-const RemoteButton = React.lazy(() => import('remote/Button'));
+const RemoteButton = lazy(() => import('remote/Button'));
 
 const App = () => (
   <div>
     <h1>Basic Host-Remote</h1>
     <h2>Host</h2>
-    <React.Suspense fallback="Loading Button">
+    <Suspense fallback="Loading Button">
       <RemoteButton />
-    </React.Suspense>
+    </Suspense>
   </div>
 );
 

--- a/examples/module-federation/host/src/bootstrap.jsx
+++ b/examples/module-federation/host/src/bootstrap.jsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 const root = createRoot(container);
 root.render(
-  <React.StrictMode>
+  <StrictMode>
     <App />
-  </React.StrictMode>,
+  </StrictMode>,
 );

--- a/examples/module-federation/remote/src/bootstrap.jsx
+++ b/examples/module-federation/remote/src/bootstrap.jsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const container = document.getElementById('root');
 const root = createRoot(container);
 root.render(
-  <React.StrictMode>
+  <StrictMode>
     <App />
-  </React.StrictMode>,
+  </StrictMode>,
 );

--- a/packages/create-rsbuild/template-react-js/src/index.jsx
+++ b/packages/create-rsbuild/template-react-js/src/index.jsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
 import App from './App';
 
-const root = ReactDOM.createRoot(document.getElementById('root'));
+const root = createRoot(document.getElementById('root'));
 root.render(
-  <React.StrictMode>
+  <StrictMode>
     <App />
-  </React.StrictMode>,
+  </StrictMode>,
 );

--- a/packages/create-rsbuild/template-react-ts/src/env.d.ts
+++ b/packages/create-rsbuild/template-react-ts/src/env.d.ts
@@ -3,7 +3,7 @@
  * @requires [@rsbuild/plugin-svgr](https://npmjs.com/package/@rsbuild/plugin-svgr)
  */
 declare module '*.svg?react' {
-  import type React from 'react';
-  const ReactComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+  import type { FunctionComponent, SVGProps } from 'react';
+  const ReactComponent: FunctionComponent<SVGProps<SVGSVGElement>>;
   export default ReactComponent;
 }

--- a/packages/create-rsbuild/template-react-ts/src/index.tsx
+++ b/packages/create-rsbuild/template-react-ts/src/index.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
 import App from './App';
 
 const rootEl = document.getElementById('root');
 if (rootEl) {
-  const root = ReactDOM.createRoot(rootEl);
+  const root = createRoot(rootEl);
   root.render(
-    <React.StrictMode>
+    <StrictMode>
       <App />
-    </React.StrictMode>,
+    </StrictMode>,
   );
 }

--- a/website/docs/en/config/html/mount-id.mdx
+++ b/website/docs/en/config/html/mount-id.mdx
@@ -41,11 +41,13 @@ After compilation:
 
 After modifying `mountId`, if there is logic in your code to obtain the `root` root node, please update the corresponding value:
 
-```ts
+```tsx
+import { createRoot } from 'react-dom/client';
+
 const domNode = document.getElementById('root'); // [!code --]
 const domNode = document.getElementById('app'); // [!code ++]
 
-ReactDOM.createRoot(domNode).render(<App />);
+createRoot(domNode).render(<App />);
 ```
 
 ### Custom templates

--- a/website/docs/en/config/output/auto-external.mdx
+++ b/website/docs/en/config/output/auto-external.mdx
@@ -67,7 +67,7 @@ export default {
 When `output.autoExternal` is applied, Rsbuild also externalizes subpath imports of matched dependencies. For example, if `react` is declared in `dependencies`, both of the following imports will be externalized:
 
 ```ts
-import React from 'react';
+import { createElement } from 'react';
 import { jsx } from 'react/jsx-runtime';
 ```
 

--- a/website/docs/en/guide/migration/tanstack-start.mdx
+++ b/website/docs/en/guide/migration/tanstack-start.mdx
@@ -152,9 +152,9 @@ Replace Vite's preset types in `tsconfig.json` with Rsbuild's preset types. If y
 
 ```ts title="src/types/svg.d.ts"
 declare module '*.svg?react' {
-  import type React from 'react';
+  import type { FunctionComponent, SVGProps } from 'react';
 
-  const ReactComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+  const ReactComponent: FunctionComponent<SVGProps<SVGSVGElement>>;
   export default ReactComponent;
 }
 ```

--- a/website/docs/en/guide/optimization/inline-assets.mdx
+++ b/website/docs/en/guide/optimization/inline-assets.mdx
@@ -38,7 +38,6 @@ export default {
 You can force an asset to be inlined by adding the `inline` query parameter when importing it, regardless of the asset's size.
 
 ```tsx
-import React from 'react';
 import img from './foo.png?inline';
 
 export default function Foo() {
@@ -67,7 +66,6 @@ Inlining large assets will significantly increase the first paint time or first 
 To prevent assets from being inlined and ensure they're always loaded as separate files (regardless of their size), add the `url` query parameter.
 
 ```tsx
-import React from 'react';
 import img from './foo.png?url';
 
 export default function Foo() {

--- a/website/docs/en/plugins/list/plugin-svgr.mdx
+++ b/website/docs/en/plugins/list/plugin-svgr.mdx
@@ -395,7 +395,8 @@ declare module '*.svg' {
   export default content;
 }
 declare module '*.svg?react' {
-  const ReactComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+  import type { FunctionComponent, SVGProps } from 'react';
+  const ReactComponent: FunctionComponent<SVGProps<SVGSVGElement>>;
   export default ReactComponent;
 }
 ```
@@ -404,11 +405,13 @@ declare module '*.svg?react' {
 
 ```ts
 declare module '*.svg' {
-  const ReactComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+  import type { FunctionComponent, SVGProps } from 'react';
+  const ReactComponent: FunctionComponent<SVGProps<SVGSVGElement>>;
   export default ReactComponent;
 }
 declare module '*.svg?react' {
-  const ReactComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+  import type { FunctionComponent, SVGProps } from 'react';
+  const ReactComponent: FunctionComponent<SVGProps<SVGSVGElement>>;
   export default ReactComponent;
 }
 ```
@@ -417,12 +420,12 @@ declare module '*.svg?react' {
 
 ```ts
 declare module '*.svg' {
-  export const ReactComponent: React.FunctionComponent<
-    React.SVGProps<SVGSVGElement>
-  >;
+  import type { FunctionComponent, SVGProps } from 'react';
+  export const ReactComponent: FunctionComponent<SVGProps<SVGSVGElement>>;
 }
 declare module '*.svg?react' {
-  const ReactComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+  import type { FunctionComponent, SVGProps } from 'react';
+  const ReactComponent: FunctionComponent<SVGProps<SVGSVGElement>>;
   export default ReactComponent;
 }
 ```
@@ -431,14 +434,14 @@ declare module '*.svg?react' {
 
 ```ts
 declare module '*.svg' {
-  export const ReactComponent: React.FunctionComponent<
-    React.SVGProps<SVGSVGElement>
-  >;
+  import type { FunctionComponent, SVGProps } from 'react';
+  export const ReactComponent: FunctionComponent<SVGProps<SVGSVGElement>>;
   const content: string;
   export default content;
 }
 declare module '*.svg?react' {
-  const ReactComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+  import type { FunctionComponent, SVGProps } from 'react';
+  const ReactComponent: FunctionComponent<SVGProps<SVGSVGElement>>;
   export default ReactComponent;
 }
 ```

--- a/website/docs/zh/config/html/mount-id.mdx
+++ b/website/docs/zh/config/html/mount-id.mdx
@@ -41,11 +41,13 @@ export default {
 
 在修改 `mountId` 后，如果你的代码中有获取 `root` 根节点的逻辑，请更新对应的值：
 
-```js
+```tsx
+import { createRoot } from 'react-dom/client';
+
 const domNode = document.getElementById('root'); // [!code --]
 const domNode = document.getElementById('app'); // [!code ++]
 
-ReactDOM.createRoot(domNode).render(<App />);
+createRoot(domNode).render(<App />);
 ```
 
 ### 自定义模板

--- a/website/docs/zh/config/output/auto-external.mdx
+++ b/website/docs/zh/config/output/auto-external.mdx
@@ -67,7 +67,7 @@ export default {
 当 `output.autoExternal` 生效时，Rsbuild 也会 external 匹配依赖的子路径导入。例如，如果 `react` 声明在 `dependencies` 中，下面两个导入都会被 external：
 
 ```ts
-import React from 'react';
+import { createElement } from 'react';
 import { jsx } from 'react/jsx-runtime';
 ```
 

--- a/website/docs/zh/guide/migration/tanstack-start.mdx
+++ b/website/docs/zh/guide/migration/tanstack-start.mdx
@@ -152,9 +152,9 @@ export default defineConfig({
 
 ```ts title="src/types/svg.d.ts"
 declare module '*.svg?react' {
-  import type React from 'react';
+  import type { FunctionComponent, SVGProps } from 'react';
 
-  const ReactComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+  const ReactComponent: FunctionComponent<SVGProps<SVGSVGElement>>;
   export default ReactComponent;
 }
 ```

--- a/website/docs/zh/guide/optimization/inline-assets.mdx
+++ b/website/docs/zh/guide/optimization/inline-assets.mdx
@@ -38,7 +38,6 @@ export default {
 你可以通过在引入资源时添加 `inline` URL 参数来强制内联该资源，无论该资源的体积是否小于阈值。
 
 ```tsx
-import React from 'react';
 import img from './foo.png?inline';
 
 export default function Foo() {
@@ -67,7 +66,6 @@ export default function Foo() {
 当你想要阻止资源被内联，并确保它们始终作为单独的文件加载（无论文件大小如何），你可以添加 `url` query 参数。
 
 ```tsx
-import React from 'react';
 import img from './foo.png?url';
 
 export default function Foo() {

--- a/website/docs/zh/plugins/list/plugin-svgr.mdx
+++ b/website/docs/zh/plugins/list/plugin-svgr.mdx
@@ -395,7 +395,8 @@ declare module '*.svg' {
   export default content;
 }
 declare module '*.svg?react' {
-  const ReactComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+  import type { FunctionComponent, SVGProps } from 'react';
+  const ReactComponent: FunctionComponent<SVGProps<SVGSVGElement>>;
   export default ReactComponent;
 }
 ```
@@ -404,11 +405,13 @@ declare module '*.svg?react' {
 
 ```ts
 declare module '*.svg' {
-  const ReactComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+  import type { FunctionComponent, SVGProps } from 'react';
+  const ReactComponent: FunctionComponent<SVGProps<SVGSVGElement>>;
   export default ReactComponent;
 }
 declare module '*.svg?react' {
-  const ReactComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+  import type { FunctionComponent, SVGProps } from 'react';
+  const ReactComponent: FunctionComponent<SVGProps<SVGSVGElement>>;
   export default ReactComponent;
 }
 ```
@@ -417,12 +420,12 @@ declare module '*.svg?react' {
 
 ```ts
 declare module '*.svg' {
-  export const ReactComponent: React.FunctionComponent<
-    React.SVGProps<SVGSVGElement>
-  >;
+  import type { FunctionComponent, SVGProps } from 'react';
+  export const ReactComponent: FunctionComponent<SVGProps<SVGSVGElement>>;
 }
 declare module '*.svg?react' {
-  const ReactComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+  import type { FunctionComponent, SVGProps } from 'react';
+  const ReactComponent: FunctionComponent<SVGProps<SVGSVGElement>>;
   export default ReactComponent;
 }
 ```
@@ -431,14 +434,14 @@ declare module '*.svg?react' {
 
 ```ts
 declare module '*.svg' {
-  export const ReactComponent: React.FunctionComponent<
-    React.SVGProps<SVGSVGElement>
-  >;
+  import type { FunctionComponent, SVGProps } from 'react';
+  export const ReactComponent: FunctionComponent<SVGProps<SVGSVGElement>>;
   const content: string;
   export default content;
 }
 declare module '*.svg?react' {
-  const ReactComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+  import type { FunctionComponent, SVGProps } from 'react';
+  const ReactComponent: FunctionComponent<SVGProps<SVGSVGElement>>;
   export default ReactComponent;
 }
 ```

--- a/website/theme/components/NextSteps.tsx
+++ b/website/theme/components/NextSteps.tsx
@@ -1,6 +1,7 @@
+import type { ReactNode } from 'react';
 import styles from './NextSteps.module.scss';
 
-const NextSteps = (props: { children?: React.ReactNode }) => {
+const NextSteps = (props: { children?: ReactNode }) => {
   return <div className={styles.nextSteps}>{props.children}</div>;
 };
 


### PR DESCRIPTION
## Summary

Standardize React and React DOM API and type usage on named imports across templates, examples, test fixtures, and documentation. Preserve the default React import in the classic JSX documentation and fixture to demonstrate the default JSX factory.