### PR TITLE
fix: defer build logs until all progress bars finish

### DIFF
--- a/e2e/cases/environments/progress-logs/index.test.ts
+++ b/e2e/cases/environments/progress-logs/index.test.ts
@@ -1,0 +1,65 @@
+import { promisify } from 'node:util';
+import { expect, test } from '@e2e/helper';
+import type { RsbuildPluginAPI, Rspack } from '@rsbuild/core';
+
+for (const mode of ['dev', 'build']) {
+  test(`should print completion logs after all progress bars finish in ${mode}`, async ({
+    devOnly,
+    build,
+    logHelper,
+  }) => {
+    let fastDone = Promise.withResolvers<number>();
+    let earlyLogs: string[] = [];
+    let compilers: Rspack.Compiler[] = [];
+    const loggedEnvironments = () =>
+      logHelper.logs
+        .filter((log) => log.includes('built in'))
+        .map((log) => log.match(/\((fast|slow)\)/)![1]);
+    const config = {
+      plugins: [
+        {
+          name: 'test-progress-logs',
+          setup(api: RsbuildPluginAPI) {
+            api.onAfterCreateCompiler(({ compiler }) => {
+              compilers = (compiler as Rspack.MultiCompiler).compilers;
+            });
+            api.onAfterEnvironmentCompile(({ environment, time }) => {
+              if (environment.name === 'fast') fastDone.resolve(time);
+            });
+            api.processAssets(
+              { stage: 'optimize', environments: ['slow'] },
+              async () => {
+                await fastDone.promise;
+                earlyLogs = loggedEnvironments();
+              },
+            );
+          },
+        },
+      ],
+    };
+
+    if (mode === 'dev') await devOnly({ config });
+    else await build({ config });
+
+    expect(await fastDone.promise).toBeGreaterThan(0);
+    expect(earlyLogs).toEqual([]);
+    expect(loggedEnvironments()).toEqual(['fast', 'slow']);
+
+    if (mode === 'build') return;
+
+    for (const names of [['fast', 'slow'], ['fast']]) {
+      logHelper.clearLogs();
+      earlyLogs = [];
+      fastDone = Promise.withResolvers<number>();
+      await Promise.all(
+        compilers
+          .filter((compiler) => names.includes(compiler.name!))
+          .map(({ watching }) =>
+            promisify(watching!.invalidate.bind(watching))(),
+          ),
+      );
+      expect(earlyLogs).toEqual([]);
+      expect(loggedEnvironments()).toEqual(names);
+    }
+  });
+}

--- a/e2e/cases/environments/progress-logs/rsbuild.config.ts
+++ b/e2e/cases/environments/progress-logs/rsbuild.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  dev: {
+    progressBar: true,
+  },
+  environments: {
+    fast: {},
+    slow: {},
+  },
+});

--- a/e2e/cases/environments/progress-logs/src/index.js
+++ b/e2e/cases/environments/progress-logs/src/index.js
@@ -1,0 +1,1 @@
+console.log('Hello Rsbuild!');

--- a/packages/core/src/createCompiler.ts
+++ b/packages/core/src/createCompiler.ts
@@ -126,6 +126,11 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
     ? (compiler as Rspack.MultiCompiler).compilers
     : [compiler as Rspack.Compiler];
 
+  const deferBuildLogs =
+    isMultiCompiler &&
+    context.environmentList.some(({ config }) => config.dev.progressBar);
+  const pendingBuildLogs: (() => void)[] = [];
+
   const finishFatalBuild = () => {
     if (
       !hasFatalError ||
@@ -139,6 +144,7 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
     context.buildState.status = 'failed';
     context.buildState.hasErrors = true;
     isCompiling = false;
+    pendingBuildLogs.length = 0;
   };
 
   const logRspackVersion = () => {
@@ -213,6 +219,10 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
     item.hooks.watchClose.tap(HOOK_NAME, finishFatalBuild);
   }
 
+  compiler.hooks.shutdown.tap(HOOK_NAME, () => {
+    pendingBuildLogs.length = 0;
+  });
+
   if (context.action === 'build') {
     // When there are multiple compilers, we only need to print the start log once
     const firstCompiler = isMultiCompiler
@@ -238,18 +248,35 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
     const suffix = isMultiCompiler ? color.dim(` (${name})`) : '';
     const timeStr = `${prettyTime(time / 1000)}${suffix}`;
 
-    if (hasErrors) {
-      logger.error(`build failed in ${timeStr}`);
+    const log = () => {
+      if (hasErrors) {
+        logger.error(`build failed in ${timeStr}`);
+      } else {
+        logger.ready(`built in ${timeStr}`);
+      }
+    };
+
+    // Logging while another environment's progress bar is drawing moves the
+    // cursor and breaks subsequent redraws. Record the time now, but log later.
+    if (deferBuildLogs) {
+      pendingBuildLogs.push(log);
     } else {
-      logger.ready(`built in ${timeStr}`);
+      log();
     }
   };
 
   if (isMultiCompiler) {
     (compiler as Rspack.MultiCompiler).compilers.forEach((item, index) => {
-      item.hooks.done.tap(HOOK_NAME, (stats) => {
-        printTime(index, stats.hasErrors());
-      });
+      item.hooks.done.tap(
+        {
+          name: HOOK_NAME,
+          // Collect the last environment's log before Rspack fires MultiCompiler.done.
+          stage: -1,
+        },
+        (stats) => {
+          printTime(index, stats.hasErrors());
+        },
+      );
     });
   }
 
@@ -257,6 +284,9 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
     HOOK_NAME,
     (statsInstance: Rspack.Stats | Rspack.MultiStats) => {
       hasFatalError = false;
+      for (const log of pendingBuildLogs.splice(0)) {
+        log();
+      }
       const stats = getRsbuildStats(
         statsInstance,
         compiler,


### PR DESCRIPTION
## Summary

Multi-environment builds with progress bars can leave duplicated bars and lose completion logs when one environment finishes early. This PR defers per-environment completion logs until all environments finish while preserving each environment's recorded build time.

## Related links

Fixes #8429