### PR TITLE
fix(deps): upgrade rspack-chain to 2.3.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,8 +302,8 @@ catalogs:
       specifier: ^2.3.0
       version: 2.3.0
     rspack-chain:
-      specifier: ^2.3.1
-      version: 2.3.1
+      specifier: ^2.3.2
+      version: 2.3.2
     rspack-manifest-plugin:
       specifier: 5.2.2
       version: 5.2.2
@@ -980,7 +980,7 @@ importers:
         version: 2.3.0
       rspack-chain:
         specifier: 'catalog:'
-        version: 2.3.1(@rspack/core@2.2.2)
+        version: 2.3.2(@rspack/core@2.2.2)
       rspack-manifest-plugin:
         specifier: 'catalog:'
         version: 5.2.2(@rspack/core@2.2.2)
@@ -4795,8 +4795,8 @@ packages:
     resolution: {integrity: sha512-g2wW/ermwzGTLlzGdJBDRc4YKz2/yPBjf57w9g5CvhtpZ91Xq95OaWku0oNHYi+XsuV6v8QrCo2oJJR/pCUR8g==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  rspack-chain@2.3.1:
-    resolution: {integrity: sha512-EvQA6S13FAV2bhdYUpemsPgEeuEpeEcsd6qaTiOfQ33U/pBRSplewUBH5+AV2Dg8CRtffi7/7GKnHeXTgKeleg==}
+  rspack-chain@2.3.2:
+    resolution: {integrity: sha512-oR0r7mM+MS+bSm1xvb18vjs3EWjSnEA+7S928QFGFal/RapnBT1HL0oAEHVBKBq5chLPm3gnsP8jrwajOO2UwQ==}
     peerDependencies:
       '@rspack/core': ^2.0.0
     peerDependenciesMeta:
@@ -9104,7 +9104,7 @@ snapshots:
 
   rslog@2.3.0: {}
 
-  rspack-chain@2.3.1(@rspack/core@2.2.2):
+  rspack-chain@2.3.2(@rspack/core@2.2.2):
     optionalDependencies:
       '@rspack/core': 2.2.2(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -114,7 +114,7 @@ catalog:
   'rsbuild-plugin-google-analytics': '^1.0.6'
   'rsbuild-plugin-open-graph': '^1.1.3'
   'rslog': '^2.3.0'
-  'rspack-chain': '^2.3.1'
+  'rspack-chain': '^2.3.2'
   'rspack-manifest-plugin': '5.2.2'
   'rspack-merge': '1.0.1'
   'rspack-vue-loader': '^17.6.2'


### PR DESCRIPTION
## Summary

Ecosystem CI exposed declaration build failures in `rsbuild-plugin-mdx` and `rsbuild-plugin-stylus` when copying loaders with `.loader(use.get('loader'))`. Upgrade `rspack-chain` to 2.3.2, which allows the getter's `string | undefined` return type in `.loader()` and restores compatibility for these plugins.

## Related links

- [Ecosystem CI failures](https://github.com/rstackjs/rstack-ecosystem-ci/actions/runs/34098918430/job/101668637218)
- [rspack-chain v2.3.2 release notes](https://github.com/rstackjs/rspack-chain/releases/tag/v2.3.2)