### PR TITLE
feat(create-rsbuild): add a Lynx template

### DIFF
--- a/packages/create-rsbuild/src/index.ts
+++ b/packages/create-rsbuild/src/index.ts
@@ -15,6 +15,8 @@ import {
   tailwindcssPlugin,
 } from './rsbuildConfig.js';
 
+const isLynx = (templateName: string) => templateName.startsWith('lynx-');
+
 const frameworkAlias: Record<string, string> = {
   vue3: 'vue',
   'solid-js': 'solid',
@@ -42,6 +44,7 @@ async function getTemplateName({ template }: Argv) {
         { value: 'solid', label: 'Solid 1' },
         { value: 'solid2', label: 'Solid 2' },
         { value: 'octane', label: 'Octane' },
+        { value: 'lynx', label: 'Lynx' },
       ],
     }),
   );
@@ -128,6 +131,8 @@ await create({
     'solid2-ts',
     'octane-js',
     'octane-ts',
+    'lynx-js',
+    'lynx-ts',
   ],
   getTemplateName,
   mapESLintTemplate,
@@ -137,6 +142,7 @@ await create({
       value: 'rstest',
       label: 'Rstest - testing',
       order: 'pre',
+      when: ({ templateName }) => !isLynx(templateName),
       action: ({ templateName, distFolder, addAgentsMdSearchDirs }) => {
         const rstestTemplate = mapRstestTemplate(templateName);
         const toolFolder = path.join(root, 'template-rstest');
@@ -163,6 +169,7 @@ await create({
     {
       value: 'tailwindcss',
       label: 'Tailwind CSS - styling',
+      when: ({ templateName }) => !isLynx(templateName),
       action: async ({ distFolder }) => {
         const from = path.join(root, 'template-tailwindcss');
         copyFolder({
@@ -191,6 +198,7 @@ await create({
     {
       value: 'storybook',
       label: 'Storybook - component development',
+      when: ({ templateName }) => !isLynx(templateName),
       command: 'npm create storybook@latest -- --skip-install --features docs',
     },
   ],

--- a/packages/create-rsbuild/template-lynx-js/package.json
+++ b/packages/create-rsbuild/template-lynx-js/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "rsbuild-lynx-js",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rsbuild build",
+    "dev": "rsbuild dev",
+    "preview": "rsbuild preview"
+  },
+  "dependencies": {
+    "@lynx-js/react": "^0.126.0"
+  },
+  "devDependencies": {
+    "@lynx-js/qrcode-rsbuild-plugin": "^0.7.1",
+    "@lynx-js/react-rsbuild-plugin": "^0.20.1",
+    "@lynx-js/rsbuild-plugin": "^0.1.1",
+    "@rsbuild/core": "^2.2.3"
+  }
+}

--- a/packages/create-rsbuild/template-lynx-js/rsbuild.config.js
+++ b/packages/create-rsbuild/template-lynx-js/rsbuild.config.js
@@ -1,0 +1,17 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginQRCode } from '@lynx-js/qrcode-rsbuild-plugin';
+import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
+import { pluginLynx } from '@lynx-js/rsbuild-plugin';
+
+// Docs: https://rsbuild.rs/config/
+export default defineConfig({
+  environments: {
+    lynx: {},
+  },
+  source: {
+    entry: {
+      main: './src/index.jsx',
+    },
+  },
+  plugins: [pluginLynx(), pluginReactLynx(), pluginQRCode()],
+});

--- a/packages/create-rsbuild/template-lynx-js/src/App.css
+++ b/packages/create-rsbuild/template-lynx-js/src/App.css
@@ -1,0 +1,13 @@
+.content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+}
+
+.title {
+  font-size: 24px;
+  font-weight: bold;
+  margin-bottom: 8px;
+}

--- a/packages/create-rsbuild/template-lynx-js/src/App.jsx
+++ b/packages/create-rsbuild/template-lynx-js/src/App.jsx
@@ -1,0 +1,10 @@
+import './App.css';
+
+export function App() {
+  return (
+    <view className="content">
+      <text className="title">Rsbuild with Lynx</text>
+      <text>Start building amazing things with Rsbuild.</text>
+    </view>
+  );
+}

--- a/packages/create-rsbuild/template-lynx-js/src/index.jsx
+++ b/packages/create-rsbuild/template-lynx-js/src/index.jsx
@@ -1,0 +1,8 @@
+import { root } from '@lynx-js/react';
+import { App } from './App.jsx';
+
+root.render(<App />);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/packages/create-rsbuild/template-lynx-ts/package.json
+++ b/packages/create-rsbuild/template-lynx-ts/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "rsbuild-lynx-ts",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rsbuild build",
+    "dev": "rsbuild dev",
+    "preview": "rsbuild preview"
+  },
+  "dependencies": {
+    "@lynx-js/react": "^0.126.0"
+  },
+  "devDependencies": {
+    "@lynx-js/qrcode-rsbuild-plugin": "^0.7.1",
+    "@lynx-js/react-rsbuild-plugin": "^0.20.1",
+    "@lynx-js/rsbuild-plugin": "^0.1.1",
+    "@lynx-js/types": "^4.2.1",
+    "@rsbuild/core": "^2.2.3",
+    "@types/react": "^19.2.18",
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/create-rsbuild/template-lynx-ts/rsbuild.config.ts
+++ b/packages/create-rsbuild/template-lynx-ts/rsbuild.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginQRCode } from '@lynx-js/qrcode-rsbuild-plugin';
+import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
+import { pluginLynx } from '@lynx-js/rsbuild-plugin';
+
+// Docs: https://rsbuild.rs/config/
+export default defineConfig({
+  environments: {
+    lynx: {},
+  },
+  source: {
+    entry: {
+      main: './src/index.tsx',
+    },
+  },
+  plugins: [pluginLynx(), pluginReactLynx(), pluginQRCode()],
+});

--- a/packages/create-rsbuild/template-lynx-ts/src/App.css
+++ b/packages/create-rsbuild/template-lynx-ts/src/App.css
@@ -1,0 +1,13 @@
+.content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+}
+
+.title {
+  font-size: 24px;
+  font-weight: bold;
+  margin-bottom: 8px;
+}

--- a/packages/create-rsbuild/template-lynx-ts/src/App.tsx
+++ b/packages/create-rsbuild/template-lynx-ts/src/App.tsx
@@ -1,0 +1,10 @@
+import './App.css';
+
+export function App() {
+  return (
+    <view className="content">
+      <text className="title">Rsbuild with Lynx</text>
+      <text>Start building amazing things with Rsbuild.</text>
+    </view>
+  );
+}

--- a/packages/create-rsbuild/template-lynx-ts/src/env.d.ts
+++ b/packages/create-rsbuild/template-lynx-ts/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@rsbuild/core/types" />

--- a/packages/create-rsbuild/template-lynx-ts/src/index.tsx
+++ b/packages/create-rsbuild/template-lynx-ts/src/index.tsx
@@ -1,0 +1,8 @@
+import { root } from '@lynx-js/react';
+import { App } from './App.jsx';
+
+root.render(<App />);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/packages/create-rsbuild/template-lynx-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-lynx-ts/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "lib": ["ES2020"],
+    "jsx": "react-jsx",
+    "jsxImportSource": "@lynx-js/react",
+    "target": "ES2020",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["@rsbuild/core/types", "@lynx-js/types"],
+    "useDefineForClassFields": true,
+
+    /* modules */
+    "moduleDetection": "force",
+    "moduleResolution": "bundler",
+    "verbatimModuleSyntax": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+
+    /* type checking */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": ["src", "rsbuild.config.ts"]
+}

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -114,6 +114,7 @@ preflights
 prefresh
 preprocessors
 pxtorem
+qrcode
 rebranded
 rolldown
 rsbuild


### PR DESCRIPTION
## Summary

Adds `lynx-ts` / `lynx-js` templates, so `npm create rsbuild@latest` can scaffold a [Lynx](https://lynxjs.org/) app alongside the existing frameworks.

The template is a plain Rsbuild project — `@rsbuild/core`, `rsbuild.config.ts`, `rsbuild build` — with the Lynx build engine applied as a plugin:

```ts
export default defineConfig({
  environments: { lynx: {} },
  source: { entry: { main: './src/index.tsx' } },
  plugins: [pluginLynx(), pluginReactLynx(), pluginQRCode()],
});
```

`rsbuild build` emits `dist/main.lynx.bundle`.

## Changes

- `template-lynx-ts/` and `template-lynx-js/`, following the existing minimal template style
- `lynx` added to the framework list and to the `--help` template list
- `rstest`, `tailwindcss` and `storybook` are hidden for Lynx templates — they assume a DOM (`template-rstest/*` uses `happy-dom` + `@testing-library/dom`; `storybook-react-rsbuild` renders in a browser; Lynx has its own Tailwind preset)
- `qrcode` added to the spell-check dictionary

## Verification

| | |
|---|---|
| `--template lynx-ts` → `npm install && npm run build` | `dist/main.lynx.bundle`, 88.6 kB |
| `--template lynx-js` → same | passes |
| `--tools eslint,prettier` on `lynx-ts` → build | passes |
| `--tools storybook,tailwindcss,rstest` on `lynx-ts` | all skipped, `package.json` untouched |
| `--template react-ts` | unaffected |
| `node --run build` / `node --run check` / `cspell` | pass |

## Open question

Template dependencies pin `@lynx-js/*` versions, so they need bumping here on each Lynx release. Renovate already manages the other templates' dependencies, so this should be covered, but happy to adjust if you would rather the template lived outside this repo and were pulled in via `--template <npm package>`.
