### PR TITLE
feat(plugin-solid): add extensions option

### DIFF
--- a/e2e/cases/plugin-solid/extensions/index.test.ts
+++ b/e2e/cases/plugin-solid/extensions/index.test.ts
@@ -1,0 +1,72 @@
+import path from 'node:path';
+import { expect, gotoPage, test } from '@e2e/helper';
+import { pluginSolid } from '@rsbuild/plugin-solid';
+import { getFileContent } from '@rstackjs/test-utils';
+
+const extensions = ['.mjsx', '.cjsx', '.mtsx', '.ctsx', '.solid'];
+
+for (const compiler of ['native', 'babel'] as const) {
+  const config = {
+    plugins: [pluginSolid({ compiler, extensions })],
+  };
+
+  test(`should build additional Solid extensions with ${compiler}`, async ({
+    build,
+    page,
+  }) => {
+    const rsbuild = await build({
+      runServer: true,
+      config: {
+        ...config,
+        output: { sourceMap: { js: 'source-map' } },
+      },
+    });
+    await gotoPage(page, rsbuild);
+
+    for (const ext of extensions) {
+      await expect(page.locator(`#${ext.slice(1)}`)).toHaveText(ext.slice(1));
+    }
+    await expect(page.locator('#raw')).toContainText('<p id="solid">');
+
+    const sourceMap = JSON.parse(
+      getFileContent(
+        rsbuild.getDistFiles({ sourceMaps: true }),
+        'index.js.map',
+      ),
+    ) as { sources: string[] };
+    for (const ext of extensions) {
+      expect(
+        sourceMap.sources.some((source) =>
+          source.endsWith(`/${ext.slice(1)}${ext}`),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  test(`should preserve state when updating Solid extensions with ${compiler}`, async ({
+    dev,
+    page,
+    editFile,
+    copySrcDir,
+  }) => {
+    const src = await copySrcDir();
+    await dev({
+      config: {
+        ...config,
+        source: { entry: { index: path.join(src, 'index.jsx') } },
+      },
+    });
+    const count = page.locator('#count');
+    await count.click();
+    await expect(count).toHaveText('1');
+
+    for (const ext of extensions) {
+      const name = ext.slice(1);
+      await editFile(path.join(src, `${name}${ext}`), (code) =>
+        code.replace(`'${name}'`, `'${name} updated'`),
+      );
+      await expect(page.locator(`#${name}`)).toHaveText(`${name} updated`);
+      await expect(count).toHaveText('1');
+    }
+  });
+}

--- a/e2e/cases/plugin-solid/extensions/src/cjsx.cjsx
+++ b/e2e/cases/plugin-solid/extensions/src/cjsx.cjsx
@@ -1,0 +1,4 @@
+export default function Component() {
+  const text = 'cjsx';
+  return <p id="cjsx">{text}</p>;
+}

--- a/e2e/cases/plugin-solid/extensions/src/ctsx.ctsx
+++ b/e2e/cases/plugin-solid/extensions/src/ctsx.ctsx
@@ -1,0 +1,4 @@
+export default function Component() {
+  const text: string = 'ctsx';
+  return <p id="ctsx">{text}</p>;
+}

--- a/e2e/cases/plugin-solid/extensions/src/index.jsx
+++ b/e2e/cases/plugin-solid/extensions/src/index.jsx
@@ -1,0 +1,27 @@
+import { render } from '@solidjs/web';
+import { createSignal } from 'solid-js';
+import Cjsx from './cjsx';
+import Ctsx from './ctsx';
+import Mjsx from './mjsx';
+import Mtsx from './mtsx';
+import Custom from './solid';
+import raw from './raw.solid?raw';
+
+function App() {
+  const [count, setCount] = createSignal(0);
+  return (
+    <>
+      <button id="count" onClick={() => setCount(count() + 1)}>
+        {count()}
+      </button>
+      <Mjsx />
+      <Cjsx />
+      <Mtsx />
+      <Ctsx />
+      <Custom />
+      <pre id="raw">{raw}</pre>
+    </>
+  );
+}
+
+render(() => <App />, document.getElementById('root'));

--- a/e2e/cases/plugin-solid/extensions/src/mjsx.mjsx
+++ b/e2e/cases/plugin-solid/extensions/src/mjsx.mjsx
@@ -1,0 +1,4 @@
+export default function Component() {
+  const text = 'mjsx';
+  return <p id="mjsx">{text}</p>;
+}

--- a/e2e/cases/plugin-solid/extensions/src/mtsx.mtsx
+++ b/e2e/cases/plugin-solid/extensions/src/mtsx.mtsx
@@ -1,0 +1,4 @@
+export default function Component() {
+  const text: string = 'mtsx';
+  return <p id="mtsx">{text}</p>;
+}

--- a/e2e/cases/plugin-solid/extensions/src/raw.solid
+++ b/e2e/cases/plugin-solid/extensions/src/raw.solid
@@ -1,0 +1,1 @@
+export default <p id="solid">raw</p>;

--- a/e2e/cases/plugin-solid/extensions/src/solid.solid
+++ b/e2e/cases/plugin-solid/extensions/src/solid.solid
@@ -1,0 +1,4 @@
+export default function Component() {
+  const text = 'solid';
+  return <p id="solid">{text}</p>;
+}

--- a/packages/plugin-solid/src/helpers.ts
+++ b/packages/plugin-solid/src/helpers.ts
@@ -1,4 +1,7 @@
-export const DEFAULT_SOLID_SCRIPT_REGEX: RegExp = /\.(?:jsx|tsx)$/i;
+const DEFAULT_SOLID_SCRIPT_REGEX = /\.(?:jsx|tsx)$/i;
 
-export const isDefaultSolidScript = (filename: string): boolean =>
-  DEFAULT_SOLID_SCRIPT_REGEX.test(filename);
+// Native transforms infer the parser from a standard JSX/TSX extension.
+export const getTransformFilename = (filename: string): string =>
+  DEFAULT_SOLID_SCRIPT_REGEX.test(filename)
+    ? filename
+    : `${filename}${/\.[mc]?tsx$/i.test(filename) ? '.tsx' : '.jsx'}`;

--- a/packages/plugin-solid/src/index.ts
+++ b/packages/plugin-solid/src/index.ts
@@ -122,7 +122,8 @@ export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
           const jsRule = chain.module.rules.get(CHAIN_ID.RULE.JS);
           const jsMainRule = jsRule.oneOfs.get(CHAIN_ID.ONE_OF.JS_MAIN);
           if (extensions.length) {
-            jsRule.test({ or: [jsRule.get('test'), scriptRegex] });
+            const test = jsRule.get('test');
+            jsRule.test(test ? { or: [test, scriptRegex] } : scriptRegex);
             jsRule.include.add(scriptRegex);
             chain.resolve.extensions.merge(extensions);
           }

--- a/packages/plugin-solid/src/index.ts
+++ b/packages/plugin-solid/src/index.ts
@@ -1,6 +1,5 @@
 import path from 'node:path';
 import type { RsbuildMode, RsbuildPlugin } from '@rsbuild/core';
-import { DEFAULT_SOLID_SCRIPT_REGEX } from './helpers.js';
 import type { SolidCompiler, SolidPresetOptions } from './types.js';
 
 export type { SolidCompiler, SolidPresetOptions } from './types.js';
@@ -23,6 +22,12 @@ export type PluginSolidOptions = {
    * @default 'native'
    */
   compiler?: SolidCompiler;
+  /**
+   * Additional file extensions to compile as Solid JSX, including the leading dot.
+   * `.mtsx` and `.ctsx` are parsed as TypeScript.
+   * @default []
+   */
+  extensions?: string[];
   /**
    * Whether to enable Solid's development runtime and compiler transforms.
    * @default `true` in development mode, `false` in production mode
@@ -60,6 +65,11 @@ export const PLUGIN_SOLID_NAME = 'rsbuild:solid';
 
 export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
   const { compiler = 'native', dev, solid, ssr } = options;
+  const extensions = options.extensions ?? [];
+  const scriptPattern = ['.jsx', '.tsx', ...extensions]
+    .map((ext) => ext.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('|');
+  const scriptRegex = new RegExp(`(?:${scriptPattern})$`, 'i');
   const isDevModeEnabled = (mode: RsbuildMode) => dev ?? mode === 'development';
 
   return {
@@ -111,6 +121,11 @@ export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
 
           const jsRule = chain.module.rules.get(CHAIN_ID.RULE.JS);
           const jsMainRule = jsRule.oneOfs.get(CHAIN_ID.ONE_OF.JS_MAIN);
+          if (extensions.length) {
+            jsRule.test({ or: [jsRule.get('test'), scriptRegex] });
+            jsRule.include.add(scriptRegex);
+            chain.resolve.extensions.merge(extensions);
+          }
           const solidRules = [
             { rule: jsMainRule },
             {
@@ -134,6 +149,7 @@ export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
               .loader(path.join(import.meta.dirname, 'solidLoader.mjs'))
               .options({
                 compiler,
+                scriptRegex,
                 decoratorVersion: environmentConfig.source.decorators.version,
                 solid: solidOptions,
                 ...(transformFilename ? { transformFilename } : {}),
@@ -145,7 +161,7 @@ export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
               .rule('solid-refresh')
               .after(CHAIN_ID.RULE.JS)
               .enforce('pre')
-              .test(DEFAULT_SOLID_SCRIPT_REGEX)
+              .test(scriptRegex)
               .dependency({ not: 'url' })
               .resourceQuery({ not: /[?&]raw(?:&|=|$)/ })
               .with({ type: { not: 'text' } });

--- a/packages/plugin-solid/src/refreshLoader.ts
+++ b/packages/plugin-solid/src/refreshLoader.ts
@@ -1,6 +1,6 @@
 import { transformRefreshAsync } from '@dom-expressions/compiler';
 import type { Rspack } from '@rsbuild/core';
-import { isDefaultSolidScript } from './helpers.js';
+import { getTransformFilename } from './helpers.js';
 
 const NODE_MODULES_REGEX = /[\\/]node_modules[\\/]/;
 
@@ -13,17 +13,14 @@ const solidRefreshLoader: Rspack.LoaderDefinition<SolidRefreshLoaderOptions> =
     const callback = this.async();
     const { granular } = this.getOptions();
 
-    if (
-      NODE_MODULES_REGEX.test(this.resourcePath) ||
-      !isDefaultSolidScript(this.resourcePath)
-    ) {
+    if (NODE_MODULES_REGEX.test(this.resourcePath)) {
       callback(null, source, sourceMap);
       return;
     }
 
     try {
       const result = await transformRefreshAsync(String(source), {
-        filename: this.resourcePath,
+        filename: getTransformFilename(this.resourcePath),
         bundler: 'rspack-esm',
         fixRender: true,
         ...(typeof granular === 'boolean' ? { granular } : {}),

--- a/packages/plugin-solid/src/solidLoader.ts
+++ b/packages/plugin-solid/src/solidLoader.ts
@@ -9,7 +9,7 @@ import {
 } from '@dom-expressions/compiler';
 import remapping from '@jridgewell/remapping';
 import type { Decorators, Rspack } from '@rsbuild/core';
-import { isDefaultSolidScript } from './helpers.js';
+import { getTransformFilename } from './helpers.js';
 import type { SolidCompiler, SolidPresetOptions } from './types.js';
 
 const require = createRequire(import.meta.url);
@@ -18,6 +18,7 @@ const TSX_REGEX = /\.tsx$/i;
 
 export type SolidLoaderOptions = {
   compiler: SolidCompiler;
+  scriptRegex: RegExp;
   decoratorVersion: NonNullable<Decorators['version']>;
   solid: SolidPresetOptions;
   transformFilename?: string;
@@ -56,13 +57,14 @@ const solidLoader: Rspack.LoaderDefinition<SolidLoaderOptions> =
     const callback = this.async();
     const options = this.getOptions();
     const sourceFilename = this.resourcePath;
-    const filename = options.transformFilename ?? sourceFilename;
+    const resourceFilename = options.transformFilename ?? sourceFilename;
 
-    if (!isDefaultSolidScript(filename)) {
+    if (!options.scriptRegex.test(resourceFilename)) {
       callback(null, source, sourceMap);
       return;
     }
 
+    const filename = getTransformFilename(resourceFilename);
     const { compiler, decoratorVersion, solid } = options;
     const inputSourceMap = normalizeSourceMap(sourceMap);
 

--- a/packages/plugin-solid/tests/index.test.ts
+++ b/packages/plugin-solid/tests/index.test.ts
@@ -293,6 +293,7 @@ describe('plugin-solid', () => {
 
     expect(config.resolve?.extensions).toContain('.solid+jsx');
     expect(hasRefreshLoader('a.solid+jsx')).toBe(true);
+    // cspell:disable-next-line
     expect(hasRefreshLoader('a.solidddjsx')).toBe(false);
     expect(hasRefreshLoader('a.solid+jsx.js')).toBe(false);
     expect(hasRefreshLoader('a.jsx')).toBe(true);

--- a/packages/plugin-solid/tests/index.test.ts
+++ b/packages/plugin-solid/tests/index.test.ts
@@ -47,6 +47,7 @@ describe('plugin-solid', () => {
 
     expect(getSolidLoaderOptions(config[0])).toEqual({
       compiler: 'native',
+      scriptRegex: /(?:\.jsx|\.tsx)$/i,
       decoratorVersion: '2023-11',
       solid: {
         builtIns: [
@@ -273,6 +274,27 @@ describe('plugin-solid', () => {
 
     expect(hasRefreshLoader('a.js')).toBe(false);
     expect(hasRefreshLoader('a.ts')).toBe(false);
+    expect(hasRefreshLoader('a.jsx')).toBe(true);
+    expect(hasRefreshLoader('a.tsx')).toBe(true);
+  });
+
+  it('should match additional extensions literally', async () => {
+    const rsbuild = await createRsbuild({
+      config: {
+        ...rsbuildConfig,
+        plugins: [pluginSolid({ extensions: ['.solid+jsx'] })],
+      },
+    });
+    const [config] = await rsbuild.initConfigs();
+    const hasRefreshLoader = (filename: string) =>
+      JSON.stringify(matchRules(config, filename)).includes(
+        'refreshLoader.mjs',
+      );
+
+    expect(config.resolve?.extensions).toContain('.solid+jsx');
+    expect(hasRefreshLoader('a.solid+jsx')).toBe(true);
+    expect(hasRefreshLoader('a.solidddjsx')).toBe(false);
+    expect(hasRefreshLoader('a.solid+jsx.js')).toBe(false);
     expect(hasRefreshLoader('a.jsx')).toBe(true);
     expect(hasRefreshLoader('a.tsx')).toBe(true);
   });

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -16,6 +16,7 @@ caniuse
 chenjiahan
 chunkhash
 Chunktmp
+cjsx
 classname
 codegen
 codesandbox
@@ -27,6 +28,7 @@ corejs
 corepack
 craco
 crossorigin
+ctsx
 darkgrey
 datauri
 deepmerge
@@ -76,8 +78,10 @@ microfrontend
 microfrontends
 minifiers
 miniflare
+mjsx
 modularly
 mrmime
+mtsx
 mYbzBtlg6o
 napi
 nolyfill

--- a/website/docs/en/plugins/list/plugin-solid.mdx
+++ b/website/docs/en/plugins/list/plugin-solid.mdx
@@ -94,6 +94,23 @@ pluginSolid({
 });
 ```
 
+### extensions
+
+Additional file extensions to compile as Solid JSX. The default `.jsx` and `.tsx` extensions are always included. Extensions must include the leading dot and are also added to module resolution, so imports can omit them.
+
+`.mtsx` and `.ctsx` files are parsed as TypeScript with JSX; other additional extensions are parsed as JavaScript with JSX. This option applies to both JSX compilation and Solid Refresh.
+
+- **Type:** `string[]`
+- **Default:** `[]`
+- **Version:** `>= 2.0.0`
+- **Example:**
+
+```ts
+pluginSolid({
+  extensions: ['.mjsx', '.cjsx', '.mtsx', '.ctsx', '.solid'],
+});
+```
+
 ### dev
 
 Whether to enable Solid's development runtime and development-only compiler transforms. Set it to `false` to disable both behaviors in development mode, or set it to `true` to enable them in production mode.

--- a/website/docs/zh/plugins/list/plugin-solid.mdx
+++ b/website/docs/zh/plugins/list/plugin-solid.mdx
@@ -90,6 +90,23 @@ pluginSolid({
 });
 ```
 
+### extensions
+
+需要作为 Solid JSX 编译的额外文件扩展名。默认的 `.jsx` 和 `.tsx` 扩展名始终保留。扩展名必须以点开头，并会添加到模块解析配置中，因此导入时可以省略扩展名。
+
+`.mtsx` 和 `.ctsx` 文件按 TypeScript JSX 解析，其他额外扩展名按 JavaScript JSX 解析。此选项同时作用于 JSX 编译和 Solid Refresh。
+
+- **类型：** `string[]`
+- **默认值：** `[]`
+- **版本：** `>= 2.0.0`
+- **示例：**
+
+```ts
+pluginSolid({
+  extensions: ['.mjsx', '.cjsx', '.mtsx', '.ctsx', '.solid'],
+});
+```
+
 ### dev
 
 是否启用 Solid 的开发环境运行时和编译转换。设置为 `false` 可以在开发模式下同时禁用两者，设置为 `true` 可以在生产模式下同时启用两者。


### PR DESCRIPTION
## Summary

Solid compilation currently only handles `.jsx` and `.tsx` files. This PR adds an `extensions` option for additional suffixes, including `.mjsx`, `.cjsx`, `.mtsx`, `.ctsx`, and custom extensions, across both compiler backends and Solid Refresh.

The default extensions remain supported, and additional extensions are added to module resolution so imports can omit them.