### PR TITLE
fix(plugin-solid): preserve native hydration module imports

### DIFF
--- a/e2e/cases/plugin-solid/hydration-assets/index.test.ts
+++ b/e2e/cases/plugin-solid/hydration-assets/index.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from '@e2e/helper';
+
+test('should preserve native imports for Solid hydration assets without warnings', async ({
+  runBoth,
+}) => {
+  await runBoth(({ result }) => {
+    result.expectNoLog('Critical dependency');
+    const content = Object.values(result.getDistFiles()).join('\n');
+    expect(content).toContain('import(entryUrl)');
+  });
+});

--- a/e2e/cases/plugin-solid/hydration-assets/index.test.ts
+++ b/e2e/cases/plugin-solid/hydration-assets/index.test.ts
@@ -1,11 +1,36 @@
+import { copyFile, cp } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import path from 'node:path';
 import { expect, test } from '@e2e/helper';
 
-test('should preserve native imports for Solid hydration assets without warnings', async ({
-  runBoth,
-}) => {
-  await runBoth(({ result }) => {
-    result.expectNoLog('Critical dependency');
-    const content = Object.values(result.getDistFiles()).join('\n');
-    expect(content).toContain('import(entryUrl)');
+for (const aliased of [false, true]) {
+  test(`should preserve native imports for Solid hydration assets${aliased ? ' with an alias' : ''}`, async ({
+    runBoth,
+    copySrcDir,
+  }) => {
+    const alias: Record<string, string> = {};
+    if (aliased) {
+      const packageDir = path.dirname(
+        path.dirname(createRequire(import.meta.url).resolve('@solidjs/web')),
+      );
+      const localPackage = path.join(await copySrcDir(), 'solid-web');
+      await cp(path.join(packageDir, 'dist'), path.join(localPackage, 'dist'), {
+        recursive: true,
+      });
+      await copyFile(
+        path.join(packageDir, 'package.json'),
+        path.join(localPackage, 'package.json'),
+      );
+      alias['@solidjs/web'] = path.join(localPackage, 'dist/web.js');
+    }
+
+    await runBoth(
+      ({ result }) => {
+        result.expectNoLog('Critical dependency');
+        const content = Object.values(result.getDistFiles()).join('\n');
+        expect(content).toContain('import(entryUrl)');
+      },
+      { config: { resolve: { alias } } },
+    );
   });
-});
+}

--- a/e2e/cases/plugin-solid/hydration-assets/index.test.ts
+++ b/e2e/cases/plugin-solid/hydration-assets/index.test.ts
@@ -1,36 +1,11 @@
-import { copyFile, cp } from 'node:fs/promises';
-import { createRequire } from 'node:module';
-import path from 'node:path';
 import { expect, test } from '@e2e/helper';
 
-for (const aliased of [false, true]) {
-  test(`should preserve native imports for Solid hydration assets${aliased ? ' with an alias' : ''}`, async ({
-    runBoth,
-    copySrcDir,
-  }) => {
-    const alias: Record<string, string> = {};
-    if (aliased) {
-      const packageDir = path.dirname(
-        path.dirname(createRequire(import.meta.url).resolve('@solidjs/web')),
-      );
-      const localPackage = path.join(await copySrcDir(), 'solid-web');
-      await cp(path.join(packageDir, 'dist'), path.join(localPackage, 'dist'), {
-        recursive: true,
-      });
-      await copyFile(
-        path.join(packageDir, 'package.json'),
-        path.join(localPackage, 'package.json'),
-      );
-      alias['@solidjs/web'] = path.join(localPackage, 'dist/web.js');
-    }
-
-    await runBoth(
-      ({ result }) => {
-        result.expectNoLog('Critical dependency');
-        const content = Object.values(result.getDistFiles()).join('\n');
-        expect(content).toContain('import(entryUrl)');
-      },
-      { config: { resolve: { alias } } },
-    );
+test('should preserve native imports for Solid hydration assets without warnings', async ({
+  runBoth,
+}) => {
+  await runBoth(({ result }) => {
+    result.expectNoLog('Critical dependency');
+    const content = Object.values(result.getDistFiles()).join('\n');
+    expect(content).toContain('import(entryUrl)');
   });
-}
+});

--- a/e2e/cases/plugin-solid/hydration-assets/rsbuild.config.ts
+++ b/e2e/cases/plugin-solid/hydration-assets/rsbuild.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginSolid } from '@rsbuild/plugin-solid';
+
+export default defineConfig({
+  plugins: [pluginSolid()],
+  output: {
+    minify: false,
+  },
+});

--- a/e2e/cases/plugin-solid/hydration-assets/src/index.js
+++ b/e2e/cases/plugin-solid/hydration-assets/src/index.js
@@ -1,0 +1,4 @@
+import { hydrate } from '@solidjs/web';
+
+// Keep the hydration runtime in the bundle without invoking it.
+globalThis.hydrate = hydrate;

--- a/packages/plugin-solid/src/index.ts
+++ b/packages/plugin-solid/src/index.ts
@@ -119,6 +119,15 @@ export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
             ...solid,
           };
 
+          // Solid loads hydration modules from runtime URLs. Preserve native
+          // import() instead of generating an empty context dependency.
+          chain.module
+            .rule('solid-runtime')
+            .test(
+              /[\\/]node_modules[\\/]@solidjs[\\/]web[\\/]dist[\\/](?:web|dev)\.(?:js|cjs)$/,
+            )
+            .parser({ importDynamic: false });
+
           const jsRule = chain.module.rules.get(CHAIN_ID.RULE.JS);
           const jsMainRule = jsRule.oneOfs.get(CHAIN_ID.ONE_OF.JS_MAIN);
           if (extensions.length) {

--- a/packages/plugin-solid/src/index.ts
+++ b/packages/plugin-solid/src/index.ts
@@ -123,9 +123,7 @@ export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
           // import() instead of generating an empty context dependency.
           chain.module
             .rule('solid-runtime')
-            .test(
-              /[\\/]node_modules[\\/]@solidjs[\\/]web[\\/]dist[\\/](?:web|dev)\.(?:js|cjs)$/,
-            )
+            .set('descriptionData', { name: /^@solidjs\/web$/ })
             .parser({ importDynamic: false });
 
           const jsRule = chain.module.rules.get(CHAIN_ID.RULE.JS);


### PR DESCRIPTION
## Summary

Solid 2 loads hydration modules from runtime URLs, but Rspack turns these imports into an empty context dependency, emitting a critical dependency warning and causing module loading to fail when invoked. This PR preserves native dynamic imports in the `@solidjs/web` browser runtime so hydration modules can load correctly.