### PR TITLE
refactor(plugin-solid): simplify compiler defaults

### DIFF
--- a/packages/plugin-solid/src/index.ts
+++ b/packages/plugin-solid/src/index.ts
@@ -4,18 +4,6 @@ import type { SolidCompiler, SolidPresetOptions } from './types.js';
 
 export type { SolidCompiler, SolidPresetOptions } from './types.js';
 
-const SOLID_BUILT_INS = [
-  'For',
-  'Show',
-  'Switch',
-  'Match',
-  'Loading',
-  'Reveal',
-  'Portal',
-  'Repeat',
-  'Dynamic',
-  'Errored',
-];
 export type PluginSolidOptions = {
   /**
    * JSX compiler backend to use.
@@ -100,22 +88,10 @@ export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
             environmentConfig.dev.hmr &&
             target === 'web';
 
-          const defaultPresetOptions: SolidPresetOptions = {
-            moduleName: '@solidjs/web',
-            builtIns: SOLID_BUILT_INS,
-            contextToCustomElements: true,
-            wrapConditionals: true,
-            generate: 'dom',
-            hydratable: false,
+          const solidOptions: SolidPresetOptions = {
+            generate: ssr && target === 'node' ? 'ssr' : 'dom',
+            hydratable: Boolean(ssr),
             dev: useDevMode,
-            ...(ssr
-              ? target === 'node'
-                ? { generate: 'ssr', hydratable: true }
-                : { generate: 'dom', hydratable: true }
-              : {}),
-          };
-          const solidOptions = {
-            ...defaultPresetOptions,
             ...solid,
           };
 

--- a/packages/plugin-solid/tests/index.test.ts
+++ b/packages/plugin-solid/tests/index.test.ts
@@ -50,24 +50,9 @@ describe('plugin-solid', () => {
       scriptRegex: /(?:\.jsx|\.tsx)$/i,
       decoratorVersion: '2023-11',
       solid: {
-        builtIns: [
-          'For',
-          'Show',
-          'Switch',
-          'Match',
-          'Loading',
-          'Reveal',
-          'Portal',
-          'Repeat',
-          'Dynamic',
-          'Errored',
-        ],
-        contextToCustomElements: true,
         dev: false,
         generate: 'dom',
         hydratable: false,
-        moduleName: '@solidjs/web',
-        wrapConditionals: true,
       },
     });
   });


### PR DESCRIPTION
## Summary

The Solid compilers now provide the runtime module, built-in components, and other Solid defaults internally. This PR removes the duplicate defaults from the plugin and simplifies SSR option selection, preserving user overrides and the current compilation behavior.

## Related links

- #8445