### PR TITLE
test(plugin-solid): expand SSR and hydration coverage

### DIFF
--- a/e2e/cases/plugin-solid/ssr/index.test.ts
+++ b/e2e/cases/plugin-solid/ssr/index.test.ts
@@ -1,14 +1,51 @@
 import { expect, test } from '@e2e/helper';
+import { pluginSolid } from '@rsbuild/plugin-solid';
 
-test('should render and hydrate a Solid app', async ({ page, devOnly }) => {
-  const rsbuild = await devOnly();
+for (const compiler of ['native', 'babel'] as const) {
+  for (const mode of ['dev', 'preview'] as const) {
+    const options = {
+      config: {
+        plugins: [pluginSolid({ compiler, ssr: true })],
+        output: { distPath: { root: `dist-${compiler}` } },
+      },
+    };
 
-  const response = await page.goto(`http://localhost:${rsbuild.port}`);
-  expect(await response?.text()).toContain('<button');
+    test(`should server-render HTML with ${compiler} in ${mode}`, async ({
+      devOnly,
+      build,
+    }) => {
+      const result =
+        mode === 'dev'
+          ? await devOnly(options)
+          : await build({ ...options, runServer: true });
+      const response = await fetch(`http://localhost:${result.port}`);
+      const html = (await response.text()).replace(/<!--.*?-->/gs, '');
 
-  const button = page.locator('#button');
-  await expect(button).toHaveText('count: 0');
+      expect(response.status).toBe(200);
+      expect(html).toMatch(/<button[^>]*id="button"[^>]*>count: 0<\/button>/);
+    });
 
-  await button.click();
-  await expect(button).toHaveText('count: 1');
-});
+    test(`should hydrate existing DOM with ${compiler} in ${mode}`, async ({
+      page,
+      devOnly,
+      build,
+    }) => {
+      const result =
+        mode === 'dev'
+          ? await devOnly(options)
+          : await build({ ...options, runServer: true });
+      await page.goto(`http://localhost:${result.port}`);
+
+      const serverButton = await page.evaluateHandle('window.ssrButton');
+      const button = page.locator('#button');
+      await button.click();
+      await expect(button).toHaveText('count: 1');
+      expect(
+        await button.evaluate(
+          (node, original) => node === original,
+          serverButton,
+        ),
+      ).toBe(true);
+    });
+  }
+}

--- a/e2e/cases/plugin-solid/ssr/rsbuild.config.ts
+++ b/e2e/cases/plugin-solid/ssr/rsbuild.config.ts
@@ -1,48 +1,43 @@
-import {
-  defineConfig,
-  type RequestHandler,
-  type RsbuildDevServer,
-} from '@rsbuild/core';
-import { pluginSolid } from '@rsbuild/plugin-solid';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { defineConfig } from '@rsbuild/core';
 
-const serverRender =
-  ({ environments }: RsbuildDevServer): RequestHandler =>
-  async (_req, res) => {
-    const bundle = await environments.node.loadBundle<{
-      render: () => {
-        app: string;
-        hydrationScript: string;
-      };
-    }>('index');
-    const { app, hydrationScript } = bundle.render();
-    const template = await environments.web.getTransformedHtml('index');
-
-    res.writeHead(200, {
-      'Content-Type': 'text/html',
-    });
-    res.end(
-      template
-        .replace('<!--hydration-script-->', hydrationScript)
-        .replace('<!--app-content-->', app),
-    );
-  };
+type ServerBundle = {
+  render: () => { app: string; hydrationScript: string };
+};
 
 export default defineConfig({
-  plugins: [pluginSolid({ ssr: true })],
   server: {
-    setup: ({ action, server }) => {
-      if (action !== 'dev') {
-        return;
-      }
-
-      const render = serverRender(server);
-
-      server.middlewares.use((req, res, next) => {
-        if (req.method === 'GET' && req.url === '/') {
-          return render(req, res, next);
+    setup: ({ action, server, environments }) => {
+      server.middlewares.use(async (req, res, next) => {
+        if (req.method !== 'GET' || req.url !== '/') {
+          return next();
         }
 
-        next();
+        const bundle: ServerBundle =
+          action === 'dev'
+            ? await server.environments.node.loadBundle<ServerBundle>('index')
+            : await import(
+                pathToFileURL(
+                  path.join(environments.node.distPath, 'index.mjs'),
+                ).href
+              );
+        const template =
+          action === 'dev'
+            ? await server.environments.web.getTransformedHtml('index')
+            : await readFile(
+                path.join(environments.web.distPath, 'index.html'),
+                'utf8',
+              );
+        const { app, hydrationScript } = bundle.render();
+
+        res.setHeader('Content-Type', 'text/html');
+        res.end(
+          template
+            .replace('<!--hydration-script-->', hydrationScript)
+            .replace('<!--app-content-->', app),
+        );
       });
     },
   },
@@ -57,6 +52,7 @@ export default defineConfig({
     node: {
       output: {
         target: 'node',
+        filename: { js: '[name].mjs' },
       },
       source: {
         entry: {

--- a/e2e/cases/plugin-solid/ssr/template.html
+++ b/e2e/cases/plugin-solid/ssr/template.html
@@ -8,5 +8,9 @@
   </head>
   <body>
     <div id="root"><!--app-content--></div>
+    <script>
+      // Capture the server-rendered node before the client bundle hydrates it.
+      window.ssrButton = document.getElementById('button');
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

Solid SSR coverage previously exercised only the native compiler in development and did not verify that hydration reused the server-rendered DOM. This PR adds separate SSR and hydration tests for both native and Babel compilers in development and production preview, checking rendered HTML, DOM reuse, and interactive updates.

## Related links

https://github.com/web-infra-dev/rsbuild/pull/8445