### PR TITLE
chore(build): enable Rspack runtime mode

### DIFF
--- a/packages/core/rstack.config.ts
+++ b/packages/core/rstack.config.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import { nodeMinifyConfig } from '@scripts/config/lib';
 import { baseConfig } from '@scripts/config/test';
 import { define as rstack } from 'rstack';
-import type { Rsbuild, Rspack } from 'rstack/lib';
+import { type Rsbuild, type Rspack, rspack } from 'rstack/lib';
 import pkgJson from './package.json' with { type: 'json' };
 import prebundleConfig from './prebundle.config.ts';
 
@@ -80,7 +80,7 @@ const replacePlugin: Rsbuild.RsbuildPlugin = {
 
     api.processAssets(
       { stage: 'optimize-inline' },
-      ({ assets, compiler, compilation, sources }) => {
+      ({ assets, compilation, sources }) => {
         for (const name of Object.keys(assets)) {
           const asset = assets[name];
           if (!name.endsWith('.js')) {
@@ -94,7 +94,9 @@ const replacePlugin: Rsbuild.RsbuildPlugin = {
 
           const replacedSource = source.replaceAll(
             RSPACK_INTERCEPT_MODULE_EXECUTION,
-            compiler.rspack.RuntimeGlobals.interceptModuleExecution,
+            // Keep `__webpack_require__.i` in the output so the consuming
+            // compiler can translate it to the app's runtime mode.
+            rspack.RuntimeGlobals.interceptModuleExecution,
           );
           compilation.updateAsset(name, new sources.RawSource(replacedSource));
         }
@@ -113,6 +115,7 @@ rstack.lib({
   tools: {
     rspack: {
       experiments: {
+        runtimeMode: 'rspack',
         nativeWatcher: true,
       },
     },

--- a/packages/plugin-solid/rstack.config.ts
+++ b/packages/plugin-solid/rstack.config.ts
@@ -1,8 +1,9 @@
-import { esmConfig } from '@scripts/config/lib';
+import { esmConfig, runtimeModeConfig } from '@scripts/config/lib';
 import { baseConfig } from '@scripts/config/test';
 import { define } from 'rstack';
 
 define.lib({
+  ...runtimeModeConfig,
   lib: [
     esmConfig,
     {

--- a/packages/plugin-svgr/rstack.config.ts
+++ b/packages/plugin-svgr/rstack.config.ts
@@ -1,8 +1,9 @@
-import { esmConfig } from '@scripts/config/lib';
+import { esmConfig, runtimeModeConfig } from '@scripts/config/lib';
 import { baseConfig } from '@scripts/config/test';
 import { define } from 'rstack';
 
 define.lib({
+  ...runtimeModeConfig,
   lib: [
     esmConfig,
     {

--- a/scripts/config/lib.ts
+++ b/scripts/config/lib.ts
@@ -13,7 +13,18 @@ export const nodeMinifyConfig = {
   },
 } satisfies Rsbuild.Minify;
 
+export const runtimeModeConfig: LibConfig = {
+  tools: {
+    rspack: {
+      experiments: {
+        runtimeMode: 'rspack',
+      },
+    },
+  },
+};
+
 export const esmConfig: LibConfig = {
+  ...runtimeModeConfig,
   syntax: 'es2023',
   dts: {
     isolated: true,


### PR DESCRIPTION
## Summary

Enable `experiments.runtimeMode: 'rspack'` for the `@rsbuild/core` Rslib build. Preserve `__webpack_require__.i` in the distributed HMR client so the consuming compiler can translate it to the app's runtime mode.

The generated output changes in the following ways:

- `rslib-runtime.js` exports `rspackRequire`, `moduleFactories`, and individual helpers as named ESM bindings instead of attaching them to `__webpack_require__`; dependent chunks import the bindings they use.
- The HMR client's internal `init` function becomes `hmr_init`, while its public `init` export and module-execution hook remain unchanged.
- File names, public entry and loader exports, all 123 declaration files, loader output, and overlay output remain unchanged.

Measured JavaScript output under `packages/core/dist` against baseline a33149938, using Rslib 1.0.0 and Rspack 2.2.2. Both builds started with clean output and Rspack cache directories, with Node's compile cache disabled:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| JavaScript size | 1,026,017 B | 1,025,694 B | −323 B (−0.0315%) |
| Sum of individually gzipped JavaScript files | 265,522 B | 265,708 B | +186 B (+0.0701%) |

The size difference is negligible. These figures exclude `compiled`; gzip totals do not represent the npm tarball size. A second clean core build produced byte-identical output.

Build and static checks passed, along with 396 unit tests and 1,064 E2E tests. Additional consumer tests verified HMR, state preservation, and custom messages in both webpack and rspack runtime modes.

Also enable the shared runtime mode for all 10 plugin packages, including the Solid and SVGR loaders; their generated output is unchanged, while `create-rsbuild` keeps its default configuration.

## Related links

- [Rspack runtimeMode documentation](https://rspack.rs/zh/config/experiments#experimentsruntimemode)
