### PR TITLE
test: fail e2e tests on unexpected build warnings

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -42,9 +42,7 @@ test('normalize path', () => {
 
 Use `@e2e/helper` for Rsbuild-specific fixtures and helpers. Import generic test utilities directly from `@rstackjs/test-utils`.
 
-Tests fail by default if captured output contains `Build warning:` or `Build warnings:`, including warnings from rebuilds and CLI commands. Calling `clearLogs()` does not clear this check's history. This checks emitted logs, so warnings suppressed by logging or stats configuration are not rejected.
-
-For tests that intentionally verify build warnings, use `expectWarning()` to assert the expected message and allow build warnings for that test:
+Tests fail on build warning logs by default. Use `expectWarning()` to assert an expected message and allow build warnings for the current test:
 
 ```ts
 import { test } from '@e2e/helper';
@@ -54,7 +52,5 @@ test('should report the expected warning', async ({ build }) => {
   await rsbuild.expectWarning('Expected warning message');
 });
 ```
-
-`expectWarning()` accepts the same arguments as `expectLog()` and is also available on `logHelper`. It allows all build warnings for the current test, rather than filtering individual warnings. Use `logHelper.allowBuildWarnings()` only when no specific warning message can be asserted.
 
 You can use the local skill at [`write-e2e-cases`](../.agents/skills/write-e2e-cases/SKILL.md) to add new test cases.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -42,4 +42,18 @@ test('normalize path', () => {
 
 Use `@e2e/helper` for Rsbuild-specific fixtures and helpers. Import generic test utilities directly from `@rstackjs/test-utils`.
 
+Tests fail by default if captured output contains `Build warning:` or `Build warnings:`, including warnings from rebuilds and CLI commands. Calling `clearLogs()` does not clear this check's history. This checks emitted logs, so warnings suppressed by logging or stats configuration are not rejected.
+
+For tests that intentionally verify build warnings, explicitly opt in and assert the expected warning:
+
+```ts
+import { test } from '@e2e/helper';
+
+test('should report the expected warning', async ({ build, logHelper }) => {
+  logHelper.allowBuildWarnings();
+  const rsbuild = await build();
+  await rsbuild.expectLog('Expected warning message');
+});
+```
+
 You can use the local skill at [`write-e2e-cases`](../.agents/skills/write-e2e-cases/SKILL.md) to add new test cases.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -44,16 +44,17 @@ Use `@e2e/helper` for Rsbuild-specific fixtures and helpers. Import generic test
 
 Tests fail by default if captured output contains `Build warning:` or `Build warnings:`, including warnings from rebuilds and CLI commands. Calling `clearLogs()` does not clear this check's history. This checks emitted logs, so warnings suppressed by logging or stats configuration are not rejected.
 
-For tests that intentionally verify build warnings, explicitly opt in and assert the expected warning:
+For tests that intentionally verify build warnings, use `expectWarning()` to assert the expected message and allow build warnings for that test:
 
 ```ts
 import { test } from '@e2e/helper';
 
-test('should report the expected warning', async ({ build, logHelper }) => {
-  logHelper.allowBuildWarnings();
+test('should report the expected warning', async ({ build }) => {
   const rsbuild = await build();
-  await rsbuild.expectLog('Expected warning message');
+  await rsbuild.expectWarning('Expected warning message');
 });
 ```
+
+`expectWarning()` accepts the same arguments as `expectLog()` and is also available on `logHelper`. It allows all build warnings for the current test, rather than filtering individual warnings. Use `logHelper.allowBuildWarnings()` only when no specific warning message can be asserted.
 
 You can use the local skill at [`write-e2e-cases`](../.agents/skills/write-e2e-cases/SKILL.md) to add new test cases.

--- a/e2e/cases/config/stats-options/index.test.ts
+++ b/e2e/cases/config/stats-options/index.test.ts
@@ -2,11 +2,10 @@ import { test } from '@e2e/helper';
 
 const WARNING_MSG = 'Using / for division outside of calc() is deprecated';
 
-test('should log warning by default', async ({ build, logHelper }) => {
-  logHelper.allowBuildWarnings();
+test('should log warning by default', async ({ build }) => {
   const rsbuild = await build();
 
-  await rsbuild.expectLog(WARNING_MSG);
+  await rsbuild.expectWarning(WARNING_MSG);
 });
 
 test('should not log warning when set stats.warnings false', async ({

--- a/e2e/cases/config/stats-options/index.test.ts
+++ b/e2e/cases/config/stats-options/index.test.ts
@@ -2,7 +2,8 @@ import { test } from '@e2e/helper';
 
 const WARNING_MSG = 'Using / for division outside of calc() is deprecated';
 
-test('should log warning by default', async ({ build }) => {
+test('should log warning by default', async ({ build, logHelper }) => {
+  logHelper.allowBuildWarnings();
   const rsbuild = await build();
 
   await rsbuild.expectLog(WARNING_MSG);

--- a/e2e/cases/diagnostic/type-warnings/index.test.ts
+++ b/e2e/cases/diagnostic/type-warnings/index.test.ts
@@ -6,12 +6,11 @@ test('should print async build warnings in browser console', async ({
   dev,
   logHelper,
 }) => {
-  logHelper.allowBuildWarnings();
-  const { addLog, expectLog } = logHelper;
+  const { addLog, expectWarning } = logHelper;
   page.on('console', (consoleMessage) => {
     addLog(consoleMessage.text());
   });
 
   await dev();
-  await expectLog('TS2322:');
+  await expectWarning('TS2322:');
 });

--- a/e2e/cases/diagnostic/type-warnings/index.test.ts
+++ b/e2e/cases/diagnostic/type-warnings/index.test.ts
@@ -6,6 +6,7 @@ test('should print async build warnings in browser console', async ({
   dev,
   logHelper,
 }) => {
+  logHelper.allowBuildWarnings();
   const { addLog, expectLog } = logHelper;
   page.on('console', (consoleMessage) => {
     addLog(consoleMessage.text());

--- a/e2e/cases/manifest/integrity/index.test.ts
+++ b/e2e/cases/manifest/integrity/index.test.ts
@@ -16,15 +16,11 @@ const checkManifestIntegrity = (rsbuild: {
   });
 };
 
-test('should generate manifest file with integrity', async ({
-  runBoth,
-  logHelper,
-}) => {
-  logHelper.allowBuildWarnings();
+test('should generate manifest file with integrity', async ({ runBoth }) => {
   await runBoth(async ({ result, mode }) => {
     checkManifestIntegrity(result);
     if (mode === 'dev') {
-      await result.expectLog(
+      await result.expectWarning(
         'SubResourceIntegrityPlugin may interfere with hot reloading',
       );
     }
@@ -33,14 +29,12 @@ test('should generate manifest file with integrity', async ({
 
 test('should generate manifest file with integrity when html plugin is disabled', async ({
   runBoth,
-  logHelper,
 }) => {
-  logHelper.allowBuildWarnings();
   await runBoth(
     async ({ result, mode }) => {
       checkManifestIntegrity(result);
       if (mode === 'dev') {
-        await result.expectLog(
+        await result.expectWarning(
           'SubResourceIntegrityPlugin may interfere with hot reloading',
         );
       }

--- a/e2e/cases/manifest/integrity/index.test.ts
+++ b/e2e/cases/manifest/integrity/index.test.ts
@@ -16,18 +16,34 @@ const checkManifestIntegrity = (rsbuild: {
   });
 };
 
-test('should generate manifest file with integrity', async ({ runBoth }) => {
-  await runBoth(({ result }) => {
+test('should generate manifest file with integrity', async ({
+  runBoth,
+  logHelper,
+}) => {
+  logHelper.allowBuildWarnings();
+  await runBoth(async ({ result, mode }) => {
     checkManifestIntegrity(result);
+    if (mode === 'dev') {
+      await result.expectLog(
+        'SubResourceIntegrityPlugin may interfere with hot reloading',
+      );
+    }
   });
 });
 
 test('should generate manifest file with integrity when html plugin is disabled', async ({
   runBoth,
+  logHelper,
 }) => {
+  logHelper.allowBuildWarnings();
   await runBoth(
-    ({ result }) => {
+    async ({ result, mode }) => {
       checkManifestIntegrity(result);
+      if (mode === 'dev') {
+        await result.expectLog(
+          'SubResourceIntegrityPlugin may interfere with hot reloading',
+        );
+      }
     },
     {
       config: {

--- a/e2e/cases/plugin-api/plugin-on-exit-hook/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-on-exit-hook/index.test.ts
@@ -6,7 +6,7 @@ import fse from 'fs-extra';
 
 const distFile = path.join(import.meta.dirname, 'node_modules/hooksTempFile');
 
-test('should run onExit hook before process exit', async () => {
+test('should run onExit hook before process exit', async ({ logHelper }) => {
   await fse.remove(distFile);
 
   await new Promise<void>((resolve, reject) => {
@@ -18,8 +18,10 @@ test('should run onExit hook before process exit', async () => {
     const childProcess = exec(
       'node ./run.js',
       { cwd: import.meta.dirname },
-      (error) => {
+      (error, stdout, stderr) => {
         clearTimeout(timeoutId);
+        logHelper.addLog(stdout);
+        logHelper.addLog(stderr);
         if (error) {
           reject(error);
           return;

--- a/e2e/cases/plugin-api/plugin-on-exit-hook/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-on-exit-hook/index.test.ts
@@ -6,7 +6,7 @@ import fse from 'fs-extra';
 
 const distFile = path.join(import.meta.dirname, 'node_modules/hooksTempFile');
 
-test('should run onExit hook before process exit', async ({ logHelper }) => {
+test('should run onExit hook before process exit', async () => {
   await fse.remove(distFile);
 
   await new Promise<void>((resolve, reject) => {
@@ -18,10 +18,8 @@ test('should run onExit hook before process exit', async ({ logHelper }) => {
     const childProcess = exec(
       'node ./run.js',
       { cwd: import.meta.dirname },
-      (error, stdout, stderr) => {
+      (error) => {
         clearTimeout(timeoutId);
-        logHelper.addLog(stdout);
-        logHelper.addLog(stderr);
         if (error) {
           reject(error);
           return;

--- a/e2e/cases/security/sri-enable-dev/index.test.ts
+++ b/e2e/cases/security/sri-enable-dev/index.test.ts
@@ -3,7 +3,9 @@ import { expect, test } from '@e2e/helper';
 test('generate integrity for script and style tags in dev build', async ({
   page,
   dev,
+  logHelper,
 }) => {
+  logHelper.allowBuildWarnings();
   const rsbuild = await dev();
 
   const testEl = page.locator('#root');

--- a/e2e/cases/security/sri-enable-dev/index.test.ts
+++ b/e2e/cases/security/sri-enable-dev/index.test.ts
@@ -3,9 +3,7 @@ import { expect, test } from '@e2e/helper';
 test('generate integrity for script and style tags in dev build', async ({
   page,
   dev,
-  logHelper,
 }) => {
-  logHelper.allowBuildWarnings();
   const rsbuild = await dev();
 
   const testEl = page.locator('#root');
@@ -17,7 +15,7 @@ test('generate integrity for script and style tags in dev build', async ({
     ),
   ).toMatch(/sha384-[A-Za-z0-9+/=]+/);
 
-  await rsbuild.expectLog(
+  await rsbuild.expectWarning(
     'SubResourceIntegrityPlugin may interfere with hot reloading',
   );
 });

--- a/e2e/cases/security/sri-native-html-plugin/index.test.ts
+++ b/e2e/cases/security/sri-native-html-plugin/index.test.ts
@@ -23,11 +23,9 @@ test('should generate integrity attributes in build with native html plugin', as
 test('should generate integrity attributes in dev with native html plugin', async ({
   page,
   dev,
-  logHelper,
 }) => {
-  logHelper.allowBuildWarnings();
   const rsbuild = await dev();
-  await rsbuild.expectLog(
+  await rsbuild.expectWarning(
     'SubResourceIntegrityPlugin may interfere with hot reloading',
   );
 

--- a/e2e/cases/security/sri-native-html-plugin/index.test.ts
+++ b/e2e/cases/security/sri-native-html-plugin/index.test.ts
@@ -23,8 +23,13 @@ test('should generate integrity attributes in build with native html plugin', as
 test('should generate integrity attributes in dev with native html plugin', async ({
   page,
   dev,
+  logHelper,
 }) => {
-  await dev();
+  logHelper.allowBuildWarnings();
+  const rsbuild = await dev();
+  await rsbuild.expectLog(
+    'SubResourceIntegrityPlugin may interfere with hot reloading',
+  );
 
   const testEl = page.locator('#root');
   await expect(testEl).toHaveText('Hello Rsbuild!');

--- a/e2e/cases/source/define/index.test.ts
+++ b/e2e/cases/source/define/index.test.ts
@@ -15,7 +15,7 @@ test('should warn when define `process.env`', async ({ buildPreview }) => {
     config: {
       source: {
         define: {
-          'process.env': process.env,
+          'process.env': { PATH: process.env.PATH },
         },
       },
     },
@@ -31,7 +31,7 @@ test('should warn when define stringified `process.env`', async ({
     config: {
       source: {
         define: {
-          'process.env': JSON.stringify(process.env),
+          'process.env': JSON.stringify({ PATH: process.env.PATH }),
         },
       },
     },

--- a/e2e/cases/workers/worker-query-self-reference/index.test.ts
+++ b/e2e/cases/workers/worker-query-self-reference/index.test.ts
@@ -3,8 +3,11 @@ import { expect, test } from '@e2e/helper';
 test('should support self reference worker query imports', async ({
   page,
   runBothServe,
+  logHelper,
 }) => {
-  await runBothServe(async () => {
+  logHelper.allowBuildWarnings();
+  await runBothServe(async ({ result }) => {
+    await result.expectLog('Circular dependency between chunks with runtime');
     await expect(page.locator('#worker')).toContainText('pong: main');
     await expect(page.locator('#worker')).toContainText('pong: nested');
   });

--- a/e2e/cases/workers/worker-query-self-reference/index.test.ts
+++ b/e2e/cases/workers/worker-query-self-reference/index.test.ts
@@ -3,11 +3,11 @@ import { expect, test } from '@e2e/helper';
 test('should support self reference worker query imports', async ({
   page,
   runBothServe,
-  logHelper,
 }) => {
-  logHelper.allowBuildWarnings();
   await runBothServe(async ({ result }) => {
-    await result.expectLog('Circular dependency between chunks with runtime');
+    await result.expectWarning(
+      'Circular dependency between chunks with runtime',
+    );
     await expect(page.locator('#worker')).toContainText('pong: main');
     await expect(page.locator('#worker')).toContainText('pong: nested');
   });

--- a/e2e/helper/fixture.ts
+++ b/e2e/helper/fixture.ts
@@ -1,7 +1,7 @@
 import {
   type ChildProcess,
   type ExecSyncOptions,
-  execSync,
+  spawnSync,
   type SpawnOptions,
   spawn as nodeSpawn,
 } from 'node:child_process';
@@ -218,16 +218,20 @@ const rsbuildTest = rsbuildBase.extend<RsbuildFixture>({
   logHelper: [
     async ({ task }, use) => {
       const logHelper = proxyConsole();
-      await use(logHelper);
-      logHelper.restore();
+      try {
+        await use(logHelper);
+      } finally {
+        logHelper.restore();
+      }
 
       // If the test failed, log the console output for debugging
-      if (task.result?.status === 'fail' && logHelper.logs.length) {
+      if (task.result?.status === 'fail' && logHelper.originalLogs.length) {
         const { header, footer } = makeBox(task.name);
         console.log(header);
         logHelper.printCapturedLogs();
         console.log(footer);
       }
+      logHelper.expectNoBuildWarnings();
     },
     { auto: true },
   ],
@@ -375,12 +379,28 @@ const rsbuildTest = rsbuildBase.extend<RsbuildFixture>({
     await use(execCli);
   },
 
-  execCliSync: async ({ cwd }, use) => {
+  execCliSync: async ({ cwd, logHelper }, use) => {
     const execCliSync: ExecSync = (command, options = {}) => {
-      return execSync(
-        `node ${RSBUILD_BIN_PATH} ${command}`,
-        setupExecOptions(options, cwd),
-      ).toString();
+      const cmd = `"${process.execPath}" "${RSBUILD_BIN_PATH}" ${command}`;
+      const result = spawnSync(
+        cmd,
+        setupExecOptions({ shell: true, ...options }, cwd),
+      );
+      for (const output of [result.stdout, result.stderr]) {
+        if (output) {
+          logHelper.addLog(output.toString());
+        }
+      }
+      if (result.error || result.status !== 0) {
+        throw Object.assign(
+          result.error ||
+            new Error(
+              `Command failed: ${cmd}\n${result.stderr?.toString() || ''}`,
+            ),
+          result,
+        );
+      }
+      return result.stdout?.toString() || '';
     };
     await use(execCliSync);
   },

--- a/e2e/helper/logs.ts
+++ b/e2e/helper/logs.ts
@@ -1,3 +1,4 @@
+import { stripVTControlCharacters } from 'node:util';
 import {
   type ExtendedLogHelper as BaseExtendedLogHelper,
   type LogHelper as BaseLogHelper,
@@ -6,21 +7,37 @@ import {
 } from '@rstackjs/test-utils';
 import { BUILD_END_LOG } from './constants.ts';
 
-type ExpectBuildEnd = {
+type BuildLogHelper = {
   expectBuildEnd: () => Promise<boolean>;
+  /** Allow build warnings for this test. Expected warnings should still be asserted. */
+  allowBuildWarnings: () => void;
+  expectNoBuildWarnings: () => void;
 };
 
-export type LogHelper = BaseLogHelper & ExpectBuildEnd;
+export type LogHelper = BaseLogHelper & BuildLogHelper;
 
-export type ExtendedLogHelper = BaseExtendedLogHelper & ExpectBuildEnd;
+export type ExtendedLogHelper = BaseExtendedLogHelper & BuildLogHelper;
 
 export const proxyConsole = (
   options?: ProxyConsoleOptions,
 ): ExtendedLogHelper => {
   const logHelper = baseProxyConsole(options);
+  let buildWarningsAllowed = false;
 
   return {
     ...logHelper,
     expectBuildEnd: async () => logHelper.expectLog(BUILD_END_LOG),
+    allowBuildWarnings: () => {
+      buildWarningsAllowed = true;
+    },
+    expectNoBuildWarnings: () => {
+      // Keep warnings across clearLogs() and join split CLI output before matching.
+      const output = stripVTControlCharacters(logHelper.originalLogs.join(''));
+      if (!buildWarningsAllowed && /\bBuild warnings?:/.test(output)) {
+        throw new Error(
+          `Unexpected build warning. Call logHelper.allowBuildWarnings() only in tests that intentionally verify warnings.\n\n${output}`,
+        );
+      }
+    },
   };
 };

--- a/e2e/helper/logs.ts
+++ b/e2e/helper/logs.ts
@@ -9,7 +9,9 @@ import { BUILD_END_LOG } from './constants.ts';
 
 type BuildLogHelper = {
   expectBuildEnd: () => Promise<boolean>;
-  /** Allow build warnings for this test. Expected warnings should still be asserted. */
+  /** Assert an expected warning and allow build warnings for this test. */
+  expectWarning: BaseLogHelper['expectLog'];
+  /** Allow build warnings without asserting a specific message. Prefer expectWarning(). */
   allowBuildWarnings: () => void;
   expectNoBuildWarnings: () => void;
 };
@@ -27,6 +29,10 @@ export const proxyConsole = (
   return {
     ...logHelper,
     expectBuildEnd: async () => logHelper.expectLog(BUILD_END_LOG),
+    expectWarning: (...args) => {
+      buildWarningsAllowed = true;
+      return logHelper.expectLog(...args);
+    },
     allowBuildWarnings: () => {
       buildWarningsAllowed = true;
     },
@@ -35,7 +41,7 @@ export const proxyConsole = (
       const output = stripVTControlCharacters(logHelper.originalLogs.join(''));
       if (!buildWarningsAllowed && /\bBuild warnings?:/.test(output)) {
         throw new Error(
-          `Unexpected build warning. Call logHelper.allowBuildWarnings() only in tests that intentionally verify warnings.\n\n${output}`,
+          `Unexpected build warning. Use expectWarning() to assert intentional warnings.\n\n${output}`,
         );
       }
     },


### PR DESCRIPTION
## Summary

Build warnings can currently go unnoticed in passing e2e tests. This PR makes tests fail when captured output contains build warnings, including rebuild and CLI output, and preserves warning history across `clearLogs()` calls. 

Tests use `expectWarning()` to assert an expected message and allow build warnings for the current test, with `logHelper.allowBuildWarnings()` retained for exceptional cases. Warnings suppressed by logging or stats configuration remain outside this check.