### PR TITLE
release: @rsbuild/plugin-solid v2.0.0-rc.0

### DIFF
--- a/packages/create-rsbuild/template-solid2-js/package.json
+++ b/packages/create-rsbuild/template-solid2-js/package.json
@@ -14,6 +14,6 @@
   },
   "devDependencies": {
     "@rsbuild/core": "^2.2.3",
-    "@rsbuild/plugin-solid": "^2.0.0-beta.2"
+    "@rsbuild/plugin-solid": "^2.0.0-rc.0"
   }
 }

--- a/packages/create-rsbuild/template-solid2-ts/package.json
+++ b/packages/create-rsbuild/template-solid2-ts/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "^2.2.3",
-    "@rsbuild/plugin-solid": "^2.0.0-beta.2",
+    "@rsbuild/plugin-solid": "^2.0.0-rc.0",
     "@types/node": "^24.13.3",
     "typescript": "^6.0.3"
   }

--- a/packages/plugin-solid/CHANGELOG.md
+++ b/packages/plugin-solid/CHANGELOG.md
@@ -1,5 +1,43 @@
 # @rsbuild/plugin-solid
 
+## 2.0.0-rc.0 (2026-09-08)
+
+### Breaking changes
+
+- feat(plugin-solid)!: publish as pure ESM package by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/8371
+- feat(plugin-solid)!: drop Rsbuild v1 support by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/8372
+
+### New features
+
+- feat(plugin-solid): add extensions option by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/8443
+
+### Performance
+
+- perf(plugin-solid): skip transforms for plain JS and TS by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/8391
+
+### Bug fixes
+
+- fix(plugin-solid): respect legacy decorator config by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/8374
+- fix(plugin-solid): support JSX in JavaScript data URIs by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/8386
+- fix(plugin-solid): preserve native hydration module imports by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/8444
+
+### Refactor
+
+- refactor(plugin-solid): migrate to Solid compiler packages by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/8445
+- refactor(plugin-solid): simplify compiler defaults by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/8446
+
+### Document
+
+- docs: clarify Solid plugin setup and capabilities by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/8450
+
+### Other changes
+
+- test(plugin-solid): cover dev hydration walk output by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/8375
+- chore(deps): update all patch dependencies by @renovate in https://github.com/web-infra-dev/rsbuild/pull/8396
+- chore: update Rstack config by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/8411
+- test(plugin-solid): expand SSR and hydration coverage by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/8447
+- chore(build): enable Rspack runtime mode by @Timeless0911 in https://github.com/web-infra-dev/rsbuild/pull/8448
+
 ## 2.0.0-beta.2 (2026-08-25)
 
 ### Breaking changes

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-solid",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-rc.0",
   "description": "Solid plugin for Rsbuild",
   "homepage": "https://rsbuild.rs",
   "bugs": {

--- a/website/docs/en/plugins/list/plugin-solid.mdx
+++ b/website/docs/en/plugins/list/plugin-solid.mdx
@@ -51,11 +51,11 @@ Babel compilation will introduce extra overhead, in the example above, we use `i
 
 ## Solid v2
 
-Solid v2 support is currently in beta and requires `solid-js` and `@solidjs/web` version `2.0.0-rc.6` or later. The default setup does not require `@rsbuild/plugin-babel`.
+Solid v2 support is currently in the release candidate (RC) stage and requires `solid-js` and `@solidjs/web` version `2.0.0-rc.6` or later. The default setup does not require `@rsbuild/plugin-babel`.
 
-Install and register the beta version of `@rsbuild/plugin-solid`:
+Install and register the RC version of `@rsbuild/plugin-solid`:
 
-<PackageManagerTabs command="add @rsbuild/plugin-solid@beta -D" />
+<PackageManagerTabs command="add @rsbuild/plugin-solid@rc -D" />
 
 ```ts title="rsbuild.config.ts"
 import { pluginSolid } from '@rsbuild/plugin-solid';

--- a/website/docs/zh/plugins/list/plugin-solid.mdx
+++ b/website/docs/zh/plugins/list/plugin-solid.mdx
@@ -51,11 +51,11 @@ Babel 编译会产生额外的编译开销，在上述例子中，我们通过 `
 
 ## Solid v2
 
-Solid v2 支持目前处于 beta 阶段，要求 `solid-js` 和 `@solidjs/web` 为 `2.0.0-rc.6` 或更高版本。默认无需安装 `@rsbuild/plugin-babel`。
+Solid v2 支持目前处于候选发布（RC）阶段，要求 `solid-js` 和 `@solidjs/web` 为 `2.0.0-rc.6` 或更高版本。默认无需安装 `@rsbuild/plugin-babel`。
 
-安装并注册 `@rsbuild/plugin-solid` 的 beta 版本：
+安装并注册 `@rsbuild/plugin-solid` 的 RC 版本：
 
-<PackageManagerTabs command="add @rsbuild/plugin-solid@beta -D" />
+<PackageManagerTabs command="add @rsbuild/plugin-solid@rc -D" />
 
 ```ts title="rsbuild.config.ts"
 import { pluginSolid } from '@rsbuild/plugin-solid';


### PR DESCRIPTION
## Summary

Release `@rsbuild/plugin-solid` v2.0.0-rc.0.

## Changes

- https://github.com/web-infra-dev/rsbuild/pull/8371
- https://github.com/web-infra-dev/rsbuild/pull/8372
- https://github.com/web-infra-dev/rsbuild/pull/8443
- https://github.com/web-infra-dev/rsbuild/pull/8391
- https://github.com/web-infra-dev/rsbuild/pull/8374
- https://github.com/web-infra-dev/rsbuild/pull/8386
- https://github.com/web-infra-dev/rsbuild/pull/8444
- https://github.com/web-infra-dev/rsbuild/pull/8445
- https://github.com/web-infra-dev/rsbuild/pull/8446
- https://github.com/web-infra-dev/rsbuild/pull/8450
- https://github.com/web-infra-dev/rsbuild/pull/8375
- https://github.com/web-infra-dev/rsbuild/pull/8396
- https://github.com/web-infra-dev/rsbuild/pull/8411
- https://github.com/web-infra-dev/rsbuild/pull/8447
- https://github.com/web-infra-dev/rsbuild/pull/8448