### PR TITLE
docs: simplify repository agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,4 @@
 - Keep shared dependency versions in `pnpm-workspace.yaml` catalogs.
 - Run `pnpm build` once before unit or e2e tests, including focused runs; tests depend on built workspace packages.
 - Prefer e2e coverage for build/dev behavior; use unit tests for single-function behavior.
+- Update all affected unit test snapshots, not just a subset.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,59 +1,6 @@
 # AGENTS.md
 
-## Stack
-
-- Use repo Node.js/pnpm versions (`package.json`, `.node-version`)
-- `pnpm` workspace; shared deps in `pnpm-workspace.yaml` catalogs
-- TypeScript strict, Rspack/Rsbuild
-- Unit tests: Rstest; e2e: Rstest with Playwright browser automation
-
-## Commands
-
-```bash
-# setup
-corepack enable && pnpm install
-
-# dev checks
-pnpm check
-pnpm test
-
-# build / format / docs
-pnpm build
-pnpm format
-pnpm doc
-
-# focused work
-pnpm --filter @rsbuild/core run build
-pnpm test packages/core/tests/foo.test.ts
-pnpm e2e css
-
-# full e2e when needed
-pnpm e2e
-```
-
-## Testing
-
-- Prefer adding e2e tests over unit tests, unless testing single-function behavior.
-- Update all affected unit test snapshots, not just a subset.
-- Run `pnpm build` once before `pnpm test` or any `pnpm e2e` command, including focused cases.
-
-## Project structure
-
-```text
-packages/core/              # core + CLI
-packages/plugin-*/          # plugins
-packages/create-rsbuild/    # scaffold
-e2e/                        # e2e tests
-examples/                   # runnable examples
-website/                    # docs
-scripts/                    # repo tooling
-```
-
-## Skills
-
-Use matching `.agents/skills/*/SKILL.md` for release, Rspack upgrade, e2e, docs sync, PR, and perf tasks
-
-## Code style
-
-- `rs fmt`; single quotes
-- camelCase functions/files; PascalCase types/classes
+- Use Node.js from `.node-version` and pnpm from `package.json`.
+- Keep shared dependency versions in `pnpm-workspace.yaml` catalogs.
+- Run `pnpm build` once before unit or e2e tests, including focused runs; tests depend on built workspace packages.
+- Prefer e2e coverage for build/dev behavior; use unit tests for single-function behavior.


### PR DESCRIPTION
## Summary

Reduce always-loaded agent context by removing redundant command lists, repository structure, and guidance already expressed by configuration or skills. Keep the repository-specific runtime versions, dependency catalogs, build prerequisite, and test selection preference.

## Related links

- https://x.com/pvncher/status/2095991462416490862