### PR TITLE
feat(core): support Rsdoctor v2 auto-loading

### DIFF
--- a/e2e/cases/profiling/enable-rsdoctor/_node_modules/@rsdoctor/core/index.js
+++ b/e2e/cases/profiling/enable-rsdoctor/_node_modules/@rsdoctor/core/index.js
@@ -1,0 +1,4 @@
+export class RsdoctorRspackPlugin {
+  isRsdoctorPlugin = true;
+  apply() {}
+}

--- a/e2e/cases/profiling/enable-rsdoctor/_node_modules/@rsdoctor/core/package.json
+++ b/e2e/cases/profiling/enable-rsdoctor/_node_modules/@rsdoctor/core/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@rsdoctor/core",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": "./index.js"
+}

--- a/e2e/cases/profiling/enable-rsdoctor/index.test.ts
+++ b/e2e/cases/profiling/enable-rsdoctor/index.test.ts
@@ -4,20 +4,14 @@ import { join } from 'node:path';
 import { expect, test } from '@e2e/helper';
 import { createRsbuild, type Rspack } from '@rsbuild/core';
 import { onTestFinished } from '@rstest/core';
-
-type RsdoctorExports = {
-  RsdoctorRspackPlugin: new (
-    options?: Record<string, unknown>,
-  ) => Rspack.RspackPluginInstance;
-};
+import { RsdoctorRspackPlugin } from './_node_modules/@rsdoctor/rspack-plugin/index.js';
 
 const getRsdoctorPlugins = (config: Pick<Rspack.Configuration, 'plugins'>) =>
   config.plugins?.filter(
     (plugin) => plugin?.constructor?.name === 'RsdoctorRspackPlugin',
   );
 
-test.beforeEach(async ({ copyNodeModules }) => {
-  await copyNodeModules();
+test.beforeEach(() => {
   process.env.RSDOCTOR = 'true';
 });
 
@@ -25,15 +19,12 @@ test.afterEach(() => {
   delete process.env.RSDOCTOR;
 });
 
-for (const [core, legacy, expectedLog] of [
-  ['current', false, '@rsdoctor/core enabled.'],
-  ['current', true, '@rsdoctor/core enabled.'],
-  ['missing', true, '@rsdoctor/rspack-plugin enabled.'],
-  ['legacy', true, '@rsdoctor/rspack-plugin enabled.'],
-  ['broken', true, 'failed to load @rsdoctor/core module.'],
-  ['missing', false, 'please install @rsdoctor/rspack-plugin package.'],
+for (const [core, expectedLog] of [
+  ['current', '@rsdoctor/core enabled.'],
+  ['missing', '@rsdoctor/rspack-plugin enabled.'],
+  ['legacy', '@rsdoctor/rspack-plugin enabled.'],
 ] as const) {
-  test(`should auto-load Rsdoctor with ${core} core and legacy plugin ${legacy ? 'installed' : 'missing'}`, async ({
+  test(`should auto-load Rsdoctor with ${core} core and legacy plugin installed`, async ({
     logHelper,
   }) => {
     // Use separate paths to isolate package resolution and the ESM module cache.
@@ -43,25 +34,18 @@ for (const [core, legacy, expectedLog] of [
     await cp(join(import.meta.dirname, 'src'), join(cwd, 'src'), {
       recursive: true,
     });
-    for (const name of [
-      core !== 'missing' && 'core',
-      legacy && 'rspack-plugin',
-    ]) {
-      if (name) {
-        await cp(
-          join(import.meta.dirname, 'node_modules/@rsdoctor', name),
-          join(packagesPath, name),
-          { recursive: true },
-        );
-      }
+    await cp(
+      join(import.meta.dirname, '_node_modules/@rsdoctor'),
+      packagesPath,
+      {
+        recursive: true,
+      },
+    );
+    if (core === 'missing') {
+      await rm(join(packagesPath, 'core'), { recursive: true });
     }
-    if (core === 'legacy' || core === 'broken') {
-      await writeFile(
-        join(packagesPath, 'core/index.js'),
-        core === 'legacy'
-          ? 'export {};'
-          : 'throw new Error("Broken Rsdoctor core fixture");',
-      );
+    if (core === 'legacy') {
+      await writeFile(join(packagesPath, 'core/index.js'), 'export {};');
     }
 
     const rsbuild = await createRsbuild({
@@ -73,32 +57,18 @@ for (const [core, legacy, expectedLog] of [
     const compiler = (await rsbuild.createCompiler()) as Rspack.MultiCompiler;
     expect(compiler.compilers).toHaveLength(2);
     for (const child of compiler.compilers) {
-      expect(getRsdoctorPlugins(child.options)).toHaveLength(
-        expectedLog.endsWith('enabled.') ? 1 : 0,
-      );
+      expect(getRsdoctorPlugins(child.options)).toHaveLength(1);
     }
     await logHelper.expectLog(expectedLog);
   });
 }
 
-test('should not register Rsdoctor when disabled', async ({ logHelper }) => {
-  process.env.RSDOCTOR = 'false';
-  const rsbuild = await createRsbuild({ cwd: import.meta.dirname });
-  const compiler = await rsbuild.createCompiler();
-  expect(
-    getRsdoctorPlugins(compiler.options as Rspack.Configuration),
-  ).toHaveLength(0);
-  logHelper.expectNoLog(/@rsdoctor\/.* enabled/);
-});
-
 test('should preserve a manually registered Rsdoctor plugin', async ({
+  copyNodeModules,
   logHelper,
 }) => {
-  const rsdoctorPackageName = '@rsdoctor/rspack-plugin';
-  const { RsdoctorRspackPlugin } = (await import(
-    rsdoctorPackageName
-  )) as RsdoctorExports;
-  const plugin = new RsdoctorRspackPlugin({ disableClientServer: true });
+  await copyNodeModules();
+  const plugin = new RsdoctorRspackPlugin();
   const rsbuild = await createRsbuild({
     cwd: import.meta.dirname,
     config: { tools: { rspack: { plugins: [plugin] } } },

--- a/e2e/cases/profiling/enable-rsdoctor/index.test.ts
+++ b/e2e/cases/profiling/enable-rsdoctor/index.test.ts
@@ -1,6 +1,9 @@
+import { cp, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { expect, test } from '@e2e/helper';
 import { createRsbuild, type Rspack } from '@rsbuild/core';
-import { matchPlugin } from '@scripts/test-helper';
+import { onTestFinished } from '@rstest/core';
 
 type RsdoctorExports = {
   RsdoctorRspackPlugin: new (
@@ -8,95 +11,114 @@ type RsdoctorExports = {
   ) => Rspack.RspackPluginInstance;
 };
 
-const RSDOCTOR_LOG = '@rsdoctor/rspack-plugin enabled';
+const UPGRADE_LOG =
+  'Please upgrade to Rsdoctor v2 by replacing @rsdoctor/rspack-plugin with @rsdoctor/core.';
+
+const getRsdoctorPlugins = (config: Pick<Rspack.Configuration, 'plugins'>) =>
+  config.plugins?.filter(
+    (plugin) => plugin?.constructor?.name === 'RsdoctorRspackPlugin',
+  );
+
+test.beforeEach(async ({ copyNodeModules }) => {
+  await copyNodeModules();
+  process.env.RSDOCTOR = 'true';
+});
 
 test.afterEach(() => {
-  process.env.RSDOCTOR = '';
+  delete process.env.RSDOCTOR;
 });
 
-test('should register Rsdoctor plugin when process.env.RSDOCTOR is true', async ({
-  copyNodeModules,
-  logHelper,
-}) => {
-  const { expectLog } = logHelper;
-  await copyNodeModules();
-  process.env.RSDOCTOR = 'true';
+for (const [core, legacy, expectedLog] of [
+  ['current', false, '@rsdoctor/core enabled.'],
+  ['current', true, '@rsdoctor/core enabled.'],
+  ['missing', true, '@rsdoctor/rspack-plugin enabled.'],
+  ['legacy', true, '@rsdoctor/rspack-plugin enabled.'],
+  ['broken', true, 'failed to load @rsdoctor/core module.'],
+  [
+    'missing',
+    false,
+    'please install @rsdoctor/core or @rsdoctor/rspack-plugin package.',
+  ],
+] as const) {
+  test(`should auto-load Rsdoctor with ${core} core and legacy plugin ${legacy ? 'installed' : 'missing'}`, async ({
+    logHelper,
+  }) => {
+    // Use separate paths to isolate package resolution and the ESM module cache.
+    const cwd = await mkdtemp(join(tmpdir(), 'rsbuild-rsdoctor-'));
+    onTestFinished(() => rm(cwd, { recursive: true, force: true }));
+    const packagesPath = join(cwd, 'node_modules/@rsdoctor');
+    await cp(join(import.meta.dirname, 'src'), join(cwd, 'src'), {
+      recursive: true,
+    });
+    for (const name of [
+      core !== 'missing' && 'core',
+      legacy && 'rspack-plugin',
+    ]) {
+      if (name) {
+        await cp(
+          join(import.meta.dirname, 'node_modules/@rsdoctor', name),
+          join(packagesPath, name),
+          { recursive: true },
+        );
+      }
+    }
+    if (core === 'legacy' || core === 'broken') {
+      await writeFile(
+        join(packagesPath, 'core/index.js'),
+        core === 'legacy'
+          ? 'export {};'
+          : 'throw new Error("Broken Rsdoctor core fixture");',
+      );
+    }
 
-  const rsbuild = await createRsbuild({
-    cwd: import.meta.dirname,
+    const rsbuild = await createRsbuild({
+      cwd,
+      config: {
+        environments: { web: {}, node: { output: { target: 'node' } } },
+      },
+    });
+    const compiler = (await rsbuild.createCompiler()) as Rspack.MultiCompiler;
+    expect(compiler.compilers).toHaveLength(2);
+    for (const child of compiler.compilers) {
+      expect(getRsdoctorPlugins(child.options)).toHaveLength(
+        expectedLog.endsWith('enabled.') ? 1 : 0,
+      );
+    }
+    await logHelper.expectLog(expectedLog);
+    if (expectedLog === '@rsdoctor/rspack-plugin enabled.') {
+      await logHelper.expectLog(UPGRADE_LOG);
+    } else {
+      logHelper.expectNoLog(UPGRADE_LOG);
+    }
   });
+}
 
-  const compiler = await rsbuild.createCompiler();
-
-  await expectLog(RSDOCTOR_LOG);
-
-  expect(
-    matchPlugin(
-      compiler.options as Rspack.Configuration,
-      'RsdoctorRspackPlugin',
-    ),
-  ).toBeTruthy();
-});
-
-test('should not register Rsdoctor plugin when process.env.RSDOCTOR is false', async ({
-  logHelper,
-}) => {
-  const { expectNoLog } = logHelper;
+test('should not register Rsdoctor when disabled', async ({ logHelper }) => {
   process.env.RSDOCTOR = 'false';
-
-  const rsbuild = await createRsbuild({
-    cwd: import.meta.dirname,
-  });
-
+  const rsbuild = await createRsbuild({ cwd: import.meta.dirname });
   const compiler = await rsbuild.createCompiler();
-
-  expectNoLog(RSDOCTOR_LOG);
-
   expect(
-    matchPlugin(
-      compiler.options as Rspack.Configuration,
-      'RsdoctorRspackPlugin',
-    ),
-  ).toBeFalsy();
+    getRsdoctorPlugins(compiler.options as Rspack.Configuration),
+  ).toHaveLength(0);
+  logHelper.expectNoLog(/@rsdoctor\/.* enabled/);
+  logHelper.expectNoLog(UPGRADE_LOG);
 });
 
-test('should not register Rsdoctor plugin when process.env.RSDOCTOR is true and the plugin has been registered', async ({
-  copyNodeModules,
+test('should preserve a manually registered Rsdoctor plugin', async ({
   logHelper,
 }) => {
-  const { expectNoLog } = logHelper;
-
-  await copyNodeModules();
-  process.env.RSDOCTOR = 'true';
-
   const rsdoctorPackageName = '@rsdoctor/rspack-plugin';
   const { RsdoctorRspackPlugin } = (await import(
     rsdoctorPackageName
   )) as RsdoctorExports;
-
+  const plugin = new RsdoctorRspackPlugin({ disableClientServer: true });
   const rsbuild = await createRsbuild({
     cwd: import.meta.dirname,
-    config: {
-      tools: {
-        rspack: {
-          plugins: [
-            new RsdoctorRspackPlugin({
-              disableClientServer: true,
-            }),
-          ],
-        },
-      },
-    },
+    config: { tools: { rspack: { plugins: [plugin] } } },
   });
-
   const compiler = await rsbuild.createCompiler();
-
-  expect(
-    matchPlugin(
-      compiler.options as Rspack.Configuration,
-      'RsdoctorRspackPlugin',
-    ),
-  ).toBeTruthy();
-
-  expectNoLog(RSDOCTOR_LOG);
+  expect(getRsdoctorPlugins(compiler.options as Rspack.Configuration)).toEqual([
+    plugin,
+  ]);
+  logHelper.expectNoLog(/@rsdoctor\/.* enabled/);
 });

--- a/e2e/cases/profiling/enable-rsdoctor/index.test.ts
+++ b/e2e/cases/profiling/enable-rsdoctor/index.test.ts
@@ -85,11 +85,7 @@ for (const [core, legacy, expectedLog] of [
       );
     }
     await logHelper.expectLog(expectedLog);
-    if (expectedLog === '@rsdoctor/rspack-plugin enabled.') {
-      await logHelper.expectLog(UPGRADE_LOG);
-    } else {
-      logHelper.expectNoLog(UPGRADE_LOG);
-    }
+    logHelper.expectNoLog(UPGRADE_LOG);
   });
 }
 

--- a/e2e/cases/profiling/enable-rsdoctor/index.test.ts
+++ b/e2e/cases/profiling/enable-rsdoctor/index.test.ts
@@ -34,11 +34,7 @@ for (const [core, legacy, expectedLog] of [
   ['missing', true, '@rsdoctor/rspack-plugin enabled.'],
   ['legacy', true, '@rsdoctor/rspack-plugin enabled.'],
   ['broken', true, 'failed to load @rsdoctor/core module.'],
-  [
-    'missing',
-    false,
-    'please install @rsdoctor/core or @rsdoctor/rspack-plugin package.',
-  ],
+  ['missing', false, 'please install @rsdoctor/core package.'],
 ] as const) {
   test(`should auto-load Rsdoctor with ${core} core and legacy plugin ${legacy ? 'installed' : 'missing'}`, async ({
     logHelper,

--- a/e2e/cases/profiling/enable-rsdoctor/index.test.ts
+++ b/e2e/cases/profiling/enable-rsdoctor/index.test.ts
@@ -11,9 +11,6 @@ type RsdoctorExports = {
   ) => Rspack.RspackPluginInstance;
 };
 
-const UPGRADE_LOG =
-  'Please upgrade to Rsdoctor v2 by replacing @rsdoctor/rspack-plugin with @rsdoctor/core.';
-
 const getRsdoctorPlugins = (config: Pick<Rspack.Configuration, 'plugins'>) =>
   config.plugins?.filter(
     (plugin) => plugin?.constructor?.name === 'RsdoctorRspackPlugin',
@@ -34,7 +31,7 @@ for (const [core, legacy, expectedLog] of [
   ['missing', true, '@rsdoctor/rspack-plugin enabled.'],
   ['legacy', true, '@rsdoctor/rspack-plugin enabled.'],
   ['broken', true, 'failed to load @rsdoctor/core module.'],
-  ['missing', false, 'please install @rsdoctor/core package.'],
+  ['missing', false, 'please install @rsdoctor/rspack-plugin package.'],
 ] as const) {
   test(`should auto-load Rsdoctor with ${core} core and legacy plugin ${legacy ? 'installed' : 'missing'}`, async ({
     logHelper,
@@ -81,7 +78,6 @@ for (const [core, legacy, expectedLog] of [
       );
     }
     await logHelper.expectLog(expectedLog);
-    logHelper.expectNoLog(UPGRADE_LOG);
   });
 }
 
@@ -93,7 +89,6 @@ test('should not register Rsdoctor when disabled', async ({ logHelper }) => {
     getRsdoctorPlugins(compiler.options as Rspack.Configuration),
   ).toHaveLength(0);
   logHelper.expectNoLog(/@rsdoctor\/.* enabled/);
-  logHelper.expectNoLog(UPGRADE_LOG);
 });
 
 test('should preserve a manually registered Rsdoctor plugin', async ({

--- a/packages/core/src/plugins/rsdoctor.ts
+++ b/packages/core/src/plugins/rsdoctor.ts
@@ -80,7 +80,7 @@ export const pluginRsdoctor = (): RsbuildPlugin => ({
       }
 
       api.logger.warn(
-        `\`process.env.RSDOCTOR\` enabled, please install ${color.bold(color.yellow('@rsdoctor/core'))} package.`,
+        `\`process.env.RSDOCTOR\` enabled, please install ${color.bold(color.yellow('@rsdoctor/rspack-plugin'))} package.`,
       );
     });
   },

--- a/packages/core/src/plugins/rsdoctor.ts
+++ b/packages/core/src/plugins/rsdoctor.ts
@@ -76,11 +76,6 @@ export const pluginRsdoctor = (): RsbuildPlugin => ({
         }
 
         api.logger.info(`${color.bold(color.yellow(packageName))} enabled.`);
-        if (packageName === '@rsdoctor/rspack-plugin') {
-          api.logger.warn(
-            'Please upgrade to Rsdoctor v2 by replacing @rsdoctor/rspack-plugin with @rsdoctor/core.',
-          );
-        }
         return;
       }
 

--- a/packages/core/src/plugins/rsdoctor.ts
+++ b/packages/core/src/plugins/rsdoctor.ts
@@ -4,7 +4,7 @@ import { color, require } from '../helpers';
 import type { RsbuildPlugin, Rspack } from '../types';
 
 type RsdoctorExports = {
-  RsdoctorRspackPlugin: { new (): Rspack.RspackPluginInstance };
+  RsdoctorRspackPlugin?: { new (): Rspack.RspackPluginInstance };
 };
 
 type MaybeRsdoctorPlugin = Rspack.RspackPluginInstance & {
@@ -39,43 +39,56 @@ export const pluginRsdoctor = (): RsbuildPlugin => ({
         }
       }
 
-      const packageName = '@rsdoctor/rspack-plugin';
-      let packagePath: string;
+      const packageNames = ['@rsdoctor/core', '@rsdoctor/rspack-plugin'];
 
-      try {
-        packagePath = require.resolve(packageName, {
-          paths: [api.context.rootPath],
-        });
-      } catch {
-        api.logger.warn(
-          `\`process.env.RSDOCTOR\` enabled, please install ${color.bold(color.yellow(packageName))} package.`,
-        );
+      for (const packageName of packageNames) {
+        let packagePath: string;
+        try {
+          packagePath = require.resolve(packageName, {
+            paths: [api.context.rootPath],
+          });
+        } catch {
+          continue;
+        }
+
+        let module: RsdoctorExports;
+        try {
+          const moduleURL = isWindows
+            ? pathToFileURL(packagePath).href
+            : packagePath;
+          module = await import(moduleURL);
+        } catch {
+          api.logger.error(
+            `\`process.env.RSDOCTOR\` enabled, but failed to load ${color.bold(color.yellow(packageName))} module.`,
+          );
+          return;
+        }
+
+        // Rsdoctor 1.x core does not export the plugin.
+        const RsdoctorPlugin = module[pluginName];
+        if (typeof RsdoctorPlugin !== 'function') {
+          continue;
+        }
+
+        for (const config of bundlerConfigs) {
+          config.plugins ||= [];
+          config.plugins.push(new RsdoctorPlugin());
+        }
+
+        api.logger.info(`${color.bold(color.yellow(packageName))} enabled.`);
+        if (packageName === '@rsdoctor/rspack-plugin') {
+          api.logger.warn(
+            'Please upgrade to Rsdoctor v2 by replacing @rsdoctor/rspack-plugin with @rsdoctor/core.',
+          );
+        }
         return;
       }
 
-      let module: RsdoctorExports;
-      try {
-        const moduleURL = isWindows
-          ? pathToFileURL(packagePath).href
-          : packagePath;
-        module = await import(moduleURL);
-      } catch {
-        api.logger.error(
-          `\`process.env.RSDOCTOR\` enabled, but failed to load ${color.bold(color.yellow(packageName))} module.`,
-        );
-        return;
-      }
-
-      if (!module || !module[pluginName]) {
-        return;
-      }
-
-      for (const config of bundlerConfigs) {
-        config.plugins ||= [];
-        config.plugins.push(new module[pluginName]());
-      }
-
-      api.logger.info(`${color.bold(color.yellow(packageName))} enabled.`);
+      api.logger.warn(
+        `\`process.env.RSDOCTOR\` enabled, please install ${packageNames
+          .map((name) => color.bold(color.yellow(name)))
+          .join(' or ')} package.`,
+      );
     });
   },
 });

--- a/packages/core/src/plugins/rsdoctor.ts
+++ b/packages/core/src/plugins/rsdoctor.ts
@@ -80,9 +80,7 @@ export const pluginRsdoctor = (): RsbuildPlugin => ({
       }
 
       api.logger.warn(
-        `\`process.env.RSDOCTOR\` enabled, please install ${packageNames
-          .map((name) => color.bold(color.yellow(name)))
-          .join(' or ')} package.`,
+        `\`process.env.RSDOCTOR\` enabled, please install ${color.bold(color.yellow('@rsdoctor/core'))} package.`,
       );
     });
   },


### PR DESCRIPTION
## Summary

Rsdoctor v2 exports its Rspack plugin from `@rsdoctor/core`, so `RSDOCTOR=true` currently fails to enable analysis when only the new package is installed.

Prefer `@rsdoctor/core`, falling back to `@rsdoctor/rspack-plugin` when the new entry is missing or has no plugin export. Keep v1 compatibility without an upgrade warning, preserve manual registration, and report import failures without silently falling back to v1.