### PR TITLE
chore(skills): refine workflows and update installed skills

### DIFF
--- a/.agents/skills/add-doc-anchor-ids/SKILL.md
+++ b/.agents/skills/add-doc-anchor-ids/SKILL.md
@@ -1,88 +1,24 @@
 ---
 name: add-doc-anchor-ids
-description: Align Rspress heading anchor IDs between English and Chinese docs. Use for MDX `\{#...}` anchors, shortened hashes, redundant anchors, or dead links.
+description: Fix or align heading anchors and hash links in the mirrored English and Chinese Rsbuild docs.
 ---
 
 # Add doc anchor IDs
 
-Use this skill for Rspress docs mirrored under `website/docs/en` and `website/docs/zh`.
+Work on the requested `.md`/`.mdx` files under `website/docs/en` and `website/docs/zh`, pairing files by locale-relative path. Expand the search to inbound links when changing an existing ID; a local anchor fix does not require scanning every heading.
 
-## Rules
+## Anchor rules
 
-- Treat the English document as the source for stable anchor IDs.
-- If an English heading has 4 words or fewer, use the default Rspress anchor generated from the English heading.
-- If an English heading has more than 4 words, choose a shorter semantic anchor ID and add that same custom ID to both English and Chinese headings.
-- Do not add custom IDs that match Rspress default output. For example, keep `### parallel`, not `### parallel \{#parallel}`.
-- In Chinese docs, add a custom ID only when the Chinese default anchor would differ from the desired English ID.
-- In Chinese docs, remove custom IDs from pure English headings when the custom ID equals the Rspress default.
-- MDX custom anchor syntax must be escaped: `\{#anchor-id}`.
-- Keep changes limited to `.md`/`.mdx` documentation files unless the user explicitly asks otherwise.
-- Do not add persistent validation or update scripts as part of this skill's work.
+- Use the English heading's intentional custom ID when present.
+- Otherwise, use the English default anchor for headings of 4 words or fewer. For longer headings, choose a short semantic ID and apply it in both locales.
+- Add a Chinese custom ID only when its default anchor differs from the desired English ID. Remove custom IDs identical to the default, including pure English headings in Chinese pages.
+- MDX custom IDs use escaped syntax: `## 开发服务器 \{#dev-server}`.
+- Verify the actual Rspress slug for punctuation, underscores, and duplicate-heading suffixes rather than guessing. Preserve intentional existing IDs and duplicate suffixes.
 
-## Workflow
+## Editing and verification
 
-1. Inspect the current branch and work tree before editing:
+Update same-page and cross-page links to changed IDs. Search for the old hashes in Markdown links and JSX `href` attributes, including both `.md` and `.mdx` files.
 
-   ```bash
-   git branch --show-current
-   git status --short
-   ```
+Format the edited files with `pnpm exec rs fmt <edited-files>` and check the diff. Verify each changed link against its target heading. Use the docs build (`pnpm --dir website build`) when generated slugs or MDX behavior remain uncertain, rather than for every anchor edit.
 
-2. Find relevant custom anchors and hash links:
-
-   ```bash
-   rg -n -F '\{#' website/docs/en website/docs/zh --glob '*.mdx'
-   rg -n "\]\([^)]*#[A-Za-z0-9_-]+[^)]*\)" website/docs/en website/docs/zh --glob '*.mdx'
-   rg -n "href=['\"][^'\"]*#[A-Za-z0-9_-]+" website/docs/en website/docs/zh --glob '*.mdx'
-   ```
-
-3. For each edited or referenced document pair, compare the English file with its Chinese counterpart at the same locale-relative path:
-
-   ```text
-   website/docs/en/guide/configuration/rsbuild.mdx
-   website/docs/zh/guide/configuration/rsbuild.mdx
-   ```
-
-4. For each heading pair, decide the desired anchor:
-   - English heading has an intentional custom ID: use that ID in both locales.
-   - English heading has no custom ID and has 4 words or fewer: use the English default ID.
-   - English heading has no custom ID and has more than 4 words: choose a shorter semantic ID and add it to both locales.
-   - Chinese heading is pure English and its custom ID equals the default ID: remove the custom ID.
-
-5. Apply edits directly in the affected `.md`/`.mdx` files. Examples:
-
-   ```mdx
-   ## 指定配置文件 \{#specify-config-file}
-   ```
-
-   ```mdx
-   ## Dev server and client communication \{#dev-server-client-communication}
-
-   ## 开发服务器与客户端通信 \{#dev-server-client-communication}
-   ```
-
-6. Update all links that point to an old hash:
-
-   ```mdx
-   [指定配置文件](/guide/configuration/rsbuild#specify-config-file)
-   ```
-
-7. Validate the result:
-
-   ```bash
-   git diff --check
-   changed_docs=$(git diff --name-only -- '*.md' '*.mdx')
-   if [ -n "$changed_docs" ]; then
-     printf '%s\n' "$changed_docs" | xargs pnpm dlx cspell --no-progress
-     printf '%s\n' "$changed_docs" | xargs pnpm exec rs fmt
-   fi
-   ```
-
-8. If there is an existing repository command for docs link checking or docs build, run it. Otherwise, inspect changed hashes with `rg` and verify each target heading exists in the target file.
-
-## Rspress anchor notes
-
-- Rspress/GitHub-style anchors lowercase headings and remove punctuation such as `.` from API names; verify these IDs instead of guessing.
-- Some characters are preserved by the actual Rspress slugger, such as underscores in `BASE_URL`; avoid guessing when a link already works.
-- Duplicate headings get numbered suffixes like `#environment-api-1`. Preserve those suffixes when the English page relies on them.
-- A custom anchor changes the actual target ID, so update same-page and cross-page links that still point to the old generated hash.
+Keep edits in documentation unless the user requests tooling changes; do not add persistent migration or validation scripts for a one-off anchor update.

--- a/.agents/skills/docs-en-improvement/SKILL.md
+++ b/.agents/skills/docs-en-improvement/SKILL.md
@@ -1,24 +1,12 @@
 ---
 name: docs-en-improvement
-description: Improve English documentation under `website/docs/en` by rewriting unnatural translated sentences into clear, professional English while preserving meaning. Use when editing or polishing English docs.
+description: Polish unnatural English prose in `website/docs/en` while preserving technical meaning.
 ---
 
-# Docs en improvement
+# English documentation
 
-## Steps
+Rewrite sentences that materially improve clarity or naturalness. Preserve the original meaning; do not add claims or remove technical details. Keep reasonable abbreviations such as `dev server`; use simple English for non-native readers and sentence-case headings.
 
-1. Focus on files in `website/docs/en`.
+Work within the requested files or topic. Limit each PR to 10 documentation files or fewer, including changes in both languages. A prose-only English correction does not require translating the Chinese page again. If the user also requests technical corrections or changes to examples or structure, mirror those changes under `website/docs/zh`.
 
-2. Rewrite only sentences that clearly improve clarity, correctness, or naturalness in English.
-
-3. Preserve original meaning exactly; do not introduce new claims or remove technical details.
-
-4. If a file in `website/docs/en` is updated, check the mirrored file in `website/docs/zh` and apply equivalent updates when needed.
-
-## Constraints
-
-- Limit each PR to 10 documentation files or fewer.
-- Start PR titles with `docs:`.
-- Keep reasonable technical abbreviations (for example, `dev server`).
-- Keep wording simple and readable for non-native English readers.
-- Use sentence case for Markdown headings.
+Format edited files with `pnpm exec rs fmt <edited-files>`. If creating a PR is requested, use a `docs:` title and the repository's `pr-creator` skill.

--- a/.agents/skills/pr-creator/SKILL.md
+++ b/.agents/skills/pr-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-creator
-description: Use when asked to create a pull request for this repository. It helps the PR follow the repository's branch safety rules, title convention, pull request template, and concise English writing style.
+description: Create a pull request using repository branch rules, title conventions, templates, and concise English descriptions.
 metadata:
   internal: true
 ---

--- a/.agents/skills/release-core/SKILL.md
+++ b/.agents/skills/release-core/SKILL.md
@@ -1,34 +1,30 @@
 ---
 name: release-core
-description: Use when asked to release `@rsbuild/core` for a specific version.
+description: Prepare the version changes and release PR for `@rsbuild/core` and `create-rsbuild`.
 ---
 
 # Release core
 
-## Input
+Resolve the target version from the request or release context; ask only if it cannot be determined. This workflow prepares a release PR; it does not publish npm packages or a GitHub release.
 
-- Target version, for example `1.2.3`
+## Version changes
 
-If the version is missing, ask for it before making changes.
+Use a dedicated branch before committing, following the user's or environment's naming convention (for example, `release/v<version>` when no prefix is specified). Reuse an existing branch only after verifying it belongs to this release. Preserve unrelated local changes; isolate the release work when needed instead of stopping for every dirty worktree.
 
-## Steps
+Update:
 
-1. Check the worktree with `git status --short`. If there are uncommitted edits, stop and ask the user how to proceed.
+- `packages/core/package.json`: `version`
+- `packages/create-rsbuild/package.json`: `version`
+- `packages/create-rsbuild/template-*/package.json`: `@rsbuild/core` dependency ranges to `^<version>`
 
-2. Update release versions:
-   - `packages/core/package.json`: `version`
-   - `packages/create-rsbuild/package.json`: `version`
-   - `packages/create-rsbuild/template-*/package.json`: `@rsbuild/core` to `^<version>`
+Verify the edited JSON and all matching template ranges. Keep the release diff limited to those fields. Pure version changes do not require a build or e2e run. If the requested versions are already set, check whether a matching release PR exists before creating duplicate work.
 
-3. Create and switch to branch `release/v<version>`. If the branch already exists, stop and ask the user how to proceed.
+## Release PR
 
-4. Review the diff and confirm it is limited to the fields above. Run `rg -n '"@rsbuild/core":' packages/create-rsbuild/template-*/package.json` and confirm every template uses `^<version>`.
+Commit only the task changes, push the task branch, and create the PR using `.github/PULL_REQUEST_TEMPLATE.md`. Prefer the Codex GitHub connector when available; otherwise use `gh`. Consult [pr-creator](../pr-creator/SKILL.md) only when additional PR guidance is needed. Use:
 
-5. Create a commit with this exact message: `release: v<version>`
+- Commit and PR title: `release: v<version>`
+- `Summary`: `Release @rsbuild/core and create-rsbuild <version>.`
+- `Related links`: `https://github.com/web-infra-dev/rsbuild/releases/tag/v<version>`
 
-6. Push the branch. If running in Codex, create the PR with the GitHub connector/plugin. Otherwise, use the GitHub workflow available in the current environment. Use the same text for the PR title as the commit message: `release: v<version>`
-
-7. If `.github/PULL_REQUEST_TEMPLATE.md` exists, keep its structure.
-   Fill it with:
-   - `Summary`: `Release @rsbuild/core and create-rsbuild <version>.`
-   - `Related Links`: `https://github.com/web-infra-dev/rsbuild/releases/tag/v<version>`
+Finish with the PR URL and any unresolved release preparation issue.

--- a/.agents/skills/release-plugin-package/SKILL.md
+++ b/.agents/skills/release-plugin-package/SKILL.md
@@ -1,37 +1,31 @@
 ---
 name: release-plugin-package
-description: Use when asked to create a release PR for an official Rsbuild plugin package under `packages/plugin-*`, such as `@rsbuild/plugin-react v2.1.0` or `@rsbuild/plugin-sass v2.0.0`.
+description: Prepare a release PR and changelog for an official package under `packages/plugin-*`.
 ---
 
 # Release plugin package
 
-## Input
+Resolve the package and target version from the request; ask only for missing required inputs. This skill prepares a PR, not an npm publication. Use [release-core](../release-core/SKILL.md) for the coupled core/create-rsbuild release.
 
-- Plugin package name or short name, for example `@rsbuild/plugin-react` or `plugin-react`.
-- Target version, for example `2.1.0`.
+## Release changes
 
-If the package or version is missing, ask for it before making changes.
+Inspect the branch and worktree, preserving unrelated changes. Isolate work when needed, and use a task branch before committing. Follow the user's or environment's branch naming convention; otherwise `release/plugin-<name>-v<version>` is a useful name.
 
-## Scope
+Confirm that `packages/plugin-<name>/package.json` names the intended package. If this release already has version edits, a changelog entry, or a PR, read [references/resume-release.md](references/resume-release.md) before choosing the baseline or editing.
 
-Use this skill only for official plugin packages in `packages/plugin-*`.
+For a new release, use the user-specified changelog baseline, or record the current package version and its release commit or tag before bumping it. Resolve an ambiguous range before generating the changelog.
 
-Do not use it for:
+Update:
 
-- `@rsbuild/core` or `create-rsbuild` releases. Use `release-core` instead.
-- Publishing npm packages directly. This skill creates the release PR only.
+- The plugin's package version.
+- Its `CHANGELOG.md`, following the changelog rules below.
+- Matching `@rsbuild/plugin-<name>` ranges in `packages/create-rsbuild/template-*/package.json` to `^<version>`. Preserve `workspace:*` dependencies in `packages/create-rsbuild/package.json`.
 
-## Changelog requirements
+Review the task diff against these fields and files. Preserve pre-existing unrelated changes. Investigate unexpected edits caused by the release work before committing.
 
-Every plugin release PR must update the plugin changelog:
+## Changelog
 
-```text
-packages/plugin-<name>/CHANGELOG.md
-```
-
-If `CHANGELOG.md` does not exist, create it with `# @rsbuild/plugin-<name>` as the title.
-Insert the new entry immediately below the title. If an entry for the target version already exists, update that entry instead of adding a duplicate.
-Use this format:
+Create `packages/plugin-<name>/CHANGELOG.md` if missing, titled `# @rsbuild/plugin-<name>`. Add the version entry immediately below the title, or update an existing entry for that version.
 
 ```markdown
 ## <version> (<YYYY-MM-DD>)
@@ -41,129 +35,30 @@ Use this format:
 - feat(plugin-<name>): change summary by @user in https://github.com/web-infra-dev/rsbuild/pull/<number>
 ```
 
-Rules:
+Use the current date unless the user supplies one. Do not add compare links to version headings. Use `-` bullets and non-empty, sentence-case sections in this order:
 
-- Use the current date in `YYYY-MM-DD` format unless the user provides a release date.
-- Do not add version compare links to version headings.
-- Use `-` bullets.
-- Use sentence-case section headings.
-- Use this section order when sections are present: `Breaking changes`, `New features`, `Performance`, `Bug fixes`, `Refactor`, `Document`, `Other changes`.
-- Add a section heading only when it has at least one bullet.
-- If there are no plugin-specific changes, add `- No plugin-specific changes.` directly under the version heading and do not add `### Other changes`.
-- Preserve change item wording, author, and PR URL as much as possible.
-- Exclude the plugin release or version-bump PR itself from changelog items.
+- `Breaking changes`: `!` or `BREAKING CHANGE`
+- `New features`: `feat`
+- `Performance`: `perf`
+- `Bug fixes`: `fix`
+- `Refactor`: `refactor`
+- `Document`: `docs`
+- `Other changes`: remaining types
 
-To collect changelog items:
+Prefer change PRs supplied by the user or identified in the release context. Supplement incomplete lists with commits and merged PRs since the resolved baseline. Include plugin code and directly relevant shared code, build configuration, dependencies, docs, or templates. Exclude the release/version-bump PR itself. Preserve item wording, authors, and PR URLs as much as possible.
 
-1. Prefer related change PRs provided by the user or already listed in the release PR context.
-2. If related PRs are missing or incomplete, inspect commits and merged PRs since the previous package version recorded before editing `package.json`.
-3. Keep only changes that affect the released plugin, including:
-   - files under `packages/plugin-<name>`
-   - shared code, build config, or dependencies that directly affect the plugin
-   - docs or template changes that are specifically about that plugin
-4. Categorize items by conventional commit type:
-   - `feat` -> `New features`
-   - `perf` -> `Performance`
-   - `fix` -> `Bug fixes`
-   - `refactor` -> `Refactor`
-   - `docs` -> `Document`
-   - breaking changes marked with `!` or `BREAKING CHANGE` -> `Breaking changes`
-   - everything else -> `Other changes`
+If there are no plugin-specific changes, write `- No plugin-specific changes.` directly under the version heading, without a category heading.
 
-## Workflow
+## Validation
 
-1. Check the worktree:
+For version/changelog-only edits, validate edited JSON, matching template ranges, and changelog content. Use a focused plugin build or create-rsbuild e2e case when executable template or package behavior also changes; follow the root `AGENTS.md` build prerequisite before e2e. Avoid repository-wide spelling and e2e runs for a metadata-only bump.
 
-   ```bash
-   git status --short
-   git branch --show-current
-   ```
+## Pull request
 
-   If there are uncommitted edits, stop and ask the user how to proceed.
+Commit only the task changes, push the task branch, and create the PR using `.github/PULL_REQUEST_TEMPLATE.md`. Prefer the Codex GitHub connector when available; otherwise use `gh`. Consult [pr-creator](../pr-creator/SKILL.md) only when additional PR guidance is needed. Use:
 
-2. Resolve the package directory:
+- Commit and PR title: `release: @rsbuild/plugin-<name> v<version>`
+- `Summary`: `Release @rsbuild/plugin-<name> v<version>.`
+- An optional `Changes` section linking the same verified change PRs used in the changelog; omit it when no links are known.
 
-   - `@rsbuild/plugin-react` -> `packages/plugin-react`
-   - `plugin-react` -> `packages/plugin-react`
-
-   Confirm that `packages/plugin-<name>/package.json` exists and its `name` field matches the target package.
-   Record the current package `version` before editing it; use that as the previous package version for changelog collection unless the user provides a different baseline.
-
-3. Create and switch to a dedicated branch if the current branch is the default branch. Prefer:
-
-   ```text
-   release/plugin-<name>-v<version>
-   ```
-
-4. Update only the plugin package version first:
-
-   ```text
-   packages/plugin-<name>/package.json
-   ```
-
-5. Update `packages/plugin-<name>/CHANGELOG.md` for the target version using the changelog requirements above.
-
-6. Sync `create-rsbuild` template dependency versions only when that plugin appears in template `package.json` files:
-
-   ```bash
-   rg -n '@rsbuild/plugin-<name>' packages/create-rsbuild --glob 'package.json'
-   ```
-
-   Update matching template dependency ranges to `^<version>`. Do not change `workspace:*` dev dependencies in `packages/create-rsbuild/package.json`.
-
-7. Review the diff and confirm it is limited to:
-
-   - the released plugin package version
-   - the released plugin changelog
-   - matching `packages/create-rsbuild/template-*/package.json` dependency ranges, if any
-
-   If other files changed, stop and explain the unexpected diff.
-
-8. Validate JSON and run focused checks:
-
-   ```bash
-   node -e "for (const f of process.argv.slice(1)) JSON.parse(require('fs').readFileSync(f, 'utf8'))" <edited-package-json-files>
-   node --run check-spell
-   pnpm --filter @rsbuild/plugin-<name> run build
-   ```
-
-   If `create-rsbuild` templates changed, also run `pnpm build` once and then the focused create-rsbuild e2e case when practical:
-
-   ```bash
-   pnpm build
-   pnpm e2e create-rsbuild
-   ```
-
-   Report any skipped validation in the final response.
-
-9. Commit with this exact title:
-
-   ```text
-   release: @rsbuild/plugin-<name> v<version>
-   ```
-
-10. Push the branch after re-checking it is not the default branch.
-
-11. If running in Codex, create the PR with the GitHub connector/plugin. Otherwise, use the GitHub workflow available in the current environment.
-
-## PR body
-
-Use the repository PR template. Keep the body concise.
-
-For `Summary`, use:
-
-```markdown
-Release `@rsbuild/plugin-<name>` v<version>.
-```
-
-If related change PRs were provided or can be confidently identified, add a `Changes` section:
-
-```markdown
-## Changes
-
-- https://github.com/web-infra-dev/rsbuild/pull/<number>
-- https://github.com/web-infra-dev/rsbuild/pull/<number>
-```
-
-Use the same related change PRs that were added to the changelog. Do not invent change links.
-If no related links are known, omit `Changes` instead of adding an empty section.
+Return the PR URL and relevant validation results or limitations.

--- a/.agents/skills/release-plugin-package/references/resume-release.md
+++ b/.agents/skills/release-plugin-package/references/resume-release.md
@@ -1,0 +1,8 @@
+# Continue a plugin release
+
+Read this when the target release already has version edits, a changelog entry, or a PR.
+
+- Verify the existing work belongs to the requested package and target version before reusing its branch or PR. Preserve unrelated changes.
+- Honor a user-specified baseline. Otherwise, recover the pre-bump package version and its release commit or tag from Git history or the preceding published package release. The working-tree version may already be the target version and is not a valid baseline in that case. Resolve an ambiguous range with the user before regenerating notes.
+- Complete missing version, template, and changelog changes using the main skill's rules. Preserve valid existing notes and update the target entry rather than duplicating it.
+- Update the matching PR when one exists. If the release is already complete, report its status instead of creating another PR.

--- a/.agents/skills/rspress-description-generator/SKILL.md
+++ b/.agents/skills/rspress-description-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rspress-description-generator
-description: Generate and maintain description frontmatter for Rspress documentation files (.md/.mdx). Use when a user wants to add SEO descriptions, improve search engine snippets, generate llms.txt metadata, prepare docs for AI summarization, or batch-update frontmatter across an Rspress doc site. Also use when adding new documentation pages to an Rspress project — every new doc file needs a description.
+description: Generate missing description frontmatter for Rspress Markdown/MDX pages, including new docs pages and site-wide SEO metadata updates.
 ---
 
 # Rspress Description Generator

--- a/.agents/skills/rstack-cli-docs/SKILL.md
+++ b/.agents/skills/rstack-cli-docs/SKILL.md
@@ -3,7 +3,7 @@ name: rstack-cli-docs
 description: Consult installed, version-matched Rstack docs only for user-facing `rs` command behavior, `rstack.config.*` semantics, or public `rstack` APIs. Do not use for purely internal implementation, tests, performance, or repository maintenance.
 ---
 
-# Rstack CLI Docs
+# Rstack CLI docs
 
 Rstack CLI is the `rstack` package, exposed through the `rs` binaries. It provides one CLI, one
 config file, and a consistent workflow for the Rstack JavaScript toolchain.

--- a/.agents/skills/sync-zh-en-docs/SKILL.md
+++ b/.agents/skills/sync-zh-en-docs/SKILL.md
@@ -1,22 +1,14 @@
 ---
 name: sync-zh-en-docs
-description: Sync uncommitted docs between `website/docs/zh` and `website/docs/en`. Use when authors update docs in one language and need to align the mirrored `.md`/`.mdx` file in the other language.
+description: Sync uncommitted documentation changes between `website/docs/zh` and `website/docs/en`.
 ---
 
-# Sync Zh/En documentation
+# Documentation sync
 
-## Steps
+Inspect staged, unstaged, and new docs in the requested scope. Map each source file to the same locale-relative path in the other language.
 
-1. Check uncommitted changes under `website/docs/zh` and `website/docs/en`.
+Translate the changed content, preserving technical meaning, structure, commands, and code unless localization is needed. Preserve unrelated edits in both languages. If both counterparts changed, reconcile compatible edits; ask only when conflicting technical meanings cannot be resolved from the request and context.
 
-2. Translate each changed file to the counterpart path (`zh` <-> `en`), and keep:
+Keep corresponding heading IDs and links aligned. Use [add-doc-anchor-ids](../add-doc-anchor-ids/SKILL.md) when headings or hashes change.
 
-- meaning and structure consistent
-- technical terms / commands / code blocks unchanged unless localization is required
-- concise, clear, professional technical-doc style
-
-3. Format and verify:
-
-```bash
-node --run format
-```
+Format only the edited files with `pnpm exec rs fmt <edited-files>` and review the paired diff for omissions or accidental changes to code examples.

--- a/.agents/skills/upgrade-rspack/SKILL.md
+++ b/.agents/skills/upgrade-rspack/SKILL.md
@@ -1,34 +1,29 @@
 ---
 name: upgrade-rspack
-description: Use when asked to upgrade `@rspack/core` in this repository to a specific version, run dependency installation and validation, then commit and create a pull request.
+description: Upgrade `@rspack/core` in this repository, validate compatibility, and prepare a pull request.
 ---
 
 # Upgrade Rspack
 
-## Input
+Resolve the requested target version; ask if it is unspecified and cannot be inferred from the request. If the user limits the task to local changes or inspection, honor that scope.
 
-- Target version, for example `2.0.0`
+## Dependency update
 
-If the version is missing, ask for it before making changes.
+- Inspect the branch and worktree. Preserve unrelated edits and use an isolated checkout if needed. Create a task branch before committing when on the default branch; never commit directly to it.
+- Change the default catalog's `@rspack/core` entry in `pnpm-workspace.yaml` to `~<version>`, preserving package dependencies as `catalog:`.
+- Run `pnpm update @rspack/core --recursive` to update dependencies and the lockfile. A separate install is only needed if dependency resolution or installation remains incomplete.
+- Review the catalog and lockfile diff for unintended dependency changes. If already at the requested version with no changes, report that instead of creating an empty commit or PR.
 
-## Steps
+## Validation
 
-1. Check the worktree with `git status --short`. If there are uncommitted edits, stop and ask the user how to proceed.
+Rspack affects the entire build pipeline, so run `pnpm build`, `pnpm test`, and `pnpm e2e` once for the upgrade. Investigate failures and fix compatibility issues within the requested scope, then rerun the affected checks. Rebuild when source changes require fresh outputs.
 
-2. Update the `@rspack/core` entry in the default catalog in `pnpm-workspace.yaml` to `~<version>`, preserving package dependencies as `catalog:`, then run `pnpm update @rspack/core --recursive`.
+Do not commit or create the PR while required checks remain failed or incomplete. Report an unresolved blocker with its evidence; ask only when resolution requires a scope or compatibility decision from the user.
 
-3. Run `pnpm i` at the repository root.
+## Pull request
 
-4. Run `pnpm build`, `pnpm test`, and then `pnpm e2e`. If any command fails, stop, report the failure, and do not commit or create a PR.
+Commit only the task changes, push the task branch, and create the PR using `.github/PULL_REQUEST_TEMPLATE.md`. Prefer the Codex GitHub connector when available; otherwise use `gh`. Consult [pr-creator](../pr-creator/SKILL.md) only when additional PR guidance is needed. Use:
 
-5. Review the diff and confirm it only contains the intended dependency upgrade and lockfile changes. If `@rspack/core` is already at the target version and there is no diff, report that nothing changed and stop.
-
-6. Commit with this exact message: `feat(deps): update @rspack/core to <version>`
-
-7. Before pushing, confirm the current branch with `git branch --show-current`. If it is the default branch, create and switch to a dedicated branch first. Never push the default branch directly.
-
-8. If `.github/PULL_REQUEST_TEMPLATE.md` exists, keep its structure exactly.
-   Create the PR with:
-   - Title: `feat(deps): update @rspack/core to <version>`
-   - `Summary`: `Update @rspack/core to <version>.`
-   - `Related Links`: `https://github.com/web-infra-dev/rspack/releases/tag/v<version>`
+- Commit and PR title: `feat(deps): update @rspack/core to <version>`
+- `Summary`: `Update @rspack/core to <version>.` Add relevant compatibility changes if needed.
+- `Related links`: `https://github.com/web-infra-dev/rspack/releases/tag/v<version>`

--- a/.agents/skills/write-e2e-cases/SKILL.md
+++ b/.agents/skills/write-e2e-cases/SKILL.md
@@ -1,33 +1,22 @@
 ---
 name: write-e2e-cases
-description: Use when adding or updating Rsbuild end-to-end tests in `e2e/cases`, including new feature coverage, bug reproduction, and regression prevention.
+description: Add or update Rsbuild regression and feature tests in `e2e/cases`.
 ---
 
-# Write E2E cases
+# Write e2e cases
 
-## Steps
+Use [e2e/README.md](../../../e2e/README.md) for helper conventions and warning assertions, and a nearby case for the relevant fixture pattern.
 
-1. Review uncommitted git changes to define test scope and target behavior.
+## Case conventions
 
-2. Read `e2e/README.md` and follow its conventions.
+- Use `@e2e/helper` for Rsbuild fixtures (`test`, `dev`, `build`). Import generic utilities such as `getDistFiles`, `findFile`, and `getFileContent` directly from `@rstackjs/test-utils`.
+- Include a `src` directory in each case. Prefer static config in `rsbuild.config.ts` for debugging with `npx rsbuild`; use inline config for dynamic values or small per-test variations.
+- Split case directories when they need different source files or Rsbuild configs.
+- Reuse `@e2e/assets` where possible. Put case-specific package mocks in `_node_modules` and call `copyNodeModules()` before resolving them.
+- Assert observable behavior with stable assertions. Use `expectWarning()` for expected build warnings; unexpected warnings fail tests by default.
 
-3. Use `@e2e/helper` for Rsbuild-specific fixtures and helpers, such as `test`, `dev`, and `build`. Import generic test utilities, such as `getDistFiles`, `findFile`, and `getFileContent`, directly from `@rstackjs/test-utils`.
+## Validation and completion
 
-4. Add Playwright cases under `e2e/cases`, following existing directory patterns.
+Follow the root `AGENTS.md` build prerequisite, then run `pnpm e2e <case-or-filter>` for the affected cases. Expand to the full suite when shared helpers or broad behavior changes justify it.
 
-5. Use short, direct, and stable assertions. Avoid redundant setup and checks.
-
-6. Run `pnpm build` once, then run `pnpm e2e` to validate.
-
-## Case structure
-
-- Include a `src` directory in every case (required).
-- Prefer putting static Rsbuild configurations in `rsbuild.config.ts` to enable easier debugging via `npx rsbuild`.
-- Use inline config for dynamic values or minor per-test variations.
-- Split into multiple case directories when cases need different `src` code or different Rsbuild configs.
-- When static assets are needed, prefer reusing assets from `@e2e/assets` before adding new files.
-- For package mocks used by one case, place them under that case's `_node_modules` directory and call `copyNodeModules()` before they are resolved.
-
-## Constraints
-
-- If tests can pass only after source-code changes, do not change source code directly. Explain the required source change and ask the user before proceeding.
+For a bug-fix or feature request, make the source changes needed by the requested behavior and rerun affected tests. For a reproduction-only or tests-only request, preserve that boundary and report the expected failure and required source fix.

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -11,7 +11,7 @@
       "source": "rstackjs/agent-skills",
       "sourceType": "github",
       "skillPath": ".agents/skills/pr-creator/SKILL.md",
-      "computedHash": "c115b708a4c627af4b6dbaca0cfa0ae0fb0153f122bd2229f7803c803fa97c67"
+      "computedHash": "6b16aae8df116895d7bf8a567999ad54826ffa4b0c2353ba5187bf361d6e40f8"
     },
     "release-blog-writer": {
       "source": "rstackjs/agent-skills",
@@ -23,14 +23,14 @@
       "source": "rstackjs/agent-skills",
       "sourceType": "github",
       "skillPath": "skills/rspress-description-generator/SKILL.md",
-      "computedHash": "ca2693ca055d1b4e5903bdfacab522f46ca0e13cbc5db59e6c9589fdc8efc6ad"
+      "computedHash": "0e22059b170e09395e5d95513f17dc133b257f5bba7f16d8bc852b1923edbec9"
     },
     "rstack-cli-docs": {
       "source": "rstackjs/rstack-cli",
       "ref": "main",
       "sourceType": "github",
       "skillPath": ".agents/skills/rstack-cli-docs/SKILL.md",
-      "computedHash": "3bd67c05c2cb4121edd24be65d118e0e7402177bca8a0f1b5bb0ce55dee5e61c"
+      "computedHash": "8b5451af88d29195dc2f257543013ad66aa14a7791e401ab4cffdb11941cf27a"
     }
   }
 }


### PR DESCRIPTION
## Summary

Focus skill workflows on the requested scope: format affected docs, run targeted e2e cases, and continue release preparation while preserving version and changelog requirements. Make PR guidance optional and load recovery instructions only when resuming a plugin release. Refresh installed upstream skills and `skills-lock.json` using the `skills` CLI.

## Related links

- https://github.com/web-infra-dev/rsbuild/pull/8452
- https://x.com/pvncher/status/2095991462416490862