### PR TITLE
docs: simplify AGENTS.md examples

### DIFF
--- a/website/docs/en/guide/start/ai.mdx
+++ b/website/docs/en/guide/start/ai.mdx
@@ -77,8 +77,6 @@ Example `AGENTS.md` content:
 ```markdown wrapCode
 # AGENTS.md
 
-You are an expert in JavaScript, Rsbuild, and web application development. You write maintainable, performant, and accessible code.
-
 ## Commands
 
 - `npm run dev` - Start the dev server

--- a/website/docs/zh/guide/start/ai.mdx
+++ b/website/docs/zh/guide/start/ai.mdx
@@ -77,8 +77,6 @@ https://rsbuild.rs/guide/start/index.md
 ```markdown wrapCode
 # AGENTS.md
 
-You are an expert in JavaScript, Rsbuild, and web application development. You write maintainable, performant, and accessible code.
-
 ## Commands
 
 - `npm run dev` - Start the dev server


### PR DESCRIPTION
## Summary

Remove the generic expert-role prompt from the `AGENTS.md` examples in the English and Chinese AI guides, keeping the examples focused on project commands and documentation links.