### PR TITLE
docs: correct dev asset prefix resolution

### DIFF
--- a/website/docs/en/config/dev/asset-prefix.mdx
+++ b/website/docs/en/config/dev/asset-prefix.mdx
@@ -34,7 +34,9 @@ export default {
 
 ## Boolean type
 
-If `assetPrefix` is set to `true`, the URL prefix will be `http://localhost:<port>/`:
+If `assetPrefix` is set to `true`, Rsbuild generates an absolute URL prefix from the dev server's protocol, hostname, actual listening port, and [server.base](/config/server/base).
+
+With the default server configuration, the prefix is `http://localhost:<port>/`:
 
 ```ts title="rsbuild.config.ts"
 export default {
@@ -47,10 +49,12 @@ export default {
 The resource URL loaded in the browser is as follows:
 
 ```html
-<script defer src="http://localhost:3000/static/js/main.js"></script>
+<script defer src="http://localhost:3000/static/js/index.js"></script>
 ```
 
-If `assetPrefix` is set to `false` or not set, `/` is used as the default value.
+Enabling [server.https](/config/server/https) changes the protocol to `https`. The hostname follows [server.host](/config/server/host), except that `0.0.0.0` is replaced with `localhost`. Rsbuild also appends `server.base` to the URL. For example, with `server.host: '127.0.0.1'`, `server.base: '/foo'`, and a listening port of `3000`, the prefix is `http://127.0.0.1:3000/foo/`.
+
+If `assetPrefix` is set to `false`, the prefix is `/`, even when `server.base` is customized. If `assetPrefix` is not set, it inherits `server.base` instead.
 
 ## String type
 
@@ -69,7 +73,7 @@ export default {
 The resource URL loaded in the browser is as follows:
 
 ```html
-<script defer src="http://localhost:3000/example/static/js/index.js"></script>
+<script defer src="/example/static/js/index.js"></script>
 ```
 
 - For example, set to a complete URL:

--- a/website/docs/zh/config/dev/asset-prefix.mdx
+++ b/website/docs/zh/config/dev/asset-prefix.mdx
@@ -34,7 +34,9 @@ export default {
 
 ## Boolean 类型
 
-如果设置 `assetPrefix` 为 `true`，Rsbuild 会使用 `http://localhost:<port>/` 作为 URL 前缀：
+如果设置 `assetPrefix` 为 `true`，Rsbuild 会根据开发服务器的协议、主机名、实际监听端口和 [server.base](/config/server/base) 生成绝对 URL 前缀。
+
+使用默认服务器配置时，前缀为 `http://localhost:<port>/`：
 
 ```ts title="rsbuild.config.ts"
 export default {
@@ -47,10 +49,12 @@ export default {
 在浏览器中加载的资源 URL 如下：
 
 ```html
-<script defer src="http://localhost:3000/static/js/main.js"></script>
+<script defer src="http://localhost:3000/static/js/index.js"></script>
 ```
 
-如果设置 `assetPrefix` 为 `false` 或不设置，则默认使用 `/` 作为访问前缀。
+开启 [server.https](/config/server/https) 后，协议会变为 `https`。主机名取自 [server.host](/config/server/host)，其中 `0.0.0.0` 会被替换为 `localhost`。Rsbuild 还会将 `server.base` 拼接到 URL 中。例如，当 `server.host` 为 `'127.0.0.1'`、`server.base` 为 `'/foo'`、监听端口为 `3000` 时，前缀为 `http://127.0.0.1:3000/foo/`。
+
+如果设置 `assetPrefix` 为 `false`，即使自定义了 `server.base`，前缀也为 `/`。如果不设置 `assetPrefix`，则会继承 `server.base`。
 
 ## String 类型
 
@@ -69,7 +73,7 @@ export default {
 在浏览器中加载的资源 URL 如下：
 
 ```html
-<script defer src="http://localhost:3000/example/static/js/index.js"></script>
+<script defer src="/example/static/js/index.js"></script>
 ```
 
 - 比如设置为完整 URL：


### PR DESCRIPTION
## Summary

Correct the English and Chinese `dev.assetPrefix` documentation to match how Rsbuild resolves asset URLs:

- Explain that `true` uses the dev server's protocol, hostname, actual listening port, and `server.base`, including the `0.0.0.0` to `localhost` substitution.
- Distinguish an explicit `false` value, which uses `/`, from an omitted value, which inherits `server.base`.
- Correct the HTML examples to use the default `index` entry and preserve a root-relative asset prefix.

## Validation

- Checked the resolution logic in `packages/core/src/plugins/output.ts`, `packages/core/src/defaultConfig.ts`, and `packages/core/src/server/devServer.ts`.
- Ran 11 configuration scenarios against `@rsbuild/core@2.2.4` with Node.js 24.16.0, covering omitted/false/true values, custom base and host, HTTPS, `0.0.0.0`, dynamic ports, root-relative and absolute strings, and the `<port>` placeholder. Confirmed the relevant published implementation matches the current source.
- Compiled a development entry and checked that the generated HTML contains `src="/example/static/js/index.js"`.
- Passed Prettier checks for both changed MDX files with the repository's `singleQuote` setting and `git diff --check`.

- Passed project-configured CSpell checks, MDX compilation, and internal route checks for both changed pages; headings are unchanged.

- The full documentation site build was not run locally; verification fixtures are separate and are not included in the PR.

## Related links

- [dev.assetPrefix](https://rsbuild.rs/config/dev/asset-prefix)
- [server.base](https://rsbuild.rs/config/server/base)

## Checklist

- [x] English and Chinese documentation are synchronized.
- [x] The documented behavior was checked against source and executed configuration/build scenarios.
- [x] This change only updates documentation.
