### PR TITLE
docs: correct HTML tag examples and hash behavior

### DIFF
--- a/website/docs/en/config/html/tags.mdx
+++ b/website/docs/en/config/html/tags.mdx
@@ -152,9 +152,9 @@ export default {
 Controls whether to add a hash query parameter to asset URLs for cache invalidation, only affects the `src` attribute of the `script` tag and the `href` attribute of the `link` tag.
 
 - `false`: No hash query
-- `true`: Generate hash based on HTML content
+- `true`: Appends the Rspack compilation hash
 - `string`: Uses a custom hash string
-- `function`: Custom hash generation via a function
+- `function`: Returns a URL based on the asset URL and Rspack compilation hash
 
 ```ts title="rsbuild.config.ts"
 export default {
@@ -369,7 +369,7 @@ export default {
         }
       },
       (tags) => {
-        // Insert 'b.js' after 'a.js'
+        // Insert 'd.js' after 'a.js'
         const targetIndex = tags.findIndex((tag) => tag.attrs?.src === 'a.js');
 
         tags.splice(targetIndex + 1, 0, {
@@ -425,9 +425,9 @@ export default {
 The tag object here will be directly added to the HTML file after processing, but the `polyfill.ts` will not be transpiled or bundled, so there will be a 404 error when processing this script in the application.
 
 ```html
-<body>
+<head>
   <script src="https://example.com/src/polyfill.ts"></script>
-</body>
+</head>
 ```
 
 Reasonable use cases include:
@@ -452,10 +452,10 @@ function report() {
 }
 
 export default {
+  output: {
+    assetPrefix: 'https://example.com/',
+  },
   html: {
-    output: {
-      assetPrefix: 'https://example.com/',
-    },
     tags: [
       // Inject asset from the `public` directory.
       { tag: 'script', attrs: { src: 'service-worker.js' } },
@@ -478,7 +478,7 @@ export default {
 The result will look like:
 
 ```html
-<body>
+<head>
   <script src="https://example.com/service-worker.js"></script>
   <script src="https://cdn.example.com/foo.js"></script>
   <script>
@@ -487,7 +487,7 @@ The result will look like:
     }
     report();
   </script>
-</body>
+</head>
 ```
 
 ## Version history

--- a/website/docs/zh/config/html/tags.mdx
+++ b/website/docs/zh/config/html/tags.mdx
@@ -152,9 +152,9 @@ export default {
 控制是否为资源的 URL 添加 hash 作为 query 参数，以进行缓存失效，仅影响 `script` 标签的 `src` 属性和 `link` 标签的 `href` 属性。
 
 - `false`：不添加 hash query 参数
-- `true`：基于 HTML 内容生成 hash
+- `true`：追加 Rspack 编译的 hash
 - `string`：使用自定义的 hash 字符串
-- `function`：通过函数自定义 hash 生成
+- `function`：根据资源 URL 和 Rspack 编译的 hash 返回 URL
 
 ```ts title="rsbuild.config.ts"
 export default {
@@ -425,9 +425,9 @@ export default {
 这里的 tag 对象将会在简单处理后直接添加到 HTML 产物中，但对应的 `polyfill.ts` 将不会被转译、打包，也因此应用会在处理这行脚本时出现 404 错误。
 
 ```html
-<body>
+<head>
   <script src="https://example.com/src/polyfill.ts"></script>
-</body>
+</head>
 ```
 
 合理的使用场景包括：
@@ -452,10 +452,10 @@ function report() {
 }
 
 export default {
+  output: {
+    assetPrefix: 'https://example.com/',
+  },
   html: {
-    output: {
-      assetPrefix: 'https://example.com/',
-    },
     tags: [
       // Inject asset from the `public` directory.
       { tag: 'script', attrs: { src: 'service-worker.js' } },
@@ -478,7 +478,7 @@ export default {
 得到的产物将会类似：
 
 ```html
-<body>
+<head>
   <script src="https://example.com/service-worker.js"></script>
   <script src="https://cdn.example.com/foo.js"></script>
   <script>
@@ -487,7 +487,7 @@ export default {
     }
     report();
   </script>
-</body>
+</head>
 ```
 
 ## 版本历史


### PR DESCRIPTION
## Summary

Make the English and Chinese `html.tags` examples match the configuration API and generated HTML.

- Move `output.assetPrefix` to the top level of the CDN example so the public asset receives the documented CDN URL.
- Show custom script tags in `<head>`, their default injection position, and align the handler example's comment with its `d.js` tag.
- Clarify that `hash: true` appends the Rspack compilation hash and that a hash callback returns the complete asset URL.

## Validation

- Built 8 documented configurations across both languages with `@rsbuild/core` 2.2.4 and `@rspack/core` 2.2.3 on Node.js 24.16.0. Checked CDN URLs, tag positions, handler order, and the generated hash against build stats.
- Reproduced the previous CDN example in both languages: `html.output` fails configuration type checking and produces `/service-worker.js` instead of the documented CDN URL.
- Built 2 additional cases confirming that hash callbacks receive the prefixed asset URL and compilation hash and return the final URL.
- TypeScript 5.9.3 checks passed for all 8 documented configurations. Prettier 3.9.6 with the repository's single-quote and heading-case settings and `git diff --check` passed.
- Cross-checked the behavior against the current source. The full documentation site build was not run locally; repository dependencies are not installed. Validation fixtures are separate and are not included in the PR.

- Passed project-configured CSpell checks, MDX compilation, and internal route checks for both changed pages; headings are unchanged.

## Related links

- [HTML tag processing](https://github.com/web-infra-dev/rsbuild/blob/13e1cd4f05f15471e399db01afd2b92886f26119/packages/core/src/rspack-plugins/RsbuildHtmlPlugin.ts)
- [HTML configuration types](https://github.com/web-infra-dev/rsbuild/blob/13e1cd4f05f15471e399db01afd2b92886f26119/packages/core/src/types/config.ts)

## Checklist

- [x] Tests updated (or not required; documentation only).
- [x] Documentation updated (English and Chinese).
