### PR TITLE
feat(core): support custom compression levels in file size reporting

### DIFF
--- a/e2e/cases/print-file-size/basic/index.test.ts
+++ b/e2e/cases/print-file-size/basic/index.test.ts
@@ -208,15 +208,22 @@ test('should respect a custom total function for printFileSize', async ({
   await rsbuild.expectLog('Generated 5 files.');
 });
 
-for (const type of ['gzip', 'brotli'] as const) {
-  test(`should report accurate ${type} sizes with compressed.type`, async ({
+for (const [type, level] of [
+  ['gzip', undefined],
+  ['gzip', 0],
+  ['gzip', 9],
+  ['brotli', undefined],
+  ['brotli', 0],
+  ['brotli', 11],
+] as const) {
+  test(`should report accurate ${type} sizes at level ${level ?? 'default'}`, async ({
     build,
   }) => {
     const rsbuild = await build({
       config: {
         performance: {
           printFileSize: {
-            compressed: { type },
+            compressed: { type, level },
             detail: false,
             include: ({ name }) => name === 'index.html',
             total: ({ totalGzipSize, totalBrotliSize }) =>
@@ -229,9 +236,9 @@ for (const type of ['gzip', 'brotli'] as const) {
     const size =
       type === 'brotli'
         ? zlib.brotliCompressSync(html, {
-            params: { [zlib.constants.BROTLI_PARAM_QUALITY]: 6 },
+            params: { [zlib.constants.BROTLI_PARAM_QUALITY]: level ?? 6 },
           }).length
-        : zlib.gzipSync(html).length;
+        : zlib.gzipSync(html, { level }).length;
     await rsbuild.expectLog(
       type === 'brotli' ? `Sizes: 0/${size}` : `Sizes: ${size}/undefined`,
     );

--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -50,10 +50,13 @@ type FormattedAsset = {
 };
 
 function getCompression(compressed: PrintFileSizeOptions['compressed']) {
-  const type = typeof compressed === 'object' ? compressed.type : 'gzip';
+  const { type = 'gzip', level = 6 } =
+    typeof compressed === 'object' ? compressed : {};
+
   return type === 'brotli'
     ? ({
         type,
+        level,
         header: 'Br',
         label: 'brotli',
         sizeKey: 'brotliSize',
@@ -61,6 +64,7 @@ function getCompression(compressed: PrintFileSizeOptions['compressed']) {
       } as const)
     : ({
         type,
+        level,
         header: 'Gzip',
         label: 'gzipped',
         sizeKey: 'gzippedSize',
@@ -71,6 +75,7 @@ function getCompression(compressed: PrintFileSizeOptions['compressed']) {
 async function calcCompressedSize(
   input: Buffer | string,
   type: CompressionType,
+  level: number,
 ) {
   const data = await new Promise<Buffer>((resolve, reject) => {
     const callback = (err: Error | null, result: Buffer) => {
@@ -83,11 +88,11 @@ async function calcCompressedSize(
     if (type === 'brotli') {
       zlib.brotliCompress(
         input,
-        { params: { [zlib.constants.BROTLI_PARAM_QUALITY]: 6 } },
+        { params: { [zlib.constants.BROTLI_PARAM_QUALITY]: level } },
         callback,
       );
     } else {
-      zlib.gzip(input, callback);
+      zlib.gzip(input, { level }, callback);
     }
   });
   return data.length;
@@ -384,8 +389,8 @@ async function printFileSizes(
         formattedAssets.push(formatAsset(filePath, size, null));
       } else {
         formattedAssets.push(
-          calcCompressedSize(content, compression.type).then((compressedSize) =>
-            formatAsset(filePath, size, compressedSize),
+          calcCompressedSize(content, compression.type, compression.level).then(
+            (compressedSize) => formatAsset(filePath, size, compressedSize),
           ),
         );
       }

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -718,9 +718,15 @@ export type PrintFileSizeOptions = {
     | {
         /**
          * The compression algorithm used to calculate file sizes.
-         * Brotli uses quality 6.
+         * @default 'gzip'
          */
         type: 'gzip' | 'brotli';
+        /**
+         * The compression level: an integer from 0 to 9 for gzip, or 0 to 11 for Brotli.
+         * Higher levels generally produce smaller sizes but take longer to calculate.
+         * @default 6
+         */
+        level?: number;
       };
   /**
    * A filter function to determine which static assets to print.

--- a/website/docs/en/config/performance/print-file-size.mdx
+++ b/website/docs/en/config/performance/print-file-size.mdx
@@ -12,7 +12,7 @@ type PrintFileSizeOptions =
   | {
       total?: boolean | Function;
       detail?: boolean;
-      compressed?: boolean | { type: 'gzip' | 'brotli' };
+      compressed?: boolean | { type: 'gzip' | 'brotli'; level?: number };
       include?: (asset: PrintFileSizeAsset) => boolean;
       exclude?: (asset: PrintFileSizeAsset) => boolean;
       diff?: boolean;
@@ -134,32 +134,12 @@ export default {
 
 ### compressed
 
-- **Type:** `boolean | { type: 'gzip' | 'brotli' }`
+- **Type:** `boolean | { type: 'gzip' | 'brotli'; level?: number }`
 - **Default:** `false` when [output.target](/config/output/target) is `node`, otherwise `true`
 
-Controls whether to calculate and print compressed asset sizes after a build.
+Controls whether to calculate and print compressed asset sizes after a build. Set to `true` to report gzip sizes, `false` to skip compression calculations, or an object to configure the algorithm and level.
 
-| Value                        | Behavior                                                          |
-| ---------------------------- | ----------------------------------------------------------------- |
-| `true` or `{ type: 'gzip' }` | Report gzip sizes in the `Gzip` column.                           |
-| `{ type: 'brotli' }`         | Report Brotli sizes in the `Br` column, using quality level 6.    |
-| `false`                      | Skip compression calculations and report only uncompressed sizes. |
-
-For example, to report Brotli sizes:
-
-```ts title="rsbuild.config.ts"
-export default {
-  performance: {
-    printFileSize: {
-      compressed: {
-        type: 'brotli',
-      },
-    },
-  },
-};
-```
-
-Calculating compressed sizes adds to build time. Brotli can take longer than gzip, especially when the build produces many assets or large files. If you do not need compressed size reporting, set `compressed` to `false` to skip these calculations:
+Calculating compressed sizes adds to build time. If you do not need compressed size reporting, set `compressed` to `false` to skip these calculations:
 
 ```ts title="rsbuild.config.ts"
 export default {
@@ -175,9 +155,64 @@ export default {
 
 - This option only reports sizes; it does not generate compressed files. To serve compressed assets, you typically need to configure compression on your server or CDN. Actual transfer sizes depend on those compression settings.
 - For non-compressible assets (such as images), the compressed size is not shown in the detailed list, but their original size is included in the total compressed size.
-- When `diff` is enabled, Rsbuild compares compressed sizes only when both builds use the same algorithm. Switching algorithms does not affect comparisons of uncompressed sizes.
+- When `diff` is enabled, Rsbuild compares compressed sizes only when both builds use the same algorithm. Changes caused by adjusting `level` are included in the compressed size diff. Comparisons of uncompressed sizes are unaffected by these settings.
 
 :::
+
+#### type
+
+- **Type:** `'gzip' | 'brotli'`
+- **Default:** `'gzip'`
+
+Selects the compression algorithm used to calculate asset sizes:
+
+| Value      | Behavior                                |
+| ---------- | --------------------------------------- |
+| `'gzip'`   | Report gzip sizes in the `Gzip` column. |
+| `'brotli'` | Report Brotli sizes in the `Br` column. |
+
+For example, to report Brotli sizes:
+
+```ts title="rsbuild.config.ts"
+export default {
+  performance: {
+    printFileSize: {
+      compressed: {
+        type: 'brotli',
+      },
+    },
+  },
+};
+```
+
+Brotli can take longer than gzip, especially when the build produces many assets or large files.
+
+#### level
+
+- **Type:** `number`
+- **Default:** `6`
+
+Sets the compression level. The valid range depends on the algorithm:
+
+- **gzip**: An integer from `0` to `9`.
+- **Brotli**: An integer from `0` to `11`, corresponding to Brotli's quality parameter.
+
+For example, use Brotli's highest level to estimate the size of assets precompressed at level 11:
+
+```ts title="rsbuild.config.ts"
+export default {
+  performance: {
+    printFileSize: {
+      compressed: {
+        type: 'brotli',
+        level: 11,
+      },
+    },
+  },
+};
+```
+
+Higher levels generally produce smaller files but take longer to calculate. Brotli level 11 can be particularly slow. To estimate production transfer sizes, use the same algorithm and level as your server or CDN.
 
 ### include
 
@@ -298,7 +333,7 @@ Snapshots are stored at `<root>/node_modules/.cache/rsbuild/file-sizes-[hash].js
 
 ## Version history
 
-| Version | Changes                                                         |
-| ------- | --------------------------------------------------------------- |
-| v2.2.5  | Added `compressed.type` option to support Brotli size reporting |
-| v1.6.13 | Added `diff` option                                             |
+| Version | Changes                                                                                              |
+| ------- | ---------------------------------------------------------------------------------------------------- |
+| v2.2.5  | Added `compressed.type` and `compressed.level` options to select the compression algorithm and level |
+| v1.6.13 | Added `diff` option                                                                                  |

--- a/website/docs/zh/config/performance/print-file-size.mdx
+++ b/website/docs/zh/config/performance/print-file-size.mdx
@@ -12,7 +12,7 @@ type PrintFileSizeOptions =
   | {
       total?: boolean | Function;
       detail?: boolean;
-      compressed?: boolean | { type: 'gzip' | 'brotli' };
+      compressed?: boolean | { type: 'gzip' | 'brotli'; level?: number };
       include?: (asset: PrintFileSizeAsset) => boolean;
       exclude?: (asset: PrintFileSizeAsset) => boolean;
       diff?: boolean;
@@ -134,32 +134,12 @@ export default {
 
 ### compressed
 
-- **类型：** `boolean | { type: 'gzip' | 'brotli' }`
+- **类型：** `boolean | { type: 'gzip' | 'brotli'; level?: number }`
 - **默认值：** 当 [output.target](/config/output/target) 为 `node` 时为 `false`，否则为 `true`
 
-控制是否在构建结束后计算并输出静态资源压缩后的体积。
+控制是否在构建结束后计算并输出静态资源压缩后的体积。设置为 `true` 时统计 gzip 体积，`false` 时跳过压缩计算，也可以通过对象配置压缩算法和等级。
 
-| 配置值                       | 行为                                                  |
-| ---------------------------- | ----------------------------------------------------- |
-| `true` 或 `{ type: 'gzip' }` | 计算 gzip 体积，并在 `Gzip` 列中显示。                |
-| `{ type: 'brotli' }`         | 使用压缩等级 6 计算 Brotli 体积，并在 `Br` 列中显示。 |
-| `false`                      | 跳过压缩计算，仅输出未压缩的体积。                    |
-
-例如，以下配置会输出 Brotli 体积：
-
-```ts title="rsbuild.config.ts"
-export default {
-  performance: {
-    printFileSize: {
-      compressed: {
-        type: 'brotli',
-      },
-    },
-  },
-};
-```
-
-计算压缩体积需要额外时间。Brotli 压缩可能比 gzip 更耗时，因此开启 Brotli 体积统计可能使构建变慢，尤其是产物较多或文件较大时。如果你不需要查看压缩后的体积，可以将 `compressed` 设置为 `false`，跳过这部分计算：
+计算压缩体积需要额外时间。如果你不需要查看压缩后的体积，可以将 `compressed` 设置为 `false`，跳过这部分计算：
 
 ```ts title="rsbuild.config.ts"
 export default {
@@ -175,9 +155,64 @@ export default {
 
 - 此选项仅用于体积统计，不会生成压缩文件。要向浏览器提供压缩后的资源，通常需要在服务器或 CDN 中配置压缩，实际传输体积取决于这些压缩配置。
 - 对于不适合压缩的静态资源（如图片文件），详细列表中不会显示其压缩体积，但计算压缩后的总体积时会计入这些资源的原始大小。
-- 开启 `diff` 时，Rsbuild 仅在前后两次构建使用相同算法时比较压缩体积。切换算法不影响未压缩体积的比较。
+- 开启 `diff` 时，Rsbuild 仅在前后两次构建使用相同算法时比较压缩体积，调整 `level` 带来的体积变化也会计入差值。修改算法或等级不影响未压缩体积的比较。
 
 :::
+
+#### type
+
+- **类型：** `'gzip' | 'brotli'`
+- **默认值：** `'gzip'`
+
+指定计算资源体积时使用的压缩算法：
+
+| 配置值     | 行为                                   |
+| ---------- | -------------------------------------- |
+| `'gzip'`   | 计算 gzip 体积，并在 `Gzip` 列中显示。 |
+| `'brotli'` | 计算 Brotli 体积，并在 `Br` 列中显示。 |
+
+例如，以下配置会输出 Brotli 体积：
+
+```ts title="rsbuild.config.ts"
+export default {
+  performance: {
+    printFileSize: {
+      compressed: {
+        type: 'brotli',
+      },
+    },
+  },
+};
+```
+
+Brotli 压缩可能比 gzip 更耗时，因此开启 Brotli 体积统计可能使构建变慢，尤其是产物较多或文件较大时。
+
+#### level
+
+- **类型：** `number`
+- **默认值：** `6`
+
+设置压缩等级，取值范围取决于所选算法：
+
+- **gzip**：`0` 到 `9` 之间的整数。
+- **Brotli**：`0` 到 `11` 之间的整数，对应 Brotli 的 quality 参数。
+
+例如，使用 Brotli 的最高等级，估算以等级 11 预压缩的产物体积：
+
+```ts title="rsbuild.config.ts"
+export default {
+  performance: {
+    printFileSize: {
+      compressed: {
+        type: 'brotli',
+        level: 11,
+      },
+    },
+  },
+};
+```
+
+等级越高，压缩后的文件通常越小，但计算耗时也越长，Brotli 等级 11 尤其耗时。要估算生产环境中的传输体积，建议使用与服务器或 CDN 相同的压缩算法和等级。
 
 ### include
 
@@ -298,7 +333,7 @@ dist/static/css/index.2960ac62ab.css      0.35 kB (+0.35 kB)    0.26 kB (+0.26 k
 
 ## 版本历史
 
-| 版本    | 变更内容                                              |
-| ------- | ----------------------------------------------------- |
-| v2.2.5  | 新增 `compressed.type` 选项，支持输出 Brotli 压缩体积 |
-| v1.6.13 | 新增 `diff` 选项                                      |
+| 版本    | 变更内容                                                                  |
+| ------- | ------------------------------------------------------------------------- |
+| v2.2.5  | 新增 `compressed.type` 和 `compressed.level` 选项，支持选择压缩算法和等级 |
+| v1.6.13 | 新增 `diff` 选项                                                          |


### PR DESCRIPTION
## Summary

File size reports use a fixed compression level, which may differ from deployment settings. This PR adds `performance.printFileSize.compressed.level` to configure gzip and Brotli compression levels, preserving the default of `6` for both algorithms.

## Related links

- https://github.com/web-infra-dev/rsbuild/pull/8458