### PR TITLE
docs: simplify dev.assetPrefix boolean options

### DIFF
--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -2,6 +2,7 @@
 
 For documentation under `website/docs`:
 
+- Explain user-facing behavior concisely, adding details and examples only when they help users configure or use the feature.
 - Use sentence-case headings and keep common abbreviations such as `dev server`.
 - Keep the English and Chinese documentation in sync when changing content.
 - Keep heading IDs and links aligned across languages; use [add-doc-anchor-ids](../.agents/skills/add-doc-anchor-ids/SKILL.md) when headings or hashes change.

--- a/website/docs/en/config/dev/asset-prefix.mdx
+++ b/website/docs/en/config/dev/asset-prefix.mdx
@@ -34,9 +34,10 @@ export default {
 
 ## Boolean type
 
-If `assetPrefix` is set to `true`, Rsbuild generates an absolute URL prefix from the dev server's protocol, hostname, actual listening port, and [server.base](/config/server/base).
+- `true`: Generates an absolute URL prefix from the dev server's protocol ([server.https](/config/server/https)), hostname ([server.host](/config/server/host)), actual listening port, and [server.base](/config/server/base).
+- `false`: Uses `/` as the asset prefix.
 
-With the default server configuration, the prefix is `http://localhost:<port>/`:
+For example, when set to `true` with the default server configuration, the prefix is `http://localhost:<port>/`:
 
 ```ts title="rsbuild.config.ts"
 export default {
@@ -51,10 +52,6 @@ The resource URL loaded in the browser is as follows:
 ```html
 <script defer src="http://localhost:3000/static/js/index.js"></script>
 ```
-
-Enabling [server.https](/config/server/https) changes the protocol to `https`. The hostname follows [server.host](/config/server/host), except that `0.0.0.0` is replaced with `localhost`. Rsbuild also appends `server.base` to the URL. For example, with `server.host: '127.0.0.1'`, `server.base: '/foo'`, and a listening port of `3000`, the prefix is `http://127.0.0.1:3000/foo/`.
-
-If `assetPrefix` is set to `false`, the prefix is `/`, even when `server.base` is customized. If `assetPrefix` is not set, it inherits `server.base` instead.
 
 ## String type
 

--- a/website/docs/zh/config/dev/asset-prefix.mdx
+++ b/website/docs/zh/config/dev/asset-prefix.mdx
@@ -34,9 +34,10 @@ export default {
 
 ## Boolean 类型
 
-如果设置 `assetPrefix` 为 `true`，Rsbuild 会根据开发服务器的协议、主机名、实际监听端口和 [server.base](/config/server/base) 生成绝对 URL 前缀。
+- `true`：根据开发服务器的协议（[server.https](/config/server/https)）、主机名（[server.host](/config/server/host)）、实际监听端口和 [server.base](/config/server/base) 生成绝对 URL 前缀。
+- `false`：使用 `/` 作为资源前缀。
 
-使用默认服务器配置时，前缀为 `http://localhost:<port>/`：
+例如，设置为 `true` 且使用默认服务器配置时，前缀为 `http://localhost:<port>/`：
 
 ```ts title="rsbuild.config.ts"
 export default {
@@ -51,10 +52,6 @@ export default {
 ```html
 <script defer src="http://localhost:3000/static/js/index.js"></script>
 ```
-
-开启 [server.https](/config/server/https) 后，协议会变为 `https`。主机名取自 [server.host](/config/server/host)，其中 `0.0.0.0` 会被替换为 `localhost`。Rsbuild 还会将 `server.base` 拼接到 URL 中。例如，当 `server.host` 为 `'127.0.0.1'`、`server.base` 为 `'/foo'`、监听端口为 `3000` 时，前缀为 `http://127.0.0.1:3000/foo/`。
-
-如果设置 `assetPrefix` 为 `false`，即使自定义了 `server.base`，前缀也为 `/`。如果不设置 `assetPrefix`，则会继承 `server.base`。
 
 ## String 类型
 


### PR DESCRIPTION
## Summary

The `dev.assetPrefix` boolean section repeats URL-generation details and separates the `false` behavior from the main explanation. This PR groups `true` and `false` before the example and removes redundant details in both English and Chinese.