### PR TITLE
fix(types): make file size compression type optional

### DIFF
--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -720,7 +720,7 @@ export type PrintFileSizeOptions = {
          * The compression algorithm used to calculate file sizes.
          * @default 'gzip'
          */
-        type: 'gzip' | 'brotli';
+        type?: 'gzip' | 'brotli';
         /**
          * The compression level: an integer from 0 to 9 for gzip, or 0 to 11 for Brotli.
          * Higher levels generally produce smaller sizes but take longer to calculate.

--- a/website/docs/en/config/performance/print-file-size.mdx
+++ b/website/docs/en/config/performance/print-file-size.mdx
@@ -134,7 +134,7 @@ export default {
 
 ### compressed
 
-- **Type:** `boolean | { type: 'gzip' | 'brotli'; level?: number }`
+- **Type:** `boolean | { type?: 'gzip' | 'brotli'; level?: number }`
 - **Default:** `false` when [output.target](/config/output/target) is `node`, otherwise `true`
 
 Controls whether to calculate and print compressed asset sizes after a build. Set to `true` to report gzip sizes, `false` to skip compression calculations, or an object to configure the algorithm and level.

--- a/website/docs/en/config/performance/print-file-size.mdx
+++ b/website/docs/en/config/performance/print-file-size.mdx
@@ -12,7 +12,7 @@ type PrintFileSizeOptions =
   | {
       total?: boolean | Function;
       detail?: boolean;
-      compressed?: boolean | { type: 'gzip' | 'brotli'; level?: number };
+      compressed?: boolean | { type?: 'gzip' | 'brotli'; level?: number };
       include?: (asset: PrintFileSizeAsset) => boolean;
       exclude?: (asset: PrintFileSizeAsset) => boolean;
       diff?: boolean;

--- a/website/docs/zh/config/performance/print-file-size.mdx
+++ b/website/docs/zh/config/performance/print-file-size.mdx
@@ -134,7 +134,7 @@ export default {
 
 ### compressed
 
-- **类型：** `boolean | { type: 'gzip' | 'brotli'; level?: number }`
+- **类型：** `boolean | { type?: 'gzip' | 'brotli'; level?: number }`
 - **默认值：** 当 [output.target](/config/output/target) 为 `node` 时为 `false`，否则为 `true`
 
 控制是否在构建结束后计算并输出静态资源压缩后的体积。设置为 `true` 时统计 gzip 体积，`false` 时跳过压缩计算，也可以通过对象配置压缩算法和等级。

--- a/website/docs/zh/config/performance/print-file-size.mdx
+++ b/website/docs/zh/config/performance/print-file-size.mdx
@@ -12,7 +12,7 @@ type PrintFileSizeOptions =
   | {
       total?: boolean | Function;
       detail?: boolean;
-      compressed?: boolean | { type: 'gzip' | 'brotli'; level?: number };
+      compressed?: boolean | { type?: 'gzip' | 'brotli'; level?: number };
       include?: (asset: PrintFileSizeAsset) => boolean;
       exclude?: (asset: PrintFileSizeAsset) => boolean;
       diff?: boolean;


### PR DESCRIPTION
## Summary

The runtime defaults to gzip when `compressed.type` is omitted, but the type definition still requires it. Make `performance.printFileSize.compressed.type` optional so users can configure only the level, for example `compressed: { level: 9 }`.

## Related links

https://github.com/web-infra-dev/rsbuild/pull/8464