### PR TITLE
fix(core): show compressed size diff when only printing totals

### DIFF
--- a/e2e/cases/print-file-size/diff/__snapshots__/index.test.ts.snap
+++ b/e2e/cases/print-file-size/diff/__snapshots__/index.test.ts.snap
@@ -35,6 +35,21 @@ dist/index.html                      X.X kB (-X.X kB)   X.X kB (-X.X kB)
                             Total:   X.X kB (-X.X kB)    X.X kB (-X.X kB)"
 `;
 
+exports[`should print brotli total size differences 1`] = `
+"
+Total size (web): X.X kB (X.X kB brotli)"
+`;
+
+exports[`should print brotli total size differences 2`] = `
+"
+Total size (web): X.X kB (+X.X kB) (X.X kB (+X.X kB) brotli)"
+`;
+
+exports[`should print brotli total size differences 3`] = `
+"
+Total size (web): X.X kB (-X.X kB) (X.X kB (-X.X kB) brotli)"
+`;
+
 exports[`should print gzip size differences 1`] = `
 "
 File (web)                         Size      Gzip
@@ -60,4 +75,19 @@ dist/static/js/index.[[hash]].js     X.X kB (-X.X kB)    X.X kB (-X.X kB)
 dist/static/css/index.[[hash]].css   X.X kB              X.X kB
 dist/index.html                      X.X kB (-X.X kB)   X.X kB (-X.X kB)
                             Total:   X.X kB (-X.X kB)    X.X kB (-X.X kB)"
+`;
+
+exports[`should print gzip total size differences 1`] = `
+"
+Total size (web): X.X kB (X.X kB gzipped)"
+`;
+
+exports[`should print gzip total size differences 2`] = `
+"
+Total size (web): X.X kB (+X.X kB) (X.X kB (+X.X kB) gzipped)"
+`;
+
+exports[`should print gzip total size differences 3`] = `
+"
+Total size (web): X.X kB (-X.X kB) (X.X kB (-X.X kB) gzipped)"
 `;

--- a/e2e/cases/print-file-size/diff/index.test.ts
+++ b/e2e/cases/print-file-size/diff/index.test.ts
@@ -3,8 +3,13 @@ import { expect, test } from '@e2e/helper';
 import fse from 'fs-extra';
 import { extractFileSizeLogs } from '../helper';
 
-for (const type of ['gzip', 'brotli'] as const) {
-  test(`should print ${type} size differences`, async ({
+for (const [type, detail] of [
+  ['gzip', true],
+  ['brotli', true],
+  ['gzip', false],
+  ['brotli', false],
+] as const) {
+  test(`should print ${type} ${detail ? '' : 'total '}size differences`, async ({
     cwd,
     build,
     editFile,
@@ -14,7 +19,7 @@ for (const type of ['gzip', 'brotli'] as const) {
     await fse.remove(cacheDir);
     const srcDir = await copySrcDir();
     const config = {
-      performance: { printFileSize: { compressed: { type } } },
+      performance: { printFileSize: { compressed: { type }, detail } },
       source: {
         entry: {
           index: join(srcDir, 'index.js'),

--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -456,6 +456,15 @@ async function printFileSizes(
   const { totalSizeTitle, totalSizeLabel, totalSizeLabelLength } =
     getTotalSizeLabel();
 
+  const getCompressedTotalDiff = () => {
+    if (!showCompressedDiff) {
+      return '';
+    }
+
+    const diff = totalCompressedSize - (prev?.[compression.totalKey] ?? 0);
+    return isSignificantDiff(diff) ? ` ${formatDiff(diff).label}` : '';
+  };
+
   const getCustomTotal = () => {
     if (typeof options.total === 'function') {
       return options.total({
@@ -549,15 +558,7 @@ async function printFileSizes(
         if (options.compressed) {
           const colorFn = getAssetColor(totalCompressedSize / assets.length);
           log += ' '.repeat(maxSizeLength - totalSizeLabelLength);
-          log += `   ${colorFn(calcFileSize(totalCompressedSize))}`;
-
-          if (showCompressedDiff) {
-            const totalCompressedSizeDiff =
-              totalCompressedSize - (prev?.[compression.totalKey] ?? 0);
-            if (isSignificantDiff(totalCompressedSizeDiff)) {
-              log += ` ${formatDiff(totalCompressedSizeDiff).label}`;
-            }
-          }
+          log += `   ${colorFn(calcFileSize(totalCompressedSize))}${getCompressedTotalDiff()}`;
         }
 
         logs.push(log);
@@ -574,7 +575,7 @@ async function printFileSizes(
 
       if (options.compressed) {
         log += color.green(
-          ` (${calcFileSize(totalCompressedSize)} ${compression.label})`,
+          ` (${calcFileSize(totalCompressedSize)}${getCompressedTotalDiff()} ${compression.label})`,
         );
       }
 


### PR DESCRIPTION
## Summary

With `performance.printFileSize.detail: false`, the total output omits compressed size differences even when `diff` is enabled. This PR shares the compressed total diff logic between both display modes, so gzip and Brotli totals include differences when comparing the same algorithm. The diff is calculated only when needed for the output.