### PR TITLE
chore: update pull request template

### DIFF
--- a/.agents/skills/pr-creator/SKILL.md
+++ b/.agents/skills/pr-creator/SKILL.md
@@ -17,7 +17,7 @@ metadata:
    Do not revert unrelated user changes.
    Before creating the PR, ensure the intended changes are committed and never commit directly on the default branch.
 
-3. If `.github/PULL_REQUEST_TEMPLATE.md` exists, read it and follow its current headings and guidance.
+3. Read the repository's PR template when available and follow its current headings and guidance.
 
 4. Draft the PR title in the repository's standard format. If the repository uses Conventional Commits, common patterns include:
    - `feat(core): add ...`
@@ -29,20 +29,13 @@ metadata:
    - `release: v1.2.0`
 
 5. Write the PR body in concise, clear English.
-   - Explain the change context first: the user-facing problem, maintenance goal, or compatibility constraint that makes the change necessary.
-   - Prioritize high-signal information: public API changes, behavior changes, breaking changes, migration notes, and important compatibility implications.
-   - Then describe the main implementation change only as much as needed to understand the review.
-   - Keep the PR body concise and review-oriented: use 1-4 short standalone sentences for typical changes, covering why it matters, what changed, and any reviewer-important impact.
-   - Omit incidental updates to tests, documentation, and supporting artifacts from the PR description; mention them only when they are the PR's primary purpose or carry reviewer-relevant risk.
-   - Avoid low-signal sections such as `Test plan` or `Validation`, routine verification commands, generated file lists, or obvious implementation details unless the repository template explicitly requires them or the change has unusual validation risk.
-   - Good background examples:
-     - `This PR adds support for custom logger injection so CLI output can be isolated per instance.`
-     - `This PR fixes incorrect padding in URL labels to keep terminal output aligned across different label lengths.`
-     - `This PR updates the English docs to clarify how the extraction option works and when to enable it.`
+   - Explain the problem or motivation and why it matters, then describe the approach and resulting behavior.
+   - Include API, compatibility, or migration details when they help reviewers assess the change.
+   - Keep typical descriptions to a few short sentences. Focus on the key changes rather than a file-by-file summary.
+   - Mention tests, documentation, and validation only when required by the template, central to the change, or relevant to review risk.
 
-6. Include relevant issue links, design docs, related PRs, or discussion pages alongside the context they support.
-   If the PR upgrades an npm dependency, add a link to the upgraded version's release notes or tag page when available.
-   Example: `https://github.com/web-infra-dev/rspack/releases/tag/v1.0.0`
+6. Include relevant issue, discussion, or design links alongside the context they support, following the template's guidance.
+   For dependency upgrades, link to the target version's release notes or tag when available.
 
 7. Push the branch only after re-checking the branch name. Never push the default branch directly.
 

--- a/.agents/skills/pr-creator/SKILL.md
+++ b/.agents/skills/pr-creator/SKILL.md
@@ -17,7 +17,7 @@ metadata:
    Do not revert unrelated user changes.
    Before creating the PR, ensure the intended changes are committed and never commit directly on the default branch.
 
-3. If `.github/PULL_REQUEST_TEMPLATE.md` exists, read it and follow its structure.
+3. If `.github/PULL_REQUEST_TEMPLATE.md` exists, read it and follow its current headings and guidance.
 
 4. Draft the PR title in the repository's standard format. If the repository uses Conventional Commits, common patterns include:
    - `feat(core): add ...`
@@ -29,7 +29,7 @@ metadata:
    - `release: v1.2.0`
 
 5. Write the PR body in concise, clear English.
-   - In `Summary`, explain the change context first: the user-facing problem, maintenance goal, or compatibility constraint that makes the change necessary.
+   - Explain the change context first: the user-facing problem, maintenance goal, or compatibility constraint that makes the change necessary.
    - Prioritize high-signal information: public API changes, behavior changes, breaking changes, migration notes, and important compatibility implications.
    - Then describe the main implementation change only as much as needed to understand the review.
    - Keep the PR body concise and review-oriented: use 1-4 short standalone sentences for typical changes, covering why it matters, what changed, and any reviewer-important impact.
@@ -40,10 +40,9 @@ metadata:
      - `This PR fixes incorrect padding in URL labels to keep terminal output aligned across different label lengths.`
      - `This PR updates the English docs to clarify how the extraction option works and when to enable it.`
 
-6. Fill `Related Links` with issue links, design docs, related PRs, or discussion pages.
+6. Include relevant issue links, design docs, related PRs, or discussion pages alongside the context they support.
    If the PR upgrades an npm dependency, add a link to the upgraded version's release notes or tag page when available.
    Example: `https://github.com/web-infra-dev/rspack/releases/tag/v1.0.0`
-   If there is no relevant link, omit the entire `Related Links` section from the PR body.
 
 7. Push the branch only after re-checking the branch name. Never push the default branch directly.
 

--- a/.agents/skills/release-core/SKILL.md
+++ b/.agents/skills/release-core/SKILL.md
@@ -21,10 +21,10 @@ Verify the edited JSON and all matching template ranges. Keep the release diff l
 
 ## Release PR
 
-Commit only the task changes, push the task branch, and create the PR using `.github/PULL_REQUEST_TEMPLATE.md`. Prefer the Codex GitHub connector when available; otherwise use `gh`. Consult [pr-creator](../pr-creator/SKILL.md) only when additional PR guidance is needed. Use:
+Commit only the task changes, push the task branch, and create the PR. Read `.github/PULL_REQUEST_TEMPLATE.md` when drafting the description and follow its current headings and guidance. Prefer the Codex GitHub connector when available; otherwise use `gh`. Consult [pr-creator](../pr-creator/SKILL.md) only when additional PR guidance is needed. Use:
 
 - Commit and PR title: `release: v<version>`
-- `Summary`: `Release @rsbuild/core and create-rsbuild <version>.`
-- `Related links`: `https://github.com/web-infra-dev/rsbuild/releases/tag/v<version>`
+- Explain that the PR prepares the release of `@rsbuild/core` and `create-rsbuild` at `<version>` and updates their package versions and template dependency ranges.
+- Include the release link: `https://github.com/web-infra-dev/rsbuild/releases/tag/v<version>`.
 
 Finish with the PR URL and any unresolved release preparation issue.

--- a/.agents/skills/release-plugin-package/SKILL.md
+++ b/.agents/skills/release-plugin-package/SKILL.md
@@ -55,10 +55,10 @@ For version/changelog-only edits, validate edited JSON, matching template ranges
 
 ## Pull request
 
-Commit only the task changes, push the task branch, and create the PR using `.github/PULL_REQUEST_TEMPLATE.md`. Prefer the Codex GitHub connector when available; otherwise use `gh`. Consult [pr-creator](../pr-creator/SKILL.md) only when additional PR guidance is needed. Use:
+Commit only the task changes, push the task branch, and create the PR. Read `.github/PULL_REQUEST_TEMPLATE.md` when drafting the description and follow its current headings and guidance. Prefer the Codex GitHub connector when available; otherwise use `gh`. Consult [pr-creator](../pr-creator/SKILL.md) only when additional PR guidance is needed. Use:
 
 - Commit and PR title: `release: @rsbuild/plugin-<name> v<version>`
-- `Summary`: `Release @rsbuild/plugin-<name> v<version>.`
-- An optional `Changes` section linking the same verified change PRs used in the changelog; omit it when no links are known.
+- Explain that the PR prepares the release of `@rsbuild/plugin-<name>` at `v<version>` and updates its version, changelog, and matching template dependency ranges where applicable.
+- Include links to the same verified change PRs used in the changelog when available.
 
 Return the PR URL and relevant validation results or limitations.

--- a/.agents/skills/upgrade-rspack/SKILL.md
+++ b/.agents/skills/upgrade-rspack/SKILL.md
@@ -22,8 +22,8 @@ Do not commit or create the PR while required checks remain failed or incomplete
 
 ## Pull request
 
-Commit only the task changes, push the task branch, and create the PR using `.github/PULL_REQUEST_TEMPLATE.md`. Prefer the Codex GitHub connector when available; otherwise use `gh`. Consult [pr-creator](../pr-creator/SKILL.md) only when additional PR guidance is needed. Use:
+Commit only the task changes, push the task branch, and create the PR. Read `.github/PULL_REQUEST_TEMPLATE.md` when drafting the description and follow its current headings and guidance. Prefer the Codex GitHub connector when available; otherwise use `gh`. Consult [pr-creator](../pr-creator/SKILL.md) only when additional PR guidance is needed. Use:
 
 - Commit and PR title: `feat(deps): update @rspack/core to <version>`
-- `Summary`: `Update @rspack/core to <version>.` Add relevant compatibility changes if needed.
-- `Related links`: `https://github.com/web-infra-dev/rspack/releases/tag/v<version>`
+- Explain why the upgrade matters to Rsbuild using verified upstream changes, and describe the update to `@rspack/core` at `<version>` and any relevant compatibility changes.
+- Include the upstream release link: `https://github.com/web-infra-dev/rspack/releases/tag/v<version>`.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,7 @@
-## Summary
+## Motivation
 
-## Related links
+<!-- Explain the problem or motivation and why it matters. Include relevant context and links to issues or discussions. -->
 
-<!--- Provide links of related issues or pages -->
+## Changes
+
+<!-- Describe how this PR addresses the motivation and what behavior changes. Focus on the key approach rather than a file-by-file summary. -->

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -11,7 +11,7 @@
       "source": "rstackjs/agent-skills",
       "sourceType": "github",
       "skillPath": ".agents/skills/pr-creator/SKILL.md",
-      "computedHash": "6b16aae8df116895d7bf8a567999ad54826ffa4b0c2353ba5187bf361d6e40f8"
+      "computedHash": "ed4ca0b83b380c9a4a350047ef5f2616c0446b2830d59e3a06839cb827fd39b4"
     },
     "release-blog-writer": {
       "source": "rstackjs/agent-skills",


### PR DESCRIPTION
## Motivation

PR descriptions should foreground the problem and context so reviewers can understand why a change is needed, following [Rspack #15584](https://github.com/web-infra-dev/rspack/pull/15584).

## Changes

Replace Summary and Related links with Motivation and Changes, with prompts for relevant context, issue links, and the key approach. Align PR creation, release, and Rspack upgrade skills to read the current template instead of hardcoding its old headings.