### PR TITLE
release: v2.2.5

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/core",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "The Rspack-based build tool.",
   "homepage": "https://rsbuild.rs",
   "bugs": {

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rsbuild",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Create a new Rsbuild project",
   "homepage": "https://rsbuild.rs",
   "bugs": {

--- a/packages/create-rsbuild/template-lit-js/package.json
+++ b/packages/create-rsbuild/template-lit-js/package.json
@@ -12,6 +12,6 @@
     "lit": "^3.3.3"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.2.4"
+    "@rsbuild/core": "^2.2.5"
   }
 }

--- a/packages/create-rsbuild/template-lit-ts/package.json
+++ b/packages/create-rsbuild/template-lit-ts/package.json
@@ -12,7 +12,7 @@
     "lit": "^3.3.3"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.2.4",
+    "@rsbuild/core": "^2.2.5",
     "@types/node": "^24.13.3",
     "typescript": "^6.0.3"
   }

--- a/packages/create-rsbuild/template-octane-js/package.json
+++ b/packages/create-rsbuild/template-octane-js/package.json
@@ -13,6 +13,6 @@
   },
   "devDependencies": {
     "@octanejs/rsbuild-plugin": "^0.1.47",
-    "@rsbuild/core": "^2.2.4"
+    "@rsbuild/core": "^2.2.5"
   }
 }

--- a/packages/create-rsbuild/template-octane-ts/package.json
+++ b/packages/create-rsbuild/template-octane-ts/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@octanejs/rsbuild-plugin": "^0.1.47",
-    "@rsbuild/core": "^2.2.4",
+    "@rsbuild/core": "^2.2.5",
     "@tsrx/typescript-plugin": "^0.3.133",
     "@types/node": "^24.13.3",
     "typescript": "^5.9.3"

--- a/packages/create-rsbuild/template-preact-js/package.json
+++ b/packages/create-rsbuild/template-preact-js/package.json
@@ -12,7 +12,7 @@
     "preact": "^10.29.8"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.2.4",
+    "@rsbuild/core": "^2.2.5",
     "@rsbuild/plugin-preact": "^2.1.0"
   }
 }

--- a/packages/create-rsbuild/template-preact-ts/package.json
+++ b/packages/create-rsbuild/template-preact-ts/package.json
@@ -12,7 +12,7 @@
     "preact": "^10.29.8"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.2.4",
+    "@rsbuild/core": "^2.2.5",
     "@rsbuild/plugin-preact": "^2.1.0",
     "@types/node": "^24.13.3",
     "typescript": "^6.0.3"

--- a/packages/create-rsbuild/template-react-js/package.json
+++ b/packages/create-rsbuild/template-react-js/package.json
@@ -13,7 +13,7 @@
     "react-dom": "^19.2.8"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.2.4",
+    "@rsbuild/core": "^2.2.5",
     "@rsbuild/plugin-react": "^2.1.0"
   }
 }

--- a/packages/create-rsbuild/template-react-ts/package.json
+++ b/packages/create-rsbuild/template-react-ts/package.json
@@ -13,7 +13,7 @@
     "react-dom": "^19.2.8"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.2.4",
+    "@rsbuild/core": "^2.2.5",
     "@rsbuild/plugin-react": "^2.1.0",
     "@types/node": "^24.13.3",
     "@types/react": "^19.2.18",

--- a/packages/create-rsbuild/template-solid-js/package.json
+++ b/packages/create-rsbuild/template-solid-js/package.json
@@ -12,7 +12,7 @@
     "solid-js": "^1.9.15"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.2.4",
+    "@rsbuild/core": "^2.2.5",
     "@rsbuild/plugin-babel": "^2.1.0",
     "@rsbuild/plugin-solid": "^1.2.2"
   }

--- a/packages/create-rsbuild/template-solid-ts/package.json
+++ b/packages/create-rsbuild/template-solid-ts/package.json
@@ -12,7 +12,7 @@
     "solid-js": "^1.9.15"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.2.4",
+    "@rsbuild/core": "^2.2.5",
     "@rsbuild/plugin-babel": "^2.1.0",
     "@rsbuild/plugin-solid": "^1.2.2",
     "@types/node": "^24.13.3",

--- a/packages/create-rsbuild/template-solid2-js/package.json
+++ b/packages/create-rsbuild/template-solid2-js/package.json
@@ -13,7 +13,7 @@
     "solid-js": "^2.0.0-rc.6"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.2.4",
+    "@rsbuild/core": "^2.2.5",
     "@rsbuild/plugin-solid": "^2.0.0-rc.0"
   }
 }

--- a/packages/create-rsbuild/template-solid2-ts/package.json
+++ b/packages/create-rsbuild/template-solid2-ts/package.json
@@ -13,7 +13,7 @@
     "solid-js": "^2.0.0-rc.6"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.2.4",
+    "@rsbuild/core": "^2.2.5",
     "@rsbuild/plugin-solid": "^2.0.0-rc.0",
     "@types/node": "^24.13.3",
     "typescript": "^6.0.3"

--- a/packages/create-rsbuild/template-svelte-js/package.json
+++ b/packages/create-rsbuild/template-svelte-js/package.json
@@ -12,7 +12,7 @@
     "svelte": "^5.56.10"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.2.4",
+    "@rsbuild/core": "^2.2.5",
     "@rsbuild/plugin-svelte": "^2.0.1"
   }
 }

--- a/packages/create-rsbuild/template-svelte-ts/package.json
+++ b/packages/create-rsbuild/template-svelte-ts/package.json
@@ -13,7 +13,7 @@
     "svelte": "^5.56.10"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.2.4",
+    "@rsbuild/core": "^2.2.5",
     "@rsbuild/plugin-svelte": "^2.0.1",
     "@types/node": "^24.13.3",
     "svelte-check": "^4.7.6",

--- a/packages/create-rsbuild/template-vanilla-js/package.json
+++ b/packages/create-rsbuild/template-vanilla-js/package.json
@@ -9,6 +9,6 @@
     "preview": "rsbuild preview"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.2.4"
+    "@rsbuild/core": "^2.2.5"
   }
 }

--- a/packages/create-rsbuild/template-vanilla-ts/package.json
+++ b/packages/create-rsbuild/template-vanilla-ts/package.json
@@ -9,7 +9,7 @@
     "preview": "rsbuild preview"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.2.4",
+    "@rsbuild/core": "^2.2.5",
     "@types/node": "^24.13.3",
     "typescript": "^6.0.3"
   }

--- a/packages/create-rsbuild/template-vue-js/package.json
+++ b/packages/create-rsbuild/template-vue-js/package.json
@@ -12,7 +12,7 @@
     "vue": "^3.5.42"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.2.4",
+    "@rsbuild/core": "^2.2.5",
     "@rsbuild/plugin-vue": "^2.0.1"
   }
 }

--- a/packages/create-rsbuild/template-vue-ts/package.json
+++ b/packages/create-rsbuild/template-vue-ts/package.json
@@ -12,7 +12,7 @@
     "vue": "^3.5.42"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.2.4",
+    "@rsbuild/core": "^2.2.5",
     "@rsbuild/plugin-vue": "^2.0.1",
     "@types/node": "^24.13.3",
     "typescript": "^6.0.3",


### PR DESCRIPTION
## Motivation

Prepare the 2.2.5 release of `@rsbuild/core` and `create-rsbuild`.

Release: https://github.com/web-infra-dev/rsbuild/releases/tag/v2.2.5

## Changes

Update both package versions to `2.2.5` and all 18 template `@rsbuild/core` dependency ranges to `^2.2.5`.

Validated JSON, version ranges, and diff formatting. Build and tests are not required for these version-only changes.