### PR TITLE
chore(docs): disable automatic browser opening

### DIFF
--- a/website/rstack.config.ts
+++ b/website/rstack.config.ts
@@ -253,9 +253,6 @@ define.doc({
         },
       }),
     ],
-    server: {
-      open: true,
-    },
     tools: {
       rspack: {
         experiments: {


### PR DESCRIPTION
## Motivation

Agents do not need a browser to open automatically when starting the documentation dev server. Opening it by default adds an unnecessary side effect to agent development workflows.

## Changes

Remove `server.open: true` from the website configuration so the documentation dev server no longer opens a browser automatically.