### PR TITLE
fix(core): use absolute paths for deeply nested parent references

### DIFF
--- a/packages/core/src/helpers/format.ts
+++ b/packages/core/src/helpers/format.ts
@@ -1,11 +1,16 @@
 import { builtinModules } from 'node:module';
-import { sep } from 'node:path';
+import { resolve, sep } from 'node:path';
 import { stripVTControlCharacters as stripAnsi } from 'node:util';
 import type { StatsError } from '@rspack/core';
 import { color } from 'rslog';
 import { LAZY_COMPILATION_IDENTIFIER } from '../constants';
 import { isVerbose, type Logger } from '../logger';
 import { removeLoaderChainDelimiter } from './stats';
+
+function formatDiagnosticPath(filePath: string, root: string): string {
+  // Avoid long chains of parent directories, e.g. paths to pnpm's global store.
+  return /^(\.\.[\\/]){4}/.test(filePath) ? resolve(root, filePath) : filePath;
+}
 
 const formatFileName = (fileName: string, stats: StatsError, root: string) => {
   // File name may be empty when the error is not related to a file.
@@ -30,6 +35,8 @@ const formatFileName = (fileName: string, stats: StatsError, root: string) => {
   const prefix = root + sep;
   if (fileName.startsWith(prefix)) {
     fileName = fileName.replace(prefix, `.${sep}`);
+  } else {
+    fileName = formatDiagnosticPath(fileName, root);
   }
 
   if (/:\d+:\d+/.test(fileName)) {
@@ -85,6 +92,7 @@ function resolveFileName(stats: StatsError, logger: Logger) {
 function formatModuleTrace(
   stats: StatsError,
   errorFile: string,
+  root: string,
   level: 'error' | 'warning',
   logger: Logger,
 ) {
@@ -114,7 +122,10 @@ function formatModuleTrace(
   }
 
   // Current moduleTrace is usually error -> entry, so reverse to entry -> error.
-  let trace = moduleNames.slice().reverse();
+  let trace = moduleNames
+    .slice()
+    .reverse()
+    .map((name) => formatDiagnosticPath(name, root));
   const MAX = 4;
 
   // Truncate long traces in non-verbose mode
@@ -265,7 +276,7 @@ export function formatStatsError(
 
   // display module trace for errors
   if (level === 'error' || isVerbose(logger)) {
-    const moduleTrace = formatModuleTrace(stats, fileName, level, logger);
+    const moduleTrace = formatModuleTrace(stats, fileName, root, level, logger);
     if (moduleTrace) {
       message += moduleTrace;
     }

--- a/packages/core/tests/format.test.ts
+++ b/packages/core/tests/format.test.ts
@@ -1,0 +1,38 @@
+import { resolve } from 'node:path';
+import { formatStatsError } from '../src/helpers/format';
+import { createLogger } from '../src/logger';
+
+const root = resolve('/project/a/b/c/d');
+const logger = createLogger({ level: 'info' });
+
+describe('diagnostic paths', () => {
+  it.each([
+    ['../../../dependency.js', '../../../dependency.js:1:1'],
+    ['../../../../dependency.js', `${resolve('/project/dependency.js')}:1:1`],
+    ['../../../../../dependency.js:2:3', `${resolve('/dependency.js')}:2:3`],
+  ])('should format %s as %s', (file, expected) => {
+    expect(formatStatsError({ file, message: '' }, root, 'error', logger)).toBe(
+      `File: ${expected}`,
+    );
+  });
+
+  it('should format long relative paths in import traces', () => {
+    const file = '../../../../dependency.js';
+    const message = formatStatsError(
+      {
+        moduleName: file,
+        message: '',
+        moduleTrace: [{ originName: '../../../shared.js' }],
+      },
+      root,
+      'error',
+      logger,
+    );
+
+    expect(message).toContain(
+      'Import traces (entry → error):\n' +
+        '  ../../../shared.js\n' +
+        `  ${resolve('/project/dependency.js')} ×`,
+    );
+  });
+});


### PR DESCRIPTION
## Motivation

Diagnostic paths to dependencies in pnpm's global virtual store can start with many `../` segments, making file locations difficult to interpret.

## Changes

Use absolute paths for file locations and import traces that start with four or more parent-directory segments, preserving line and column information.