### PR TITLE
fix(core): move import maps before module loading tags

### DIFF
--- a/e2e/cases/html/import-map-order/index.test.ts
+++ b/e2e/cases/html/import-map-order/index.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@e2e/helper';
+import type { Page } from 'playwright';
+
+const expectTagOrder = async (page: Page) => {
+  await expect(page.locator('#root')).toHaveText('Hello Rsbuild!');
+  expect(
+    await page
+      .locator('head > [id]')
+      .evaluateAll((tags) => tags.map((tag) => tag.id)),
+  ).toEqual(['first-map', 'meta', 'second-map', 'preload']);
+  expect(
+    await page
+      .locator('body > [id]')
+      .evaluateAll((tags) => tags.map((tag) => tag.id)),
+  ).toEqual(['root', 'body-map', 'body-module']);
+};
+
+test('should move import maps before module scripts and preloads', async ({
+  page,
+  runBothServe,
+}) => {
+  await runBothServe(() => expectTagOrder(page));
+});
+
+test('should move import maps with the native HTML plugin', async ({
+  page,
+  runBothServe,
+}) => {
+  await runBothServe(() => expectTagOrder(page), {
+    config: { html: { implementation: 'native' } },
+  });
+});

--- a/e2e/cases/html/import-map-order/rsbuild.config.ts
+++ b/e2e/cases/html/import-map-order/rsbuild.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  html: {
+    tags: [
+      {
+        tag: 'script',
+        attrs: { id: 'first-map', type: 'importmap' },
+        children: '{}',
+      },
+      { tag: 'meta', attrs: { id: 'meta', name: 'description' } },
+      {
+        tag: 'link',
+        attrs: {
+          id: 'preload',
+          rel: 'alternate MODULEPRELOAD',
+          href: 'data:text/javascript,export{}',
+        },
+      },
+      {
+        tag: 'script',
+        attrs: { id: 'second-map', type: 'IMPORTMAP' },
+        children: '{}',
+      },
+      {
+        tag: 'script',
+        attrs: { id: 'body-module', type: 'MODULE' },
+        head: false,
+      },
+      {
+        tag: 'script',
+        attrs: { id: 'body-map', type: 'importmap' },
+        children: '{}',
+        head: false,
+      },
+    ],
+  },
+});

--- a/e2e/cases/html/import-map-order/src/index.js
+++ b/e2e/cases/html/import-map-order/src/index.js
@@ -1,0 +1,1 @@
+document.querySelector('#root').textContent = 'Hello Rsbuild!';

--- a/packages/core/src/rspack-plugins/RsbuildHtmlPlugin.ts
+++ b/packages/core/src/rspack-plugins/RsbuildHtmlPlugin.ts
@@ -111,6 +111,67 @@ const sortTags = (tags: HtmlTag[], tagConfig: TagConfig) =>
   );
 
 /**
+ * Move import maps before the first module script or modulepreload link in place,
+ * preserving earlier tags and the relative order within each group.
+ */
+const moveImportMaps = (tags: HtmlTagObject[]): HtmlTagObject[] => {
+  const hasImportMap = tags.some((tag) => {
+    const type = tag.attributes.type;
+    return (
+      typeof type === 'string' &&
+      type.length === 'importmap'.length &&
+      type.toLowerCase() === 'importmap' &&
+      tag.tagName.toLowerCase() === 'script'
+    );
+  });
+
+  if (!hasImportMap) {
+    return tags;
+  }
+
+  let firstModuleIndex = -1;
+  let importMaps: HtmlTagObject[] | undefined;
+
+  for (let index = 0; index < tags.length; index++) {
+    const tag = tags[index];
+    const name = tag.tagName.toLowerCase();
+    const type = tag.attributes.type;
+    const scriptType =
+      name === 'script' && typeof type === 'string' ? type.toLowerCase() : '';
+
+    if (firstModuleIndex === -1) {
+      const rel = tag.attributes.rel;
+      if (
+        scriptType === 'module' ||
+        (name === 'link' &&
+          typeof rel === 'string' &&
+          rel
+            .toLowerCase()
+            .split(/[\t\n\f\r ]+/)
+            .includes('modulepreload'))
+      ) {
+        firstModuleIndex = index;
+      }
+    } else if (scriptType === 'importmap') {
+      importMaps ??= [];
+      importMaps.push(tag);
+      continue;
+    }
+
+    // Close the gaps left by collected import maps without changing tag order.
+    if (importMaps) {
+      tags[index - importMaps.length] = tag;
+    }
+  }
+
+  if (importMaps) {
+    tags.length -= importMaps.length;
+    tags.splice(firstModuleIndex, 0, ...importMaps);
+  }
+  return tags;
+};
+
+/**
  * `HtmlTagObject` -> `HtmlBasicTag`
  */
 const formatBasicTag = (tag: HtmlTagObject): HtmlBasicTag => ({
@@ -478,6 +539,9 @@ export class RsbuildHtmlPlugin {
             environment.config.security.nonce,
           );
         }
+
+        data.headTags = moveImportMaps(data.headTags);
+        data.bodyTags = moveImportMaps(data.bodyTags);
 
         return data;
       });

--- a/website/docs/en/config/html/tags.mdx
+++ b/website/docs/en/config/html/tags.mdx
@@ -319,8 +319,7 @@ The final injection position of the tag is determined by the [head](#head) and [
 - `append`: Defines the injection position of the current tag relative to existing tags, defaults to `true`
 - `head`: Specifies whether to add the current tag to the HTML `<head>` element, defaults to `true` for element types allowed in the `<head>`, otherwise `false`.
 - If two tag objects have the same `head` and `append` options, they will be inserted into the same area and hold their relative positions to each other.
-
-As an exception, Rsbuild moves import maps before the first module script or modulepreload link within each injected head or body tag list, preserving the relative order of the import maps; tags written in HTML templates or changed by `modifyHTML` are not reordered.
+- Import maps are moved before module scripts and modulepreload links within each injected head or body tag list.
 
 ```html
 <html>

--- a/website/docs/en/config/html/tags.mdx
+++ b/website/docs/en/config/html/tags.mdx
@@ -319,7 +319,7 @@ The final injection position of the tag is determined by the [head](#head) and [
 - `append`: Defines the injection position of the current tag relative to existing tags, defaults to `true`
 - `head`: Specifies whether to add the current tag to the HTML `<head>` element, defaults to `true` for element types allowed in the `<head>`, otherwise `false`.
 - If two tag objects have the same `head` and `append` options, they will be inserted into the same area and hold their relative positions to each other.
-- Import maps are moved before module scripts and modulepreload links within each injected head or body tag list.
+- Import maps are moved before module scripts and modulepreload links.
 
 ```html
 <html>

--- a/website/docs/en/config/html/tags.mdx
+++ b/website/docs/en/config/html/tags.mdx
@@ -320,6 +320,8 @@ The final injection position of the tag is determined by the [head](#head) and [
 - `head`: Specifies whether to add the current tag to the HTML `<head>` element, defaults to `true` for element types allowed in the `<head>`, otherwise `false`.
 - If two tag objects have the same `head` and `append` options, they will be inserted into the same area and hold their relative positions to each other.
 
+As an exception, Rsbuild moves import maps before the first module script or modulepreload link within each injected head or body tag list, preserving the relative order of the import maps; tags written in HTML templates or changed by `modifyHTML` are not reordered.
+
 ```html
 <html>
   <head>

--- a/website/docs/zh/config/html/tags.mdx
+++ b/website/docs/zh/config/html/tags.mdx
@@ -320,6 +320,8 @@ export default {
 - `head` 指定是否将当前标签添加到 HTML 的 `<head>` 元素中，对于允许在 `<head>` 中包含的元素类型，默认为 `true`，否则为 `false`
 - 如果两个标签对象的 `head` 和 `append` 选项一致，它们将被插入到相同区域，并且维持彼此之间的相对位置。
 
+import map 是一个例外：Rsbuild 会在注入的 head 和 body 标签列表内，分别将 import map 移至第一个 module script 或 modulepreload 标签之前，并保留多张 map 的相对顺序；不会调整 HTML 模板中写死的标签或 `modifyHTML` 修改后的顺序。
+
 ```html
 <html>
   <head>

--- a/website/docs/zh/config/html/tags.mdx
+++ b/website/docs/zh/config/html/tags.mdx
@@ -319,8 +319,7 @@ export default {
 - `append` 定义当前标签相对于已有标签的插入位置，默认值为 `true`
 - `head` 指定是否将当前标签添加到 HTML 的 `<head>` 元素中，对于允许在 `<head>` 中包含的元素类型，默认为 `true`，否则为 `false`
 - 如果两个标签对象的 `head` 和 `append` 选项一致，它们将被插入到相同区域，并且维持彼此之间的相对位置。
-
-import map 是一个例外：Rsbuild 会在注入的 head 和 body 标签列表内，分别将 import map 移至第一个 module script 或 modulepreload 标签之前，并保留多张 map 的相对顺序；不会调整 HTML 模板中写死的标签或 `modifyHTML` 修改后的顺序。
+- 注入的 head 和 body 标签列表内，import map 会分别移至 module script 和 modulepreload 标签之前。
 
 ```html
 <html>

--- a/website/docs/zh/config/html/tags.mdx
+++ b/website/docs/zh/config/html/tags.mdx
@@ -319,7 +319,7 @@ export default {
 - `append` 定义当前标签相对于已有标签的插入位置，默认值为 `true`
 - `head` 指定是否将当前标签添加到 HTML 的 `<head>` 元素中，对于允许在 `<head>` 中包含的元素类型，默认为 `true`，否则为 `false`
 - 如果两个标签对象的 `head` 和 `append` 选项一致，它们将被插入到相同区域，并且维持彼此之间的相对位置。
-- 注入的 head 和 body 标签列表内，import map 会分别移至 module script 和 modulepreload 标签之前。
+- import map 会移至 module script 和 modulepreload 标签之前。
 
 ```html
 <html>


### PR DESCRIPTION
## Motivation

Injected import maps can appear after module scripts or modulepreload links, causing module specifiers to be resolved before their mappings are available.

## Changes

Move import maps before the first module script or modulepreload link within each injected head or body tag list, preserving earlier tags and the relative order within each group. Skip reordering when no import map is present; HTML template content and subsequent `modifyHTML` changes remain under user control.