### PR TITLE
chore(ci): skip tests for documentation and repository metadata

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -1,0 +1,8 @@
+# Paths excluded from unit, e2e, and ecosystem tests.
+changed:
+  - '!**/*.{md,mdx}'
+  - '!**/{LICENSE,_meta.json,dictionary.txt}'
+  - '!{website,.agents,.vscode}/**'
+  - '!.github/ISSUE_TEMPLATE/**'
+  - '!.github/{FUNDING.yml,renovate.json}'
+  - '!{skills-lock.json,cspell.config.js}'

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -30,12 +30,7 @@ jobs:
         id: changes
         with:
           predicate-quantifier: 'every'
-          filters: |
-            changed:
-              - "!**/*.md"
-              - "!**/*.mdx"
-              - "!**/_meta.json"
-              - "!**/dictionary.txt"
+          filters: .github/filters.yml
 
   ecosystem_ci_dispatch:
     name: Dispatch ecosystem CI

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,12 +37,7 @@ jobs:
         id: changes
         with:
           predicate-quantifier: 'every'
-          filters: |
-            changed:
-              - "!**/*.md"
-              - "!**/*.mdx"
-              - "!**/_meta.json"
-              - "!**/dictionary.txt"
+          filters: .github/filters.yml
 
       - name: Setup Node.js
         if: steps.changes.outputs.changed == 'true'
@@ -85,12 +80,7 @@ jobs:
         id: changes
         with:
           predicate-quantifier: 'every'
-          filters: |
-            changed:
-              - "!**/*.md"
-              - "!**/*.mdx"
-              - "!**/_meta.json"
-              - "!**/dictionary.txt"
+          filters: .github/filters.yml
 
       - name: Setup Node.js
         if: steps.changes.outputs.changed == 'true'


### PR DESCRIPTION
## Motivation

Documentation assets, Skills, and repository metadata changes currently trigger unnecessary unit, e2e, and ecosystem tests.

## Changes

Share the path exclusions across all three test jobs and expand them to cover the website, Skills, editor settings, issue templates, and other repository metadata. Source, dependency, and CI configuration changes continue to trigger tests.

Validated YAML syntax and path matching for excluded files, test inputs, and mixed changes.